### PR TITLE
feat: Migrate DAQiFi Desktop to .NET 9

### DIFF
--- a/Daqifi.Desktop.Bootloader.Test/Daqifi.Desktop.Bootloader.Test.csproj
+++ b/Daqifi.Desktop.Bootloader.Test/Daqifi.Desktop.Bootloader.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Daqifi.Desktop.Bootloader/Daqifi.Desktop.Bootloader.csproj
+++ b/Daqifi.Desktop.Bootloader/Daqifi.Desktop.Bootloader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Daqifi.Desktop.Common.Test/Daqifi.Desktop.Common.Test.csproj
+++ b/Daqifi.Desktop.Common.Test/Daqifi.Desktop.Common.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
+++ b/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Daqifi.Desktop.DataModel.Test/Daqifi.Desktop.DataModel.Test.csproj
+++ b/Daqifi.Desktop.DataModel.Test/Daqifi.Desktop.DataModel.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
+++ b/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Daqifi.Desktop.Setup/global.json
+++ b/Daqifi.Desktop.Setup/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "9.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
+++ b/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>
@@ -57,7 +57,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Daqifi.Core" Version="0.4.1" />
-		<PackageReference Include="EFCore.BulkExtensions" Version="8.1.3" />
+		<PackageReference Include="EFCore.BulkExtensions" Version="9.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.10" />
 		<PackageReference Include="MahApps.Metro.IconPacks" Version="6.1.0" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.1.0" />


### PR DESCRIPTION
## Summary
- Migrates the entire DAQiFi Desktop application from .NET 8 to .NET 9
- Updates all project target frameworks from `net8.0`/`net8.0-windows` to `net9.0`/`net9.0-windows`
- Updates global.json SDK version from 8.0.0 to 9.0.0
- Updates EFCore.BulkExtensions from 8.1.3 to 9.0.1 for .NET 9 compatibility
- All Entity Framework packages already compatible at version 9.0.8

## Testing Results
✅ **Bootloader.Test**: 10/10 tests passing  
✅ **IO.Test**: 6/6 tests passing  
✅ **Build**: Successful with expected warnings only  
❌ **WPF Tests**: Fail on macOS (expected - Windows-only framework)  

## Benefits
- Performance improvements from .NET 9 runtime
- Access to latest .NET features and APIs
- Continued support on latest Microsoft framework
- Enhanced security and bug fixes

## Breaking Changes
- Requires .NET 9 SDK for development
- Windows development machines need .NET 9 SDK installed

## Test Plan
- [x] Build solution successfully
- [x] Run automated test suite
- [x] Verify Entity Framework operations work
- [x] Check package compatibility
- [ ] Manual testing on Windows development environment
- [ ] Verify device communication functionality
- [ ] Test firewall configuration (requires Windows + admin privileges)
- [ ] Validate WPF UI rendering and performance

Resolves #232

🤖 Generated with [Claude Code](https://claude.ai/code)