### PR TITLE
fix: disable firmware update option on WiFi

### DIFF
--- a/Daqifi.Desktop/Converters/InvertedBoolToVisibilityConverter.cs
+++ b/Daqifi.Desktop/Converters/InvertedBoolToVisibilityConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Daqifi.Desktop.Converters
+{
+    [ValueConversion(typeof(bool), typeof(Visibility))]
+    public class InvertedBoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool booleanValue)
+            {
+                return booleanValue ? Visibility.Collapsed : Visibility.Visible;
+            }
+            return Visibility.Collapsed; // Default to collapsed if input is not bool
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Visibility visibilityValue)
+            {
+                return visibilityValue == Visibility.Collapsed;
+            }
+            return false; // Default or throw exception based on requirements
+        }
+    }
+} 

--- a/Daqifi.Desktop/View/Flyouts/DevicesFlyout.xaml
+++ b/Daqifi.Desktop/View/Flyouts/DevicesFlyout.xaml
@@ -49,6 +49,7 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis"/>
         <local:NotNullToBoolConverter x:Key="NotNullToBoolConverter"/>
         <converters:ConnectionTypeToUsbConverter x:Key="ConnectionTypeToUsbConverter"/>
+        <local:InvertedBoolToVisibilityConverter x:Key="InvertedBoolToVis" />
         
         <!-- Text Styles -->
         <Style x:Key="HeaderTextBlockStyle" TargetType="TextBlock">
@@ -435,30 +436,41 @@
                                  Style="{StaticResource SectionHeaderStyle}" 
                                  Margin="0,0,0,15"/>
                         
-                        <DockPanel LastChildFill="True" Margin="0,0,0,15">
-                            <Button DockPanel.Dock="Right"
-                                    Content="browse"
-                                    Style="{StaticResource ButtonStyle}"
-                                    Margin="10,0,0,0"
-                                    Command="{Binding BrowseForFirmwareCommand}"/>
-                            <TextBox Style="{StaticResource TextBoxStyle}"
-                                    Text="{Binding FirmwareFilePath, Mode=TwoWay}"/>
-                        </DockPanel>
+                        <!-- Firmware Update Controls (Visible only for USB) -->
+                        <StackPanel Visibility="{Binding IsSelectedDeviceUsb, Converter={StaticResource BoolToVis}}">
+                            <DockPanel LastChildFill="True" Margin="0,0,0,15">
+                                <Button DockPanel.Dock="Right"
+                                        Content="browse"
+                                        Style="{StaticResource ButtonStyle}"
+                                        Margin="10,0,0,0"
+                                        Command="{Binding BrowseForFirmwareCommand}"/>
+                                <TextBox Style="{StaticResource TextBoxStyle}"
+                                         Text="{Binding FirmwareFilePath, Mode=TwoWay}"/>
+                            </DockPanel>
 
-                        <DockPanel LastChildFill="True">
-                            <Button DockPanel.Dock="Right"
-                                    Content="update"
-                                    Style="{StaticResource AccentButtonStyle}"
-                                    Margin="10,0,0,0"
-                                    Width="80"
-                                    Command="{Binding UploadFirmwareCommand}"/>
-                            <controls:MetroProgressBar Height="35"
-                                                     Background="#333333"
-                                                     Foreground="#4B8FE2"
-                                                     Minimum="0"
-                                                     Maximum="100"
-                                                     Value="{Binding UploadFirmwareProgress}"/>
-                        </DockPanel>
+                            <DockPanel LastChildFill="True">
+                                <Button DockPanel.Dock="Right"
+                                        Content="update"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        Margin="10,0,0,0"
+                                        Width="80"
+                                        Command="{Binding UploadFirmwareCommand}"/>
+                                <controls:MetroProgressBar Height="35"
+                                                         Background="#333333"
+                                                         Foreground="#4B8FE2"
+                                                         Minimum="0"
+                                                         Maximum="100"
+                                                         Value="{Binding UploadFirmwareProgress}"/>
+                            </DockPanel>
+                        </StackPanel>
+
+                        <!-- Informational Message (Visible only for non-USB) -->
+                        <TextBlock Text="Firmware updates require the device to be connected via USB." 
+                                   Foreground="#FFCC00" 
+                                   Margin="0,10,0,0"
+                                   TextWrapping="Wrap"
+                                   Visibility="{Binding IsSelectedDeviceUsb, Converter={StaticResource InvertedBoolToVis}}"/>
+
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/Daqifi.Desktop/View/Flyouts/FirmwareFlyout.xaml
+++ b/Daqifi.Desktop/View/Flyouts/FirmwareFlyout.xaml
@@ -8,6 +8,7 @@
              xmlns:local="clr-namespace:Daqifi.Desktop.View.Flyouts"
                    xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
              xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+             xmlns:converters="clr-namespace:Daqifi.Desktop.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
                   Width="{Binding FlyoutWidth}" Height="{Binding FlyoutHeight}" IsOpen="{Binding IsFirmwareUpdatationFlyoutOpen, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" Position="Right" Header="Firmware Update">
@@ -26,6 +27,9 @@
                 <x:Type TypeName="networkDataModel:WifiSecurityType" />
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+        <!-- Converters -->
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <converters:InvertedBoolToVisibilityConverter x:Key="InvertedBoolToVis" />
     </Controls:Flyout.Resources>
 
     <Grid>
@@ -60,26 +64,35 @@
         </GroupBox>
         <!-- Update Firmware -->
         <GroupBox Grid.Column="0" Grid.Row="2" Header="Update Firmware">
-     <Grid>
-         <Grid.ColumnDefinitions>
-             <ColumnDefinition Width="*"/>
-             <ColumnDefinition Width="Auto"/>
-         </Grid.ColumnDefinitions>
-         <Grid.RowDefinitions>
-             <RowDefinition Height="Auto"/>
-             <RowDefinition Height="Auto"/>
-             <RowDefinition Height="Auto"/>
-             <RowDefinition Height="Auto"/>
-         </Grid.RowDefinitions>
+            <StackPanel>
+                <!-- Firmware Update Controls (Visible only for USB) -->
+                <Grid Visibility="{Binding IsSelectedDeviceUsb, Converter={StaticResource BoolToVis}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
 
-         <Label Grid.Column="0" Grid.Row="0" Content="Firmware Update" VerticalAlignment="Center" />
-         <controls:MetroProgressBar Grid.Column="0" Grid.Row="1" Height="25" Minimum="0" Maximum="100" Value="{Binding UploadFirmwareProgress}" />
+                    <Label Grid.Column="0" Grid.Row="0" Content="Firmware Update" VerticalAlignment="Center" />
+                    <controls:MetroProgressBar Grid.Column="0" Grid.Row="1" Height="25" Minimum="0" Maximum="100" Value="{Binding UploadFirmwareProgress}" />
 
-         <Label Grid.Column="0" Grid.Row="2" Content="WIFI Module Update" VerticalAlignment="Center" />
-         <controls:MetroProgressBar Grid.Column="0" Grid.Row="3" Height="25" Minimum="0" Maximum="100" Value="{Binding UploadWiFiProgress}" />
+                    <Label Grid.Column="0" Grid.Row="2" Content="WIFI Module Update" VerticalAlignment="Center" />
+                    <controls:MetroProgressBar Grid.Column="0" Grid.Row="3" Height="25" Minimum="0" Maximum="100" Value="{Binding UploadWiFiProgress}" />
 
-         <Button Grid.Column="1" Grid.Row="3" Width="50" Margin="5,0,0,0" Content="Update" Command="{Binding UploadFirmwareCommand}" />
-     </Grid>
- </GroupBox>
+                    <Button Grid.Column="1" Grid.Row="3" Width="50" Margin="5,0,0,0" Content="Update" Command="{Binding UploadFirmwareCommand}" />
+                </Grid>
+                <!-- Informational Message (Visible only for non-USB) -->
+                <TextBlock Text="Firmware updates require the device to be connected via USB." 
+                           Foreground="#FFCC00" 
+                           Margin="0,10,0,0"
+                           TextWrapping="Wrap"
+                           Visibility="{Binding IsSelectedDeviceUsb, Converter={StaticResource InvertedBoolToVis}}"/>
+            </StackPanel>
+        </GroupBox>
     </Grid>
 </Controls:Flyout>

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -23,6 +23,7 @@ using System.Windows.Input;
 using Daqifi.Desktop.Device.SerialDevice;
 using Application = System.Windows.Application;
 using File = System.IO.File;
+using Daqifi.Desktop.DataModel.Network;
 
 namespace Daqifi.Desktop.ViewModels;
 
@@ -435,6 +436,7 @@ public class DaqifiViewModel : CommunityToolkit.Mvvm.ComponentModel.ObservableOb
         {
             _selectedDevice = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(IsSelectedDeviceUsb));
         }
     }
 
@@ -545,6 +547,8 @@ public class DaqifiViewModel : CommunityToolkit.Mvvm.ComponentModel.ObservableOb
     }
 
     public DeviceLogsViewModel DeviceLogsViewModel { get; private set; }
+
+    public bool IsSelectedDeviceUsb => SelectedDevice is SerialStreamingDevice;
     #endregion
 
     #region Constructor
@@ -632,7 +636,7 @@ public class DaqifiViewModel : CommunityToolkit.Mvvm.ComponentModel.ObservableOb
     public ICommand UploadFirmwareCommand { get; set; }
     private bool CanUploadFirmware(object o)
     {
-        return true;
+        return _selectedDevice is SerialStreamingDevice;
     }
 
     public ICommand ShowAddProfileDialogCommand { get; private set; }

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -636,7 +636,7 @@ public class DaqifiViewModel : CommunityToolkit.Mvvm.ComponentModel.ObservableOb
     public ICommand UploadFirmwareCommand { get; set; }
     private bool CanUploadFirmware(object o)
     {
-        return _selectedDevice is SerialStreamingDevice;
+        return true;
     }
 
     public ICommand ShowAddProfileDialogCommand { get; private set; }


### PR DESCRIPTION
This feature is only available when connected via USB

<img width="800" alt="image" src="https://github.com/user-attachments/assets/f5d151fa-43a0-4c38-aa57-1aa7a7e7d149" />

<img width="802" alt="image" src="https://github.com/user-attachments/assets/314eb0c8-2b5f-4153-b18a-340003ea255e" />

closes #134 