### PR TITLE
chore: update dependabot PR prefix to 'deps: '

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     labels:
       - "dependencies"
       - "nuget"
+    commit-message:
+      prefix: "deps: "
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +17,5 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    commit-message:
+      prefix: "deps: "


### PR DESCRIPTION
### **User description**
## Summary
- Updated Dependabot configuration to prefix dependency update PRs with "deps: "
- This applies to both NuGet and GitHub Actions dependency updates
- Follows conventional commit standards for dependency updates

## Test plan
- Wait for next Dependabot run to verify PR titles include "deps: " prefix
- Verify configuration syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Other


___

### **Description**
- Configure Dependabot to use "deps: " prefix for commit messages

- Apply consistent prefix to both NuGet and GitHub Actions updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot Config"] --> B["NuGet Updates"]
  A --> C["GitHub Actions Updates"]
  B --> D["deps: prefix"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Add commit message prefix configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Added <code>commit-message</code> configuration with <code>prefix: "deps: "</code> for NuGet <br>package ecosystem<br> <li> Added <code>commit-message</code> configuration with <code>prefix: "deps: "</code> for GitHub <br>Actions package ecosystem</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/206/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

