### PR TITLE
fix: fixes behavior with DIO

### DIFF
--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -200,7 +200,7 @@ public abstract class AbstractStreamingDevice : ObservableObject, IStreamingDevi
         }
 
         // Loop through channels for this device
-        foreach (var channel in DataChannels.Where(c => c.IsActive && c.Direction == ChannelDirection.Input))
+        foreach (var channel in DataChannels.Where(c => c.IsActive))
         {
             try
             {
@@ -216,8 +216,11 @@ public abstract class AbstractStreamingDevice : ObservableObject, IStreamingDevi
                         bit = (digitalData2 & (1 << digitalCount % 8)) != 0;
                     }
 
-                    // Assign the sample for the digital channel
-                    channel.ActiveSample = new DataSample(this, channel, messageTimestamp, Convert.ToInt32(bit));
+                    // Assign the sample for the digital input channel
+                    if (channel.Direction == ChannelDirection.Input)
+                    {
+                        channel.ActiveSample = new DataSample(this, channel, messageTimestamp, Convert.ToInt32(bit));
+                    }
                     digitalCount++;
                 }
                 else if (channel.Type == ChannelType.Analog && hasAnalogData)

--- a/Daqifi.Desktop/View/Flyouts/ChannelsFlyout.xaml
+++ b/Daqifi.Desktop/View/Flyouts/ChannelsFlyout.xaml
@@ -87,7 +87,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-                        <Controls:ToggleSwitch Grid.Row="0" IsOn="{Binding SelectedChannel.IsDigitalOn, Mode=TwoWay}" OffContent="On" OnContent="Off" HorizontalAlignment="Center"/>
+                        <Controls:ToggleSwitch Grid.Row="0" IsOn="{Binding SelectedChannel.IsDigitalOn, Mode=TwoWay}" OffContent="Off" OnContent="On" HorizontalAlignment="Center"/>
                     </Grid>
                 </GroupBox>
             </Grid>


### PR DESCRIPTION
- on/off on DIO Output was backwards
- the app made a bad assumption of the data being sent for DIO. It assumed that only input would be sent. In reality, both input and output are sent. This caused a bad mapping of DIO values to channel.

Closes #141 
Closes #142