### PR TITLE
fix: UDP port conflict with emulator

### DIFF
--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
@@ -44,7 +44,7 @@ namespace Daqifi.Desktop.Device.WiFiDevice
             try
             {
                 Destination = new IPEndPoint(GetBroadcastAddress(), broadcastPort);
-                Client = new UdpClient(broadcastPort);
+                Client = new UdpClient(broadcastPort + 1);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Don't have the UDP client be on the same port as the broadcast port. This causes issues if you are running the emulator on the same machine.