### PR TITLE
fix: improve chart performance with large datasets using LTTB downsampling

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/CircularBufferTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/CircularBufferTests.cs
@@ -1,0 +1,141 @@
+using Daqifi.Desktop.Logger;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+[TestClass]
+public class CircularBufferTests
+{
+    #region Constructor Tests
+    [TestMethod]
+    public void Constructor_ZeroCapacity_Throws()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new CircularBuffer<int>(0));
+    }
+
+    [TestMethod]
+    public void Constructor_ValidCapacity_CreatesEmptyBuffer()
+    {
+        var buffer = new CircularBuffer<int>(10);
+        Assert.AreEqual(0, buffer.Count);
+        Assert.AreEqual(10, buffer.Capacity);
+    }
+    #endregion
+
+    #region Add and Count Tests
+    [TestMethod]
+    public void Add_BelowCapacity_IncrementsCount()
+    {
+        var buffer = new CircularBuffer<int>(5);
+        buffer.Add(1);
+        buffer.Add(2);
+        buffer.Add(3);
+        Assert.AreEqual(3, buffer.Count);
+    }
+
+    [TestMethod]
+    public void Add_AtCapacity_CountStaysAtCapacity()
+    {
+        var buffer = new CircularBuffer<int>(3);
+        buffer.Add(1);
+        buffer.Add(2);
+        buffer.Add(3);
+        buffer.Add(4);
+        Assert.AreEqual(3, buffer.Count);
+    }
+    #endregion
+
+    #region Indexer Tests
+    [TestMethod]
+    public void Indexer_BelowCapacity_ReturnsCorrectItems()
+    {
+        var buffer = new CircularBuffer<int>(5);
+        buffer.Add(10);
+        buffer.Add(20);
+        buffer.Add(30);
+        Assert.AreEqual(10, buffer[0]);
+        Assert.AreEqual(20, buffer[1]);
+        Assert.AreEqual(30, buffer[2]);
+    }
+
+    [TestMethod]
+    public void Indexer_AfterWraparound_ReturnsOldestFirst()
+    {
+        var buffer = new CircularBuffer<int>(3);
+        buffer.Add(1);
+        buffer.Add(2);
+        buffer.Add(3);
+        buffer.Add(4); // Overwrites 1
+        buffer.Add(5); // Overwrites 2
+
+        Assert.AreEqual(3, buffer[0]); // Oldest surviving
+        Assert.AreEqual(4, buffer[1]);
+        Assert.AreEqual(5, buffer[2]); // Newest
+    }
+
+    [TestMethod]
+    public void Indexer_OutOfRange_Throws()
+    {
+        var buffer = new CircularBuffer<int>(5);
+        buffer.Add(1);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => buffer[1]);
+    }
+    #endregion
+
+    #region ToList Tests
+    [TestMethod]
+    public void ToList_BelowCapacity_ReturnsAllItems()
+    {
+        var buffer = new CircularBuffer<int>(5);
+        buffer.Add(10);
+        buffer.Add(20);
+        var list = buffer.ToList();
+        CollectionAssert.AreEqual(new[] { 10, 20 }, list);
+    }
+
+    [TestMethod]
+    public void ToList_AfterWraparound_ReturnsInInsertionOrder()
+    {
+        var buffer = new CircularBuffer<int>(3);
+        for (var i = 1; i <= 7; i++)
+        {
+            buffer.Add(i);
+        }
+
+        var list = buffer.ToList();
+        CollectionAssert.AreEqual(new[] { 5, 6, 7 }, list);
+    }
+
+    [TestMethod]
+    public void ToList_Empty_ReturnsEmptyList()
+    {
+        var buffer = new CircularBuffer<int>(5);
+        var list = buffer.ToList();
+        Assert.AreEqual(0, list.Count);
+    }
+    #endregion
+
+    #region Clear Tests
+    [TestMethod]
+    public void Clear_ResetsCountToZero()
+    {
+        var buffer = new CircularBuffer<int>(5);
+        buffer.Add(1);
+        buffer.Add(2);
+        buffer.Clear();
+        Assert.AreEqual(0, buffer.Count);
+    }
+
+    [TestMethod]
+    public void Clear_AllowsReuse()
+    {
+        var buffer = new CircularBuffer<int>(3);
+        buffer.Add(1);
+        buffer.Add(2);
+        buffer.Add(3);
+        buffer.Clear();
+        buffer.Add(10);
+        Assert.AreEqual(1, buffer.Count);
+        Assert.AreEqual(10, buffer[0]);
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.Test/Loggers/DataPointDecimatorTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/DataPointDecimatorTests.cs
@@ -229,6 +229,35 @@ public class DataPointDecimatorTests
     }
 
     [TestMethod]
+    public void DecimateWithGaps_RespectsGlobalThreshold()
+    {
+        // Create data with many gaps to stress the threshold enforcement
+        var points = new List<DataPoint>();
+        const int segmentSize = 2000;
+        const int segmentCount = 10;
+        for (var seg = 0; seg < segmentCount; seg++)
+        {
+            if (seg > 0) points.Add(DataPoint.Undefined);
+            var offset = seg * (segmentSize + 100);
+            for (var i = 0; i < segmentSize; i++)
+            {
+                points.Add(new DataPoint(offset + i, Math.Sin(i * 0.01)));
+            }
+        }
+
+        const int threshold = 500;
+        var result = DataPointDecimator.DecimateWithGaps(points, threshold);
+
+        // Total output (data points + gap markers) should not exceed the threshold
+        Assert.IsTrue(result.Count <= threshold,
+            $"DecimateWithGaps returned {result.Count} points, expected <= {threshold}");
+
+        // Gap markers should still be preserved
+        var gapCount = result.Count(p => double.IsNaN(p.X));
+        Assert.AreEqual(segmentCount - 1, gapCount, "All gap markers should be preserved");
+    }
+
+    [TestMethod]
     public void DecimateWithGaps_PreservesFirstAndLastOfEachSegment()
     {
         var points = new List<DataPoint>();

--- a/Daqifi.Desktop.Test/Loggers/DataPointDecimatorTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/DataPointDecimatorTests.cs
@@ -1,0 +1,290 @@
+using Daqifi.Desktop.Logger;
+using OxyPlot;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+[TestClass]
+public class DataPointDecimatorTests
+{
+    #region Null and Small Input Tests
+    [TestMethod]
+    public void Decimate_NullInput_ReturnsNull()
+    {
+        var result = DataPointDecimator.Decimate(null);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void Decimate_EmptyList_ReturnsSameList()
+    {
+        var points = new List<DataPoint>();
+        var result = DataPointDecimator.Decimate(points);
+        Assert.AreSame(points, result);
+    }
+
+    [TestMethod]
+    public void Decimate_PointsBelowThreshold_ReturnsSameList()
+    {
+        var points = GenerateLinearPoints(100);
+        var result = DataPointDecimator.Decimate(points, 200);
+        Assert.AreSame(points, result);
+    }
+
+    [TestMethod]
+    public void Decimate_PointsEqualToThreshold_ReturnsSameList()
+    {
+        var points = GenerateLinearPoints(100);
+        var result = DataPointDecimator.Decimate(points, 100);
+        Assert.AreSame(points, result);
+    }
+
+    [TestMethod]
+    public void Decimate_ThresholdLessThan3_ReturnsSameList()
+    {
+        var points = GenerateLinearPoints(100);
+        var result = DataPointDecimator.Decimate(points, 2);
+        Assert.AreSame(points, result);
+    }
+    #endregion
+
+    #region Output Size Tests
+    [TestMethod]
+    public void Decimate_ReturnsExactlyThresholdPoints()
+    {
+        var points = GenerateLinearPoints(10000);
+        const int threshold = 500;
+
+        var result = DataPointDecimator.Decimate(points, threshold);
+
+        Assert.AreEqual(threshold, result.Count);
+    }
+
+    [TestMethod]
+    public void Decimate_DefaultThreshold_Returns5000Points()
+    {
+        var points = GenerateLinearPoints(20000);
+
+        var result = DataPointDecimator.Decimate(points);
+
+        Assert.AreEqual(DataPointDecimator.DEFAULT_THRESHOLD, result.Count);
+    }
+    #endregion
+
+    #region First and Last Point Preservation
+    [TestMethod]
+    public void Decimate_PreservesFirstAndLastPoints()
+    {
+        var points = GenerateSineWavePoints(10000);
+        const int threshold = 100;
+
+        var result = DataPointDecimator.Decimate(points, threshold);
+
+        Assert.AreEqual(points[0].X, result[0].X, "First point X should be preserved");
+        Assert.AreEqual(points[0].Y, result[0].Y, "First point Y should be preserved");
+        Assert.AreEqual(points[^1].X, result[^1].X, "Last point X should be preserved");
+        Assert.AreEqual(points[^1].Y, result[^1].Y, "Last point Y should be preserved");
+    }
+    #endregion
+
+    #region Visual Fidelity Tests
+    [TestMethod]
+    public void Decimate_SineWave_PreservesPeaksAndTroughs()
+    {
+        // Generate a sine wave with known peaks and troughs
+        const int pointCount = 10000;
+        const int threshold = 200;
+        var points = GenerateSineWavePoints(pointCount);
+
+        var result = DataPointDecimator.Decimate(points, threshold);
+
+        // Find max and min Y in the decimated result
+        var maxY = result.Max(p => p.Y);
+        var minY = result.Min(p => p.Y);
+
+        // The decimated data should preserve the amplitude of the sine wave
+        Assert.IsTrue(maxY > 0.95, $"Max Y ({maxY}) should be close to 1.0 (sine peak)");
+        Assert.IsTrue(minY < -0.95, $"Min Y ({minY}) should be close to -1.0 (sine trough)");
+    }
+
+    [TestMethod]
+    public void Decimate_SpikeInFlatData_PreservesSpike()
+    {
+        // Create flat data with a single spike - LTTB should preserve the spike
+        var points = new List<DataPoint>();
+        for (var i = 0; i < 10000; i++)
+        {
+            var y = i == 5000 ? 100.0 : 0.0;
+            points.Add(new DataPoint(i, y));
+        }
+
+        var result = DataPointDecimator.Decimate(points, 100);
+
+        // The spike should be preserved because it forms the largest triangle
+        var maxY = result.Max(p => p.Y);
+        Assert.AreEqual(100.0, maxY, "Spike should be preserved in decimated output");
+    }
+    #endregion
+
+    #region Ordering Tests
+    [TestMethod]
+    public void Decimate_OutputIsOrderedByX()
+    {
+        var points = GenerateSineWavePoints(10000);
+        const int threshold = 500;
+
+        var result = DataPointDecimator.Decimate(points, threshold);
+
+        for (var i = 1; i < result.Count; i++)
+        {
+            Assert.IsTrue(result[i].X >= result[i - 1].X,
+                $"Point at index {i} (X={result[i].X}) should be >= point at index {i - 1} (X={result[i - 1].X})");
+        }
+    }
+    #endregion
+
+    #region Large Dataset Performance
+    [TestMethod]
+    public void Decimate_LargeDataset_CompletesQuickly()
+    {
+        // 1 million points should decimate in well under a second
+        var points = GenerateLinearPoints(1_000_000);
+        const int threshold = 5000;
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var result = DataPointDecimator.Decimate(points, threshold);
+        stopwatch.Stop();
+
+        Assert.AreEqual(threshold, result.Count);
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds < 1000,
+            $"Decimation of 1M points took {stopwatch.ElapsedMilliseconds}ms, expected < 1000ms");
+    }
+    #endregion
+
+    #region DecimateWithGaps Tests
+    [TestMethod]
+    public void DecimateWithGaps_NullInput_ReturnsNull()
+    {
+        var result = DataPointDecimator.DecimateWithGaps(null);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void DecimateWithGaps_NoGaps_BehavesLikeDecimate()
+    {
+        var points = GenerateLinearPoints(10000);
+        const int threshold = 500;
+
+        var result = DataPointDecimator.DecimateWithGaps(points, threshold);
+
+        // Should produce roughly the same count as Decimate
+        Assert.IsTrue(result.Count <= threshold + 1);
+        Assert.IsTrue(result.Count > 0);
+        // No NaN points in the result
+        Assert.IsFalse(result.Any(p => double.IsNaN(p.X)));
+    }
+
+    [TestMethod]
+    public void DecimateWithGaps_PreservesGapMarkers()
+    {
+        // Create data with 2 gaps (3 segments)
+        var points = new List<DataPoint>();
+        for (var i = 0; i < 5000; i++)
+        {
+            points.Add(new DataPoint(i, i * 0.1));
+        }
+        points.Add(DataPoint.Undefined);
+        for (var i = 5001; i < 10000; i++)
+        {
+            points.Add(new DataPoint(i, i * 0.1));
+        }
+        points.Add(DataPoint.Undefined);
+        for (var i = 10001; i < 15000; i++)
+        {
+            points.Add(new DataPoint(i, i * 0.1));
+        }
+
+        var result = DataPointDecimator.DecimateWithGaps(points, 300);
+
+        // Count gap markers in result
+        var gapCount = result.Count(p => double.IsNaN(p.X));
+        Assert.AreEqual(2, gapCount, "Should preserve both gap markers");
+    }
+
+    [TestMethod]
+    public void DecimateWithGaps_BelowThreshold_ReturnsSameList()
+    {
+        var points = new List<DataPoint>();
+        for (var i = 0; i < 50; i++)
+        {
+            points.Add(new DataPoint(i, i));
+        }
+        points.Add(DataPoint.Undefined);
+        for (var i = 51; i < 100; i++)
+        {
+            points.Add(new DataPoint(i, i));
+        }
+
+        var result = DataPointDecimator.DecimateWithGaps(points, 200);
+        Assert.AreSame(points, result);
+    }
+
+    [TestMethod]
+    public void DecimateWithGaps_PreservesFirstAndLastOfEachSegment()
+    {
+        var points = new List<DataPoint>();
+        // Segment 1: 0-4999
+        for (var i = 0; i < 5000; i++)
+        {
+            points.Add(new DataPoint(i, Math.Sin(i * 0.01)));
+        }
+        points.Add(DataPoint.Undefined);
+        // Segment 2: 6000-10999
+        for (var i = 6000; i < 11000; i++)
+        {
+            points.Add(new DataPoint(i, Math.Cos(i * 0.01)));
+        }
+
+        var result = DataPointDecimator.DecimateWithGaps(points, 500);
+
+        // Find the gap marker index
+        var gapIndex = result.FindIndex(p => double.IsNaN(p.X));
+        Assert.IsTrue(gapIndex > 0, "Gap marker should exist");
+
+        // First point of first segment preserved
+        Assert.AreEqual(0.0, result[0].X, "First point of segment 1 should be preserved");
+
+        // Last point before gap preserved
+        Assert.AreEqual(4999.0, result[gapIndex - 1].X, "Last point of segment 1 should be preserved");
+
+        // First point after gap preserved
+        Assert.AreEqual(6000.0, result[gapIndex + 1].X, "First point of segment 2 should be preserved");
+
+        // Last point of second segment preserved
+        Assert.AreEqual(10999.0, result[^1].X, "Last point of segment 2 should be preserved");
+    }
+    #endregion
+
+    #region Helper Methods
+    private static List<DataPoint> GenerateLinearPoints(int count)
+    {
+        var points = new List<DataPoint>(count);
+        for (var i = 0; i < count; i++)
+        {
+            points.Add(new DataPoint(i, i * 0.1));
+        }
+        return points;
+    }
+
+    private static List<DataPoint> GenerateSineWavePoints(int count)
+    {
+        var points = new List<DataPoint>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var x = i * 0.01;
+            var y = Math.Sin(x * 2 * Math.PI);
+            points.Add(new DataPoint(x, y));
+        }
+        return points;
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Loggers/CircularBuffer.cs
+++ b/Daqifi.Desktop/Loggers/CircularBuffer.cs
@@ -1,0 +1,80 @@
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// A fixed-capacity circular buffer that overwrites the oldest elements when full.
+/// Provides O(1) Add and indexed access. Enumerates in insertion order (oldest first).
+/// </summary>
+public class CircularBuffer<T>
+{
+    private readonly T[] _buffer;
+    private int _head;
+    private int _count;
+
+    public CircularBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
+        }
+
+        _buffer = new T[capacity];
+    }
+
+    public int Count => _count;
+    public int Capacity => _buffer.Length;
+
+    /// <summary>
+    /// Adds an item to the buffer. If full, overwrites the oldest item.
+    /// </summary>
+    public void Add(T item)
+    {
+        var index = (_head + _count) % _buffer.Length;
+
+        if (_count == _buffer.Length)
+        {
+            // Buffer is full — overwrite oldest and advance head
+            _buffer[_head] = item;
+            _head = (_head + 1) % _buffer.Length;
+        }
+        else
+        {
+            _buffer[index] = item;
+            _count++;
+        }
+    }
+
+    /// <summary>
+    /// Gets the element at the specified logical index (0 = oldest).
+    /// </summary>
+    public T this[int index]
+    {
+        get
+        {
+            if (index < 0 || index >= _count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            return _buffer[(_head + index) % _buffer.Length];
+        }
+    }
+
+    /// <summary>
+    /// Returns a new list containing all elements in insertion order (oldest first).
+    /// </summary>
+    public List<T> ToList()
+    {
+        var list = new List<T>(_count);
+        for (var i = 0; i < _count; i++)
+        {
+            list.Add(_buffer[(_head + i) % _buffer.Length]);
+        }
+        return list;
+    }
+
+    public void Clear()
+    {
+        _head = 0;
+        _count = 0;
+    }
+}

--- a/Daqifi.Desktop/Loggers/DataPointDecimator.cs
+++ b/Daqifi.Desktop/Loggers/DataPointDecimator.cs
@@ -143,13 +143,31 @@ public static class DataPointDecimator
             return points;
         }
 
-        // Distribute the threshold proportionally across segments
+        // Distribute the threshold proportionally across segments, enforcing global cap
         var totalDataPoints = segments.Sum(s => s.Count);
         var gapMarkerCount = segments.Count - 1;
-        var availableThreshold = threshold - gapMarkerCount;
-        if (availableThreshold < segments.Count * 3)
+        var availableThreshold = Math.Max(segments.Count * 3, threshold - gapMarkerCount);
+
+        // Use floor allocation, then distribute remainder to largest segments
+        var segmentThresholds = new int[segments.Count];
+        var allocated = 0;
+        for (var i = 0; i < segments.Count; i++)
         {
-            availableThreshold = segments.Count * 3;
+            segmentThresholds[i] = Math.Max(3, (int)Math.Floor((double)segments[i].Count / totalDataPoints * availableThreshold));
+            allocated += segmentThresholds[i];
+        }
+
+        // Distribute remaining budget to the largest segments
+        var remaining = availableThreshold - allocated;
+        if (remaining > 0)
+        {
+            var sortedIndices = Enumerable.Range(0, segments.Count)
+                .OrderByDescending(i => segments[i].Count)
+                .ToList();
+            for (var r = 0; r < remaining && r < sortedIndices.Count; r++)
+            {
+                segmentThresholds[sortedIndices[r]]++;
+            }
         }
 
         var result = new List<DataPoint>(threshold);
@@ -161,9 +179,7 @@ public static class DataPointDecimator
                 result.Add(DataPoint.Undefined);
             }
 
-            var segment = segments[i];
-            var segmentThreshold = Math.Max(3, (int)Math.Round((double)segment.Count / totalDataPoints * availableThreshold));
-            var decimated = Decimate(segment, segmentThreshold);
+            var decimated = Decimate(segments[i], segmentThresholds[i]);
             result.AddRange(decimated);
         }
 

--- a/Daqifi.Desktop/Loggers/DataPointDecimator.cs
+++ b/Daqifi.Desktop/Loggers/DataPointDecimator.cs
@@ -1,0 +1,172 @@
+using OxyPlot;
+
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// Provides data point decimation using the Largest-Triangle-Three-Buckets (LTTB) algorithm.
+/// This preserves the visual shape of time-series data while dramatically reducing point count
+/// for efficient chart rendering.
+/// </summary>
+public static class DataPointDecimator
+{
+    /// <summary>
+    /// The maximum number of points to display per series before decimation is applied.
+    /// </summary>
+    public const int DEFAULT_THRESHOLD = 5000;
+
+    /// <summary>
+    /// Downsamples a list of data points using the LTTB algorithm.
+    /// Returns the original list if the count is at or below the threshold.
+    /// </summary>
+    /// <param name="points">The source data points, assumed sorted by X (time).</param>
+    /// <param name="threshold">The target number of output points (minimum 3).</param>
+    /// <returns>A decimated list of data points preserving visual shape.</returns>
+    public static List<DataPoint> Decimate(List<DataPoint> points, int threshold = DEFAULT_THRESHOLD)
+    {
+        if (points == null || points.Count <= threshold || threshold < 3)
+        {
+            return points;
+        }
+
+        var result = new List<DataPoint>(threshold);
+
+        // Always keep the first point
+        result.Add(points[0]);
+
+        // Bucket size (excluding first and last points)
+        var bucketSize = (double)(points.Count - 2) / (threshold - 2);
+
+        var previousIndex = 0;
+
+        for (var i = 1; i < threshold - 1; i++)
+        {
+            // Calculate the range for this bucket
+            var bucketStart = (int)Math.Floor((i - 1) * bucketSize) + 1;
+            var bucketEnd = (int)Math.Floor(i * bucketSize) + 1;
+            if (bucketEnd > points.Count - 1) bucketEnd = points.Count - 1;
+
+            // Calculate the range for the next bucket (used for the average point)
+            var nextBucketStart = (int)Math.Floor(i * bucketSize) + 1;
+            var nextBucketEnd = (int)Math.Floor((i + 1) * bucketSize) + 1;
+            if (nextBucketEnd > points.Count - 1) nextBucketEnd = points.Count - 1;
+
+            // Calculate the average point of the next bucket
+            var avgX = 0.0;
+            var avgY = 0.0;
+            var nextBucketCount = 0;
+            for (var j = nextBucketStart; j < nextBucketEnd; j++)
+            {
+                avgX += points[j].X;
+                avgY += points[j].Y;
+                nextBucketCount++;
+            }
+
+            if (nextBucketCount > 0)
+            {
+                avgX /= nextBucketCount;
+                avgY /= nextBucketCount;
+            }
+
+            // Find the point in the current bucket that forms the largest triangle
+            var maxArea = -1.0;
+            var maxIndex = bucketStart;
+
+            var prevX = points[previousIndex].X;
+            var prevY = points[previousIndex].Y;
+
+            for (var j = bucketStart; j < bucketEnd; j++)
+            {
+                // Triangle area (doubled, no need for absolute since we compare)
+                var area = Math.Abs(
+                    (prevX - avgX) * (points[j].Y - prevY) -
+                    (prevX - points[j].X) * (avgY - prevY));
+
+                if (area > maxArea)
+                {
+                    maxArea = area;
+                    maxIndex = j;
+                }
+            }
+
+            result.Add(points[maxIndex]);
+            previousIndex = maxIndex;
+        }
+
+        // Always keep the last point
+        result.Add(points[^1]);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Decimates data that may contain DataPoint.Undefined gap markers.
+    /// Splits at gap markers, decimates each segment independently, then reassembles
+    /// with gap markers preserved between segments.
+    /// </summary>
+    /// <param name="points">The source data points, which may contain DataPoint.Undefined gap markers.</param>
+    /// <param name="threshold">The total target number of output points (minimum 3), distributed proportionally across segments.</param>
+    /// <returns>A decimated list with gap markers preserved.</returns>
+    public static List<DataPoint> DecimateWithGaps(List<DataPoint> points, int threshold = DEFAULT_THRESHOLD)
+    {
+        if (points == null || points.Count <= threshold || threshold < 3)
+        {
+            return points;
+        }
+
+        // Split into segments at DataPoint.Undefined markers
+        var segments = new List<List<DataPoint>>();
+        var currentSegment = new List<DataPoint>();
+
+        foreach (var point in points)
+        {
+            if (double.IsNaN(point.X) || double.IsNaN(point.Y))
+            {
+                if (currentSegment.Count > 0)
+                {
+                    segments.Add(currentSegment);
+                    currentSegment = new List<DataPoint>();
+                }
+            }
+            else
+            {
+                currentSegment.Add(point);
+            }
+        }
+
+        if (currentSegment.Count > 0)
+        {
+            segments.Add(currentSegment);
+        }
+
+        if (segments.Count == 0)
+        {
+            return points;
+        }
+
+        // Distribute the threshold proportionally across segments
+        var totalDataPoints = segments.Sum(s => s.Count);
+        var gapMarkerCount = segments.Count - 1;
+        var availableThreshold = threshold - gapMarkerCount;
+        if (availableThreshold < segments.Count * 3)
+        {
+            availableThreshold = segments.Count * 3;
+        }
+
+        var result = new List<DataPoint>(threshold);
+
+        for (var i = 0; i < segments.Count; i++)
+        {
+            if (i > 0)
+            {
+                result.Add(DataPoint.Undefined);
+            }
+
+            var segment = segments[i];
+            var segmentThreshold = Math.Max(3, (int)Math.Round((double)segment.Count / totalDataPoints * availableThreshold));
+            var decimated = Decimate(segment, segmentThreshold);
+            result.AddRange(decimated);
+        }
+
+        return result;
+    }
+}

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -255,16 +255,11 @@ public partial class DatabaseLogger : ObservableObject, ILogger
 
                 var dbSamples = context.Samples.AsNoTracking()
                     .Where(s => s.LoggingSessionID == session.ID)
+                    .OrderBy(s => s.TimestampTicks)
                     .Select(s => new { s.ChannelName, s.DeviceSerialNo, s.Type, s.Color, s.TimestampTicks, s.Value })
-                    .ToList(); // Bring data into memory
+                    .ToList();
 
                 var samplesCount = dbSamples.Count;
-                const int dataPointsToShow = 1000000;
-
-                if (samplesCount > dataPointsToShow)
-                {
-                    subtitle = $"\nOnly showing {dataPointsToShow:n0} out of {samplesCount:n0} data points";
-                }
 
                 var channelInfoList = dbSamples
                     .Select(s => new { s.ChannelName, s.DeviceSerialNo, s.Type, s.Color })
@@ -279,9 +274,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger
                     tempLegendItemsList.Add(legendItem);
                 }
 
-                // This part still needs to be careful about _allSessionPoints access if it's used by UI directly
-                // For now, _allSessionPoints is used to populate series ItemsSource later on UI thread
-                var dataSampleCount = 0;
+                // Build full data point lists per channel
                 foreach (var sample in dbSamples)
                 {
                     var key = (sample.DeviceSerialNo, sample.ChannelName);
@@ -292,12 +285,21 @@ public partial class DatabaseLogger : ObservableObject, ILogger
                     {
                         points.Add(new DataPoint(deltaTime, sample.Value));
                     }
+                }
 
-                    dataSampleCount++;
-                    if (dataSampleCount >= dataPointsToShow)
-                    {
-                        break;
-                    }
+                // Decimate each channel's data for efficient rendering
+                var totalDisplayPoints = 0;
+                foreach (var key in _allSessionPoints.Keys.ToList())
+                {
+                    var fullPoints = _allSessionPoints[key];
+                    var decimated = DataPointDecimator.Decimate(fullPoints);
+                    _allSessionPoints[key] = decimated;
+                    totalDisplayPoints += decimated.Count;
+                }
+
+                if (totalDisplayPoints < samplesCount)
+                {
+                    subtitle = $"\nShowing {totalDisplayPoints:n0} downsampled points from {samplesCount:n0} total samples";
                 }
             }
 

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -16,12 +16,17 @@ namespace Daqifi.Desktop.Logger;
 
 public partial class PlotLogger : ObservableObject, ILogger
 {
+    #region Constants
+    private const int MAX_RAW_POINTS_PER_CHANNEL = 50000;
+    #endregion
+
     #region Private Data
     private PlotModel _plotModel;
     private readonly Stopwatch _stopwatch = new();
     private long _lastUpdateMilliSeconds;
     private int _precision = 4;
     private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _loggedPoints = [];
+    private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _decimatedPoints = [];
     private Dictionary<(string deviceSerial, string channelName), LineSeries> _loggedChannels = [];
     private readonly TimestampGapDetector _gapDetector = new();
     #endregion
@@ -205,14 +210,14 @@ public partial class PlotLogger : ObservableObject, ILogger
             if (_gapDetector.IsGap(key, dataSample.FirmwareDeltaMs))
             {
                 LoggedPoints[key].Add(DataPoint.Undefined);
-                if (LoggedPoints[key].Count >= 5000)
+                if (LoggedPoints[key].Count >= MAX_RAW_POINTS_PER_CHANNEL)
                 {
                     LoggedPoints[key].RemoveAt(0);
                 }
             }
 
             LoggedPoints[key].Add(new DataPoint(deltaTime, scaledSampleValue));
-            if (LoggedPoints[key].Count >= 5000)
+            if (LoggedPoints[key].Count >= MAX_RAW_POINTS_PER_CHANNEL)
             {
                 LoggedPoints[key].RemoveAt(0);
             }
@@ -234,12 +239,14 @@ public partial class PlotLogger : ObservableObject, ILogger
     {
         var key = (DeviceSerialNo, channelName);
         var newDataPoints = new List<DataPoint>();
+        var decimatedDataPoints = new List<DataPoint>();
         LoggedPoints.Add(key, newDataPoints);
+        _decimatedPoints.Add(key, decimatedDataPoints);
 
         var newLineSeries = new LineSeries
         {
             Title = channelName,
-            ItemsSource = newDataPoints,
+            ItemsSource = decimatedDataPoints,
             Color = OxyColor.Parse(newColor)
         };
 
@@ -272,12 +279,12 @@ public partial class PlotLogger : ObservableObject, ILogger
 
     private void CompositionTargetRendering(object sender, EventArgs e)
     {
-        if (_stopwatch.ElapsedMilliseconds > _lastUpdateMilliSeconds + 1000) // Or your existing update interval
+        if (_stopwatch.ElapsedMilliseconds > _lastUpdateMilliSeconds + 1000)
         {
             lock (PlotModel.SyncRoot)
             {
                 // Iterate through subscribed channels to update series visibility
-                if (LoggingManager.Instance != null) // Ensure LoggingManager instance is available
+                if (LoggingManager.Instance != null)
                 {
                     foreach (var channel in LoggingManager.Instance.SubscribedChannels)
                     {
@@ -291,7 +298,20 @@ public partial class PlotLogger : ObservableObject, ILogger
                         }
                     }
                 }
-                PlotModel.InvalidatePlot(true); // This will redraw the plot with updated series visibility
+
+                // Decimate raw points into the display lists bound to each series
+                // Use DecimateWithGaps to preserve line breaks at data stream gaps
+                foreach (var kvp in LoggedPoints)
+                {
+                    if (_decimatedPoints.TryGetValue(kvp.Key, out var displayPoints))
+                    {
+                        var decimated = DataPointDecimator.DecimateWithGaps(kvp.Value);
+                        displayPoints.Clear();
+                        displayPoints.AddRange(decimated);
+                    }
+                }
+
+                PlotModel.InvalidatePlot(true);
                 _lastUpdateMilliSeconds = _stopwatch.ElapsedMilliseconds;
             }
         }
@@ -301,6 +321,7 @@ public partial class PlotLogger : ObservableObject, ILogger
     {
         LoggedChannels.Clear();
         LoggedPoints.Clear();
+        _decimatedPoints.Clear();
         _gapDetector.Clear();
         PlotModel.Series.Clear();
         PlotModel.InvalidatePlot(true);

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -25,7 +25,7 @@ public partial class PlotLogger : ObservableObject, ILogger
     private readonly Stopwatch _stopwatch = new();
     private long _lastUpdateMilliSeconds;
     private int _precision = 4;
-    private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _loggedPoints = [];
+    private Dictionary<(string deviceSerial, string channelName), CircularBuffer<DataPoint>> _loggedPoints = [];
     private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _decimatedPoints = [];
     private Dictionary<(string deviceSerial, string channelName), LineSeries> _loggedChannels = [];
     private readonly TimestampGapDetector _gapDetector = new();
@@ -44,7 +44,7 @@ public partial class PlotLogger : ObservableObject, ILogger
 
     public DateTime? FirstTime { get; set; }
 
-    public Dictionary<(string deviceSerial, string channelName), List<DataPoint>> LoggedPoints
+    public Dictionary<(string deviceSerial, string channelName), CircularBuffer<DataPoint>> LoggedPoints
     {
         get => _loggedPoints;
         private set { _loggedPoints = value; OnPropertyChanged(); }
@@ -210,17 +210,9 @@ public partial class PlotLogger : ObservableObject, ILogger
             if (_gapDetector.IsGap(key, dataSample.FirmwareDeltaMs))
             {
                 LoggedPoints[key].Add(DataPoint.Undefined);
-                if (LoggedPoints[key].Count >= MAX_RAW_POINTS_PER_CHANNEL)
-                {
-                    LoggedPoints[key].RemoveAt(0);
-                }
             }
 
             LoggedPoints[key].Add(new DataPoint(deltaTime, scaledSampleValue));
-            if (LoggedPoints[key].Count >= MAX_RAW_POINTS_PER_CHANNEL)
-            {
-                LoggedPoints[key].RemoveAt(0);
-            }
         }
 
         OnPropertyChanged(nameof(LoggedPoints));
@@ -238,7 +230,7 @@ public partial class PlotLogger : ObservableObject, ILogger
     private void AddChannelSeries(string channelName, string DeviceSerialNo, ChannelType channelType, string newColor)
     {
         var key = (DeviceSerialNo, channelName);
-        var newDataPoints = new List<DataPoint>();
+        var newDataPoints = new CircularBuffer<DataPoint>(MAX_RAW_POINTS_PER_CHANNEL);
         var decimatedDataPoints = new List<DataPoint>();
         LoggedPoints.Add(key, newDataPoints);
         _decimatedPoints.Add(key, decimatedDataPoints);
@@ -305,7 +297,8 @@ public partial class PlotLogger : ObservableObject, ILogger
                 {
                     if (_decimatedPoints.TryGetValue(kvp.Key, out var displayPoints))
                     {
-                        var decimated = DataPointDecimator.DecimateWithGaps(kvp.Value);
+                        var rawPoints = kvp.Value.ToList();
+                        var decimated = DataPointDecimator.DecimateWithGaps(rawPoints);
                         displayPoints.Clear();
                         displayPoints.AddRange(decimated);
                     }


### PR DESCRIPTION
## Summary

Closes #36

- Implements the **Largest-Triangle-Three-Buckets (LTTB)** downsampling algorithm to reduce rendered data points to ~5,000 per channel while preserving visual shape (peaks, troughs, spikes)
- **Live chart (PlotLogger)**: Increases raw data buffer from 5k to 50k points per channel (10x more history), decimates to 5k for rendering every 1s cycle. Uses gap-aware decimation to preserve line breaks at data stream gaps
- **Stored session playback (DatabaseLogger)**: Replaces the hard 1M point cap (which silently dropped data) with per-channel LTTB decimation that displays all data. Adds `OrderBy(TimestampTicks)` to ensure time-sorted data for correct decimation
- Adds `DataPointDecimator` with both standard and gap-aware decimation methods
- Adds 15 unit tests covering null/edge cases, output size, first/last point preservation, visual fidelity (sine wave peaks, spike preservation), ordering, gap marker preservation, and performance (1M points in <1s)

## Test plan

- [ ] Verify live chart performance with high-frequency streaming (multiple channels)
- [ ] Verify stored session playback with 100k+ sample sessions renders quickly
- [ ] Verify gap markers (line breaks) are preserved in live chart when device disconnects/reconnects
- [ ] Verify chart subtitle shows "Showing X downsampled points from Y total samples" for large sessions
- [ ] Verify visual fidelity — peaks and spikes should still be visible after downsampling
- [ ] Run unit tests on Windows CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)