### PR TITLE
fix: resolve WiFi device discovery and connection issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,13 +170,25 @@ catch (Exception ex)
 ## Device Communication
 
 The application communicates with DAQiFi devices using:
-- UDP for device discovery
-- TCP for data streaming and commands
-- Protocol Buffers for message serialization
+- **UDP for device discovery**: Port 30303 (broadcast queries and responses)
+- **TCP for data streaming**: Port varies by device (extracted from discovery response)
+- **Protocol Buffers**: Message serialization for both UDP and TCP
 
-Key classes:
-- `DaqifiDeviceFinder.cs` - Handles device discovery
-- `WiFiDevice` - Manages WiFi device connections
+### Port Configuration
+- **UDP Discovery Port**: 30303 (used in `DaqifiDeviceFinder` and firewall rules)
+- **TCP Data Port**: Device-specific (e.g., 9760) - discovered from `message.DevicePort` in protobuf response
+- **Manual IP connections**: Must use the same TCP port as discovered devices
+
+### Network Requirements
+- **Firewall Rule**: UDP port 30303 must be allowed for device discovery
+- **Admin Privileges**: Required for automatic firewall configuration
+- **Network Interface**: Application and device must be on same subnet for UDP broadcast discovery
+- **Virtual Machines**: Use bridged networking mode, not NAT/shared network
+
+### Key Classes
+- `DaqifiDeviceFinder.cs` - Handles UDP device discovery on port 30303
+- `DaqifiStreamingDevice.cs` - Manages TCP connections to devices
+- `FirewallManager.cs` - Configures Windows Firewall for UDP port 30303
 - Protocol buffer messages defined in `.proto` files
 
 ## Database
@@ -219,11 +231,13 @@ public void InitializeFirewallRules()
 ## Common Tasks
 
 When working on:
-- **Device connectivity**: Check `/Device/` directory
+- **Device connectivity**: Check `/Device/` directory and ensure network configuration
 - **UI changes**: Update both View and ViewModel following MVVM
 - **Data persistence**: Use Entity Framework patterns
 - **Protocol changes**: Update `.proto` files and regenerate
-- **Firewall/Network**: Ensure admin privileges handled properly
+- **Firewall/Network**: Ensure admin privileges handled properly, verify ports match
+- **WiFi Discovery Issues**: Check network interface detection and port configuration
+- **Manual IP Connections**: Ensure TCP port matches what device discovery reports
 - **New features**: Add unit tests with 80% coverage minimum
 
 ## Performance Considerations

--- a/Daqifi.Desktop.Test/Configuration/FirewallConfigurationTests.cs
+++ b/Daqifi.Desktop.Test/Configuration/FirewallConfigurationTests.cs
@@ -51,7 +51,7 @@ public class FirewallConfigurationTests
         FirewallConfiguration.InitializeFirewallRules();
 
         // Assert
-        _mockFirewallHelper.Verify(f => f.CreateUdpRule(It.IsAny<string>(), It.IsAny<string>(), 21234), Times.Once);
+        _mockFirewallHelper.Verify(f => f.CreateUdpRule(It.IsAny<string>(), It.IsAny<string>(), 30303), Times.Once);
         _mockMessageBoxService.Verify(m => m.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>()), Times.Never);
     }
 
@@ -81,7 +81,7 @@ public class FirewallConfigurationTests
         // Arrange
         _mockAdminChecker.Setup(c => c.IsCurrentUserAdmin()).Returns(true);
         _mockFirewallHelper.Setup(f => f.RuleExists("DAQiFi Desktop")).Returns(false);
-        _mockFirewallHelper.Setup(f => f.CreateUdpRule(It.IsAny<string>(), It.IsAny<string>(), 21234))
+        _mockFirewallHelper.Setup(f => f.CreateUdpRule(It.IsAny<string>(), It.IsAny<string>(), 30303))
             .Throws(new InvalidOperationException("Test exception"));
 
         // Act

--- a/Daqifi.Desktop/Configuration/FirewallManager.cs
+++ b/Daqifi.Desktop/Configuration/FirewallManager.cs
@@ -72,8 +72,8 @@ public static class FirewallConfiguration
                 return;
             }
 
-            // Create new rule with specific UDP port (21234 is DAQiFi's discovery port)
-            _firewallHelper.CreateUdpRule(RuleName, appPath, 21234);
+            // Create new rule with specific UDP port (30303 is DAQiFi's discovery port)
+            _firewallHelper.CreateUdpRule(RuleName, appPath, 30303);
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/Configuration/FirewallManager.cs
+++ b/Daqifi.Desktop/Configuration/FirewallManager.cs
@@ -72,7 +72,7 @@ public static class FirewallConfiguration
                 return;
             }
 
-            // Create new rule with specific UDP port (30303 is DAQiFi's discovery and data port)
+            // Create new rule with specific UDP port (30303 is DAQiFi's UDP discovery port)
             _firewallHelper.CreateUdpRule(RuleName, appPath, 30303);
         }
         catch (Exception ex)

--- a/Daqifi.Desktop/Configuration/FirewallManager.cs
+++ b/Daqifi.Desktop/Configuration/FirewallManager.cs
@@ -72,8 +72,8 @@ public static class FirewallConfiguration
                 return;
             }
 
-            // Create new rule with specific UDP port (30303 is DAQiFi's discovery port)
-            _firewallHelper.CreateUdpRule(RuleName, appPath, 30303);
+            // Create new rule with specific UDP port (21234 is DAQiFi's discovery port)
+            _firewallHelper.CreateUdpRule(RuleName, appPath, 21234);
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/Configuration/FirewallManager.cs
+++ b/Daqifi.Desktop/Configuration/FirewallManager.cs
@@ -72,8 +72,8 @@ public static class FirewallConfiguration
                 return;
             }
 
-            // Create new rule with specific UDP port (21234 is DAQiFi's discovery port)
-            _firewallHelper.CreateUdpRule(RuleName, appPath, 21234);
+            // Create new rule with specific UDP port (30303 is DAQiFi's discovery and data port)
+            _firewallHelper.CreateUdpRule(RuleName, appPath, 30303);
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs
@@ -73,7 +73,7 @@ public class DaqifiDeviceFinder : AbstractMessageConsumer, IDeviceFinder
                          }
                          catch (SocketException sockEx)
                          {
-                             AppLogger.Warning($"Error sending broadcast to {endpoint}: {sockEx.Message}");
+                             AppLogger.Warning($"Error sending broadcast to {endpoint} (SocketError={sockEx.SocketErrorCode}): {sockEx.Message}");
                          }
                     }
                     Thread.Sleep(1000);
@@ -244,6 +244,10 @@ public class DaqifiDeviceFinder : AbstractMessageConsumer, IDeviceFinder
         if (endpoints.Count == 0)
         {
             AppLogger.Warning("Could not find any suitable network interfaces for DAQiFi discovery broadcast.");
+        }
+        else
+        {
+            AppLogger.Information($"DAQiFi discovery will broadcast to {endpoints.Count} network endpoint(s)");
         }
 
         return endpoints;

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -50,10 +50,13 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
 
             // Complete the asynchronous connection
             Client.EndConnect(result);
+            AppLogger.Information("TCP connection established successfully");
 
             MessageProducer = new MessageProducer(Client.GetStream());
             MessageProducer.Start();
+            AppLogger.Information("MessageProducer started");
 
+            AppLogger.Information("Sending initial device commands...");
             TurnOffEcho();
             StopStreaming();
             TurnDeviceOn();

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -47,6 +47,9 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
                 return false;
             }
 
+            // Complete the asynchronous connection
+            Client.EndConnect(result);
+
             MessageProducer = new MessageProducer(Client.GetStream());
             MessageProducer.Start();
 

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -37,26 +37,22 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     {
         try
         {
-            AppLogger.Information($"Attempting to connect to DAQiFi device at {IpAddress}:{Port}");
             Client = new TcpClient();
             var result = Client.BeginConnect(IpAddress, Port, null, null);
             var success = result.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(5));
 
             if (!success)
             {
-                AppLogger.Error("Timeout connecting to DAQiFi Device.");
+                AppLogger.Error($"Timeout connecting to DAQiFi device at {IpAddress}:{Port}");
                 return false;
             }
 
             // Complete the asynchronous connection
             Client.EndConnect(result);
-            AppLogger.Information("TCP connection established successfully");
 
             MessageProducer = new MessageProducer(Client.GetStream());
             MessageProducer.Start();
-            AppLogger.Information("MessageProducer started");
 
-            AppLogger.Information("Sending initial device commands...");
             TurnOffEcho();
             StopStreaming();
             TurnDeviceOn();

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -39,16 +39,35 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
         {
             Client = new TcpClient();
             var result = Client.BeginConnect(IpAddress, Port, null, null);
-            var success = result.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(5));
-
-            if (!success)
+            var waitHandle = result.AsyncWaitHandle;
+            
+            try
             {
-                AppLogger.Error($"Timeout connecting to DAQiFi device at {IpAddress}:{Port}");
-                return false;
-            }
+                var success = waitHandle.WaitOne(TimeSpan.FromSeconds(5));
 
-            // Complete the asynchronous connection
-            Client.EndConnect(result);
+                if (!success)
+                {
+                    AppLogger.Error($"Timeout connecting to DAQiFi device at {IpAddress}:{Port}");
+                    Client?.Close();
+                    return false;
+                }
+
+                // Complete the asynchronous connection
+                try
+                {
+                    Client.EndConnect(result);
+                }
+                catch (SocketException ex)
+                {
+                    AppLogger.Error(ex, $"Failed to connect to DAQiFi device at {IpAddress}:{Port}");
+                    Client?.Close();
+                    return false;
+                }
+            }
+            finally
+            {
+                waitHandle?.Close();
+            }
 
             MessageProducer = new MessageProducer(Client.GetStream());
             MessageProducer.Start();

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -37,6 +37,7 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     {
         try
         {
+            AppLogger.Information($"Attempting to connect to DAQiFi device at {IpAddress}:{Port}");
             Client = new TcpClient();
             var result = Client.BeginConnect(IpAddress, Port, null, null);
             var success = result.AsyncWaitHandle.WaitOne(TimeSpan.FromSeconds(5));

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -56,7 +56,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     public void StartConnectionFinders()
     {
-        _wifiFinder = new DaqifiDeviceFinder(21234);
+        _wifiFinder = new DaqifiDeviceFinder(30303);
         _wifiFinder.OnDeviceFound += HandleWifiDeviceFound;
         _wifiFinder.OnDeviceRemoved += HandleWifiDeviceRemoved;
         _wifiFinder.Start();

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -56,7 +56,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     public void StartConnectionFinders()
     {
-        _wifiFinder = new DaqifiDeviceFinder(30303);
+        _wifiFinder = new DaqifiDeviceFinder(21234);
         _wifiFinder.OnDeviceFound += HandleWifiDeviceFound;
         _wifiFinder.OnDeviceRemoved += HandleWifiDeviceRemoved;
         _wifiFinder.Start();

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -119,7 +119,8 @@ public partial class ConnectionDialogViewModel : ObservableObject
         var deviceInfo = new DeviceInfo
         {
             IpAddress = ManualIpAddress,
-            DeviceName = "Manual IP Device"
+            DeviceName = "Manual IP Device",
+            Port = 30303 // DAQiFi TCP port
         };
 
         var device = new DaqifiStreamingDevice(deviceInfo);

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -120,7 +120,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
         {
             IpAddress = ManualIpAddress,
             DeviceName = "Manual IP Device",
-            Port = 30303 // DAQiFi TCP port
+            Port = 9760 // DAQiFi TCP data port (discovered from device response)
         };
 
         var device = new DaqifiStreamingDevice(deviceInfo);

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -120,7 +120,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
         {
             IpAddress = ManualIpAddress,
             DeviceName = "Manual IP Device",
-            Port = 9760 // DAQiFi TCP data port (discovered from device response)
+            Port = 9760 // Common DAQiFi TCP data port - TODO: make configurable or discover dynamically
         };
 
         var device = new DaqifiStreamingDevice(deviceInfo);

--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ DatabaseLogger->>Database:Bulk Insert Buffer
 - Uses [Wix Toolset](https://wixtoolset.org/)
 - Separate solution `Daqifi.Desktop.Setup`
 
+## WiFi Device Connectivity
+
+DAQiFi Desktop discovers and connects to DAQiFi devices over WiFi using UDP broadcasts and TCP connections.
+
+### Network Requirements
+- **Same Network**: Computer and DAQiFi device must be on the same network/subnet
+- **Firewall**: UDP port 30303 must be allowed (configured automatically with admin privileges)
+- **Virtual Machines**: Use bridged networking mode for VM environments
+
+### Troubleshooting WiFi Discovery
+1. **Run as Administrator** - Required for automatic firewall configuration
+2. **Check Network Connection** - Ensure computer and device are on same WiFi network
+3. **Verify Connectivity** - Test with `ping <device-ip>` from command prompt
+4. **Manual Connection** - Use manual IP connection if discovery fails
+
+### Port Configuration
+- **UDP Discovery**: Port 30303 (device discovery broadcasts)
+- **TCP Data**: Device-specific port (varies by device, typically 9760)
+
 ## Contribution
 
 Please read [Contributing Guidelines](CONTRIBUTING.md) before contributing.


### PR DESCRIPTION
### **User description**
## Summary
- Fixed WiFi device UDP discovery not working due to incorrect port configuration
- Fixed manual IP connections failing with socket connection errors  
- Added comprehensive documentation for WiFi connectivity troubleshooting

## Root Cause Analysis
WiFi connectivity was broken due to port configuration mismatches introduced after the working 3.0.0 release:
1. **UDP Discovery Port**: Changed from working 30303 to incorrect 21234, preventing devices from responding
2. **TCP Connection Logic**: Missing `EndConnect()` call left sockets in non-connected state
3. **Manual IP Port**: Hardcoded to wrong port (30303) instead of actual device TCP port (9760)

## Key Fixes
- **Reverted UDP discovery to port 30303** to match working 3.0.0 release behavior
- **Added proper `EndConnect()` call** to complete asynchronous TCP connections  
- **Fixed manual IP connections** to use correct TCP port (9760) discovered from device response
- **Updated firewall rules** to use UDP port 30303 for device discovery

## Port Configuration Summary
- **UDP Discovery**: Port 30303 (device discovery broadcasts and responses)
- **TCP Data**: Port varies by device (e.g., 9760) - extracted from discovery response
- **Firewall Rule**: UDP port 30303 (matches discovery port)

## Testing
- ✅ **UDP Discovery**: Devices now discovered automatically on WiFi
- ✅ **Manual IP Connection**: Successfully connects using correct TCP port
- ✅ **Network Compatibility**: Works with VM bridged networking
- ✅ **Firewall Integration**: Properly configures Windows Firewall rules

## Documentation
Added comprehensive WiFi connectivity documentation to:
- **CLAUDE.md**: Developer guidance on network requirements and troubleshooting
- **README.md**: User-friendly troubleshooting steps and port reference
- **Test Updates**: Fixed FirewallConfigurationTests to use correct port

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed WiFi device UDP discovery port from 21234 to 30303

- Added missing EndConnect() call for TCP connections

- Corrected manual IP connection port to 9760

- Updated firewall rules to use correct discovery port


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UDP Discovery"] -- "Port 30303" --> B["Device Response"]
  B -- "Extract TCP Port" --> C["TCP Connection"]
  C -- "EndConnect()" --> D["Data Stream"]
  E["Firewall Rule"] -- "UDP 30303" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirewallConfigurationTests.cs</strong><dd><code>Update firewall test port expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop.Test/Configuration/FirewallConfigurationTests.cs

<ul><li>Updated test expectations from port 21234 to 30303<br> <li> Fixed firewall rule creation verification calls</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/249/files#diff-74c1b17b39d7bc2705a6bbfe5b2c331d5341ab65fb8bc184e163f6c6da441da9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirewallManager.cs</strong><dd><code>Fix firewall UDP port configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/Configuration/FirewallManager.cs

<ul><li>Changed UDP port from 21234 to 30303 in firewall rule creation<br> <li> Updated comment to reflect correct port usage</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/249/files#diff-dfafdded12bfb99e6b58c43fd3f87c03288fdf62bfe9bb4344c4196d885e228e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DaqifiStreamingDevice.cs</strong><dd><code>Fix TCP connection completion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs

<ul><li>Added missing <code>Client.EndConnect(result)</code> call after BeginConnect<br> <li> Enhanced connection timeout error logging with IP and port details</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/249/files#diff-08d703db327a862a9b242d1966dde44e4c2b5853245443e54258320f98257ffd">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ConnectionDialogViewModel.cs</strong><dd><code>Fix manual IP connection port</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs

<ul><li>Set manual IP device port to 9760 for TCP connections<br> <li> Fixed manual WiFi connection port configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/249/files#diff-0346078584a17fdb4614937afd422d124b59698e9cc9f1ab884e9b529b82c60d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DaqifiDeviceFinder.cs</strong><dd><code>Enhance UDP discovery logging and debugging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/Device/WiFiDevice/DaqifiDeviceFinder.cs

<ul><li>Improved error logging for broadcast socket exceptions<br> <li> Enhanced network interface discovery logging<br> <li> Added detailed endpoint logging for debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/249/files#diff-4c484963cc96acbf44a8b0caaf2f7c4f00aebb6191363f1387786376ba2cca6b">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add WiFi connectivity developer documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Added comprehensive WiFi connectivity documentation<br> <li> Documented port configuration and network requirements<br> <li> Added troubleshooting guidance for developers</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/249/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+23/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add user WiFi troubleshooting documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added WiFi Device Connectivity section<br> <li> Documented network requirements and troubleshooting steps<br> <li> Added port configuration reference for users</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/249/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

