### PR TITLE
fix: handle null values in EnumDescriptionConverter to prevent crashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,243 @@
+# Claude Development Assistant Context
+
+This document provides context for Claude to assist with the DAQiFi Desktop application development.
+
+> **Note**: Please check the `.cursor/rules` folder periodically for any updates to development standards and incorporate those changes into this document to maintain consistency across AI-assisted development tools.
+
+## Project Overview
+
+DAQiFi Desktop is a Windows desktop application for communicating with DAQiFi hardware products. Our goal is to modernize data acquisition with user-friendly and intuitive products.
+
+### Technology Stack
+- .NET 8.0 and WPF for the desktop application
+- SQLite for local data storage
+- Google Protocol Buffers for device communication
+- EntityFramework for database operations
+- NLog for logging framework
+- MSTest with Moq for testing
+
+## Architecture
+
+The application follows MVVM (Model-View-ViewModel) pattern with these projects:
+- **Daqifi.Desktop** - Main project containing UI
+- **Daqifi.Desktop.Bootloader** - Bootloader/firmware domain
+- **Daqifi.Desktop.Common** - Shared components
+- **Daqifi.Desktop.DataModel** - Data models
+- **Daqifi.Desktop.IO** - Device messaging
+- **Daqifi.Desktop.Setup** - Wix installer
+
+## Coding Standards
+
+### Naming Conventions
+- **Interfaces**: PascalCase with I prefix (e.g., `IStreamingDevice`)
+- **Classes**: PascalCase (e.g., `FirewallConfiguration`)
+- **Methods**: PascalCase (e.g., `InitializeFirewallRules`)
+- **Properties**: PascalCase (e.g., `StreamingFrequency`)
+- **Private Fields**: camelCase with _ prefix (e.g., `_firewallHelper`)
+- **Constants**: SCREAMING_SNAKE_CASE (e.g., `RULE_NAME`)
+
+### Code Style
+- **Indentation**: 4 spaces
+- **Max line length**: 120 characters
+- **Braces**: Allman style (opening brace on new line)
+- **Regions**: Use #region for logical grouping
+- **File organization**: One main class per file
+
+### Example Code Style
+```csharp
+public class FirewallConfiguration : IFirewallConfiguration
+{
+    #region Constants
+    private const string RULE_NAME = "DAQiFi_TCP_Rule";
+    #endregion
+
+    #region Private Fields
+    private readonly IFirewallHelper _firewallHelper;
+    #endregion
+
+    #region Constructor
+    public FirewallConfiguration(IFirewallHelper firewallHelper)
+    {
+        _firewallHelper = firewallHelper;
+    }
+    #endregion
+
+    #region Public Methods
+    public void InitializeFirewallRules()
+    {
+        // Implementation
+    }
+    #endregion
+}
+```
+
+## Key Commands
+
+### Build and Test
+```bash
+# Build the solution
+dotnet build
+
+# Run all tests
+dotnet test
+
+# Run with code coverage (80% minimum required)
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+
+# Run specific test project
+dotnet test Daqifi.Desktop.Tests/Daqifi.Desktop.Tests.csproj
+```
+
+### Code Quality
+```bash
+# Format code
+dotnet format
+
+# Run code analysis
+dotnet build /p:EnforceCodeStyleInBuild=true
+```
+
+## Testing Standards
+
+- Test projects must have `.Test` suffix
+- Test files named `*Tests.cs`
+- **80% minimum code coverage**
+- Use MSTest framework with Moq for mocking
+- Follow Arrange-Act-Assert pattern
+- Mock external dependencies
+
+### Test Example
+```csharp
+[TestClass]
+public class FirewallConfigurationTests
+{
+    private Mock<IFirewallHelper> _mockFirewallHelper;
+    private FirewallConfiguration _configuration;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockFirewallHelper = new Mock<IFirewallHelper>();
+        _configuration = new FirewallConfiguration(_mockFirewallHelper.Object);
+    }
+
+    [TestMethod]
+    public void InitializeFirewallRules_Should_CreateRules()
+    {
+        // Arrange
+        _mockFirewallHelper.Setup(x => x.CreateRule(It.IsAny<string>())).Returns(true);
+
+        // Act
+        _configuration.InitializeFirewallRules();
+
+        // Assert
+        _mockFirewallHelper.Verify(x => x.CreateRule(RULE_NAME), Times.Once);
+    }
+}
+```
+
+## Security Guidelines
+
+- **Admin privileges**: Required for firewall changes
+- **Passwords**: Use SecureString
+- **Input validation**: Always validate user input
+- **Error handling**: Secure error messages, no sensitive data in logs
+- **Connection strings**: Store securely, never hardcode
+
+## Logging Standards
+
+- Use NLog framework
+- Log levels: Error, Warning, Info, Debug
+- Logs stored in: `%CommonApplicationData%\DAQifi\Logs`
+- Include stack traces for errors
+- No sensitive data in logs
+
+### Logging Example
+```csharp
+private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+try
+{
+    // Operation
+}
+catch (Exception ex)
+{
+    Logger.Error(ex, "Failed to initialize firewall rules");
+    throw;
+}
+```
+
+## Device Communication
+
+The application communicates with DAQiFi devices using:
+- UDP for device discovery
+- TCP for data streaming and commands
+- Protocol Buffers for message serialization
+
+Key classes:
+- `DaqifiDeviceFinder.cs` - Handles device discovery
+- `WiFiDevice` - Manages WiFi device connections
+- Protocol buffer messages defined in `.proto` files
+
+## Database
+
+SQLite database managed through Entity Framework:
+- Connection string in app settings
+- Migrations handled automatically
+- Local data storage for device configurations and logged data
+- Use async methods for database operations
+
+## Documentation Standards
+
+- **README.md**: Keep updated with setup instructions
+- **XML comments**: Required on all public APIs
+- **Conventional commits**: Use feat:, fix:, docs:, chore:, deps:
+- **Keep documentation in sync with code changes**
+
+### XML Comment Example
+```csharp
+/// <summary>
+/// Initializes firewall rules for DAQiFi device communication.
+/// </summary>
+/// <exception cref="UnauthorizedAccessException">Thrown when admin privileges are not available.</exception>
+public void InitializeFirewallRules()
+{
+    // Implementation
+}
+```
+
+## Git Workflow
+
+- Main branch: `main`
+- Feature branches: `feature/description`
+- Fix branches: `fix/description`
+- Chore branches: `chore/description`
+- Use conventional commits
+- Squash merge to main
+- All PRs require code review
+
+## Common Tasks
+
+When working on:
+- **Device connectivity**: Check `/Device/` directory
+- **UI changes**: Update both View and ViewModel following MVVM
+- **Data persistence**: Use Entity Framework patterns
+- **Protocol changes**: Update `.proto` files and regenerate
+- **Firewall/Network**: Ensure admin privileges handled properly
+- **New features**: Add unit tests with 80% coverage minimum
+
+## Performance Considerations
+
+- Use async/await for I/O operations
+- Implement IDisposable where appropriate
+- Avoid blocking UI thread
+- Use dependency injection for testability
+- Cache expensive operations
+
+## Error Handling
+
+- Use try-catch at appropriate levels
+- Log all errors with context
+- Provide user-friendly error messages
+- Never expose sensitive information
+- Handle device disconnection gracefully

--- a/Daqifi.Desktop.Test/Converters/EnumDescriptionConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/EnumDescriptionConverterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Windows.Data;
 using Daqifi.Desktop.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -9,21 +10,21 @@ namespace Daqifi.Desktop.Test.Converters
     [TestClass]
     public class EnumDescriptionConverterTests
     {
-        private EnumDescriptionConverter _converter;
+        private IValueConverter _converter;
 
         // Test enum with Description attributes
         private enum TestEnum
         {
-            [Description("First Option Description")]
+            [System.ComponentModel.Description("First Option Description")]
             FirstOption,
             
-            [Description("Second Option Description")]
+            [System.ComponentModel.Description("Second Option Description")]
             SecondOption,
             
             // No description attribute
             ThirdOption,
             
-            [Description("")]
+            [System.ComponentModel.Description("")]
             EmptyDescription
         }
 

--- a/Daqifi.Desktop.Test/Converters/EnumDescriptionConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/EnumDescriptionConverterTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using Daqifi.Desktop.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Daqifi.Desktop.Test.Converters
+{
+    [TestClass]
+    public class EnumDescriptionConverterTests
+    {
+        private EnumDescriptionConverter _converter;
+
+        // Test enum with Description attributes
+        private enum TestEnum
+        {
+            [Description("First Option Description")]
+            FirstOption,
+            
+            [Description("Second Option Description")]
+            SecondOption,
+            
+            // No description attribute
+            ThirdOption,
+            
+            [Description("")]
+            EmptyDescription
+        }
+
+        // Test enum without any Description attributes
+        private enum SimpleEnum
+        {
+            Value1,
+            Value2,
+            Value3
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _converter = new EnumDescriptionConverter();
+        }
+
+        [TestMethod]
+        public void Convert_NullValue_ReturnsEmptyString()
+        {
+            // Arrange
+            object value = null;
+
+            // Act
+            var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [TestMethod]
+        public void Convert_NonEnumValue_ReturnsToString()
+        {
+            // Arrange
+            var testValues = new object[]
+            {
+                "Regular String",
+                123,
+                45.67,
+                true,
+                new DateTime(2024, 1, 1)
+            };
+
+            foreach (var value in testValues)
+            {
+                // Act
+                var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+                // Assert
+                Assert.AreEqual(value.ToString(), result, $"Failed for value: {value}");
+            }
+        }
+
+        [TestMethod]
+        public void Convert_EnumWithDescription_ReturnsDescription()
+        {
+            // Arrange
+            var enumValue = TestEnum.FirstOption;
+
+            // Act
+            var result = _converter.Convert(enumValue, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual("First Option Description", result);
+        }
+
+        [TestMethod]
+        public void Convert_EnumWithoutDescription_ReturnsEnumName()
+        {
+            // Arrange
+            var enumValue = TestEnum.ThirdOption;
+
+            // Act
+            var result = _converter.Convert(enumValue, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual("ThirdOption", result);
+        }
+
+        [TestMethod]
+        public void Convert_EnumWithEmptyDescription_ReturnsEmptyString()
+        {
+            // Arrange
+            var enumValue = TestEnum.EmptyDescription;
+
+            // Act
+            var result = _converter.Convert(enumValue, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void Convert_SimpleEnumWithoutAnyDescriptions_ReturnsEnumName()
+        {
+            // Arrange
+            var testValues = new[] { SimpleEnum.Value1, SimpleEnum.Value2, SimpleEnum.Value3 };
+
+            foreach (var enumValue in testValues)
+            {
+                // Act
+                var result = _converter.Convert(enumValue, typeof(string), null, CultureInfo.InvariantCulture);
+
+                // Assert
+                Assert.AreEqual(enumValue.ToString(), result, $"Failed for enum value: {enumValue}");
+            }
+        }
+
+        [TestMethod]
+        public void Convert_DifferentCultures_ReturnsConsistentResult()
+        {
+            // Arrange
+            var enumValue = TestEnum.SecondOption;
+            var cultures = new[]
+            {
+                CultureInfo.InvariantCulture,
+                new CultureInfo("en-US"),
+                new CultureInfo("fr-FR"),
+                new CultureInfo("de-DE")
+            };
+
+            foreach (var culture in cultures)
+            {
+                // Act
+                var result = _converter.Convert(enumValue, typeof(string), null, culture);
+
+                // Assert
+                Assert.AreEqual("Second Option Description", result, $"Failed for culture: {culture.Name}");
+            }
+        }
+
+        [TestMethod]
+        public void ConvertBack_Always_ReturnsEmptyString()
+        {
+            // Arrange
+            var testValues = new object[]
+            {
+                "Some Description",
+                null,
+                123,
+                TestEnum.FirstOption
+            };
+
+            foreach (var value in testValues)
+            {
+                // Act
+                var result = _converter.ConvertBack(value, typeof(Enum), null, CultureInfo.InvariantCulture);
+
+                // Assert
+                Assert.AreEqual(string.Empty, result, $"Failed for value: {value}");
+            }
+        }
+
+        [TestMethod]
+        public void Convert_BoxedEnum_ReturnsDescription()
+        {
+            // Arrange
+            object boxedEnum = TestEnum.FirstOption;
+
+            // Act
+            var result = _converter.Convert(boxedEnum, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual("First Option Description", result);
+        }
+
+        [TestMethod]
+        public void Convert_NullableEnumWithValue_ReturnsDescription()
+        {
+            // Arrange
+            TestEnum? nullableEnum = TestEnum.SecondOption;
+
+            // Act
+            var result = _converter.Convert(nullableEnum, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual("Second Option Description", result);
+        }
+
+        [TestMethod]
+        public void Convert_NullableEnumWithNull_ReturnsEmptyString()
+        {
+            // Arrange
+            TestEnum? nullableEnum = null;
+
+            // Act
+            var result = _converter.Convert(nullableEnum, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual(string.Empty, result);
+        }
+    }
+}

--- a/Daqifi.Desktop/Helpers/EnumDescriptionConverter.cs
+++ b/Daqifi.Desktop/Helpers/EnumDescriptionConverter.cs
@@ -24,7 +24,16 @@ public class EnumDescriptionConverter : IValueConverter
 
     object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        var myEnum = (Enum)value;
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        if (value is not Enum myEnum)
+        {
+            return value.ToString();
+        }
+
         var description = GetEnumDescription(myEnum);
         return description;
     }


### PR DESCRIPTION
## Summary
- Fix InvalidCastException when disconnecting USB device after configuring AP mode with WPA
- Add proper null and type checking in EnumDescriptionConverter
- Add comprehensive unit tests for the converter

## Problem
When disconnecting a USB device after configuring it in AP mode with WPA, the application throws an InvalidCastException in EnumDescriptionConverter. This happens because:
1. When a device is disconnected, `SelectedDevice` is set to null
2. ComboBox bindings still try to access `SelectedDevice.NetworkConfiguration.Mode`
3. The converter receives null instead of an enum value and tries to cast it

## Solution
- Add null check to return empty string for null values
- Add type check to handle non-enum values gracefully
- Return ToString() for non-enum values instead of throwing

## Test plan
- [x] Added comprehensive unit tests covering:
  - Null value handling
  - Non-enum value handling
  - Enum with/without Description attributes
  - Culture independence
  - Edge cases (boxed enums, nullable enums)
- [ ] Manual testing: Connect USB device, configure AP mode with WPA, disconnect - verify no crash

🤖 Generated with [Claude Code](https://claude.ai/code)