### PR TITLE
deps: Update MahApps.Metro.IconPacks to 6.1.0

### DIFF
--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -59,8 +59,8 @@
 		<PackageReference Include="Daqifi.Core" Version="0.3.0" />
 		<PackageReference Include="EFCore.BulkExtensions" Version="8.1.3" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.10" />
-		<PackageReference Include="MahApps.Metro.IconPacks" Version="5.1.0" />
-		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="5.1.0" />
+		<PackageReference Include="MahApps.Metro.IconPacks" Version="6.1.0" />
+		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.1.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.13" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.13" />


### PR DESCRIPTION
## Summary
- Updated MahApps.Metro.IconPacks from 5.1.0 to 6.1.0
- Updated MahApps.Metro.IconPacks.Material from 5.1.0 to 6.1.0
- Combined both dependabot updates into a single PR

## Breaking Changes Analysis
The major breaking change in v6.0.0 was dropping UWP (Universal Windows Platform) support. This doesn't affect our WPF application, so no code changes are required.

## Compatibility Verified
- ✅ All existing `PackIconMaterial` usage remains compatible
- ✅ XAML namespace declarations still valid
- ✅ Build completes successfully with no errors
- ✅ All Material Design icon names unchanged

## Test plan
- [x] Build verification completed successfully
- [x] Package references updated correctly
- [x] No breaking changes affecting WPF application
- [ ] Manual testing of UI icons display correctly
- [ ] Full application testing on Windows

🤖 Generated with [Claude Code](https://claude.ai/code)