### PR TITLE
fix: profile activation prefers serial number match, falls back to model

### DIFF
--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1676,7 +1676,7 @@ public partial class DaqifiViewModel : ObservableObject
         {
             var exactMatch = ConnectionManager.Instance.ConnectedDevices.FirstOrDefault(cd =>
                 !string.IsNullOrEmpty(profileDev.DeviceSerialNo) &&
-                cd.DeviceSerialNo == profileDev.DeviceSerialNo &&
+                string.Equals(cd.DeviceSerialNo, profileDev.DeviceSerialNo, StringComparison.OrdinalIgnoreCase) &&
                 !claimedDevices.Contains(cd));
 
             if (exactMatch != null)
@@ -1871,7 +1871,7 @@ public partial class DaqifiViewModel : ObservableObject
             {
                 var exactMatch = ConnectedDevices.FirstOrDefault(cd =>
                     !string.IsNullOrEmpty(profileDevice.DeviceSerialNo) &&
-                    cd.DeviceSerialNo == profileDevice.DeviceSerialNo &&
+                    string.Equals(cd.DeviceSerialNo, profileDevice.DeviceSerialNo, StringComparison.OrdinalIgnoreCase) &&
                     !claimedDevices.Contains(cd));
 
                 if (exactMatch != null)


### PR DESCRIPTION
## Summary
- Use two-pass matching strategy in `ActivateProfile()` and `OpenProfileSettings()`: prefer exact serial number match first, then fall back to model match for unmatched profile devices
- Track claimed connected devices so no device is reused across multiple profile entries (fixes ambiguous mapping with two devices of the same model)
- Missing-device detection is now count-aware — reports specific unmatched profile devices with serial numbers instead of just checking model existence

Closes #437

## Test plan
- [ ] Create a profile with two devices of the same model (e.g., two Nq1s with different S/Ns)
- [ ] Connect both original devices — verify each profile device maps to the correct physical device by S/N
- [ ] Replace one device with a different S/N of the same model — verify the remaining original device still matches by S/N and the replacement is used via model fallback
- [ ] Connect only one device when two are needed — verify the missing-device warning includes the unmatched device name and S/N
- [ ] Connect no matching devices — verify the blocking error dialog appears
- [ ] Verify `OpenProfileSettings()` shows correct channel lists for each profile device

🤖 Generated with [Claude Code](https://claude.com/claude-code)