### PR TITLE
deps: consolidate all dependabot updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 9.0.x
 

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Leave a comment if PR title is invalid
         if: ${{ failure() }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -57,7 +57,7 @@ jobs:
 
       - name: Remove comment if PR title is valid
         if: ${{ success() }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 9.0.x
 

--- a/Daqifi.Desktop.Bootloader.Test/Daqifi.Desktop.Bootloader.Test.csproj
+++ b/Daqifi.Desktop.Bootloader.Test/Daqifi.Desktop.Bootloader.Test.csproj
@@ -20,8 +20,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Daqifi.Desktop.Bootloader\Daqifi.Desktop.Bootloader.csproj" />

--- a/Daqifi.Desktop.Common.Test/Daqifi.Desktop.Common.Test.csproj
+++ b/Daqifi.Desktop.Common.Test/Daqifi.Desktop.Common.Test.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
   </ItemGroup>
 </Project>

--- a/Daqifi.Desktop.DataModel.Test/Daqifi.Desktop.DataModel.Test.csproj
+++ b/Daqifi.Desktop.DataModel.Test/Daqifi.Desktop.DataModel.Test.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
   </ItemGroup>
 </Project>

--- a/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
+++ b/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
@@ -11,8 +11,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.10.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>

--- a/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
+++ b/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
@@ -13,9 +13,9 @@
 		<PackageReference Include="Google.Protobuf" Version="3.32.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.10.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.10.3" />
-		<PackageReference Include="protobuf-net" Version="3.1.17" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
+		<PackageReference Include="protobuf-net" Version="3.2.56" />
 		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
 		<PackageReference Include="System.ValueTuple" Version="4.6.1" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.8" />

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -77,7 +77,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.1" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.8" />
 		<PackageReference Include="System.IO.Ports" Version="9.0.8" />


### PR DESCRIPTION
### **User description**
## Summary
- Consolidates 6 separate dependabot PRs into a single clean update
- Updates NuGet packages: SQLitePCLRaw.bundle_e_sqlite3, protobuf-net, MSTest packages
- Updates GitHub Actions: setup-dotnet and github-script actions
- Avoids the massive line ending diffs that dependabot created

## Updated Packages
### NuGet Packages
- **SQLitePCLRaw.bundle_e_sqlite3**: 3.0.1 → 3.0.2
- **protobuf-net**: 3.1.17 → 3.2.56  
- **MSTest.TestAdapter**: 3.10.3 → 3.10.4 (all test projects)
- **MSTest.TestFramework**: 3.10.3 → 3.10.4 (all test projects)

### GitHub Actions
- **actions/setup-dotnet**: v4 → v5
- **actions/github-script**: v7 → v8

## Test Plan
- [x] Build solution successfully compiles
- [x] Tests pass on compatible projects
- [x] All package references updated consistently across projects
- [x] GitHub Actions workflow files updated

This replaces the following dependabot PRs that had massive line ending diffs:
- PR #248: SQLitePCLRaw.bundle_e_sqlite3 update
- PR #247: protobuf-net update  
- PR #246: MSTest.TestFramework update
- PR #245: MSTest.TestAdapter update
- PR #244: actions/setup-dotnet update
- PR #243: actions/github-script update

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Other


___

### **Description**
- Update NuGet packages: SQLitePCLRaw, protobuf-net, MSTest packages

- Update GitHub Actions: setup-dotnet v4→v5, github-script v7→v8

- Consolidate 6 separate dependabot PRs into single update

- Maintain consistent package versions across test projects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot Updates"] --> B["NuGet Packages"]
  A --> C["GitHub Actions"]
  B --> D["SQLitePCLRaw 3.0.1→3.0.2"]
  B --> E["protobuf-net 3.1.17→3.2.56"]
  B --> F["MSTest 3.10.3→3.10.4"]
  C --> G["setup-dotnet v4→v5"]
  C --> H["github-script v7→v8"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>build.yaml</strong><dd><code>Update setup-dotnet action to v5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prebuild.yaml</strong><dd><code>Update github-script action to v8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-c18dd11250e4e0f0d19035ce56dd87584b7d4f9803ff95437d4831a6d92e938a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release.yaml</strong><dd><code>Update setup-dotnet action to v5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05ada">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Daqifi.Desktop.Bootloader.Test.csproj</strong><dd><code>Update MSTest packages to 3.10.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-4b099856c1f6e4a2dc7cf39703075f6c090e07b3b75f3a09749c14821e68697a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Daqifi.Desktop.Common.Test.csproj</strong><dd><code>Update MSTest packages to 3.10.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-496fe1cf6d504616f9ee8d52ccb86ecd13024333125a42dd1e2dee4276f26cb4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Daqifi.Desktop.DataModel.Test.csproj</strong><dd><code>Update MSTest packages to 3.10.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-f1465b70bef9a52ab206c3ed74f101d07a5d506278e600bae591fc84fe481af9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Daqifi.Desktop.IO.Test.csproj</strong><dd><code>Update MSTest packages to 3.10.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-1d4a552a421ea755a188a5896978adb02f5f0d7d106fd705bc68a0d51b12f609">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Daqifi.Desktop.Test.csproj</strong><dd><code>Update MSTest and protobuf-net packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-47f99be8febd372bdc3700327c0e4e41cdff5e246a1b7c03f365facd422f003e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Daqifi.Desktop.csproj</strong><dd><code>Update SQLitePCLRaw.bundle_e_sqlite3 to 3.0.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/251/files#diff-fc717d91df9fa54e334ca821ec5e853b745063b6534f8ea271edee121a006c4b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

