### PR TITLE
feat: Implement capability-based device detection

### DIFF
--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -893,6 +893,9 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         {
             MacAddress = ProtobufDecoder.GetMacAddressString(message);
         }
+
+        // Detect device type based on capabilities
+        DeviceType = DetectByCapabilities(message);
     }
 
     private void PopulateDigitalChannels(DaqifiOutMessage message)
@@ -1066,6 +1069,32 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         {
             AppLogger.Error($"[DEBUG_MODE] Error creating debug data: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Detects device type based on hardware capabilities (analog in/out port counts)
+    /// </summary>
+    /// <param name="message">The device status message containing capability information</param>
+    /// <returns>Detected device type or Unknown if not recognized</returns>
+    protected DeviceType DetectByCapabilities(DaqifiOutMessage message)
+    {
+        var analogInPorts = message.AnalogInPortNum;
+        var analogOutPorts = message.AnalogOutPortNum;
+
+        // Nyquist 3: 8 analog in, 16 analog out ports
+        if (analogInPorts == 8 && analogOutPorts == 16)
+        {
+            return DeviceType.Nyquist3;
+        }
+
+        // Nyquist 1: 16 analog in, 0 analog out ports
+        if (analogInPorts == 16 && analogOutPorts == 0)
+        {
+            return DeviceType.Nyquist1;
+        }
+
+        // Return Unknown for unrecognized configurations
+        return DeviceType.Unknown;
     }
     #endregion
 }


### PR DESCRIPTION
### **User description**
## Summary
- Implements automatic device type detection based on hardware capabilities (analog in/out port counts)
- Adds DetectByCapabilities method to AbstractStreamingDevice 
- Integrates detection into device initialization workflow for automatic identification
- Includes comprehensive unit and integration tests

## Changes Made
- **DetectByCapabilities method**: Analyzes `DaqifiOutMessage` port counts to identify device types
- **Nyquist 3 detection**: 8 analog in + 16 analog out ports
- **Nyquist 1 detection**: 16 analog in + 0 analog out ports  
- **Unknown fallback**: Returns `DeviceType.Unknown` for unrecognized configurations
- **Automatic integration**: Device type is set automatically in `HydrateDeviceMetadata`
- **Comprehensive testing**: 8 new test methods covering all scenarios

## Test Coverage
- [x] Nyquist 3 capability signature (8 AI, 16 AO) → DeviceType.Nyquist3
- [x] Nyquist 1 capability signature (16 AI, 0 AO) → DeviceType.Nyquist1  
- [x] Unknown configuration returns DeviceType.Unknown
- [x] Edge cases (zero ports, partial matches) return DeviceType.Unknown
- [x] Integration test: Device type automatically set during initialization
- [x] Device type property implements INotifyPropertyChanged for UI binding
- [x] Project builds successfully without compilation errors

## Implementation Details
- **Protected method**: `DetectByCapabilities(DaqifiOutMessage message)` for extensibility
- **Fallback logic**: Gracefully handles unrecognized device configurations
- **Clean integration**: Uses existing `HydrateDeviceMetadata` workflow 
- **No breaking changes**: Existing devices continue working with Unknown default
- **Testable design**: Protected methods exposed via test helper class

## Value Delivered
- Device type detection works immediately without requiring exact part number strings
- Enables device-specific behavior based on hardware capabilities
- Foundation for future device-specific features and optimizations
- Robust fallback ensures compatibility with unknown/future device types

Resolves #255

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add capability-based device detection using analog port counts

- Integrate automatic device type detection into initialization workflow

- Add comprehensive unit and integration tests for detection logic

- Enable device-specific behavior based on hardware capabilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DaqifiOutMessage"] --> B["DetectByCapabilities"]
  B --> C{"Port Count Analysis"}
  C --> D["8 AI + 16 AO"] --> E["DeviceType.Nyquist3"]
  C --> F["16 AI + 0 AO"] --> G["DeviceType.Nyquist1"]
  C --> H["Other Config"] --> I["DeviceType.Unknown"]
  B --> J["HydrateDeviceMetadata"]
  J --> K["Auto-set DeviceType"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractStreamingDeviceTests.cs</strong><dd><code>Add comprehensive capability detection tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs

<ul><li>Add 8 comprehensive test methods for capability detection scenarios<br> <li> Test Nyquist 3 detection (8 AI, 16 AO ports)<br> <li> Test Nyquist 1 detection (16 AI, 0 AO ports)<br> <li> Test edge cases and integration with device initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/276/files#diff-4547f2a029017c9f45e9c14589539e72167deedddbe8d6b95c39df4d04e081d8">+168/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractStreamingDevice.cs</strong><dd><code>Implement capability-based device detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/Device/AbstractStreamingDevice.cs

<ul><li>Add <code>DetectByCapabilities</code> method for device type detection<br> <li> Integrate automatic detection into <code>HydrateDeviceMetadata</code><br> <li> Implement port count analysis for Nyquist 3 and Nyquist 1<br> <li> Return <code>DeviceType.Unknown</code> for unrecognized configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/276/files#diff-498bd1b3560c8d8839ab6182866a762d13dbd46c467de6af5b1c9f98cb18264e">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

