### PR TITLE
feat: use Core's TimestampProcessor for stream timestamp handling

### DIFF
--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -57,7 +57,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="Daqifi.Core" Version="0.7.0" />
+		<PackageReference Include="Daqifi.Core" Version="0.8.0" />
 		<PackageReference Include="EFCore.BulkExtensions" Version="9.0.2" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks" Version="6.2.1" />


### PR DESCRIPTION
### **User description**
## Summary
- Upgrade `Daqifi.Core` dependency from 0.7.0 to 0.8.0 to access `TimestampProcessor`
- Replace Desktop's internal timestamp rollover logic with Core's shared `TimestampProcessor` implementation
- Remove duplicate code (~29 lines reduced to ~6 lines) for timestamp handling with uint32 rollover detection

## Changes
- **Removed**: `TickPeriod` constant (now provided by Core)
- **Removed**: `_previousTimestamps` and `_previousDeviceTimestamps` tracking dictionaries
- **Added**: `ITimestampProcessor` instance for shared timestamp processing
- **Replaced**: 26 lines of inline rollover calculation with 3 lines calling Core's `ProcessTimestamp` method
- **Added**: `ResetAll()` call in `StopStreaming()` for clean state on restart

## Benefits
- Reduces code duplication between Desktop and Core
- Centralizes timestamp rollover logic for consistency across platforms
- Core's implementation includes thread-safety and 10-second sanity check for false positive rollover detection
- Simplifies maintenance - timestamp logic changes only need to be made in one place

## Test plan
- [x] Build succeeds
- [x] Existing tests pass (16 tests on macOS; WPF tests require Windows)
- [ ] Manual testing with device to verify streaming timestamps work correctly
- [ ] Test timestamp rollover scenario (occurs every ~85.9 seconds at 50MHz)

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace internal timestamp rollover logic with Core's shared `TimestampProcessor`

- Upgrade `Daqifi.Core` dependency from 0.7.0 to 0.8.0

- Remove duplicate timestamp tracking dictionaries and constants

- Reduce timestamp handling code from 26 lines to 3 lines

- Add `ResetAll()` call in `StopStreaming()` for clean state management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Internal Timestamp<br/>Rollover Logic"] -->|"Replace with"| B["Core's<br/>TimestampProcessor"]
  C["Daqifi.Core 0.7.0"] -->|"Upgrade to"| D["Daqifi.Core 0.8.0"]
  E["26 lines of code"] -->|"Reduce to"| F["3 lines of code"]
  B -->|"ProcessTimestamp"| G["Timestamp Result<br/>with Rollover Flag"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractStreamingDevice.cs</strong><dd><code>Replace internal timestamp logic with Core's processor</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/Device/AbstractStreamingDevice.cs

<ul><li>Removed <code>TickPeriod</code> constant (now provided by Core)<br> <li> Replaced <code>_previousTimestamps</code> and <code>_previousDeviceTimestamps</code> <br>dictionaries with <code>ITimestampProcessor</code> instance<br> <li> Simplified <code>OnStreamMessageReceived()</code> by replacing 26 lines of rollover <br>calculation with 3 lines calling <code>ProcessTimestamp()</code><br> <li> Added <code>ResetAll()</code> call in <code>StopStreaming()</code> to reset timestamp processor <br>state on stream restart</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/346/files#diff-498bd1b3560c8d8839ab6182866a762d13dbd46c467de6af5b1c9f98cb18264e">+8/-37</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Daqifi.Desktop.csproj</strong><dd><code>Upgrade Daqifi.Core dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/Daqifi.Desktop.csproj

- Updated `Daqifi.Core` package reference from version 0.7.0 to 0.8.0


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/346/files#diff-fc717d91df9fa54e334ca821ec5e853b745063b6534f8ea271edee121a006c4b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

