### PR TITLE
feat: implement simple device type detection using part number

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -128,6 +128,94 @@ public class AbstractStreamingDeviceTests
         Assert.IsTrue(propertyChanged, "DeviceType property should notify PropertyChanged");
     }
 
+    [TestMethod]
+    public void HydrateDeviceMetadata_ShouldDetectNyquist1FromPartNumber()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        var message = new DaqifiOutMessage
+        {
+            DevicePn = "Nq1"
+        };
+
+        // Act
+        device.CallHydrateDeviceMetadata(message);
+
+        // Assert
+        Assert.AreEqual(DeviceType.Nyquist1, device.DeviceType, "Should detect Nyquist1 from Nq1 part number");
+        Assert.AreEqual("Nq1", device.DevicePartNumber, "Should set DevicePartNumber");
+    }
+
+    [TestMethod]
+    public void HydrateDeviceMetadata_ShouldDetectNyquist3FromPartNumber()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        var message = new DaqifiOutMessage
+        {
+            DevicePn = "Nq3"
+        };
+
+        // Act
+        device.CallHydrateDeviceMetadata(message);
+
+        // Assert
+        Assert.AreEqual(DeviceType.Nyquist3, device.DeviceType, "Should detect Nyquist3 from Nq3 part number");
+        Assert.AreEqual("Nq3", device.DevicePartNumber, "Should set DevicePartNumber");
+    }
+
+    [TestMethod]
+    public void HydrateDeviceMetadata_ShouldHandleCaseInsensitivePartNumber()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        var message = new DaqifiOutMessage
+        {
+            DevicePn = "NQ1"
+        };
+
+        // Act
+        device.CallHydrateDeviceMetadata(message);
+
+        // Assert
+        Assert.AreEqual(DeviceType.Nyquist1, device.DeviceType, "Should detect Nyquist1 from uppercase NQ1");
+    }
+
+    [TestMethod]
+    public void HydrateDeviceMetadata_ShouldDefaultToUnknownForUnrecognizedPartNumber()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        var message = new DaqifiOutMessage
+        {
+            DevicePn = "UnknownDevice"
+        };
+
+        // Act
+        device.CallHydrateDeviceMetadata(message);
+
+        // Assert
+        Assert.AreEqual(DeviceType.Unknown, device.DeviceType, "Should default to Unknown for unrecognized part number");
+    }
+
+    [TestMethod]
+    public void HydrateDeviceMetadata_ShouldNotChangeDeviceTypeWhenPartNumberIsEmpty()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        device.DeviceType = DeviceType.Nyquist1; // Set initial value
+        var message = new DaqifiOutMessage
+        {
+            DevicePn = ""
+        };
+
+        // Act
+        device.CallHydrateDeviceMetadata(message);
+
+        // Assert
+        Assert.AreEqual(DeviceType.Nyquist1, device.DeviceType, "Should not change DeviceType when part number is empty");
+    }
+
     /// <summary>
     /// Test implementation of AbstractStreamingDevice for testing purposes
     /// </summary>
@@ -140,5 +228,10 @@ public class AbstractStreamingDeviceTests
         public override bool Disconnect() => true;
 
         public override bool Write(string command) => true;
+
+        public void CallHydrateDeviceMetadata(DaqifiOutMessage message)
+        {
+            HydrateDeviceMetadata(message);
+        }
     }
 }

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -876,6 +876,15 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         if (!string.IsNullOrWhiteSpace(message.DevicePn))
         {
             DevicePartNumber = message.DevicePn;
+
+            DeviceType = message.DevicePn.ToLowerInvariant() switch
+            {
+                "nq1" => DeviceType.Nyquist1,
+                "nq3" => DeviceType.Nyquist3,
+                _ => DeviceType.Unknown
+            };
+
+            AppLogger.Information($"Detected device type: {DeviceType} from part number: {message.DevicePn}");
         }
         if (message.DeviceSn != 0)
         {


### PR DESCRIPTION
## Summary
- Implement device type detection in `HydrateDeviceMetadata` using `message.DevicePn`
- Support case-insensitive matching: "nq1" → Nyquist1, "nq3" → Nyquist3
- Add comprehensive unit tests covering all detection scenarios
- Include logging for detected device types

This replaces the complex capability-based detection approach with a simple, direct method using the device's self-reported part number from the protobuf message.

## Test plan
- [x] Unit tests pass for all device type detection scenarios
- [x] Build completes successfully
- [x] Case-insensitive matching works correctly
- [x] Unknown devices default to DeviceType.Unknown
- [x] Logging captures device type detection events

🤖 Generated with [Claude Code](https://claude.ai/code)