### PR TITLE
feat: added a setting to change the csv delimiter

### DIFF
--- a/Daqifi.Desktop/Exporter/LoggingSessionExporter.cs
+++ b/Daqifi.Desktop/Exporter/LoggingSessionExporter.cs
@@ -6,12 +6,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Daqifi.Desktop.Models;
 
 namespace Daqifi.Desktop.Exporter
 {
     public class LoggingSessionExporter
     {
         private AppLogger AppLogger = AppLogger.Instance;
+        private readonly string Delimiter = DaqifiSettings.Instance.CsvDelimiter;
 
         public void ExportLoggingSession(LoggingSession loggingSession, string filepath)
         {
@@ -27,7 +29,7 @@ namespace Daqifi.Desktop.Exporter
 
                 // Create the header
                 var sb = new StringBuilder();
-                sb.Append("time,").Append(string.Join(",", channelNames.ToArray())).AppendLine();
+                sb.Append("time").Append(Delimiter).Append(string.Join(Delimiter, channelNames.ToArray())).AppendLine();
                 File.WriteAllText(filepath, sb.ToString());
                 sb.Clear();
 
@@ -58,7 +60,7 @@ namespace Daqifi.Desktop.Exporter
 
                         foreach (var sample in sampleDictionary)
                         {
-                            sb.Append(",");
+                            sb.Append(Delimiter);
                             sb.Append(sample.Value);
                         }
 
@@ -99,7 +101,7 @@ namespace Daqifi.Desktop.Exporter
 
                     // Create the header
                     var sb = new StringBuilder();
-                    sb.Append("time,").Append(string.Join(",", channelNames.ToArray())).AppendLine();
+                    sb.Append("time").Append(Delimiter).Append(string.Join(Delimiter, channelNames.ToArray())).AppendLine();
 
                     var count = 0;
                     var tempTotals = new List<double>();
@@ -119,10 +121,10 @@ namespace Daqifi.Desktop.Exporter
                         if (count % averageQuantity == 0)
                         {
                             // Average and write to file
-                            sb.Append(row).Append(",");
+                            sb.Append(row).Append(Delimiter);
                             foreach (var value in tempTotals)
                             {
-                                sb.Append(value / averageQuantity).Append(",");
+                                sb.Append(value / averageQuantity).Append(Delimiter);
                             }
                             sb.AppendLine();
                             tempTotals.Clear();

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -9,7 +9,7 @@
         xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
         Service:DialogService.IsRegisteredView="True"
-        Title="DAQifi v1.0.12" Height="{Binding Height, Mode=TwoWay}" Width="{Binding Width, Mode=TwoWay}" WindowState="{Binding ViewWindowState, Mode=OneWayToSource}" BorderThickness="0" GlowBrush="Black">
+        Title="DAQiFi v1.1.0" Height="{Binding Height, Mode=TwoWay}" Width="{Binding Width, Mode=TwoWay}" WindowState="{Binding ViewWindowState, Mode=OneWayToSource}" BorderThickness="0" GlowBrush="Black">
     <Window.DataContext>
         <vm:DaqifiViewModel/>
     </Window.DataContext>

--- a/Daqifi.Desktop/Models/DaqifiSettings.cs
+++ b/Daqifi.Desktop/Models/DaqifiSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Daqifi.Desktop.Common.Loggers;
 using System;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Xml.Linq;
 
@@ -9,11 +10,24 @@ namespace Daqifi.Desktop.Models
     {
         #region Private Data
         private bool _canReportErrors;
+        private string _csvDelimiter;
         private static readonly string AppDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + "\\DAQifi";
         private static readonly string SettingsXmlPath = AppDirectory + "\\DAQifiConfiguration.xml";
         #endregion
 
         #region Properties
+        public ObservableCollection<string> CsvDelimiterOptions { get; } = new ObservableCollection<string> { ",", ";" };
+
+        public string CsvDelimiter
+        {
+            get => _csvDelimiter;
+            set
+            {
+                _csvDelimiter = value;
+                SaveSettings();
+            }
+        }
+        
         public bool CanReportErrors
         {
             get => _canReportErrors;
@@ -54,21 +68,29 @@ namespace Daqifi.Desktop.Models
 
                 var xml = XElement.Load(SettingsXmlPath);
 
-                if (xml.Element("CanReportErrors") == null) return;
-                if (bool.TryParse(xml.Element("CanReportErrors").Value, out bool temp))
+                if (xml.Element("CanReportErrors") != null)
                 {
-                    _canReportErrors = temp;
+                    if (bool.TryParse(xml.Element("CanReportErrors").Value, out bool temp))
+                    {
+                        _canReportErrors = temp;
+                    }
+                }
+                
+                if (xml.Element("CsvDelimiter") != null)
+                {
+                    _csvDelimiter = xml.Element("CsvDelimiter").Value;
                 }
             }
             catch(Exception ex)
             {
-                AppLogger.Instance.Error(ex, "Problem Loading DAQifi Settings");
+                AppLogger.Instance.Error(ex, "Problem Loading DAQiFi Settings");
             }
         }
 
         private void LoadDefaultValues()
         {
             CanReportErrors = true;
+            CsvDelimiter = ",";
             SaveSettings();
         }
 
@@ -78,11 +100,12 @@ namespace Daqifi.Desktop.Models
             {
                 var xml = new XElement("DAQifiSettings");
                 xml.Add(new XElement("CanReportErrors", CanReportErrors));
+                xml.Add(new XElement("CsvDelimiter", CsvDelimiter));
                 xml.Save(SettingsXmlPath);
             }
             catch (Exception ex)
             {
-                AppLogger.Instance.Error(ex, "Problem Saving DAQifi Settings");
+                AppLogger.Instance.Error(ex, "Problem Saving DAQiFi Settings");
             }
         }
         #endregion

--- a/Daqifi.Desktop/View/SettingsDialog.xaml
+++ b/Daqifi.Desktop/View/SettingsDialog.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         mc:Ignorable="d"
-        Title="DAQifi Settings" ResizeMode="NoResize" Height="400" Width="400" GlowBrush="{DynamicResource AccentColorBrush}">
+        Title="DAQiFi Settings" ResizeMode="NoResize" Height="400" Width="400" GlowBrush="{DynamicResource AccentColorBrush}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -14,12 +14,27 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <GroupBox Grid.Row="1" Header="Report Errors">
+        <GroupBox Grid.Row="1">
             <StackPanel>
+                <TextBlock>
+                    <Run FontWeight="Bold">
+                        Export Settings
+                    </Run>
+                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="15">
+                    <TextBlock Text="CSV Delimiter" TextWrapping="WrapWithOverflow" Margin="0,0,10,0"/>
+                    <ComboBox Width="50" ItemsSource="{Binding CsvDelimiterOptions}" SelectedItem="{Binding CsvDelimiter}"/>
+                </StackPanel>
+                <Separator Margin="10,0,0,10"></Separator>
+                <TextBlock>
+                    <Run FontWeight="Bold">
+                        Anonymous Feedback
+                    </Run>
+                </TextBlock>
                 <TextBlock Text="Help us improve your experience by providing anonymous data.  No information is collected that could be used to either identify or contact you." TextWrapping="WrapWithOverflow"/>
                 <DockPanel Margin="15">
                     <CheckBox IsChecked="{Binding CanReportErrors}"/>
-                    <TextBlock  Text="Report errors and usage data" TextWrapping="WrapWithOverflow"/>
+                    <TextBlock Text="Report errors and usage data" TextWrapping="WrapWithOverflow"/>
                 </DockPanel>
             </StackPanel>
         </GroupBox>

--- a/Daqifi.Desktop/ViewModels/SettingsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/SettingsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Daqifi.Desktop.Models;
+﻿using System.Collections.ObjectModel;
+using Daqifi.Desktop.Models;
 
 namespace Daqifi.Desktop.ViewModels
 {
@@ -13,6 +14,17 @@ namespace Daqifi.Desktop.ViewModels
         {
             get => _settings.CanReportErrors;
             set => _settings.CanReportErrors = value;
+        }
+        
+        public ObservableCollection<string> CsvDelimiterOptions
+        {
+            get => _settings.CsvDelimiterOptions;
+        }
+        
+        public string CsvDelimiter
+        {
+            get => _settings.CsvDelimiter;
+            set => _settings.CsvDelimiter = value;
         }
         #endregion
     }


### PR DESCRIPTION
There are two options: `,` and `;`

![image](https://github.com/daqifi/daqifi-desktop/assets/6320493/b39e4d0a-a412-4527-929f-26b276de1a8a)

## Example Output

```csv
time;AI0;AI1;DIO14;DIO15
2022-09-03T10:48:16.5464685;0;0.0146484375;0;0
2022-09-03T10:48:17.5464685;0;0.015869140625;0;0
2022-09-03T10:48:18.5464685;0;0.015869140625;0;0
2022-09-03T10:48:19.5464685;0;0.015869140625;0;0
2022-09-03T10:48:20.5464685;0;0.015869140625;0;0
2022-09-03T10:48:21.5464685;0;0.015869140625;0;0
2022-09-03T10:48:22.5464685;0;0.015869140625;0;0
2022-09-03T10:48:23.5464685;0;0.015869140625;0;0
2022-09-03T10:48:24.5464685;0;0.015869140625;0;0
2022-09-03T10:48:25.5464685;0;0.015869140625;0;0
2022-09-03T10:48:26.5464685;0;0.0146484375;0;0
```

closes #34 