### PR TITLE
fix: turn echo on when disconnecting so that serial interface is useable by human

### DIFF
--- a/Daqifi.Desktop.IO.Test/Messages/Producers/ScipMessageProducerTests.cs
+++ b/Daqifi.Desktop.IO.Test/Messages/Producers/ScipMessageProducerTests.cs
@@ -32,11 +32,22 @@ namespace Daqifi.Desktop.IO.Test.Messages.Producers
         }
 
         [TestMethod]
-        public void EchoCommand_ReturnsCorrectCommand()
+        public void TurnOnEchoCommand_ReturnsCorrectCommand()
         {
-            var actualCommand = ScpiMessageProducer.Echo(1);
+            var actualCommand = ScpiMessageProducer.TurnOnEcho;
             var actualCommandRawData = actualCommand.GetBytes();
             const string expectedCommandText = "SYSTem:ECHO 1";
+            var expectedCommandRawData = GetBytes(expectedCommandText);
+
+            CollectionAssert.AreEqual(expectedCommandRawData, actualCommandRawData);
+        }
+        
+        [TestMethod]
+        public void TurnOffEchoCommand_ReturnsCorrectCommand()
+        {
+            var actualCommand = ScpiMessageProducer.TurnOffEcho;
+            var actualCommandRawData = actualCommand.GetBytes();
+            const string expectedCommandText = "SYSTem:ECHO -1";
             var expectedCommandRawData = GetBytes(expectedCommandText);
 
             CollectionAssert.AreEqual(expectedCommandRawData, actualCommandRawData);

--- a/Daqifi.Desktop.IO/Messages/Producers/ScpiMessageProducer.cs
+++ b/Daqifi.Desktop.IO/Messages/Producers/ScpiMessageProducer.cs
@@ -12,11 +12,9 @@ namespace Daqifi.Desktop.IO.Messages.Producers
 
         public static IMessage ForceBootloader => new ScpiMessage("SYSTem:FORceBoot");
 
-        public static IMessage Echo(int echoValue)
-        {
-            return new ScpiMessage($"SYSTem:ECHO {echoValue}");
-        }
+        public static IMessage TurnOffEcho => new ScpiMessage("SYSTem:ECHO -1");
 
+        public static IMessage TurnOnEcho => new ScpiMessage("SYSTem:ECHO 1");
         #endregion
 
         #region SD Card Logging Commands

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -569,7 +569,7 @@ namespace Daqifi.Desktop.Device
 
         protected void TurnOffEcho()
         {
-            MessageProducer.Send(ScpiMessageProducer.Echo(-1));
+            MessageProducer.Send(ScpiMessageProducer.TurnOffEcho);
         }
 
         protected void TurnDeviceOn()

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -70,12 +70,13 @@ namespace Daqifi.Desktop.Device.SerialDevice
             {
                 // First stop streaming to prevent new data from being requested
                 StopStreaming();
-
+                
                 // Stop the message producer first to prevent new messages
                 if (MessageProducer != null)
                 {
                     try
                     {
+                        MessageProducer.Send(ScpiMessageProducer.TurnOnEcho);
                         MessageProducer.StopSafely(); // Use StopSafely to ensure queued messages are sent
                     }
                     catch (Exception ex)


### PR DESCRIPTION
We needed to turn echo back on so that someone could interface with the device in Putty after using the desktop app.

closes #16 