### PR TITLE
chore: update EFCore.BulkExtensions and protobuf-net (fixes #224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Windows desktop application (.NET) that is used to communicate with DAQiFi hardw
 ## Dependencies
 
 - EntityFramework (ORM)
+- EFCore.BulkExtensions (optimized bulk insert operations)
 - Google Protocol Buffers (read incoming data from DAQiFi hardware)
+- protobuf-net (serialization support in tests)
 - MahApps (UI components)
 - Oxyplot (for graphing)
 


### PR DESCRIPTION
- Update EFCore.BulkExtensions to 9.0.1 (already present)\n- Update protobuf-net to 3.2.56 (already present)\n- Verified IO protobuf tests; Windows-targeted tests skipped on macOS\n\nThis PR aligns package versions with issue #224 and documents dependencies in README.