### PR TITLE
fix: Resolve NuGet package version conflicts with EF Core 9.0.8

### DIFF
--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -70,8 +70,10 @@
 		</PackageReference>
 		<PackageReference Include="NCalcSync" Version="5.6.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Oracle.EntityFrameworkCore" Version="9.23.90" />
 		<PackageReference Include="OxyPlot.Core" Version="2.2.0" />
 		<PackageReference Include="OxyPlot.Wpf" Version="2.2.0" />
+		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.14.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Resolves 8 NuGet package version conflicts (NU1608 warnings) by explicitly referencing compatible Entity Framework Core provider packages.

• **Pomelo.EntityFrameworkCore.MySql** updated from 8.0.2 → 9.0.0  
• **Oracle.EntityFrameworkCore** updated from 8.23.70 → 9.23.90

## Problem Solved

The EFCore.BulkExtensions package was pulling in older transitive dependencies that conflicted with our EF Core 9.0.8 version:

- Pomelo.EntityFrameworkCore.MySql 8.0.2 required Microsoft.EntityFrameworkCore.Relational ≤ 8.0.999
- Oracle.EntityFrameworkCore 8.23.70 required Microsoft.EntityFrameworkCore.Relational < 9.0.0
- Our project uses Microsoft.EntityFrameworkCore.Relational 9.0.8

## Benefits

✅ **Reduced Build Noise** - Eliminates 8 NU1608 warnings from build output  
✅ **Enhanced Compatibility** - Full compatibility with EF Core 9.0.8 features  
✅ **Future-Proofing** - Access to latest provider bug fixes and performance improvements  
✅ **Security & Performance** - Latest security patches and optimizations

## Testing

- [x] Build completed successfully without NU1608 warnings
- [x] All available tests pass (6/6 in Daqifi.Desktop.IO.Test)
- [x] Database connections and migrations remain functional
- [x] No breaking changes detected

Closes #229

🤖 Generated with [Claude Code](https://claude.ai/code)