### PR TITLE
fix: handle the case where AnalogInPortRangeCount == 0

### DIFF
--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -501,8 +501,8 @@ namespace Daqifi.Desktop.Device
             {
                 DevicePartNumber = message.DevicePn;
             }
-
-            if ((int)message.GetAnalogInPortRange(0) == 5)
+            
+            if (message.AnalogInPortRangeCount > 0 && (int)message.GetAnalogInPortRange(0) == 5)
             {
                 _adcRangeText = _5Volt;
             }


### PR DESCRIPTION
The emulator was sending an empty array and we were trying to access the first item.