### PR TITLE
fix: remove stale comment about digital channel IsEnabled default

### DIFF
--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -729,7 +729,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
                 }
                 else if (coreChannel is Daqifi.Core.Channel.IDigitalChannel coreDigitalChannel)
                 {
-                    // Core sets digital channels to IsEnabled = true by default, keep that behavior
                     DataChannels.Add(new DigitalChannel(this, coreDigitalChannel));
                 }
             }


### PR DESCRIPTION
## Summary

- Removes a stale comment from `PopulateChannelsFromCore` that incorrectly described `IsEnabled = true` on digital channels as intentional behavior
- The actual behavior was a bug (fixed in daqifi/daqifi-core — digital channels now default to `IsEnabled = false`, matching analog channels), which caused digital channels to be excluded from the Add Channel dialog

**Depends on**: daqifi/daqifi-core fix for `PopulateDigitalChannels` defaulting `IsEnabled = true`

## Test plan

- [x] No functional changes — comment removal only

🤖 Generated with [Claude Code](https://claude.com/claude-code)