### PR TITLE
fix: Use ConnectionType property for USB firmware update detection

### DIFF
--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -750,7 +750,7 @@ public partial class DaqifiViewModel : ObservableObject
             return;
         }
 
-        SelectedDeviceSupportsFirmwareUpdate = device is SerialStreamingDevice;
+        SelectedDeviceSupportsFirmwareUpdate = device.ConnectionType == Device.ConnectionType.Usb;
 
         CloseFlyouts();
         SelectedDevice = device;


### PR DESCRIPTION
### **User description**
## Summary
- Changed firmware update detection from concrete type checking to using the `ConnectionType` property
- Fixes USB-connected devices not being recognized for firmware updates
- Follows OOP principles by programming to properties rather than concrete implementations

## Changes
- **OpenFirmwareUpdateSettings (line 761)**: Use `device.ConnectionType == Device.ConnectionType.Usb` instead of `device is SerialStreamingDevice`
- **UploadFirmware (line 551)**: Add explicit `ConnectionType` check before type cast to ensure USB connection
- Used fully qualified namespace `Device.ConnectionType.Usb` to avoid ambiguity with `Daqifi.Core.Device.Discovery.ConnectionType`

## Why This Fix Works
The original code relied on runtime type checking (`device is SerialStreamingDevice`), which is brittle. The new approach uses the `ConnectionType` property that:
- Clearly indicates whether a device is USB or WiFi connected
- Works regardless of the underlying class implementation
- Is more maintainable and testable
- Future-proof for any new device types

## Test Plan
- [ ] Verify USB-connected devices show firmware update controls as enabled
- [ ] Verify WiFi-connected devices continue to show firmware update as disabled
- [ ] Verify firmware update process completes successfully for USB devices
- [ ] Confirm build succeeds with no errors (verified: 0 errors, warnings are pre-existing)

## Related Issues
Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace concrete type checking with `ConnectionType` property for USB detection

- Add explicit connection type validation in `UploadFirmware` method

- Fix USB-connected devices not recognized for firmware updates

- Follow OOP principles by using properties instead of type casting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Connection"] --> B{"Check ConnectionType<br/>== USB"}
  B -->|USB| C["Enable Firmware Update"]
  B -->|WiFi| D["Disable Firmware Update"]
  C --> E["UploadFirmware Proceeds"]
  D --> F["UploadFirmware Returns"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DaqifiViewModel.cs</strong><dd><code>Replace type checking with ConnectionType property validation</code></dd></summary>
<hr>

Daqifi.Desktop/ViewModels/DaqifiViewModel.cs

<ul><li>Modified <code>OpenFirmwareUpdateSettings</code> to check <code>device.ConnectionType == </code><br><code>Device.ConnectionType.Usb</code> instead of <code>device is SerialStreamingDevice</code><br> <li> Added explicit <code>ConnectionType</code> validation in <code>UploadFirmware</code> method <br>before type casting<br> <li> Ensures USB-connected devices are properly recognized for firmware <br>updates<br> <li> Uses fully qualified <code>Device.ConnectionType.Usb</code> to avoid namespace <br>ambiguity</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/307/files#diff-787fef735742f335df200641a3392bf8310fa0f0be92b6adf2b6f7dec8fe338c">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

