### PR TITLE
fix: fixed legend on live graph and logged data

### DIFF
--- a/Daqifi.Desktop/Channel/AbstractChannel.cs
+++ b/Daqifi.Desktop/Channel/AbstractChannel.cs
@@ -126,6 +126,9 @@ public abstract partial class AbstractChannel : ObservableObject, IChannel
 
     public Expression Expression { get; set; }
 
+    [ObservableProperty]
+    private bool _isVisible = true;
+
     public DataSample ActiveSample
     {
         get => _activeSample;

--- a/Daqifi.Desktop/Channel/Channel.cs
+++ b/Daqifi.Desktop/Channel/Channel.cs
@@ -30,6 +30,7 @@ public class Channel : IChannel
     public bool IsScalingActive { get; set; }
     public bool HasValidExpression { get; set; }
     public DataSample ActiveSample { get; set; }
+    public bool IsVisible { get; set; } = true;
     public string DeviceName { get ; set ; }
     public string DeviceSerialNo { get ; set; }
 

--- a/Daqifi.Desktop/Channel/IChannel.cs
+++ b/Daqifi.Desktop/Channel/IChannel.cs
@@ -29,6 +29,7 @@ public interface IChannel : IColorable
     bool IsScalingActive { get; set; }
     bool HasValidExpression { get; set; }
     DataSample ActiveSample { get; set; }
+    bool IsVisible { get; set; }
     #endregion
 
     #region Events

--- a/Daqifi.Desktop/Converters/OxyColorToBrushConverter.cs
+++ b/Daqifi.Desktop/Converters/OxyColorToBrushConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using OxyPlot;
+
+namespace Daqifi.Desktop.Converters
+{
+    public class OxyColorToBrushConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is OxyColor oxyColor)
+            {
+                return new SolidColorBrush(Color.FromArgb(oxyColor.A, oxyColor.R, oxyColor.G, oxyColor.B));
+            }
+            return Brushes.Transparent; // Default or fallback
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Daqifi.Desktop/Converters/OxyColorToBrushConverter.cs
+++ b/Daqifi.Desktop/Converters/OxyColorToBrushConverter.cs
@@ -3,6 +3,8 @@ using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Media;
 using OxyPlot;
+using Brushes = System.Windows.Media.Brushes;
+using Color = System.Windows.Media.Color;
 
 namespace Daqifi.Desktop.Converters
 {

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -7,6 +7,7 @@ using OxyPlot.Axes;
 using OxyPlot.Series;
 using System.Windows; // Added for Application.Current.Dispatcher
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Exception = System.Exception;
 using TickStyle = OxyPlot.Axes.TickStyle;
@@ -14,6 +15,8 @@ using Microsoft.EntityFrameworkCore;
 using EFCore.BulkExtensions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Application = System.Windows.Application;
+using FontWeights = OxyPlot.FontWeights;
 
 namespace Daqifi.Desktop.Logger;
 

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -5,7 +5,6 @@ using Daqifi.Desktop.Device;
 using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.Series;
-using System.Windows; // Added for Application.Current.Dispatcher
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics;

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -274,7 +274,7 @@
                         </StackPanel>
                     </DockPanel>
 
-                    <ListView Grid.Row="1" Grid.Column="1" Name="ActiveChannelList" Width="150" ItemsSource="{Binding ActiveInputChannels}" Background="Transparent" BorderThickness="0">
+                    <ListView Grid.Row="1" Grid.Column="1" Name="ActiveChannelList" ItemsSource="{Binding ActiveInputChannels}" Background="Transparent" BorderThickness="0">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <DockPanel Margin="5" Height="40" LastChildFill="True" HorizontalAlignment="Left">

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -9,6 +9,8 @@
         xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
         xmlns:local="clr-namespace:Daqifi.Desktop.View"
+        xmlns:converters="clr-namespace:Daqifi.Desktop.Converters"
+        xmlns:logger="clr-namespace:Daqifi.Desktop.Logger"
         service:DialogService.IsRegisteredView="True"
         Height="{Binding Height, Mode=TwoWay}" Width="{Binding Width, Mode=TwoWay}" WindowState="{Binding ViewWindowState, Mode=OneWayToSource}" BorderThickness="0" GlowBrush="Black">
 
@@ -83,6 +85,23 @@
                                 <Setter TargetName="Rectangle" Property="Visibility" Value="Visible"/>
                             </MultiDataTrigger>
                         </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <converters:OxyColorToBrushConverter x:Key="OxyColorToBrushConverter"/>
+
+        <Style x:Key="TransparentButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <ContentPresenter Content="{TemplateBinding Content}" />
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
@@ -274,21 +293,35 @@
                         </StackPanel>
                     </DockPanel>
 
-                    <ListView Grid.Row="1" Grid.Column="1" Name="ActiveChannelList" ItemsSource="{Binding ActiveInputChannels}" Background="Transparent" BorderThickness="0">
+                    <ListView Grid.Row="1" Grid.Column="1" Name="ActiveChannelList" ItemsSource="{Binding ActiveInputChannels}" Background="Transparent" BorderThickness="0"
+                                HorizontalContentAlignment="Stretch">
                         <ListView.ItemTemplate>
                             <DataTemplate>
-                                <DockPanel Margin="5" Height="40" LastChildFill="True" HorizontalAlignment="Left">
-                                    <Rectangle Width="25" Height="25" Fill="{Binding ChannelColorBrush}"/>
-                                    <StackPanel Orientation="Vertical" >
-                                        <Label Content="{Binding Name}" BorderThickness="0" VerticalAlignment="Center" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
-                                        <Label Content="{Binding DeviceSerialNo}" 
-                                               BorderThickness="0"
-                                               FontSize="8" VerticalAlignment="Top"
-                                               HorizontalAlignment="Stretch" 
-                                               HorizontalContentAlignment="Stretch"/>
-                                    </StackPanel>
-
-                                </DockPanel>
+                                <Button Command="{Binding DataContext.ToggleChannelVisibilityCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                        CommandParameter="{Binding}"
+                                        Style="{StaticResource TransparentButtonStyle}">
+                                    <DockPanel Margin="5" Height="40" HorizontalAlignment="Left">
+                                        <DockPanel.Style>
+                                            <Style TargetType="DockPanel">
+                                                <Setter Property="Opacity" Value="1.0"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                        <Setter Property="Opacity" Value="0.5"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </DockPanel.Style>
+                                        <Rectangle Width="25" Height="25" Fill="{Binding ChannelColorBrush}"/>
+                                        <StackPanel Orientation="Vertical" >
+                                            <Label Content="{Binding Name}" BorderThickness="0" VerticalAlignment="Center" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
+                                            <Label Content="{Binding DeviceSerialNo}" 
+                                                   BorderThickness="0"
+                                                   FontSize="8" VerticalAlignment="Top"
+                                                   HorizontalAlignment="Stretch" 
+                                                   HorizontalContentAlignment="Stretch"/>
+                                        </StackPanel>
+                                    </DockPanel>
+                                </Button>
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
@@ -337,8 +370,49 @@
 
                                 <!-- Logged Data Plot-->
                                 <Grid Grid.Row="0">
-                                    <oxy:PlotView Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0"/>
-                                    <DockPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>      <!-- PlotView -->
+                                        <ColumnDefinition Width="Auto"/>   <!-- New Legend -->
+                                    </Grid.ColumnDefinitions>
+
+                                    <oxy:PlotView Grid.Column="0" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0"/>
+
+                                    <ListView Grid.Column="1"
+                                              ItemsSource="{Binding DbLogger.LegendItems}"
+                                              Background="Transparent"
+                                              BorderThickness="0"
+                                              HorizontalContentAlignment="Stretch"
+                                              ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                              MaxHeight="400"> <!-- Optional: Constrain height if needed -->
+                                        <ListView.ItemTemplate>
+                                            <DataTemplate DataType="{x:Type logger:LoggedSeriesLegendItem}">
+                                                <Button Command="{Binding DataContext.ToggleLoggedSeriesVisibilityCommand, RelativeSource={RelativeSource AncestorType=controls:MetroWindow}}"
+                                                        CommandParameter="{Binding}"
+                                                        Style="{StaticResource TransparentButtonStyle}">
+                                                    <DockPanel>
+                                                        <DockPanel.Style>
+                                                            <Style TargetType="DockPanel">
+                                                                <Setter Property="Opacity" Value="1.0"/>
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                                        <Setter Property="Opacity" Value="0.5"/>
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </DockPanel.Style>
+                                                        <Rectangle Width="15" Height="15" Margin="2,0,5,0" VerticalAlignment="Center">
+                                                            <Rectangle.Fill>
+                                                                <SolidColorBrush Color="{Binding SeriesColor, Converter={StaticResource OxyColorToBrushConverter}}"/>
+                                                            </Rectangle.Fill>
+                                                        </Rectangle>
+                                                        <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center"/>
+                                                    </DockPanel>
+                                                </Button>
+                                            </DataTemplate>
+                                        </ListView.ItemTemplate>
+                                    </ListView>
+                                    
+                                    <DockPanel Grid.Column="0" Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top">
                                         <Button Command="{Binding DbLogger.SaveGraphCommand }" CommandParameter="{Binding}" ToolTip="Save as Image" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
                                             <iconPacks:PackIconMaterial Kind="ImageOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
                                         </Button>

--- a/Daqifi.Desktop/View/Flyouts/ChannelsFlyout.xaml
+++ b/Daqifi.Desktop/View/Flyouts/ChannelsFlyout.xaml
@@ -62,14 +62,6 @@
                             Command="{Binding ShowSelectColorDialogCommand}" 
                             CommandParameter="{Binding SelectedChannel}"
                             Margin="0,0,0,10"/>
-
-                    <Label Content="Show on Graph:"/>
-                    <Controls:ToggleSwitch 
-                        IsOn="{Binding SelectedChannel.IsVisible, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                        OffContent="Hidden" 
-                        OnContent="Visible" 
-                        HorizontalAlignment="Left"
-                        Margin="0,0,0,10"/>
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/Daqifi.Desktop/View/Flyouts/ChannelsFlyout.xaml
+++ b/Daqifi.Desktop/View/Flyouts/ChannelsFlyout.xaml
@@ -62,6 +62,14 @@
                             Command="{Binding ShowSelectColorDialogCommand}" 
                             CommandParameter="{Binding SelectedChannel}"
                             Margin="0,0,0,10"/>
+
+                    <Label Content="Show on Graph:"/>
+                    <Controls:ToggleSwitch 
+                        IsOn="{Binding SelectedChannel.IsVisible, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                        OffContent="Hidden" 
+                        OnContent="Visible" 
+                        HorizontalAlignment="Left"
+                        Margin="0,0,0,10"/>
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1506,11 +1506,11 @@ public partial class DaqifiViewModel : ObservableObject
                 ActiveInputChannels.Clear();
                 foreach (var channel in LoggingManager.Instance.SubscribedChannels)
                 {
-                    if (!channel.IsOutput)
+                    if (!channel.IsOutput && channel.IsVisible) // Modified condition
                     {
                         ActiveInputChannels.Add(channel);
                     }
-                    ActiveChannels.Add(channel);
+                    ActiveChannels.Add(channel); // Assuming ActiveChannels does not need this visibility filter for now
                 }
                 break;
             case "NotificationCount":

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -309,6 +309,8 @@ public partial class DaqifiViewModel : ObservableObject
     // Re-add properties for manually instantiated commands
     public ICommand DeleteLoggingSessionCommand { get; private set; }
     public ICommand DeleteAllLoggingSessionCommand { get; private set; }
+    public ICommand ToggleChannelVisibilityCommand { get; private set; }
+    public ICommand ToggleLoggedSeriesVisibilityCommand { get; private set; }
     #endregion
 
     #region Constructor
@@ -404,9 +406,33 @@ public partial class DaqifiViewModel : ObservableObject
     {
         DeleteLoggingSessionCommand = new AsyncRelayCommand<LoggingSession?>(DeleteLoggingSessionAsync);
         DeleteAllLoggingSessionCommand = new AsyncRelayCommand(DeleteAllLoggingSessionAsync, CanDeleteAllLoggingSession);
+        ToggleChannelVisibilityCommand = new RelayCommand<IChannel>(ToggleChannelVisibility);
+        ToggleLoggedSeriesVisibilityCommand = new RelayCommand<LoggedSeriesLegendItem>(ToggleLoggedSeriesVisibility);
 
         // Keep registration for external commands if necessary
         // HostCommands.ShutdownCommand.RegisterCommand(ShutdownCommand); // This would need adjustment if ShutdownCommand is generated
+    }
+    #endregion
+
+    #region Command Logic
+    private void ToggleChannelVisibility(IChannel? channel)
+    {
+        if (channel != null)
+        {
+            channel.IsVisible = !channel.IsVisible;
+            // The PropertyChanged event on IsVisible should trigger UI updates in PlotLogger and the legend's DataTrigger.
+            // No need to manually call UpdateUi here for ActiveInputChannels if it's already correctly populated.
+        }
+    }
+
+    private void ToggleLoggedSeriesVisibility(LoggedSeriesLegendItem? item)
+    {
+        if (item != null)
+        {
+            item.IsVisible = !item.IsVisible;
+            // The IsVisible setter in LoggedSeriesLegendItem handles updating
+            // the ActualSeries.IsVisible and invalidating the plot.
+        }
     }
     #endregion
 
@@ -1506,11 +1532,11 @@ public partial class DaqifiViewModel : ObservableObject
                 ActiveInputChannels.Clear();
                 foreach (var channel in LoggingManager.Instance.SubscribedChannels)
                 {
-                    if (!channel.IsOutput && channel.IsVisible) // Modified condition
+                    if (!channel.IsOutput) // Condition changed to remove IsVisible filter
                     {
                         ActiveInputChannels.Add(channel);
                     }
-                    ActiveChannels.Add(channel); // Assuming ActiveChannels does not need this visibility filter for now
+                    ActiveChannels.Add(channel); 
                 }
                 break;
             case "NotificationCount":


### PR DESCRIPTION
- On the live graph, the user can now select and unselect channels to show
- On the logged data, the legend is now scrollable instead of taking up the entire plot space

99.9% of this code was generated by Jules. I just had to fix a couple of imports.

Clickable Live Graph:
<img width="799" alt="image" src="https://github.com/user-attachments/assets/67a1001d-c673-4031-b950-80fc211e53af" />

Scrollable Logged Data:
<img width="799" alt="image" src="https://github.com/user-attachments/assets/b6c61b59-ad3e-47b7-9030-a282176d5162" />

closes #158 
