### PR TITLE
fix: prevent creating a new profile when no devices are connected

### DIFF
--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1743,7 +1743,7 @@ public partial class DaqifiViewModel : ObservableObject
         {
             if (!EnsureAnyDeviceConnected()) return;
 
-            if (ConnectedDevices.Count > 2)
+            if (ConnectionManager.Instance.ConnectedDevices.Count > 2)
             {
                 var errorDialogViewModel = new ErrorDialogViewModel("Cannot add profile with  connected devices more than two");
                 _dialogService.ShowDialog<ErrorDialog>(this, errorDialogViewModel);


### PR DESCRIPTION
## Summary
- Add guard checks to `ShowAddProfileDialog()`, `ShowAddProfileConfirmation()`, and `SaveExistingSetting()` to show an error dialog when no devices are connected
- Uses the existing `ErrorDialog`/`ErrorDialogViewModel` pattern already established in the codebase

Closes #430

## Test plan
- [ ] Launch app with no device connected, click Add Profile — verify error dialog appears
- [ ] Launch app with no device connected, click the profile confirmation button — verify error dialog appears
- [ ] Connect a device, click Add Profile — verify dialog opens normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)