### PR TITLE
fix: prevent OverflowException when exporting data with invalid timestamps

### DIFF
--- a/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
+++ b/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
@@ -159,6 +159,54 @@ stopwatch.ElapsedMilliseconds, $"Large dataset export should complete in under 5
         return samples;
     }
 
+    [TestMethod]
+    public void OptimizedExporter_InvalidTimestamps_DoesNotThrowAndMarksInvalidRows()
+    {
+        // Arrange — include negative, zero, and a value exceeding DateTime.MaxValue.Ticks
+        var invalidTimestamps = new[] { -1L, 0L, DateTime.MaxValue.Ticks + 1L };
+        var baseTime = new DateTime(2018, 1, 1, 0, 0, 0);
+
+        var samples = new List<DataSample>();
+        int id = 1;
+        foreach (var ts in invalidTimestamps)
+        {
+            samples.Add(new DataSample
+            {
+                ID = id++,
+                DeviceName = "TestDevice",
+                DeviceSerialNo = "TEST001",
+                LoggingSessionID = 1,
+                ChannelName = "Channel 1",
+                TimestampTicks = ts,
+                Value = 1.0
+            });
+        }
+        // Also include one valid sample so the file is actually created
+        samples.Add(new DataSample
+        {
+            ID = id,
+            DeviceName = "TestDevice",
+            DeviceSerialNo = "TEST001",
+            LoggingSessionID = 1,
+            ChannelName = "Channel 1",
+            TimestampTicks = baseTime.Ticks,
+            Value = 2.0
+        });
+
+        var loggingSession = new LoggingSession { ID = 1, DataSamples = samples };
+        var exportPath = Path.Combine(TestDirectoryPath, "invalid_timestamps_test.csv");
+
+        var exporter = new OptimizedLoggingSessionExporter();
+
+        // Act — must not throw
+        exporter.ExportLoggingSession(loggingSession, exportPath, false, new Progress<int>(), CancellationToken.None, 0, 1);
+
+        // Assert
+        Assert.IsTrue(File.Exists(exportPath), "Export file should be created");
+        var content = File.ReadAllText(exportPath);
+        Assert.Contains("INVALID(", content, "Invalid timestamps should be labelled rather than throwing");
+    }
+
     [TestCleanup]
     public void CleanUp()
     {

--- a/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
+++ b/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
@@ -199,7 +199,8 @@ stopwatch.ElapsedMilliseconds, $"Large dataset export should complete in under 5
         var exporter = new OptimizedLoggingSessionExporter();
 
         // Act — must not throw
-        exporter.ExportLoggingSession(loggingSession, exportPath, false, new Progress<int>(), CancellationToken.None, 0, 1);
+        exporter.ExportLoggingSession(
+            loggingSession, exportPath, false, new Progress<int>(), CancellationToken.None, 0, 1);
 
         // Assert
         Assert.IsTrue(File.Exists(exportPath), "Export file should be created");

--- a/Daqifi.Desktop/Channel/DataSample.cs
+++ b/Daqifi.Desktop/Channel/DataSample.cs
@@ -48,7 +48,8 @@ public class DataSample
     /// Firmware-measured time since the previous message, in milliseconds.
     /// Null for the first message in a session or when firmware timing is unavailable.
     /// </param>
-    public DataSample(IDevice streamingDevice, IChannel channel, DateTime timestamp, double value, double? firmwareDeltaMs = null)
+    public DataSample(
+        IDevice streamingDevice, IChannel channel, DateTime timestamp, double value, double? firmwareDeltaMs = null)
     {
         DeviceName = streamingDevice.Name;
         DeviceSerialNo=channel.DeviceSerialNo;

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -349,7 +349,8 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
                     // Assign the sample for the digital input channel
                     if (channel.Direction == ChannelDirection.Input)
                     {
-                        channel.ActiveSample = new DataSample(this, channel, messageTimestamp, Convert.ToInt32(bit), firmwareDeltaMs);
+                        channel.ActiveSample = new DataSample(
+                            this, channel, messageTimestamp, Convert.ToInt32(bit), firmwareDeltaMs);
                     }
                 }
             }

--- a/Daqifi.Desktop/Exporter/OptimizedLoggingSessionExporter.cs
+++ b/Daqifi.Desktop/Exporter/OptimizedLoggingSessionExporter.cs
@@ -206,7 +206,7 @@ public class OptimizedLoggingSessionExporter
         var timestamp = timestampSamples[0].TimestampTicks;
         var timeString = exportRelativeTime
             ? ((timestamp - firstTimestamp) / (double)TimeSpan.TicksPerSecond).ToString("F3")
-            : new DateTime(timestamp).ToString("O");
+            : FormatAbsoluteTimestamp(timestamp);
 
         sb.Clear();
         sb.Append(timeString);
@@ -308,6 +308,16 @@ public class OptimizedLoggingSessionExporter
         progress?.Report(finalProgress);
     }
 
+    /// <summary>
+    /// Formats a timestamp tick value as an ISO 8601 string, or returns an error token if the value is outside
+    /// the valid <see cref="DateTime"/> range (0–<see cref="DateTime.MaxValue"/> ticks).
+    /// Prevents <see cref="OverflowException"/> when the database contains corrupt timestamp values.
+    /// </summary>
+    private static string FormatAbsoluteTimestamp(long ticks)
+        => (ticks > 0 && ticks <= DateTime.MaxValue.Ticks)
+            ? new DateTime(ticks).ToString("O")
+            : $"INVALID({ticks})";
+
     private void WriteCompleteTimestampRow(StreamWriter writer, StringBuilder sb, List<SampleData> timestampSamples,
         List<string> channelNames, long firstTimestamp, bool exportRelativeTime)
     {
@@ -316,7 +326,7 @@ public class OptimizedLoggingSessionExporter
         var timestamp = timestampSamples[0].TimestampTicks;
         var timeString = exportRelativeTime
             ? ((timestamp - firstTimestamp) / (double)TimeSpan.TicksPerSecond).ToString("F3")
-            : new DateTime(timestamp).ToString("O");
+            : FormatAbsoluteTimestamp(timestamp);
 
         sb.Clear();
         sb.Append(timeString);
@@ -423,7 +433,7 @@ public class OptimizedLoggingSessionExporter
             {
                 var timeString = exportRelativeTime
                     ? ((sample.TimestampTicks - firstTimestampTicks.Value) / (double)TimeSpan.TicksPerSecond).ToString("F3")
-                    : new DateTime(sample.TimestampTicks).ToString("O");
+                    : FormatAbsoluteTimestamp(sample.TimestampTicks);
 
                 sb.Clear();
                 sb.Append(timeString);

--- a/Daqifi.Desktop/Exporter/OptimizedLoggingSessionExporter.cs
+++ b/Daqifi.Desktop/Exporter/OptimizedLoggingSessionExporter.cs
@@ -310,8 +310,9 @@ public class OptimizedLoggingSessionExporter
 
     /// <summary>
     /// Formats a timestamp tick value as an ISO 8601 string, or returns an error token if the value is outside
-    /// the valid <see cref="DateTime"/> range (0–<see cref="DateTime.MaxValue"/> ticks).
-    /// Prevents <see cref="OverflowException"/> when the database contains corrupt timestamp values.
+    /// the valid <see cref="DateTime"/> range (1–<see cref="DateTime.MaxValue"/> ticks inclusive).
+    /// Zero and negative values are treated as invalid. Prevents <see cref="OverflowException"/> when the
+    /// database contains corrupt timestamp values.
     /// </summary>
     private static string FormatAbsoluteTimestamp(long ticks)
         => (ticks > 0 && ticks <= DateTime.MaxValue.Ticks)


### PR DESCRIPTION
## Summary

- Adds `FormatAbsoluteTimestamp(long ticks)` helper that validates ticks are in the valid `DateTime` range (> 0 and ≤ `DateTime.MaxValue.Ticks`) before constructing a `DateTime`, emitting `INVALID(<ticks>)` for bad values instead of throwing
- Replaces all three unguarded `new DateTime(timestamp).ToString("O")` call sites in `OptimizedLoggingSessionExporter` (`WriteTimestampGroup`, `WriteCompleteTimestampRow`, `StreamAverageData`) with the helper
- Adds a regression test covering negative, zero, and > `DateTime.MaxValue.Ticks` timestamp values

Closes #424

## Test plan

- [ ] New `OptimizedExporter_InvalidTimestamps_DoesNotThrowAndMarksInvalidRows` test passes (verifies no crash and `INVALID(` label present in output)
- [ ] Existing `OptimizedExporterValidationTests` pass (basic export, relative time, large dataset, non-uniform data)
- [ ] Manual: reproduce crash by inserting a row with `TimestampTicks = -1` into the DB and confirming export completes without unhandled exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)