### PR TITLE
feat: implement prevention of computer sleep during streaming

### DIFF
--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -9,6 +9,7 @@
 		<UseWindowsForms>true</UseWindowsForms>
 		<Version>3.0.0</Version>
 		<InternalsVisibleTo>Daqifi.Desktop.Test</InternalsVisibleTo>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 	<PropertyGroup>
 		<ApplicationIcon>Images\WiFiDAQ.ico</ApplicationIcon>


### PR DESCRIPTION
When streaming, we tell the computer not to sleep, so that the streaming session does not get interrupted. We go back to the normal system setting when we stop streaming.

closes #139 