### PR TITLE
fix: broadcast discovery on all networks

### DIFF
--- a/DAQIifi Desktop.sln.DotSettings
+++ b/DAQIifi Desktop.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=daqifi/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
closes #112 

## How to Test

**Add a Microsoft Loopback Adapter**
- This creates a virtual network interface on your host machine that doesn't connect to anything physical but makes the OS think it has another active network.

How to add:
1. Open Device Manager (devmgmt.msc).
1. Click on your computer name at the top of the tree.
1. Go to the Action menu -> Add legacy hardware.
1. Click Next.
1. Choose "Install the hardware that I manually select from a list (Advanced)" -> Next.
1. Scroll down and select Network adapters -> Next.
1. Select Microsoft as the Manufacturer on the left.
1. Select Microsoft KM-TEST Loopback Adapter on the right -> Next.
1. Click Next again, then Finish.

How to configure:
1. Open Network Connections (ncpa.cpl).
1. Find the new adapter (might be named "Ethernet 2", "Ethernet 3", etc.). Right-click -> Properties.
1. Select Internet Protocol Version 4 (TCP/IPv4) -> Properties.
1. Choose "Use the following IP address".
1. Assign it an IP address and subnet mask completely different from your main network (e.g., IP: 10.1.1.1, Subnet Mask: 255.255.255.0). Leave the Gateway blank. Click OK.

- Now your PC has multiple active network interfaces. Run your application. It should still discover the DAQiFi device on your real network, proving the loopback adapter's presence doesn't interfere.