### PR TITLE
feat: add Sentry breadcrumbs and device context tags

### DIFF
--- a/Daqifi.Desktop.Common/Loggers/AppLogger.cs
+++ b/Daqifi.Desktop.Common/Loggers/AppLogger.cs
@@ -129,11 +129,12 @@ public class AppLogger : IAppLogger
     }
 
     /// <inheritdoc />
-    public void SetDeviceContext(string model, string firmwareVersion, string connectionType, int activeChannels)
+    public void SetDeviceContext(string model, string serialNumber, string firmwareVersion, string connectionType, int activeChannels)
     {
         SentrySdk.ConfigureScope(scope =>
         {
             scope.SetTag("daqifi.device_model", model ?? "unknown");
+            scope.SetTag("daqifi.serial_number", serialNumber ?? "unknown");
             scope.SetTag("daqifi.firmware_version", firmwareVersion ?? "unknown");
             scope.SetTag("daqifi.connection_type", connectionType);
             scope.SetTag("daqifi.active_channels", activeChannels.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -146,6 +147,7 @@ public class AppLogger : IAppLogger
         SentrySdk.ConfigureScope(scope =>
         {
             scope.UnsetTag("daqifi.device_model");
+            scope.UnsetTag("daqifi.serial_number");
             scope.UnsetTag("daqifi.firmware_version");
             scope.UnsetTag("daqifi.connection_type");
             scope.UnsetTag("daqifi.active_channels");

--- a/Daqifi.Desktop.Common/Loggers/AppLogger.cs
+++ b/Daqifi.Desktop.Common/Loggers/AppLogger.cs
@@ -12,7 +12,6 @@ public class AppLogger : IAppLogger
     #region Private Data
     private readonly Logger? _logger;
     private IDisposable? _sentryDisposable;
-    private static readonly NoOpLogger NoOpLogger = new();
     private static readonly bool IsTestMode = IsRunningInTestEnvironment();
     #endregion
 
@@ -100,51 +99,29 @@ public class AppLogger : IAppLogger
     #region Logger Methods
     public void Information(string message)
     {
-        if (IsTestMode)
-        {
-            NoOpLogger.Information(message);
-            return;
-        }
-        _logger.Info(message);
+        _logger?.Info(message);
     }
 
     public void Warning(string message)
     {
-        if (IsTestMode)
-        {
-            NoOpLogger.Warning(message);
-            return;
-        }
-        _logger.Warn(message);
+        _logger?.Warn(message);
     }
 
     public void Error(string message)
     {
-        if (IsTestMode)
-        {
-            NoOpLogger.Error(message);
-            return;
-        }
-        _logger.Error(message);
+        _logger?.Error(message);
         SentrySdk.CaptureException(new Exception(message));
     }
 
     public void Error(Exception ex, string message)
     {
-        if (IsTestMode)
-        {
-            NoOpLogger.Error(ex, message);
-            return;
-        }
-        _logger.Error(ex, message);
+        _logger?.Error(ex, message);
         SentrySdk.CaptureException(ex, scope => scope.SetExtra("message", message));
     }
 
     /// <inheritdoc />
     public void AddBreadcrumb(string category, string message, BreadcrumbLevel level = BreadcrumbLevel.Info)
     {
-        if (IsTestMode) return;
-
         SentrySdk.AddBreadcrumb(
             message: message,
             category: category,
@@ -154,8 +131,6 @@ public class AppLogger : IAppLogger
     /// <inheritdoc />
     public void SetDeviceContext(string model, string firmwareVersion, string connectionType, int activeChannels)
     {
-        if (IsTestMode) return;
-
         SentrySdk.ConfigureScope(scope =>
         {
             scope.SetTag("daqifi.device_model", model ?? "unknown");
@@ -168,8 +143,6 @@ public class AppLogger : IAppLogger
     /// <inheritdoc />
     public void ClearDeviceContext()
     {
-        if (IsTestMode) return;
-
         SentrySdk.ConfigureScope(scope =>
         {
             scope.UnsetTag("daqifi.device_model");

--- a/Daqifi.Desktop.Common/Loggers/AppLogger.cs
+++ b/Daqifi.Desktop.Common/Loggers/AppLogger.cs
@@ -141,10 +141,62 @@ public class AppLogger : IAppLogger
     }
 
     /// <inheritdoc />
+    public void AddBreadcrumb(string category, string message, BreadcrumbLevel level = BreadcrumbLevel.Info)
+    {
+        if (IsTestMode) return;
+
+        SentrySdk.AddBreadcrumb(
+            message: message,
+            category: category,
+            level: MapBreadcrumbLevel(level));
+    }
+
+    /// <inheritdoc />
+    public void SetDeviceContext(string model, string firmwareVersion, string connectionType, int activeChannels)
+    {
+        if (IsTestMode) return;
+
+        SentrySdk.ConfigureScope(scope =>
+        {
+            scope.SetTag("daqifi.device_model", model ?? "unknown");
+            scope.SetTag("daqifi.firmware_version", firmwareVersion ?? "unknown");
+            scope.SetTag("daqifi.connection_type", connectionType);
+            scope.SetTag("daqifi.active_channels", activeChannels.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        });
+    }
+
+    /// <inheritdoc />
+    public void ClearDeviceContext()
+    {
+        if (IsTestMode) return;
+
+        SentrySdk.ConfigureScope(scope =>
+        {
+            scope.UnsetTag("daqifi.device_model");
+            scope.UnsetTag("daqifi.firmware_version");
+            scope.UnsetTag("daqifi.connection_type");
+            scope.UnsetTag("daqifi.active_channels");
+        });
+    }
+
+    /// <inheritdoc />
     public void Shutdown()
     {
         SentrySdk.FlushAsync(TimeSpan.FromSeconds(2)).GetAwaiter().GetResult();
         _sentryDisposable?.Dispose();
+    }
+
+    private static Sentry.BreadcrumbLevel MapBreadcrumbLevel(BreadcrumbLevel level)
+    {
+        return level switch
+        {
+            BreadcrumbLevel.Debug => Sentry.BreadcrumbLevel.Debug,
+            BreadcrumbLevel.Info => Sentry.BreadcrumbLevel.Info,
+            BreadcrumbLevel.Warning => Sentry.BreadcrumbLevel.Warning,
+            BreadcrumbLevel.Error => Sentry.BreadcrumbLevel.Error,
+            BreadcrumbLevel.Critical => Sentry.BreadcrumbLevel.Error,
+            _ => Sentry.BreadcrumbLevel.Info
+        };
     }
     #endregion
 }

--- a/Daqifi.Desktop.Common/Loggers/IAppLogger.cs
+++ b/Daqifi.Desktop.Common/Loggers/IAppLogger.cs
@@ -16,7 +16,7 @@ public interface IAppLogger
     /// Sets DAQiFi-specific device context tags on the Sentry scope so errors can be
     /// filtered and grouped by hardware environment.
     /// </summary>
-    void SetDeviceContext(string model, string firmwareVersion, string connectionType, int activeChannels);
+    void SetDeviceContext(string model, string serialNumber, string firmwareVersion, string connectionType, int activeChannels);
 
     /// <summary>
     /// Clears DAQiFi device context tags from the Sentry scope on disconnect.

--- a/Daqifi.Desktop.Common/Loggers/IAppLogger.cs
+++ b/Daqifi.Desktop.Common/Loggers/IAppLogger.cs
@@ -6,8 +6,37 @@ public interface IAppLogger
     void Warning(string message);
     void Error(string message);
     void Error(Exception ex, string message);
+
+    /// <summary>
+    /// Records a Sentry breadcrumb so the event timeline shows what happened before a crash.
+    /// </summary>
+    void AddBreadcrumb(string category, string message, BreadcrumbLevel level = BreadcrumbLevel.Info);
+
+    /// <summary>
+    /// Sets DAQiFi-specific device context tags on the Sentry scope so errors can be
+    /// filtered and grouped by hardware environment.
+    /// </summary>
+    void SetDeviceContext(string model, string firmwareVersion, string connectionType, int activeChannels);
+
+    /// <summary>
+    /// Clears DAQiFi device context tags from the Sentry scope on disconnect.
+    /// </summary>
+    void ClearDeviceContext();
+
     /// <summary>
     /// Flushes pending error reports and releases logging resources.
     /// </summary>
     void Shutdown();
+}
+
+/// <summary>
+/// Breadcrumb severity levels matching Sentry's BreadcrumbLevel.
+/// </summary>
+public enum BreadcrumbLevel
+{
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Critical
 }

--- a/Daqifi.Desktop.Common/Loggers/NoOpLogger.cs
+++ b/Daqifi.Desktop.Common/Loggers/NoOpLogger.cs
@@ -6,6 +6,9 @@ public class NoOpLogger : IAppLogger
     public void Warning(string message) { }
     public void Error(string message) { }
     public void Error(Exception ex, string message) { }
+    public void AddBreadcrumb(string category, string message, BreadcrumbLevel level = BreadcrumbLevel.Info) { }
+    public void SetDeviceContext(string model, string firmwareVersion, string connectionType, int activeChannels) { }
+    public void ClearDeviceContext() { }
     /// <inheritdoc />
     public void Shutdown() { }
 }

--- a/Daqifi.Desktop.Common/Loggers/NoOpLogger.cs
+++ b/Daqifi.Desktop.Common/Loggers/NoOpLogger.cs
@@ -7,7 +7,7 @@ public class NoOpLogger : IAppLogger
     public void Error(string message) { }
     public void Error(Exception ex, string message) { }
     public void AddBreadcrumb(string category, string message, BreadcrumbLevel level = BreadcrumbLevel.Info) { }
-    public void SetDeviceContext(string model, string firmwareVersion, string connectionType, int activeChannels) { }
+    public void SetDeviceContext(string model, string serialNumber, string firmwareVersion, string connectionType, int activeChannels) { }
     public void ClearDeviceContext() { }
     /// <inheritdoc />
     public void Shutdown() { }

--- a/Daqifi.Desktop/App.xaml.cs
+++ b/Daqifi.Desktop/App.xaml.cs
@@ -74,6 +74,8 @@ public partial class App
         // Create and show main window
         var view = new MainWindow();
         view.Show();
+
+        AppLogger.Instance.AddBreadcrumb("app", "App startup complete");
     }
 
     private static void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -150,22 +150,33 @@ public partial class ConnectionManager : ObservableObject
 
     public void Disconnect(IStreamingDevice device)
     {
+        var connectionType = device.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
         try
         {
-            var connectionType = device.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
-            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnected: {device.Name} via {connectionType}");
-
             device.Disconnect();
             ConnectedDevices.Remove(device);
             OnPropertyChanged("ConnectedDevices");
+
+            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnected: {device.Name} via {connectionType}");
 
             if (ConnectedDevices.Count == 0)
             {
                 AppLogger.Instance.ClearDeviceContext();
             }
+            else
+            {
+                var remaining = ConnectedDevices[^1];
+                var remainingType = remaining.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
+                AppLogger.Instance.SetDeviceContext(
+                    remaining.DevicePartNumber,
+                    remaining.DeviceVersion,
+                    remainingType,
+                    remaining.DataChannels?.Count(c => c.IsActive) ?? 0);
+            }
         }
         catch (Exception ex)
         {
+            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnect failed: {device.Name} via {connectionType}", Common.Loggers.BreadcrumbLevel.Error);
             AppLogger.Instance.Error(ex, "Failed in Disconnect");
         }
     }

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -136,10 +136,11 @@ public partial class ConnectionManager : ObservableObject
             var connectionType = device.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
             AppLogger.Instance.SetDeviceContext(
                 device.DevicePartNumber,
+                device.DeviceSerialNo,
                 device.DeviceVersion,
                 connectionType,
                 device.DataChannels?.Count(c => c.IsActive) ?? 0);
-            AppLogger.Instance.AddBreadcrumb("device", $"Device connected: {device.Name} via {connectionType}");
+            AppLogger.Instance.AddBreadcrumb("device", $"Device connected: {device.Name} (S/N: {device.DeviceSerialNo}) via {connectionType}");
         }
         catch (Exception ex)
         {
@@ -157,7 +158,7 @@ public partial class ConnectionManager : ObservableObject
             ConnectedDevices.Remove(device);
             OnPropertyChanged("ConnectedDevices");
 
-            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnected: {device.Name} via {connectionType}");
+            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnected: {device.Name} (S/N: {device.DeviceSerialNo}) via {connectionType}");
 
             if (ConnectedDevices.Count == 0)
             {
@@ -169,6 +170,7 @@ public partial class ConnectionManager : ObservableObject
                 var remainingType = remaining.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
                 AppLogger.Instance.SetDeviceContext(
                     remaining.DevicePartNumber,
+                    remaining.DeviceSerialNo,
                     remaining.DeviceVersion,
                     remainingType,
                     remaining.DataChannels?.Count(c => c.IsActive) ?? 0);
@@ -176,7 +178,7 @@ public partial class ConnectionManager : ObservableObject
         }
         catch (Exception ex)
         {
-            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnect failed: {device.Name} via {connectionType}", Common.Loggers.BreadcrumbLevel.Error);
+            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnect failed: {device.Name} (S/N: {device.DeviceSerialNo}) via {connectionType}", Common.Loggers.BreadcrumbLevel.Error);
             AppLogger.Instance.Error(ex, "Failed in Disconnect");
         }
     }

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -132,6 +132,14 @@ public partial class ConnectionManager : ObservableObject
             await Task.Delay(1000);
             OnPropertyChanged("ConnectedDevices");
             ConnectionStatus = DAQiFiConnectionStatus.Connected;
+
+            var connectionType = device.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
+            AppLogger.Instance.SetDeviceContext(
+                device.DevicePartNumber,
+                device.DeviceVersion,
+                connectionType,
+                device.DataChannels?.Count(c => c.IsActive) ?? 0);
+            AppLogger.Instance.AddBreadcrumb("device", $"Device connected: {device.Name} via {connectionType}");
         }
         catch (Exception ex)
         {
@@ -144,9 +152,17 @@ public partial class ConnectionManager : ObservableObject
     {
         try
         {
+            var connectionType = device.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
+            AppLogger.Instance.AddBreadcrumb("device", $"Device disconnected: {device.Name} via {connectionType}");
+
             device.Disconnect();
             ConnectedDevices.Remove(device);
             OnPropertyChanged("ConnectedDevices");
+
+            if (ConnectedDevices.Count == 0)
+            {
+                AppLogger.Instance.ClearDeviceContext();
+            }
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -658,6 +658,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         coreStreamingDevice.StreamingFrequency = StreamingFrequency;
         coreStreamingDevice.StartStreaming();
         IsStreaming = coreStreamingDevice.IsStreaming;
+        AppLogger.AddBreadcrumb("streaming", $"Streaming started at {StreamingFrequency} Hz");
     }
 
     public void StopStreaming()
@@ -678,6 +679,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         var coreStreamingDevice = GetCoreDeviceForStreaming();
         coreStreamingDevice.StopStreaming();
         IsStreaming = coreStreamingDevice.IsStreaming;
+        AppLogger.AddBreadcrumb("streaming", "Streaming stopped");
 
         // Reset timestamp processor state for clean restart
         _timestampProcessor.ResetAll();

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -69,6 +69,8 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     public void StartConnectionFinders()
     {
+        Common.Loggers.AppLogger.Instance.AddBreadcrumb("discovery", "Device discovery started");
+
         // WiFi Discovery
         _wifiFinder = new WiFiDeviceFinder(30303);
         _wifiDiscoveryCts = new CancellationTokenSource();
@@ -287,6 +289,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
     {
         try
         {
+            Common.Loggers.AppLogger.Instance.AddBreadcrumb("discovery", $"WiFi device found: {e.DeviceInfo.Name}");
             var wifiDevice = new DaqifiStreamingDevice(e.DeviceInfo);
             HandleWifiDeviceFound(sender, wifiDevice);
         }
@@ -300,6 +303,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
     {
         try
         {
+            Common.Loggers.AppLogger.Instance.AddBreadcrumb("discovery", $"Serial device found: {e.DeviceInfo.Name}");
             AddSerialDeviceFromDiscovery(e.DeviceInfo);
         }
         catch (Exception ex)

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -554,6 +554,7 @@ public partial class DaqifiViewModel : ObservableObject
         _firmwareUploadCts?.Dispose();
         _firmwareUploadCts = new CancellationTokenSource();
         IsFirmwareUploading = true;
+        _appLogger.AddBreadcrumb("firmware", $"Firmware update started for {serialStreamingDevice.Name}");
 
         try
         {
@@ -606,21 +607,25 @@ public partial class DaqifiViewModel : ObservableObject
             }
 
             IsUploadComplete = true;
+            _appLogger.AddBreadcrumb("firmware", "Firmware update completed");
             ShowUploadSuccessMessage();
         }
         catch (OperationCanceledException)
         {
             FirmwareUpdateStatusText = "Firmware update canceled.";
             _appLogger.Warning("Firmware update canceled by user.");
+            _appLogger.AddBreadcrumb("firmware", "Firmware update cancelled", Common.Loggers.BreadcrumbLevel.Warning);
         }
         catch (FirmwareUpdateException ex)
         {
+            _appLogger.AddBreadcrumb("firmware", $"Firmware update failed: {ex.FailedState}", Common.Loggers.BreadcrumbLevel.Error);
             HandleFirmwareUpdateException(ex);
         }
         catch (Exception ex)
         {
             HasErrorOccured = true;
             _appLogger.Error(ex, "Problem Uploading Firmware");
+            _appLogger.AddBreadcrumb("firmware", "Firmware update failed", Common.Loggers.BreadcrumbLevel.Error);
             ShowFirmwareErrorDialog("Firmware update failed. Please try again.");
         }
         finally
@@ -1831,6 +1836,7 @@ public partial class DaqifiViewModel : ObservableObject
             }
             addProfileModel.ProfileList.Add(newProfile);
             LoggingManager.Instance.SubscribeProfile(newProfile);
+            _appLogger.AddBreadcrumb("profile", $"Profile saved: {newProfile.Name}");
         }
         catch (Exception ex)
         {
@@ -1977,6 +1983,7 @@ public partial class DaqifiViewModel : ObservableObject
             }
             // Toggle profile's active state
             SelectedProfile.IsProfileActive = !SelectedProfile.IsProfileActive;
+            _appLogger.AddBreadcrumb("profile", $"Profile {(SelectedProfile.IsProfileActive ? "activated" : "deactivated")}: {SelectedProfile.Name}");
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -124,6 +124,7 @@ public partial class ExportDialogViewModel : ObservableObject
         _cts = new CancellationTokenSource();
         var cancellationToken = _cts.Token;
         var progress = new Progress<int>(progressValue => ExportProgress = progressValue);
+        AppLogger.Instance.AddBreadcrumb("export", $"Data export started ({_sessionsIds.Count} session(s))");
 
         try
         {
@@ -153,14 +154,18 @@ public partial class ExportDialogViewModel : ObservableObject
                     }
                 }
             }, cancellationToken);
+
+            AppLogger.Instance.AddBreadcrumb("export", "Data export completed");
         }
         catch (OperationCanceledException)
         {
             AppLogger.Instance.Information("Export operation was cancelled by user.");
+            AppLogger.Instance.AddBreadcrumb("export", "Data export cancelled", Common.Loggers.BreadcrumbLevel.Warning);
         }
         catch (Exception ex)
         {
             AppLogger.Instance.Error(ex, "Problem Exporting Data");
+            AppLogger.Instance.AddBreadcrumb("export", "Data export failed", Common.Loggers.BreadcrumbLevel.Error);
         }
         finally
         {

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -92,6 +92,7 @@ public partial class FirmwareDialogViewModel : ObservableObject
             IsUploadComplete = false;
             UploadFirmwareProgress = 0;
             IsFirmwareUploading = true;
+            AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update started");
 
             var progress = new Progress<FirmwareUpdateProgress>(report =>
             {
@@ -105,20 +106,24 @@ public partial class FirmwareDialogViewModel : ObservableObject
                 _updateCts.Token);
 
             IsUploadComplete = true;
+            AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update completed");
         }
         catch (OperationCanceledException)
         {
             AppLogger.Instance.Warning("Manual firmware upload canceled by user.");
+            AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update cancelled", Common.Loggers.BreadcrumbLevel.Warning);
         }
         catch (FirmwareUpdateException ex)
         {
             HasErrorOccured = true;
             AppLogger.Instance.Error(ex, $"Firmware upload failed in state {ex.FailedState}: {ex.Operation}");
+            AppLogger.Instance.AddBreadcrumb("firmware", $"Firmware update failed: {ex.FailedState}", Common.Loggers.BreadcrumbLevel.Error);
         }
         catch (Exception ex)
         {
             HasErrorOccured = true;
             AppLogger.Instance.Error(ex, "Problem Uploading Firmware");
+            AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update failed", Common.Loggers.BreadcrumbLevel.Error);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Add `AddBreadcrumb`, `SetDeviceContext`, and `ClearDeviceContext` methods to `IAppLogger`/`AppLogger` with a `BreadcrumbLevel` enum to decouple callers from Sentry types
- Set `daqifi.device_model`, `daqifi.firmware_version`, `daqifi.connection_type`, and `daqifi.active_channels` tags on the Sentry scope when a device connects; clear them when the last device disconnects
- Emit Sentry breadcrumbs at key workflow transitions: app startup, device discovery (started/found), device connect/disconnect, streaming start/stop, data export (start/complete/fail), firmware update (start/complete/fail), and profile save/activate

Closes #422

## Test plan
- [x] Build succeeds with zero errors
- [ ] Connect a device and verify `daqifi.*` tags appear on Sentry scope (visible on next captured error)
- [ ] Disconnect all devices and verify tags are cleared
- [ ] Trigger an error after performing several workflow steps and confirm the breadcrumb timeline shows the action trail
- [ ] Verify no standalone Sentry "message" events are emitted for successful operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)