### PR TITLE
fix: Replace Label with TextBlock in logging session list

### DIFF
--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -312,7 +312,7 @@
                                             <DataTemplate>
                                                 <Border>
                                                     <DockPanel >
-                                                        <Label Content="{Binding Name}" DockPanel.Dock="Left" FontWeight="Bold"/>
+                                                        <TextBlock Text="{Binding Name}" DockPanel.Dock="Left" FontWeight="Bold" VerticalAlignment="Center"/>
 
                                                         <!-- Delete Logging Session -->
                                                         <Button DockPanel.Dock="Right" Command="{Binding ElementName=LoggingSessionList, Path=DataContext.DeleteLoggingSessionCommand}" CommandParameter="{Binding}" Background="#88FFFFFF" ToolTip="Delete" Padding="5">


### PR DESCRIPTION
fixes #123 

In WPF, `Label` controls interpret underscores (`_`) as access key markers by default. The first underscore in a `Label.Content` is treated as a marker for keyboard shortcuts.

That's why:
   - The plot title showed correctly (it was using direct text assignment)
   - The list view showed incorrectly (it was using a `Label` with `Content` binding)

The fix:
   - Replaced the `Label` with a `TextBlock`
   - Used `Text` binding instead of `Content` binding
   - Added `VerticalAlignment="Center"` to maintain the same visual appearance

Now the underscores should display correctly in both the plot title and the list view.
