### PR TITLE
chore: Reduce installer bloat deps

### DIFF
--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -58,9 +58,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Daqifi.Core" Version="0.19.4" />
-		<PackageReference Include="EFCore.BulkExtensions" Version="9.0.2" />
+		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="9.0.2" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
-		<PackageReference Include="MahApps.Metro.IconPacks" Version="6.2.1" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.14" />


### PR DESCRIPTION
### **User description**
## Summary
- swap EFCore.BulkExtensions to SQLite-only package to avoid unused DB providers
- remove MahApps.IconPacks meta-package to avoid shipping unused icon packs

## Testing
- dotnet restore
- dotnet build Daqifi.Desktop/Daqifi.Desktop.csproj -c Release

Fixes #359


___

### **PR Type**
Enhancement


___

### **Description**
- Replace EFCore.BulkExtensions with SQLite-only variant

- Remove unused MahApps.Metro.IconPacks meta-package

- Reduce installer size by eliminating unnecessary dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Project Dependencies"] -->|Replace| B["EFCore.BulkExtensions.Sqlite"]
  A -->|Remove| C["MahApps.Metro.IconPacks"]
  B --> D["Smaller Installer"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Daqifi.Desktop.csproj</strong><dd><code>Optimize project dependencies for smaller installer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Daqifi.Desktop/Daqifi.Desktop.csproj

<ul><li>Replaced <code>EFCore.BulkExtensions</code> with <code>EFCore.BulkExtensions.Sqlite</code> to <br>avoid unused database providers<br> <li> Removed <code>MahApps.Metro.IconPacks</code> meta-package dependency<br> <li> Retained <code>MahApps.Metro.IconPacks.Material</code> for Material Design icons</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-desktop/pull/363/files#diff-fc717d91df9fa54e334ca821ec5e853b745063b6534f8ea271edee121a006c4b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

