### PR TITLE
feat:Create, edit, load, delete profiles #40

### DIFF
--- a/Daqifi.Desktop.DataModel/Device/DeviceInfo.cs
+++ b/Daqifi.Desktop.DataModel/Device/DeviceInfo.cs
@@ -7,6 +7,8 @@
         public string IpAddress { get; set; }
 
         public string MacAddress { get; set; }
+        
+        public uint Port { get; set; }
 
         public bool IsPowerOn { get; set; }
 

--- a/Daqifi.Desktop.DataModel/Device/DeviceInfo.cs
+++ b/Daqifi.Desktop.DataModel/Device/DeviceInfo.cs
@@ -9,5 +9,7 @@
         public string MacAddress { get; set; }
 
         public bool IsPowerOn { get; set; }
+
+        public string DeviceSerialNo { get; set; }
     }
 }

--- a/Daqifi.Desktop/Channel/DataSample.cs
+++ b/Daqifi.Desktop/Channel/DataSample.cs
@@ -28,6 +28,7 @@ namespace Daqifi.Desktop.Channel
         public DataSample(IDevice streamingDevice, IChannel channel, DateTime timestamp, double value)
         {
             DeviceName = streamingDevice.Name;
+            
             ChannelName = channel.Name;
             Type = channel.Type;
             Color = channel.ChannelColorBrush.ToString();

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj.user
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj.user
@@ -10,4 +10,20 @@
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Update="View\AddprofileDialog.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="View\Flyouts\UpdateProfileFlyout.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="View\AddprofileDialog.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="View\Flyouts\UpdateProfileFlyout.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
 </Project>

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.ObjectPool;
+using Daqifi.Desktop.IO.Messages.Decoders;
 
 namespace Daqifi.Desktop.Device
 {
@@ -36,8 +37,11 @@ namespace Daqifi.Desktop.Device
         public int Id { get; set; }
 
         public string Name { get; set; }
+        public string MacAddress {  get; set; }
 
         public string DevicePartNumber { get; private set; } = string.Empty;
+
+        public string DeviceSerialNo { get; set; }=string.Empty;
 
         public int StreamingFrequency
         {
@@ -146,6 +150,7 @@ namespace Daqifi.Desktop.Device
                 // The board only sends relative timestamps based on a timestamp clock frequency
                 _previousTimestamp = DateTime.Now;
                 _previousDeviceTimestamp = message.MsgTimeStamp;
+                
             }
 
             // Get timestamp difference (i.e. number of clock cycles between messages)
@@ -501,7 +506,11 @@ namespace Daqifi.Desktop.Device
             {
                 DevicePartNumber = message.DevicePn;
             }
-            
+            if (message.HasDeviceSn)
+                DeviceSerialNo=message.DeviceSn.ToString();
+            if(message.HasMacAddr)
+                MacAddress= ProtobufDecoder.GetMacAddressString(message);
+
             if (message.AnalogInPortRangeCount > 0 && (int)message.GetAnalogInPortRange(0) == 5)
             {
                 _adcRangeText = _5Volt;

--- a/Daqifi.Desktop/Device/DeviceMessage.cs
+++ b/Daqifi.Desktop/Device/DeviceMessage.cs
@@ -6,6 +6,7 @@
         public long TimestampTicks { get; set; }
         public long AppTicks { get; set; }
         public string DeviceName { get; set; }
+        
         public int DigitalChannelCount { get; set; }
         public int AnalogChannelCount { get; set; }
         public int DeviceStatus { get; set; }

--- a/Daqifi.Desktop/Device/IStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/IStreamingDevice.cs
@@ -13,6 +13,8 @@ namespace Daqifi.Desktop.Device
         NetworkConfiguration NetworkConfiguration { get; }
         List<string> AdcRanges { get; }
         string AdcRangeText { get; set; }
+        string MacAddress { get; set; }
+        string DeviceSerialNo { get; set; }
         int StreamingFrequency { get; set; }
         IMessageConsumer MessageConsumer { get; set; }
         IMessageProducer MessageProducer { get; set; }

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
@@ -136,6 +136,7 @@ namespace Daqifi.Desktop.Device.WiFiDevice
             var macAddress = ProtobufDecoder.GetMacAddressString(message);
             var ipAddress = ProtobufDecoder.GetIpAddressString(message);
             var isPowerOn = message.PwrStatus == 1;
+            var port = message.DevicePort;
             var device_sn= message.DeviceSn;
 
             var deviceInfo = new DeviceInfo
@@ -143,6 +144,7 @@ namespace Daqifi.Desktop.Device.WiFiDevice
                 DeviceName = deviceName,
                 IpAddress = ipAddress,
                 MacAddress = macAddress,
+                Port = port,
                 IsPowerOn = isPowerOn,
                 DeviceSerialNo= device_sn.ToString()
 

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
@@ -136,13 +136,16 @@ namespace Daqifi.Desktop.Device.WiFiDevice
             var macAddress = ProtobufDecoder.GetMacAddressString(message);
             var ipAddress = ProtobufDecoder.GetIpAddressString(message);
             var isPowerOn = message.PwrStatus == 1;
+            var device_sn= message.DeviceSn;
 
             var deviceInfo = new DeviceInfo
             {
                 DeviceName = deviceName,
                 IpAddress = ipAddress,
                 MacAddress = macAddress,
-                IsPowerOn = isPowerOn
+                IsPowerOn = isPowerOn,
+                DeviceSerialNo= device_sn.ToString()
+
             };
 
             var device = new DaqifiStreamingDevice(deviceInfo);

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -13,6 +13,7 @@ namespace Daqifi.Desktop.Device.WiFiDevice
         public TcpClient Client { get; set; }
         public string IpAddress { get; set; }
         public string MacAddress { get; set; }
+        public int Port { get; set; }
         public bool IsPowerOn { get; set; }
         public string DeviceSerialNo { get; set; }
 
@@ -25,6 +26,7 @@ namespace Daqifi.Desktop.Device.WiFiDevice
             DeviceSerialNo= deviceInfo.DeviceSerialNo;
             IpAddress = deviceInfo.IpAddress;
             MacAddress = deviceInfo.MacAddress;
+            Port = (int)deviceInfo.Port;
             IsPowerOn = deviceInfo.IsPowerOn;
             IsStreaming = false;
         }
@@ -36,10 +38,8 @@ namespace Daqifi.Desktop.Device.WiFiDevice
         {
             try
             {
-                //Client = new TcpClient(IpAddress, 9760);
-
                 Client = new TcpClient();
-                var result = Client.BeginConnect(IpAddress, 9760, null, null);
+                var result = Client.BeginConnect(IpAddress, Port, null, null);
                 var success = result.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(5));
 
                 if (!success)

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -14,6 +14,7 @@ namespace Daqifi.Desktop.Device.WiFiDevice
         public string IpAddress { get; set; }
         public string MacAddress { get; set; }
         public bool IsPowerOn { get; set; }
+        public string DeviceSerialNo { get; set; }
 
         #endregion
 
@@ -21,6 +22,7 @@ namespace Daqifi.Desktop.Device.WiFiDevice
         public DaqifiStreamingDevice(DeviceInfo deviceInfo)
         {
             Name = deviceInfo.DeviceName;
+            DeviceSerialNo= deviceInfo.DeviceSerialNo;
             IpAddress = deviceInfo.IpAddress;
             MacAddress = deviceInfo.MacAddress;
             IsPowerOn = deviceInfo.IsPowerOn;

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -2,6 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Models;
+using System;
+using Daqifi.Desktop.Common.Loggers;
+using System.IO;
+using System.Xml.Linq;
+using System.Collections.ObjectModel;
 
 namespace Daqifi.Desktop.Logger
 {
@@ -11,8 +17,11 @@ namespace Daqifi.Desktop.Logger
 
         private List<IChannel> _subscribedChannels;
         private List<LoggingSession> _loggingSessions;
+        private List<Profile> _subscribedProfiles;
         private bool _active;
-
+        public AppLogger AppLogger = AppLogger.Instance;
+        private static string ProfileAppDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + "\\DAQifi";
+        private static readonly string ProfileSettingsXmlPath = ProfileAppDirectory + "\\DAQifiProfilesConfiguration.xml";
         #endregion
 
         #region Properties
@@ -28,20 +37,22 @@ namespace Daqifi.Desktop.Logger
             }
         }
 
+       
+
         public bool Active
         {
             get => _active;
             set
             {
                 //Set up the current logging session
-                if(!_active)
+                if (!_active)
                 {
                     //Check if database has a previouse section
                     using (var context = new LoggingContext())
                     {
                         var ids = (from s in context.Sessions.AsNoTracking() select s.ID).ToList();
                         var newId = 0;
-                        if(ids.Count > 0) newId = ids.Max() + 1;
+                        if (ids.Count > 0) newId = ids.Max() + 1;
                         Session = new LoggingSession(newId);
                         context.Sessions.Add(Session);
                         context.SaveChanges();
@@ -79,10 +90,273 @@ namespace Daqifi.Desktop.Logger
         {
             Loggers = new List<ILogger>();
             SubscribedChannels = new List<IChannel>();
+            SubscribedProfiles = new List<Profile>();
         }
 
         public static LoggingManager Instance => instance;
 
+        #endregion
+
+        #region Profile Subscription
+        public List<Profile> SubscribedProfiles
+        {
+            get => _subscribedProfiles;
+            private set
+            {
+                _subscribedProfiles = value;
+                NotifyPropertyChanged("SubscribedProfiles");
+            }
+        }
+        private Profile _selectedProfile;
+        public Profile SelectedProfile
+        {
+            get => _selectedProfile;
+            set
+            {
+                _selectedProfile = value;
+                NotifyPropertyChanged("SelectedProfile");
+               
+            }
+        }
+        private bool _flag;
+        public bool Flag
+        {
+            get => _flag;
+            set
+            {
+                _flag = value;
+                NotifyPropertyChanged("Flag");
+
+            }
+        }
+        private ObservableCollection<ProfileChannel> _SelectedProfileChannels = new ObservableCollection<ProfileChannel>();
+        public ObservableCollection<ProfileChannel> SelectedProfileChannels
+        {
+            get => _SelectedProfileChannels;
+            set
+            {
+                _SelectedProfileChannels = value;
+                NotifyPropertyChanged("SelectedProfileChannels");
+            }
+        }
+        public void SubscribeProfile(Profile profile)
+        {
+            try
+            {
+                if (SubscribedProfiles.Contains(profile)) return;
+                AddAndRemoveProfileXml(profile, true);
+                SubscribedProfiles.Add(profile);
+                NotifyPropertyChanged("SubscribedProfiles");
+            }
+            catch (Exception ex)
+            {
+
+                AppLogger.Error(ex, $"Error Subscribe Profile");
+            }
+            
+        }
+        public void callPropertyChange()
+        {
+            NotifyPropertyChanged("SelectedProfileChannels");
+            
+        }
+        public void UpdateProfileInXml(Profile profile)
+        {
+            try
+            {
+                // Ensure the file exists before attempting to update
+                if (!File.Exists(ProfileSettingsXmlPath))
+                {
+                    AppLogger.Error("Profile settings XML file does not exist.");
+                    return;
+                }
+
+                // Load the XML document
+                XDocument doc = XDocument.Load(ProfileSettingsXmlPath);
+
+                // Find the profile by ProfileId
+                var profileToUpdate = doc.Descendants("Profile")
+                                         .FirstOrDefault(p => (Guid)p.Element("ProfileID") == profile.ProfileId);
+
+                if (profileToUpdate != null)
+                {
+                    // Update the profile fields
+                    profileToUpdate.Element("Name")?.SetValue(profile.Name);
+                    profileToUpdate.Element("CreatedOn")?.SetValue(profile.CreatedOn);
+
+                    // Update devices
+                    var devicesElement = profileToUpdate.Element("Devices");
+                    devicesElement?.RemoveAll();  // Clear existing devices
+
+                    foreach (var device in profile.Devices)
+                    {
+                        XElement deviceElement = new XElement("Device",
+                            new XElement("DeviceName", device.DeviceName),
+                            new XElement("DevicePartNumber", device.DevicePartName),
+                            new XElement("MACAddress", device.MACAddress),
+                            new XElement("DeviceSerialNo", device.DeviceSerialNo),
+                            new XElement("SamplingFrequency", device.SamplingFrequency),
+                            new XElement("Channels",
+                                from channel in device.Channels
+                                select new XElement("Channel",
+                                    new XElement("Name", channel.Name),
+                                    new XElement("Type", channel.Type),
+                                    new XElement("IsActive", channel.IsChannelActive)
+                                )
+                            )
+                        );
+
+                        devicesElement?.Add(deviceElement);
+                    }
+
+                    // Save the updated document
+                    doc.Save(ProfileSettingsXmlPath);
+                    //AppLogger.Info($"Profile '{profile.Name}' has been updated successfully.");
+                }
+                else
+                {
+                    AppLogger.Error($"Profile with ID {profile.ProfileId} not found for updating.");
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error(ex, "Error updating profile in XML");
+            }
+        }
+
+        private void AddAndRemoveProfileXml(Profile profile, bool AddProfileFlag)
+        {
+            try
+            {
+                // Ensure the directory exists
+                if (!Directory.Exists(ProfileAppDirectory))
+                {
+                    Directory.CreateDirectory(ProfileAppDirectory);
+                }
+
+                // Ensure the file exists, create an empty structure if it doesn't
+                if (!File.Exists(ProfileSettingsXmlPath))
+                {
+                    // Create the initial structure if the file doesn't exist
+                    XDocument newDoc = new XDocument(
+                        new XElement("Profiles")
+                    );
+                    newDoc.Save(ProfileSettingsXmlPath);
+                }
+
+                // Load the XML document
+                XDocument doc = XDocument.Load(ProfileSettingsXmlPath);
+
+                if (AddProfileFlag)
+                {
+                    // Add the profile information to the XML file
+                    XElement newProfile = new XElement("Profile",
+                        new XElement("Name", profile.Name),
+                        new XElement("ProfileID", profile.ProfileId),
+                        new XElement("CreatedOn", profile.CreatedOn),
+                        new XElement("Devices",
+                            from device in profile.Devices
+                            select new XElement("Device",
+                                new XElement("DeviceName", device.DeviceName),
+                                new XElement("DevicePartNumber", device.DevicePartName),
+                                new XElement("MACAddress", device.MACAddress),
+                                new XElement("DeviceSerialNo", device.DeviceSerialNo),
+                                new XElement("Channels",
+                                    from channel in device.Channels
+                                    select new XElement("Channel",
+                                        new XElement("Name", channel.Name),
+                                        new XElement("Type",channel.Type),   
+                                        new XElement("IsActive", channel.IsChannelActive)
+
+                                    )
+                                ),
+                                new XElement("SamplingFrequency", device.SamplingFrequency)
+                            )
+                        )
+                    );
+
+                    doc.Root?.Add(newProfile);
+                }
+                else
+                {
+                    // Logic for removing the profile (e.g., by profile name)
+                    var profileToRemove = doc.Descendants("Profile")
+                                             .FirstOrDefault(p => (Guid)p.Element("ProfileID") == profile.ProfileId);
+                    profileToRemove?.Remove();
+                    SubscribedProfiles.Remove(profile);
+                }
+
+                // Save the updated document
+                doc.Save(ProfileSettingsXmlPath);
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error(ex, "Error Setting Selected profile");
+            }
+        }
+        public List<Profile> LoadProfilesFromXml()
+        {
+            var profiles = new List<Profile>();
+
+            try
+            {
+                // Check if the profile settings file exists
+                if (File.Exists(ProfileSettingsXmlPath))
+                {
+                    // Load the XML document
+                    XDocument doc = XDocument.Load(ProfileSettingsXmlPath);
+
+                    // Parse the XML and retrieve the profiles
+                    profiles = doc.Descendants("Profile").Select(p => new Profile
+                    {
+                        Name = (string)p.Element("Name"),
+                        ProfileId = (Guid)p.Element("ProfileID"),
+                        CreatedOn = (DateTime)p.Element("CreatedOn"),
+                        Devices = new ObservableCollection<ProfileDevice>(p.Element("Devices")?.Elements("Device").Select(d => new ProfileDevice
+                        {
+                            DeviceName = (string)d.Element("DeviceName"),
+                            DevicePartName = (string)d.Element("DevicePartNumber"),
+                            MACAddress = (string)d.Element("MACAddress"),
+                            DeviceSerialNo = (string)d.Element("DeviceSerialNo"),
+                            SamplingFrequency = (int)d.Element("SamplingFrequency"),
+                            Channels = d.Element("Channels")?.Elements("Channel").Select(c => new ProfileChannel
+                            {
+                                Name = (string)c.Element("Name"),
+                                Type = (string)c.Element("Type"),
+                                IsChannelActive=(bool)c.Element("IsActive")
+                            }).ToList()
+                        }).ToList())
+                    }).ToList();
+                }
+
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error(ex, "Error Loading Profiles from XML");
+            }
+            SubscribedProfiles = profiles;
+            //if (SubscribedProfiles != null && SubscribedProfiles.Count > 0)
+            //    NotifyPropertyChanged("SubscribedProfiles");
+            return profiles;
+        }
+
+        public void UnsubscribeProfile(Profile profile)
+        {
+            try
+            {
+                // Don't unsubscribe a channel that isn't subscribed
+                if (!SubscribedProfiles.Where(x => x.ProfileId == profile.ProfileId).Any()) return;
+                AddAndRemoveProfileXml(profile, false);
+                SubscribedProfiles.Remove(profile);
+                NotifyPropertyChanged("SubscribedProfiles");
+            }
+            catch (Exception ex)
+            {
+
+                AppLogger.Error(ex, $"Error Unsubscribe Profile");
+            }
+           
+        }
         #endregion
 
         #region Channel Subscription
@@ -138,7 +412,7 @@ namespace Daqifi.Desktop.Logger
             }
 
             sample.LoggingSessionID = Session.ID;
-            
+
             // Log channel value to whatever loggers are being managed
             foreach (var logger in Loggers)
             {

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -68,7 +68,7 @@
         </Style>
 
     </Window.Resources>
-    
+
     <Controls:MetroWindow.Flyouts>
         <Controls:FlyoutsControl VerticalAlignment="Bottom">
             <!-- Live Graph Flyout -->
@@ -80,6 +80,9 @@
             <!-- Channel Settings Flyout -->
             <flyouts:ChannelsFlyout DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"/>
 
+            <!-- Channel Settings Flyout -->
+            <flyouts:UpdateProfileFlyout DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"/>
+
             <!-- Logging Session Settings Flyout-->
             <flyouts:LoggedSessionFlyout DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"/>
 
@@ -88,10 +91,10 @@
 
         </Controls:FlyoutsControl>
     </Controls:MetroWindow.Flyouts>
-    
+
     <Grid>
         <TabControl TabStripPlacement="Left" SelectedIndex="{Binding SelectedIndex}">
-            
+
             <!-- Live Graph -->
             <TabItem>
                 <TabItem.Header>
@@ -178,7 +181,7 @@
                         </StackPanel>
                     </DockPanel>
 
-                        <ListView Grid.Row="1" Grid.Column="1" Name="ActiveChannelList" Width="150" ItemsSource="{Binding ActiveInputChannels}" Background="Transparent" BorderThickness="0">
+                    <ListView Grid.Row="1" Grid.Column="1" Name="ActiveChannelList" Width="150" ItemsSource="{Binding ActiveInputChannels}" Background="Transparent" BorderThickness="0">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <DockPanel Margin="5" Height="40" LastChildFill="True" HorizontalAlignment="Left">
@@ -194,7 +197,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                     </Grid>
-                    
+
                 </Grid>
             </TabItem>
 
@@ -215,7 +218,7 @@
                         <RowDefinition Height="2*"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    
+
                     <!-- Logged Data Plot-->
                     <Grid Grid.Row="0">
                         <oxy:PlotView Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0"/>
@@ -264,7 +267,7 @@
                                         <RowDefinition Height="*"/>
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
-                                    
+
                                     <ListView Name="LoggingSessionList"  Grid.Row="0" ItemsSource="{Binding LoggingSessions}" Background="Transparent" BorderThickness="0">
                                         <i:Interaction.Triggers>
                                             <i:EventTrigger EventName="SelectionChanged">
@@ -304,14 +307,14 @@
                                         </ListView.ItemTemplate>
                                     </ListView>
                                     <DockPanel Grid.Row="1" LastChildFill="False">
-                                        
+
                                         <!-- Delete All Logging Session -->
                                         <Button Name="DeleteAllLoggingSessionsButton"  DockPanel.Dock="Right" Command="{Binding ElementName=LoggingSessionList, Path=DataContext.DeleteAllLoggingSessionCommand}" Background="#88FFFFFF" ToolTip="Delete All" Padding="5">
                                             <Button.Content>
                                                 <iconPacks:PackIconMaterial Kind="TrashCanOutline" HorizontalAlignment="Center" Height="20" Width="20"/>
                                             </Button.Content>
                                         </Button>
-                                        
+
                                         <!-- Export All Logging Session -->
                                         <Button Name="ExportAllLoggingSessionsButton" DockPanel.Dock="Right" Command="{Binding ElementName=LoggingSessionList, Path=DataContext.ExportAllLoggingSessionCommand}" Background="#88FFFFFF" ToolTip="Export All" Padding="5">
                                             <Button.Content>
@@ -382,7 +385,7 @@
                                                         <Label Content="{Binding Name}" FontSize="16" Padding="5,0,0,0"/>
                                                         <Label Content="{Binding TypeString}" Padding="5,0,0,0"/>
                                                     </StackPanel>
-                                                    
+
                                                     <Button Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center" Command="{Binding ElementName=ActiveChannelList, Path=DataContext.OpenChannelSettingsCommand}" CommandParameter="{Binding}" ToolTip="Channel Settings">
                                                         <Button.Content>
                                                             <iconPacks:PackIconMaterial Kind="Cog" HorizontalAlignment="Center" Height="20" Width="20"/>
@@ -428,7 +431,7 @@
                     </ContentPresenter.ContentTemplate>
                 </ContentPresenter>
             </TabItem>
-            
+
             <!-- Devices -->
             <TabItem>
                 <TabItem.Header>
@@ -525,6 +528,108 @@
                     </ContentPresenter.ContentTemplate>
                 </ContentPresenter>
             </TabItem>
+
+            <!--profile-->
+            <TabItem>
+                <TabItem.Header>
+                    <Label>
+                        <Label.Content>
+                            <StackPanel Width="75" Margin="0,10,0,10">
+                                <iconPacks:PackIconMaterial Kind="FaceWomanProfile" HorizontalAlignment="Center" Height="30" Width="30"/>
+                                <TextBlock TextWrapping="WrapWithOverflow" Text="Profiles" TextAlignment="Center" IsEnabled="False"/>
+                            </StackPanel>
+                        </Label.Content>
+                    </Label>
+                </TabItem.Header>
+                <ContentPresenter Content="{Binding}">
+                    <ContentPresenter.ContentTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <ListView Name="ActiveProfileList" ItemsSource="{Binding profiles}" Background="Transparent" BorderThickness="0" SelectedItem="{Binding SelectedProfile, Mode=OneWayToSource}">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Height="50">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <StackPanel Grid.Column="0" VerticalAlignment="Center" Orientation="Horizontal">
+                                                        <Ellipse Width="16" Height="16" VerticalAlignment="Center" Margin="5,5,5,0">
+                                                            <Ellipse.Style>
+                                                                <Style TargetType="Ellipse">
+                                                                    <Setter Property="Fill" Value="IndianRed"/>
+                                                                    <!-- Default is red -->
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsProfileActive}" Value="True">
+                                                                            <Setter Property="Fill" Value="LightGreen"/>
+                                                                            <!-- Change to green when active -->
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Ellipse.Style>
+                                                        </Ellipse>
+
+                                                        <!-- Name Label -->
+                                                        <Label Content="{Binding Name}" FontWeight="DemiBold" FontSize="16" Padding="5,0,0,0"/>
+                                                        <Label Content="{Binding CreatedOn}" FontWeight="DemiBold" Foreground="LightGray" FontSize="10" Padding="20,5,0,0"/>
+                                                        
+                                                    </StackPanel>
+                                                    <Button Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" Command="{Binding ElementName=ActiveProfileList, Path=DataContext.OpenProfileSettingsCommand}" CommandParameter="{Binding}" ToolTip="Profile Settings">
+                                                        <Button.Content>
+                                                            <iconPacks:PackIconMaterial Kind="Cog" HorizontalAlignment="Center" Height="20" Width="20"/>
+                                                        </Button.Content>
+                                                    </Button>
+                                                    <Button Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center" Command="{Binding ElementName=ActiveProfileList, Path=DataContext.RemoveProfileCommand}" CommandParameter="{Binding}" ToolTip="Delete Profile">
+                                                        <Button.Content>
+                                                            <iconPacks:PackIconMaterial Kind="TrashCanOutline" HorizontalAlignment="Center" Height="20" Width="20"/>
+                                                        </Button.Content>
+                                                    </Button>
+                                                    <Button Grid.Column="3" HorizontalAlignment="Right" VerticalAlignment="Center" Command="{Binding ElementName=ActiveProfileList, Path=DataContext.IsprofileActiveCommand}" CommandParameter="{Binding}" ToolTip="Active Profile">
+
+                                                        <Button.Content>
+                                                            <iconPacks:PackIconMaterial Kind="Power" HorizontalAlignment="Center" Height="20" Width="20"/>
+                                                        </Button.Content>
+                                                    </Button>
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                                <Border Name="EmptyActiveProfileListLabel" Visibility="Collapsed" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                    <Label HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" VerticalAlignment="Stretch" VerticalContentAlignment="Center">
+                                        <Label.Content>
+                                            <StackPanel Orientation="Vertical" Width="150" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <Label Content="No Profiles Data" VerticalContentAlignment="Center" HorizontalContentAlignment="Center"/>
+                                            </StackPanel>
+                                        </Label.Content>
+                                    </Label>
+                                </Border>
+
+                                <!-- Add profile Button -->
+                                <Button HorizontalAlignment="Right" VerticalAlignment="Bottom" Width="50" Height="50" Command="{Binding ShowAddProfileDialogCommand}" Style="{DynamicResource MetroCircleButtonStyle}" Margin="10" Background="#CC119EDA" >
+                                    <Button.Content>
+                                        <iconPacks:PackIconMaterial Kind="Plus" HorizontalAlignment="Center" Height="20" Width="20" Foreground="White"/>
+                                    </Button.Content>
+                                    <Button.BitmapEffect>
+                                        <DropShadowBitmapEffect Color="Black" Direction="270" Softness="1" ShadowDepth="15" Opacity="0.25" />
+                                    </Button.BitmapEffect>
+                                </Button>
+                            </Grid>
+                            <DataTemplate.Triggers>
+                                <DataTrigger Binding="{Binding profiles.Count}" Value="0">
+                                    <Setter TargetName="ActiveProfileList" Property="Visibility" Value="Collapsed"/>
+                                    <Setter TargetName="EmptyActiveProfileListLabel" Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </DataTemplate.Triggers>
+                        </DataTemplate>
+                    </ContentPresenter.ContentTemplate>
+                </ContentPresenter>
+            </TabItem>
+
         </TabControl>
         <Grid Background="Black" Opacity="0.5" Visibility="{Binding IsBusy, FallbackValue=Hidden, Converter={StaticResource BoolToVis}}">
             <Controls:ProgressRing IsActive="{Binding IsBusy, Mode=OneWay}"/>

--- a/Daqifi.Desktop/Models/AddProfileModel.cs
+++ b/Daqifi.Desktop/Models/AddProfileModel.cs
@@ -1,0 +1,205 @@
+﻿using Daqifi.Desktop.Device;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Remoting.Channels;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Daqifi.Desktop.Models
+{
+    public class AddProfileModel
+    {
+        public List<Profile> ProfileList { get; set; }
+    }
+
+    public class Profile : INotifyPropertyChanged
+    {
+        private string name;
+        private Guid profileId;
+        private DateTime createdOn;
+        private bool isProfileActive;
+        private ObservableCollection<ProfileDevice> devices;
+
+        public string Name
+        {
+            get => name;
+            set
+            {
+                name = value;
+                RaisePropertyChanged(nameof(Name));
+            }
+        }
+        public DateTime CreatedOn
+        {
+            get => createdOn;
+            set
+            {
+                createdOn = value;
+                RaisePropertyChanged(nameof(CreatedOn));
+            }
+        }
+
+        public Guid ProfileId
+        {
+            get => profileId;
+            set
+            {
+                profileId = value;
+                RaisePropertyChanged(nameof(ProfileId));
+            }
+        }
+
+        public bool IsProfileActive
+        {
+            get => isProfileActive;
+            set
+            {
+                isProfileActive = value;
+                RaisePropertyChanged(nameof(IsProfileActive));
+            }
+        }
+
+        public ObservableCollection<ProfileDevice> Devices
+        {
+            get => devices;
+            set
+            {
+                devices = value;
+                RaisePropertyChanged(nameof(Devices));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void RaisePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    public class ProfileDevice : INotifyPropertyChanged
+    {
+        private string deviceName;
+        private string devicePartName;
+        private string deviceSerialNo;
+        private string macAddress;
+        private int samplingFrequency;
+        private List<ProfileChannel> channels;
+
+        public string DeviceName
+        {
+            get => deviceName;
+            set
+            {
+                deviceName = value;
+                RaisePropertyChanged(nameof(DeviceName));
+            }
+        }
+
+        public string DevicePartName
+        {
+            get => devicePartName;
+            set
+            {
+                devicePartName = value;
+                RaisePropertyChanged(nameof(DevicePartName));
+            }
+        }
+
+        public string DeviceSerialNo
+        {
+            get => deviceSerialNo;
+            set
+            {
+                deviceSerialNo = value;
+                RaisePropertyChanged(nameof(DeviceSerialNo));
+            }
+        }
+
+        public string MACAddress
+        {
+            get => macAddress;
+            set
+            {
+                macAddress = value;
+                RaisePropertyChanged(nameof(MACAddress));
+            }
+        }
+
+        public int SamplingFrequency
+        {
+            get => samplingFrequency;
+            set
+            {
+                samplingFrequency = value;
+                RaisePropertyChanged(nameof(SamplingFrequency));
+            }
+        }
+
+        public List<ProfileChannel> Channels
+        {
+            get => channels;
+            set
+            {
+                channels = value;
+                RaisePropertyChanged(nameof(Channels));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void RaisePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    public class ProfileChannel : INotifyPropertyChanged
+    {
+        private string name;
+
+        public string Name
+        {
+            get => name;
+            set
+            {
+                name = value;
+                RaisePropertyChanged(nameof(Name));
+            }
+        }
+        private string type;
+
+        public string Type
+        {
+            get => type;
+            set
+            {
+                type = value;
+                RaisePropertyChanged(nameof(Type));
+            }
+        }
+
+        private bool isChannelActive;
+
+        public bool IsChannelActive
+        {
+            get => isChannelActive;
+            set
+            {
+                isChannelActive = value;
+                RaisePropertyChanged(nameof(IsChannelActive));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void RaisePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+}

--- a/Daqifi.Desktop/View/AddprofileDialog.xaml
+++ b/Daqifi.Desktop/View/AddprofileDialog.xaml
@@ -1,0 +1,70 @@
+﻿<controls:MetroWindow x:Class="Daqifi.Desktop.View.AddprofileDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Daqifi.Desktop.View"
+        mc:Ignorable="d"
+        xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+        Title="Add Profile" ResizeMode="NoResize" Height="400" Width="500"
+                      GlowBrush="{DynamicResource AccentColorBrush}">
+    <Grid>
+        <Border>
+            <DockPanel Name="AddChannelUI" HorizontalAlignment="Stretch"  VerticalAlignment="Stretch" LastChildFill="True" Margin="5">
+                <!-- Add Channel Button -->
+                <Button Name="btnAdd" DockPanel.Dock="Bottom" CommandParameter="{Binding ElementName=ChannelList, Path=SelectedItems}" Command="{Binding AddProfileCommand}" Click="btn_addprofile" Content="Add" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+
+                <DockPanel DockPanel.Dock="Top" Margin="5"  LastChildFill="True">
+                    <Label Content="Name:" DockPanel.Dock="Left"/>
+                    <TextBox Text="{Binding ProfileName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" MaxLength="50"/>
+                </DockPanel>
+
+                <!-- Device Selector -->
+                <DockPanel DockPanel.Dock="Top" Margin="5" LastChildFill="True">
+                    <Label Content="Device:" DockPanel.Dock="Left"/>
+                    <ComboBox Name="SelectedDevice" ItemsSource="{Binding AvailableDevices}" SelectedItem="{Binding SelectedDevice}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border >
+                                    <StackPanel Orientation="Vertical">
+                                        <Label Content="{Binding Name}"/>
+                                        <!--<Label Content="{Binding IPAddress}"/>
+                                        <Label Content="{Binding MACAddress}"/>-->
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </DockPanel>
+                
+                <!--frequency slider-->
+                <DockPanel DockPanel.Dock="Top" Margin="5" LastChildFill="True">
+                    <Label Content="Frequency:" DockPanel.Dock="Left"/>
+                    <TextBox  Text="{Binding ElementName=FrequencySlider, Path=Value, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalContentAlignment="Center" FontSize="20"/>
+                    <Slider  Name="FrequencySlider" HorizontalAlignment="Stretch" Minimum="0" Maximum="1000" TickFrequency="1" IsSnapToTickEnabled="True" Value="{Binding SelectedStreamingFrequency, Delay=500, UpdateSourceTrigger=PropertyChanged}"/>
+                </DockPanel>
+
+
+                <!-- Channel List -->
+                <Grid Margin="5">
+                    <ListView Name="ChannelList" ItemsSource="{Binding AvailableChannels}" SelectionMode="Multiple" Margin="5" Background="Transparent" BorderThickness="0">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <Border >
+                                    <StackPanel Orientation="Horizontal">
+                                        <Label Content="Channel:"/>
+                                        <Label Content="{Binding Name}"/>
+                                        <Label Content="Type:"/>
+                                        <Label Content="{Binding TypeString}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+
+
+                </Grid>
+            </DockPanel>
+        </Border>
+    </Grid>
+</controls:MetroWindow>

--- a/Daqifi.Desktop/View/AddprofileDialog.xaml.cs
+++ b/Daqifi.Desktop/View/AddprofileDialog.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Daqifi.Desktop.View
+{
+    /// <summary>
+    /// Interaction logic for AddprofileDialog.xaml
+    /// </summary>
+    public partial class AddprofileDialog 
+    {
+        public AddprofileDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void btn_addprofile(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/Daqifi.Desktop/View/Flyouts/UpdateProfileFlyout.xaml
+++ b/Daqifi.Desktop/View/Flyouts/UpdateProfileFlyout.xaml
@@ -1,0 +1,73 @@
+﻿<Controls:Flyout x:Class="Daqifi.Desktop.View.Flyouts.UpdateProfileFlyout"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+                  xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks" xmlns:viewmodels="clr-namespace:Daqifi.Desktop.ViewModels" d:DataContext="{d:DesignInstance Type=viewmodels:DaqifiViewModel}"
+                 mc:Ignorable="d" 
+             d:DesignHeight="600" d:DesignWidth="600"
+             Width="{Binding FlyoutWidth}" Height="{Binding FlyoutHeight}" IsOpen="{Binding IsProfileSettingsOpen, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" Position="Right" Header="Profile Settings">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0">
+            <GroupBox Header="Profile Name">
+                <TextBox x:Name="UpdatedProfileNameLbl" TextChanged="UpdatedProfileNameLblChanged" Text="{Binding SelectedProfile.Name}" Height="30" FontSize="16" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
+            </GroupBox>
+           
+            <GroupBox Header="Selected Device">
+                <TextBox x:Name="UpdatedProfileDeviceNameLbl" Text="{Binding SelectedProfile.Devices[0].DeviceName}" Tag="{Binding SelectedProfile.Devices[0].DeviceSerialNo}" IsEnabled="False" Height="30" FontSize="16" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
+            </GroupBox>
+
+            <GroupBox Header="Selected Device">
+                <DockPanel DockPanel.Dock="Top" Margin="5" LastChildFill="True">
+                    <Label Content="Frequency:" DockPanel.Dock="Left"/>
+                    <TextBox  Text="{Binding ElementName=UpdatedProfileSamplingFrequencyLbl, Path=Value, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalContentAlignment="Center" FontSize="20"/>
+                    <Slider x:Name="UpdatedProfileSamplingFrequencyLbl" ValueChanged ="UpdatedProfileSamplingFrequencyLblvalueChanged"  HorizontalAlignment="Stretch" Minimum="0" Maximum="1000" TickFrequency="1" IsSnapToTickEnabled="True" Value="{Binding  SelectedProfile.Devices[0].SamplingFrequency, Delay=500, UpdateSourceTrigger=PropertyChanged}"/>
+                </DockPanel>
+            </GroupBox>
+
+
+        </StackPanel>
+
+        <StackPanel Grid.Column="1">
+
+            <GroupBox Header="Selected Channels">
+                <Grid Margin="5">
+                    <ListView Name="UpdatedProfileChannelList" Height="160" SelectionChanged="UpdatedProfileChannelListSelectionChanged"  ItemsSource="{Binding SelectedProfile.Devices[0].Channels}"   SelectionMode="Multiple"   Margin="5" Background="Transparent" BorderThickness="0">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <EventSetter Event="PreviewMouseLeftButtonDown" Handler="ListViewItem_PreviewMouseLeftButtonDown" />
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <Border >
+                                    <StackPanel Orientation="Horizontal">
+                                        <Label Content="Channel:"/>
+                                        <Label Content="{Binding Name}"/>
+                                        <Label Content="Type:"/>
+                                        <Label Content="{Binding Type}"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+
+
+                </Grid>
+            </GroupBox>
+
+        </StackPanel>
+        <!--<Button Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center" VerticalAlignment="Center" Command="{Binding ElementName=ActiveProfileList, Path=DataContext.IsprofileActiveCommand}" CommandParameter="{Binding}" ToolTip="Active Profile">
+
+            <Button.Content>
+                Save
+            </Button.Content>
+        </Button>-->
+    </Grid>
+</Controls:Flyout>

--- a/Daqifi.Desktop/View/Flyouts/UpdateProfileFlyout.xaml.cs
+++ b/Daqifi.Desktop/View/Flyouts/UpdateProfileFlyout.xaml.cs
@@ -1,0 +1,144 @@
+﻿using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.DialogService;
+using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Models;
+using Daqifi.Desktop.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Daqifi.Desktop.View.Flyouts
+{
+    /// <summary>
+    /// Interaction logic for UpdateProfileFlyout.xaml
+    /// </summary>
+    public partial class UpdateProfileFlyout
+    {
+        private bool _isInitializing = true;
+        private readonly IDialogService _dialogService;
+        public UpdateProfileFlyout() : this(ServiceLocator.Resolve<IDialogService>()) { }
+        public UpdateProfileFlyout(IDialogService dialogService)
+        {
+            _dialogService = dialogService;
+            InitializeComponent();
+            LoggingManager.Instance.PropertyChanged -= UpdateChannelUi;
+            LoggingManager.Instance.PropertyChanged += UpdateChannelUi;
+        }
+        public AppLogger AppLogger = AppLogger.Instance;
+
+        private void UpdateChannelUi(object sender, PropertyChangedEventArgs e)
+        {
+            try
+            {
+                UpdatedProfileChannelList.SelectedItems.Clear();
+                foreach (var channel in LoggingManager.Instance.SelectedProfileChannels)
+                {
+                    if (channel.IsChannelActive == true)  // Assuming IsChannelActive is a string
+                    {
+                        UpdatedProfileChannelList.SelectedItems.Add(channel);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+
+                AppLogger.Error(ex, "Error in updating ui of profile flyout");
+            }
+
+
+        }
+        private void ListViewItem_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                if (LoggingManager.Instance.SelectedProfile != null)
+                {
+                    
+
+                    var item = sender as ListViewItem;
+                    if (item.DataContext is ProfileChannel channel && channel != null)
+                    {
+                        var data = LoggingManager.Instance.SelectedProfile.Devices[0].Channels.Where(x => x.Name == channel.Name).FirstOrDefault();
+                        if (item != null && item.IsSelected)
+                            data.IsChannelActive = false;
+                        else
+                            data.IsChannelActive = true;
+                    }
+                    LoggingManager.Instance.UpdateProfileInXml(LoggingManager.Instance.SelectedProfile);
+                }
+            }
+            catch (Exception ex)
+            {
+
+                AppLogger.Error(ex, "Error editing profile channels");
+            }
+
+        }
+        private void UpdatedProfileChannelListSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isInitializing)
+            {
+                return;
+            }
+        }
+
+
+        private void UpdatedProfileNameLblChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                if (LoggingManager.Instance.SelectedProfile != null)
+                {
+                  
+
+                    if (sender is TextBox profilename && !string.IsNullOrWhiteSpace(profilename.Text))
+                        LoggingManager.Instance.SelectedProfile.Name = profilename.Text;
+
+                    LoggingManager.Instance.UpdateProfileInXml(LoggingManager.Instance.SelectedProfile);
+                }
+            }
+            catch (Exception ex)
+            {
+
+                AppLogger.Error(ex, "Error editing profile Name");
+            }
+
+
+        }
+
+        private void UpdatedProfileSamplingFrequencyLblvalueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            try
+            {
+                if (LoggingManager.Instance.SelectedProfile != null)
+                {
+                   
+
+                    if (sender is Slider freq && freq.Value != 0)
+                        LoggingManager.Instance.SelectedProfile.Devices[0].SamplingFrequency = Convert.ToInt32(freq.Value);
+
+                    LoggingManager.Instance.UpdateProfileInXml(LoggingManager.Instance.SelectedProfile);
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error(ex, "Error editing profile device frequency");
+            }
+
+
+        }
+    }
+}

--- a/Daqifi.Desktop/ViewModels/AddProfileDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/AddProfileDialogViewModel.cs
@@ -1,0 +1,195 @@
+﻿using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Commands;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.DialogService;
+using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Models;
+using Daqifi.Desktop.View;
+using GalaSoft.MvvmLight;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+
+namespace Daqifi.Desktop.ViewModels
+{
+    public class AddProfileDialogViewModel : ViewModelBase
+    {
+        #region Private Variables
+        private IStreamingDevice _selectedDevice;
+        private string _profileName;
+        private readonly IDialogService _dialogService;
+        private int _selectedStreamingFrequency;
+        #endregion
+
+        #region Properties
+        public AppLogger AppLogger = AppLogger.Instance;
+
+        public ObservableCollection<IStreamingDevice> AvailableDevices { get; } = new ObservableCollection<IStreamingDevice>();
+        public ObservableCollection<IChannel> AvailableChannels { get; } = new ObservableCollection<IChannel>();
+
+        public IStreamingDevice SelectedDevice
+        {
+            get => _selectedDevice;
+            set
+            {
+                _selectedDevice = value;
+                GetAvailableChannels(_selectedDevice);
+                RaisePropertyChanged();
+            }
+        }
+        public string ProfileName
+        {
+            get => _profileName;
+            set
+            {
+                _profileName = value;
+                RaisePropertyChanged();
+            }
+        }
+        public int SelectedStreamingFrequency
+        {
+            get => _selectedStreamingFrequency;
+            set
+            {
+                if (value < 1) return;
+                _selectedStreamingFrequency = value;
+                RaisePropertyChanged();
+            }
+        }
+        #endregion
+
+        #region Constructor
+        public AddProfileDialogViewModel() : this(ServiceLocator.Resolve<IDialogService>()) { }
+
+        public AddProfileDialogViewModel(IDialogService dialogService)
+        {
+
+            _dialogService = dialogService;
+            foreach (var device in ConnectionManager.Instance.ConnectedDevices)
+            {
+                AvailableDevices.Add(device);
+            }
+            if (AvailableDevices.Count > 0) SelectedDevice = AvailableDevices.ElementAt(0);
+        }
+        #endregion
+
+        public void GetAvailableChannels(IStreamingDevice device)
+        {
+            try
+            {
+                AvailableChannels.Clear();
+                foreach (var channel in device.DataChannels)
+                {
+                    /*if (!channel.IsActive)*/
+                    AvailableChannels.Add(channel);
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error(ex, "Error in getting Available Channels");
+            }
+
+        }
+
+
+        #region Command Delegatges
+        public ICommand AddProfileCommand => new DelegateCommand(OnSelectedProfileExecute, OnSelectedProfileCanExecute);
+
+        private bool OnSelectedProfileCanExecute(object selectedItems)
+        {
+            //TODO might use this later could not find a good way to raise can execute change
+            return true;
+        }
+
+        private void OnSelectedProfileExecute(object selectedItems)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(ProfileName))
+                {
+                    // _dialogService.ShowDialog<ErrorDialog>(this, new ErrorDialogViewModel("Profile name is required."));
+                    return;
+                }
+                if (AvailableDevices == null || AvailableDevices.Count == 0)
+                {
+                    // _dialogService.ShowDialog<ErrorDialog>(this, new ErrorDialogViewModel("Available devices are required."));
+                    return;
+                }
+                if (SelectedDevice?.DataChannels?.Count == 0)
+                {
+                    // _dialogService.ShowDialog<ErrorDialog>(this, new ErrorDialogViewModel("Selected device must have data channels."));
+                    return;
+                }
+                if (SelectedStreamingFrequency == 0)
+                {
+                    // _dialogService.ShowDialog<ErrorDialog>(this, new ErrorDialogViewModel("Streaming frequency must be greater than 0."));
+                    return;
+                }
+
+                // Get selected channels
+                var selectedChannels = ((IEnumerable)selectedItems).Cast<IChannel>().ToList();
+                if (!selectedChannels.Any())
+                    return;
+
+                if (SelectedDevice != null && SelectedDevice.DataChannels.Count > 0)
+                {
+                    // Initialize the profile and device objects
+                    var addProfileModel = new AddProfileModel
+                    {
+                        ProfileList = new List<Profile>
+            {
+                new Profile
+                {
+                    Name = ProfileName,
+                    ProfileId = Guid.NewGuid(),
+                    CreatedOn = DateTime.Now,
+                    Devices = new ObservableCollection<ProfileDevice>
+                    {
+                        new ProfileDevice
+                        {
+                            MACAddress = SelectedDevice.MacAddress,
+                            DeviceName = SelectedDevice.Name,
+                            DevicePartName = SelectedDevice.DevicePartNumber,
+                            DeviceSerialNo = SelectedDevice.DeviceSerialNo,
+                            SamplingFrequency = SelectedStreamingFrequency,
+                            Channels = new List<ProfileChannel>()
+                        }
+                    }
+                }
+            }
+                    };
+
+                    // Add all channels from SelectedDevice.DataChannels
+                    foreach (var dataChannel in SelectedDevice.DataChannels)
+                    {
+                        // Check if this channel is in the selected channels list
+                        var isSelected = selectedChannels.Any(sc => sc.Name == dataChannel.Name);
+
+                        var profileChannel = new ProfileChannel
+                        {
+                            Name = dataChannel.Name,
+                            Type = dataChannel.TypeString.ToString(),
+                            IsChannelActive = isSelected ? true : false // Set IsChannelActive based on whether it's selected or not
+                        };
+
+                        // Add the channel to the profile
+                        addProfileModel.ProfileList[0].Devices[0].Channels.Add(profileChannel);
+                    }
+
+                    // Subscribe the profile (logging or any additional operations)
+                    LoggingManager.Instance.SubscribeProfile(addProfileModel.ProfileList[0]);
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Error(ex, "Error in getting on selected profile execute");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -147,8 +147,11 @@ namespace Daqifi.Desktop.ViewModels
             _wifiFinder.Stop();
 
             var selectedDevices = ((IEnumerable)selectedItems).Cast<IStreamingDevice>();
+      
+
             foreach (var device in selectedDevices)
             {
+               //var data=device.mac
                 ConnectionManager.Instance.Connect(device);
             }            
         }


### PR DESCRIPTION
Users who run the same setup over and over shouldn't have to configure DAQiFi from scratch each time. Rather, they should be able to create, edit, load, and delete a profile.

Success Criteria:

As a user I want to create a profile that contains:
Connected devices (could be multiple)
Enabled channels
Configuration of enabled channels (name, input, output, scaling functions)
Data collection frequency
XML export preferences and file location
As a user I want to edit a profile
As a user I want to load a profile
As a user I want to delete a profile