### PR TITLE
feat: add overview minimap for large dataset navigation

### DIFF
--- a/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
+++ b/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
@@ -1,0 +1,96 @@
+using OxyPlot;
+
+namespace Daqifi.Desktop.Helpers;
+
+/// <summary>
+/// Provides efficient min/max downsampling for large time-series datasets.
+/// </summary>
+public static class MinMaxDownsampler
+{
+    /// <summary>
+    /// Downsamples a sorted list of data points using min/max aggregation per bucket.
+    /// Produces at most <paramref name="bucketCount"/> * 2 output points.
+    /// </summary>
+    /// <param name="points">Time-sorted data points to downsample.</param>
+    /// <param name="bucketCount">Number of buckets to divide the time range into.</param>
+    /// <returns>A downsampled list of data points preserving the visual envelope.</returns>
+    public static List<DataPoint> Downsample(IReadOnlyList<DataPoint> points, int bucketCount)
+    {
+        if (points.Count <= bucketCount * 2)
+        {
+            return new List<DataPoint>(points);
+        }
+
+        var result = new List<DataPoint>(bucketCount * 2);
+
+        var xMin = points[0].X;
+        var xMax = points[points.Count - 1].X;
+        var xRange = xMax - xMin;
+
+        if (xRange <= 0)
+        {
+            return [points[0]];
+        }
+
+        var bucketWidth = xRange / bucketCount;
+        var pointIndex = 0;
+
+        for (var bucket = 0; bucket < bucketCount; bucket++)
+        {
+            var bucketStart = xMin + bucket * bucketWidth;
+            var bucketEnd = bucketStart + bucketWidth;
+
+            var minY = double.MaxValue;
+            var maxY = double.MinValue;
+            var minYX = bucketStart;
+            var maxYX = bucketStart;
+            var hasPoints = false;
+
+            var isLastBucket = bucket == bucketCount - 1;
+            while (pointIndex < points.Count && (isLastBucket || points[pointIndex].X < bucketEnd))
+            {
+                var p = points[pointIndex];
+                hasPoints = true;
+
+                if (p.Y < minY)
+                {
+                    minY = p.Y;
+                    minYX = p.X;
+                }
+
+                if (p.Y > maxY)
+                {
+                    maxY = p.Y;
+                    maxYX = p.X;
+                }
+
+                pointIndex++;
+            }
+
+            if (!hasPoints)
+            {
+                continue;
+            }
+
+            // Emit min and max in X-order to preserve visual continuity
+            if (minYX <= maxYX)
+            {
+                result.Add(new DataPoint(minYX, minY));
+                if (Math.Abs(minY - maxY) > double.Epsilon)
+                {
+                    result.Add(new DataPoint(maxYX, maxY));
+                }
+            }
+            else
+            {
+                result.Add(new DataPoint(maxYX, maxY));
+                if (Math.Abs(minY - maxY) > double.Epsilon)
+                {
+                    result.Add(new DataPoint(minYX, minY));
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
+++ b/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
@@ -16,6 +16,13 @@ public static class MinMaxDownsampler
     /// <returns>A downsampled list of data points preserving the visual envelope.</returns>
     public static List<DataPoint> Downsample(IReadOnlyList<DataPoint> points, int bucketCount)
     {
+        ArgumentNullException.ThrowIfNull(points);
+
+        if (points.Count == 0 || bucketCount <= 0)
+        {
+            return [];
+        }
+
         if (points.Count <= bucketCount * 2)
         {
             return new List<DataPoint>(points);

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -23,34 +23,6 @@ using FontWeights = OxyPlot.FontWeights;
 
 namespace Daqifi.Desktop.Logger;
 
-/// <summary>
-/// Groups legend items by device for compact display in the legend panel.
-/// </summary>
-public partial class DeviceLegendGroup : ObservableObject
-{
-    /// <summary>
-    /// Full device serial number.
-    /// </summary>
-    public string DeviceSerialNo { get; }
-
-    /// <summary>
-    /// Truncated serial for display (e.g., "...4104").
-    /// </summary>
-    public string TruncatedSerialNo => DeviceSerialNo?.Length > 4
-        ? $"...{DeviceSerialNo[^4..]}"
-        : DeviceSerialNo ?? string.Empty;
-
-    /// <summary>
-    /// Channel legend items belonging to this device.
-    /// </summary>
-    public ObservableCollection<LoggedSeriesLegendItem> Channels { get; } = new();
-
-    public DeviceLegendGroup(string deviceSerialNo)
-    {
-        DeviceSerialNo = deviceSerialNo;
-    }
-}
-
 public partial class LoggedSeriesLegendItem : ObservableObject
 {
     [ObservableProperty]

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -156,6 +156,13 @@ public partial class DatabaseLogger : ObservableObject, ILogger
     /// </summary>
     [ObservableProperty]
     private bool _isLegendPanelVisible = true;
+
+    /// <summary>
+    /// Indicates whether a session with data is currently loaded.
+    /// Controls visibility of the minimap, legend, and empty state placeholder.
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasSessionData;
     #endregion
 
     #region Legend
@@ -422,6 +429,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger
 
             MinimapPlotModel.Series.Clear();
             MinimapPlotModel.InvalidatePlot(true);
+
+            HasSessionData = false;
         });
     }
 
@@ -577,6 +586,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger
                 }
 
                 MinimapPlotModel.InvalidatePlot(true);
+
+                HasSessionData = tempSeriesList.Count > 0;
 
                 OnPropertyChanged("SessionPoints"); // If SessionPoints is still relevant
                 PlotModel.InvalidatePlot(true);

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -34,6 +34,13 @@ public partial class LoggedSeriesLegendItem : ObservableObject
     [ObservableProperty]
     private string _deviceSerialNo;
 
+    /// <summary>
+    /// Truncated serial number for compact legend display (e.g., "...4104").
+    /// </summary>
+    public string TruncatedSerialNo => _deviceSerialNo?.Length > 4
+        ? $"...{_deviceSerialNo[^4..]}"
+        : _deviceSerialNo ?? string.Empty;
+
     [ObservableProperty]
     private OxyColor _seriesColor;
 
@@ -114,6 +121,20 @@ public partial class DatabaseLogger : ObservableObject, ILogger
     /// </summary>
     [ObservableProperty]
     private PlotModel _minimapPlotModel;
+
+    /// <summary>
+    /// Controls visibility of the channel legend panel.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isLegendPanelVisible = true;
+    #endregion
+
+    #region Legend
+    [RelayCommand]
+    private void ToggleLegendPanel()
+    {
+        IsLegendPanelVisible = !IsLegendPanelVisible;
+    }
     #endregion
 
     #region Constructor

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -59,7 +59,18 @@ public partial class LoggedSeriesLegendItem : ObservableObject
     private readonly PlotModel _plotModel;
     private readonly DatabaseLogger _databaseLogger;
 
-    public LoggedSeriesLegendItem(string displayName, string channelName, string deviceSerialNo, OxyColor seriesColor, bool isVisible, LineSeries actualSeries, PlotModel plotModel, DatabaseLogger databaseLogger = null)
+    /// <summary>
+    /// Initializes a new legend item linked to a plot series and optional minimap sync.
+    /// </summary>
+    public LoggedSeriesLegendItem(
+        string displayName,
+        string channelName,
+        string deviceSerialNo,
+        OxyColor seriesColor,
+        bool isVisible,
+        LineSeries actualSeries,
+        PlotModel plotModel,
+        DatabaseLogger databaseLogger = null)
     {
         _displayName = displayName;
         _channelName = channelName;
@@ -96,6 +107,9 @@ public partial class DatabaseLogger : ObservableObject, ILogger
     [ObservableProperty]
     private PlotModel _plotModel;
 
+    /// <summary>
+    /// PlotModel for the overview minimap showing downsampled data and a selection rectangle.
+    /// </summary>
     [ObservableProperty]
     private PlotModel _minimapPlotModel;
     #endregion
@@ -344,6 +358,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger
 
                 var dbSamples = context.Samples.AsNoTracking()
                     .Where(s => s.LoggingSessionID == session.ID)
+                    .OrderBy(s => s.TimestampTicks)
                     .Select(s => new { s.ChannelName, s.DeviceSerialNo, s.Type, s.Color, s.TimestampTicks, s.Value })
                     .ToList(); // Bring data into memory
 

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -4,7 +4,9 @@ using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
 using ChannelType = Daqifi.Core.Channel.ChannelType;
 using Daqifi.Desktop.Device;
 using Daqifi.Desktop.Helpers;
+using Daqifi.Desktop.View;
 using OxyPlot;
+using OxyPlot.Annotations;
 using OxyPlot.Axes;
 using OxyPlot.Series;
 using System.Collections.Concurrent;
@@ -44,15 +46,20 @@ public partial class LoggedSeriesLegendItem : ObservableObject
             if (SetProperty(ref _isVisible, value) && ActualSeries != null)
             {
                 ActualSeries.IsVisible = _isVisible;
-                Application.Current.Dispatcher.Invoke(() => _plotModel?.InvalidatePlot(true));
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    _plotModel?.InvalidatePlot(true);
+                    _databaseLogger?.SetMinimapSeriesVisibility(_deviceSerialNo, _channelName, _isVisible);
+                });
             }
         }
     }
 
     public LineSeries ActualSeries { get; }
     private readonly PlotModel _plotModel;
+    private readonly DatabaseLogger _databaseLogger;
 
-    public LoggedSeriesLegendItem(string displayName, string channelName, string deviceSerialNo, OxyColor seriesColor, bool isVisible, LineSeries actualSeries, PlotModel plotModel)
+    public LoggedSeriesLegendItem(string displayName, string channelName, string deviceSerialNo, OxyColor seriesColor, bool isVisible, LineSeries actualSeries, PlotModel plotModel, DatabaseLogger databaseLogger = null)
     {
         _displayName = displayName;
         _channelName = channelName;
@@ -62,24 +69,35 @@ public partial class LoggedSeriesLegendItem : ObservableObject
         ActualSeries = actualSeries;
         ActualSeries.IsVisible = isVisible; // Ensure series visibility matches
         _plotModel = plotModel;
+        _databaseLogger = databaseLogger;
     }
 }
 
 public partial class DatabaseLogger : ObservableObject, ILogger
 {
+    #region Constants
+    private const int MINIMAP_BUCKET_COUNT = 800;
+    #endregion
+
     #region Private Data
     public ObservableCollection<LoggedSeriesLegendItem> LegendItems { get; } = new();
     private readonly Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _allSessionPoints = new();
     private readonly BlockingCollection<DataSample> _buffer = new();
     private readonly Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _sessionPoints = new();
+    private readonly Dictionary<(string deviceSerial, string channelName), LineSeries> _minimapSeries = new();
 
     private DateTime? _firstTime;
     private readonly AppLogger _appLogger = AppLogger.Instance;
     private readonly IDbContextFactory<LoggingContext> _loggingContext;
     private readonly ManualResetEventSlim _consumerGate = new(true);
+    private RectangleAnnotation _minimapSelectionRect;
+    private MinimapInteractionController _minimapInteraction;
 
     [ObservableProperty]
     private PlotModel _plotModel;
+
+    [ObservableProperty]
+    private PlotModel _minimapPlotModel;
     #endregion
 
     #region Constructor
@@ -150,10 +168,77 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         PlotModel.Axes.Add(digitalAxis);
         PlotModel.Axes.Add(timeAxis);
         PlotModel.IsLegendVisible = false; // Disable the built-in legend
-        // PlotModel.Legends.Add(legend); // Remove legend from plot model
+
+        // Subscribe to main time axis changes for minimap sync
+        timeAxis.AxisChanged += OnMainTimeAxisChanged;
+
+        // Initialize minimap PlotModel
+        InitializeMinimapPlotModel();
 
         var consumerThread = new Thread(Consumer) { IsBackground = true };
         consumerThread.Start();
+    }
+    #endregion
+
+    #region Minimap Initialization
+    private void InitializeMinimapPlotModel()
+    {
+        MinimapPlotModel = new PlotModel
+        {
+            IsLegendVisible = false,
+            PlotMargins = new OxyThickness(50, 2, 20, 20),
+            Padding = new OxyThickness(0)
+        };
+
+        var minimapTimeAxis = new LinearAxis
+        {
+            Position = AxisPosition.Bottom,
+            Key = "MinimapTime",
+            TickStyle = TickStyle.Inside,
+            MajorGridlineStyle = LineStyle.None,
+            MinorGridlineStyle = LineStyle.None,
+            TitleFontSize = 0,
+            FontSize = 9,
+            IsZoomEnabled = false,
+            IsPanEnabled = false
+        };
+
+        var minimapYAxis = new LinearAxis
+        {
+            Position = AxisPosition.Left,
+            Key = "MinimapY",
+            TickStyle = TickStyle.None,
+            MajorGridlineStyle = LineStyle.None,
+            MinorGridlineStyle = LineStyle.None,
+            TitleFontSize = 0,
+            FontSize = 0,
+            IsZoomEnabled = false,
+            IsPanEnabled = false,
+            MinimumPadding = 0.1,
+            MaximumPadding = 0.1
+        };
+
+        MinimapPlotModel.Axes.Add(minimapTimeAxis);
+        MinimapPlotModel.Axes.Add(minimapYAxis);
+
+        _minimapSelectionRect = new RectangleAnnotation
+        {
+            Fill = OxyColor.FromArgb(40, 0, 120, 215),
+            Stroke = OxyColor.FromRgb(0, 120, 215),
+            StrokeThickness = 1.5,
+            MinimumY = double.MinValue,
+            MaximumY = double.MaxValue,
+            Layer = AnnotationLayer.AboveSeries,
+            XAxisKey = "MinimapTime",
+            YAxisKey = "MinimapY"
+        };
+
+        MinimapPlotModel.Annotations.Add(_minimapSelectionRect);
+
+        _minimapInteraction = new MinimapInteractionController(
+            PlotModel,
+            MinimapPlotModel,
+            _minimapSelectionRect);
     }
     #endregion
 
@@ -227,11 +312,15 @@ public partial class DatabaseLogger : ObservableObject, ILogger
             _firstTime = null;
             _sessionPoints.Clear();
             _allSessionPoints.Clear();
+            _minimapSeries.Clear();
             PlotModel.Series.Clear();
             LegendItems.Clear();
             PlotModel.Title = string.Empty;
             PlotModel.Subtitle = string.Empty;
             PlotModel.InvalidatePlot(true);
+
+            MinimapPlotModel.Series.Clear();
+            MinimapPlotModel.InvalidatePlot(true);
         });
     }
 
@@ -301,6 +390,22 @@ public partial class DatabaseLogger : ObservableObject, ILogger
                 }
             }
 
+            // Prepare downsampled minimap data on the background thread
+            var minimapSeriesData = new List<(string channelName, string deviceSerial, OxyColor color, List<DataPoint> downsampled)>();
+            foreach (var kvp in _allSessionPoints)
+            {
+                if (kvp.Value.Count > 0)
+                {
+                    var downsampled = MinMaxDownsampler.Downsample(kvp.Value, MINIMAP_BUCKET_COUNT);
+                    var matchingSeries = tempSeriesList.FirstOrDefault(s =>
+                    {
+                        var parts = s.Title.Split([" : ("], StringSplitOptions.None);
+                        return parts.Length == 2 && parts[0] == kvp.Key.channelName && parts[1].TrimEnd(')') == kvp.Key.deviceSerial;
+                    });
+                    minimapSeriesData.Add((kvp.Key.channelName, kvp.Key.deviceSerial, matchingSeries?.Color ?? OxyColors.Gray, downsampled));
+                }
+            }
+
             // Update UI-bound collections and properties on the UI thread
             Application.Current.Dispatcher.Invoke(() =>
             {
@@ -323,6 +428,37 @@ public partial class DatabaseLogger : ObservableObject, ILogger
                         series.ItemsSource = points;
                     }
                 }
+
+                // Populate minimap with downsampled series
+                MinimapPlotModel.Series.Clear();
+                _minimapSeries.Clear();
+                foreach (var (channelName, deviceSerial, color, downsampled) in minimapSeriesData)
+                {
+                    var minimapLine = new LineSeries
+                    {
+                        Color = color,
+                        StrokeThickness = 1,
+                        ItemsSource = downsampled,
+                        XAxisKey = "MinimapTime",
+                        YAxisKey = "MinimapY"
+                    };
+                    MinimapPlotModel.Series.Add(minimapLine);
+                    _minimapSeries[(deviceSerial, channelName)] = minimapLine;
+                }
+
+                MinimapPlotModel.ResetAllAxes();
+
+                // Initialize selection rectangle to full data range
+                // Use data bounds directly since ActualMinimum/Maximum aren't set until render
+                if (minimapSeriesData.Count > 0)
+                {
+                    var dataMinX = minimapSeriesData.Where(d => d.downsampled.Count > 0).Min(d => d.downsampled[0].X);
+                    var dataMaxX = minimapSeriesData.Where(d => d.downsampled.Count > 0).Max(d => d.downsampled[^1].X);
+                    _minimapSelectionRect.MinimumX = dataMinX;
+                    _minimapSelectionRect.MaximumX = dataMaxX;
+                }
+
+                MinimapPlotModel.InvalidatePlot(true);
 
                 OnPropertyChanged("SessionPoints"); // If SessionPoints is still relevant
                 PlotModel.InvalidatePlot(true);
@@ -430,7 +566,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger
             newLineSeries.Color,
             newLineSeries.IsVisible,
             newLineSeries,
-            PlotModel);
+            PlotModel,
+            this);
         // LegendItems.Add(legendItem); // Removed: To be added in DisplayLoggingSession on UI thread
 
         newLineSeries.YAxisKey = type switch
@@ -444,6 +581,33 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         // OnPropertyChanged("PlotModel"); // Removed: To be called in DisplayLoggingSession on UI thread
         return (newLineSeries, legendItem);
     }
+
+    #region Minimap Synchronization
+    private void OnMainTimeAxisChanged(object? sender, AxisChangedEventArgs e)
+    {
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Time");
+        if (timeAxis == null)
+        {
+            return;
+        }
+
+        _minimapSelectionRect.MinimumX = timeAxis.ActualMinimum;
+        _minimapSelectionRect.MaximumX = timeAxis.ActualMaximum;
+        MinimapPlotModel.InvalidatePlot(false);
+    }
+
+    /// <summary>
+    /// Updates the visibility of a minimap series to match its main plot counterpart.
+    /// </summary>
+    public void SetMinimapSeriesVisibility(string deviceSerialNo, string channelName, bool visible)
+    {
+        if (_minimapSeries.TryGetValue((deviceSerialNo, channelName), out var series))
+        {
+            series.IsVisible = visible;
+            MinimapPlotModel.InvalidatePlot(false);
+        }
+    }
+    #endregion
 
     #region Commands
     [RelayCommand]

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -240,13 +240,13 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         // Dim overlays for areas outside the selected range
         _minimapDimLeft = new RectangleAnnotation
         {
-            Fill = OxyColor.FromArgb(140, 255, 255, 255),
+            Fill = OxyColor.FromArgb(150, 200, 200, 200),
             Stroke = OxyColors.Transparent,
             StrokeThickness = 0,
-            MinimumX = double.MinValue,
+            MinimumX = -1e18,
             MaximumX = 0,
-            MinimumY = double.MinValue,
-            MaximumY = double.MaxValue,
+            MinimumY = -1e18,
+            MaximumY = 1e18,
             Layer = AnnotationLayer.AboveSeries,
             XAxisKey = "MinimapTime",
             YAxisKey = "MinimapY"
@@ -254,13 +254,13 @@ public partial class DatabaseLogger : ObservableObject, ILogger
 
         _minimapDimRight = new RectangleAnnotation
         {
-            Fill = OxyColor.FromArgb(140, 255, 255, 255),
+            Fill = OxyColor.FromArgb(150, 200, 200, 200),
             Stroke = OxyColors.Transparent,
             StrokeThickness = 0,
             MinimumX = 0,
-            MaximumX = double.MaxValue,
-            MinimumY = double.MinValue,
-            MaximumY = double.MaxValue,
+            MaximumX = 1e18,
+            MinimumY = -1e18,
+            MaximumY = 1e18,
             Layer = AnnotationLayer.AboveSeries,
             XAxisKey = "MinimapTime",
             YAxisKey = "MinimapY"
@@ -269,11 +269,11 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         // Selection rectangle border
         _minimapSelectionRect = new RectangleAnnotation
         {
-            Fill = OxyColor.FromArgb(20, 0, 120, 215),
+            Fill = OxyColors.Transparent,
             Stroke = OxyColor.FromRgb(0, 120, 215),
             StrokeThickness = 2,
-            MinimumY = double.MinValue,
-            MaximumY = double.MaxValue,
+            MinimumY = -1e18,
+            MaximumY = 1e18,
             Layer = AnnotationLayer.AboveSeries,
             XAxisKey = "MinimapTime",
             YAxisKey = "MinimapY"

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -202,7 +202,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         MinimapPlotModel = new PlotModel
         {
             IsLegendVisible = false,
-            PlotMargins = new OxyThickness(50, 2, 20, 20),
+            PlotMargins = new OxyThickness(4, 2, 4, 2),
             Padding = new OxyThickness(0)
         };
 
@@ -210,11 +210,11 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         {
             Position = AxisPosition.Bottom,
             Key = "MinimapTime",
-            TickStyle = TickStyle.Inside,
+            TickStyle = TickStyle.None,
             MajorGridlineStyle = LineStyle.None,
             MinorGridlineStyle = LineStyle.None,
             TitleFontSize = 0,
-            FontSize = 9,
+            FontSize = 0,
             IsZoomEnabled = false,
             IsPanEnabled = false
         };
@@ -270,8 +270,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         _minimapSelectionRect = new RectangleAnnotation
         {
             Fill = OxyColors.Transparent,
-            Stroke = OxyColor.FromRgb(0, 120, 215),
-            StrokeThickness = 2,
+            Stroke = OxyColor.FromRgb(0, 90, 180),
+            StrokeThickness = 3,
             MinimumY = -1e18,
             MaximumY = 1e18,
             Layer = AnnotationLayer.AboveSeries,

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -23,6 +23,34 @@ using FontWeights = OxyPlot.FontWeights;
 
 namespace Daqifi.Desktop.Logger;
 
+/// <summary>
+/// Groups legend items by device for compact display in the legend panel.
+/// </summary>
+public partial class DeviceLegendGroup : ObservableObject
+{
+    /// <summary>
+    /// Full device serial number.
+    /// </summary>
+    public string DeviceSerialNo { get; }
+
+    /// <summary>
+    /// Truncated serial for display (e.g., "...4104").
+    /// </summary>
+    public string TruncatedSerialNo => DeviceSerialNo?.Length > 4
+        ? $"...{DeviceSerialNo[^4..]}"
+        : DeviceSerialNo ?? string.Empty;
+
+    /// <summary>
+    /// Channel legend items belonging to this device.
+    /// </summary>
+    public ObservableCollection<LoggedSeriesLegendItem> Channels { get; } = new();
+
+    public DeviceLegendGroup(string deviceSerialNo)
+    {
+        DeviceSerialNo = deviceSerialNo;
+    }
+}
+
 public partial class LoggedSeriesLegendItem : ObservableObject
 {
     [ObservableProperty]
@@ -99,6 +127,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger
 
     #region Private Data
     public ObservableCollection<LoggedSeriesLegendItem> LegendItems { get; } = new();
+    public ObservableCollection<DeviceLegendGroup> DeviceLegendGroups { get; } = new();
     private readonly Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _allSessionPoints = new();
     private readonly BlockingCollection<DataSample> _buffer = new();
     private readonly Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _sessionPoints = new();
@@ -386,6 +415,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger
             _minimapSeries.Clear();
             PlotModel.Series.Clear();
             LegendItems.Clear();
+            DeviceLegendGroups.Clear();
             PlotModel.Title = string.Empty;
             PlotModel.Subtitle = string.Empty;
             PlotModel.InvalidatePlot(true);
@@ -487,6 +517,20 @@ public partial class DatabaseLogger : ObservableObject, ILogger
                 foreach (var legendItem in tempLegendItemsList)
                 {
                     LegendItems.Add(legendItem);
+                }
+
+                // Build grouped legend by device
+                DeviceLegendGroups.Clear();
+                var groupDict = new Dictionary<string, DeviceLegendGroup>();
+                foreach (var legendItem in tempLegendItemsList)
+                {
+                    if (!groupDict.TryGetValue(legendItem.DeviceSerialNo, out var group))
+                    {
+                        group = new DeviceLegendGroup(legendItem.DeviceSerialNo);
+                        groupDict[legendItem.DeviceSerialNo] = group;
+                        DeviceLegendGroups.Add(group);
+                    }
+                    group.Channels.Add(legendItem);
                 }
 
                 foreach (var series in tempSeriesList)

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -102,6 +102,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger
     private readonly IDbContextFactory<LoggingContext> _loggingContext;
     private readonly ManualResetEventSlim _consumerGate = new(true);
     private RectangleAnnotation _minimapSelectionRect;
+    private RectangleAnnotation _minimapDimLeft;
+    private RectangleAnnotation _minimapDimRight;
     private MinimapInteractionController _minimapInteraction;
 
     [ObservableProperty]
@@ -235,11 +237,14 @@ public partial class DatabaseLogger : ObservableObject, ILogger
         MinimapPlotModel.Axes.Add(minimapTimeAxis);
         MinimapPlotModel.Axes.Add(minimapYAxis);
 
-        _minimapSelectionRect = new RectangleAnnotation
+        // Dim overlays for areas outside the selected range
+        _minimapDimLeft = new RectangleAnnotation
         {
-            Fill = OxyColor.FromArgb(40, 0, 120, 215),
-            Stroke = OxyColor.FromRgb(0, 120, 215),
-            StrokeThickness = 1.5,
+            Fill = OxyColor.FromArgb(140, 255, 255, 255),
+            Stroke = OxyColors.Transparent,
+            StrokeThickness = 0,
+            MinimumX = double.MinValue,
+            MaximumX = 0,
             MinimumY = double.MinValue,
             MaximumY = double.MaxValue,
             Layer = AnnotationLayer.AboveSeries,
@@ -247,12 +252,43 @@ public partial class DatabaseLogger : ObservableObject, ILogger
             YAxisKey = "MinimapY"
         };
 
+        _minimapDimRight = new RectangleAnnotation
+        {
+            Fill = OxyColor.FromArgb(140, 255, 255, 255),
+            Stroke = OxyColors.Transparent,
+            StrokeThickness = 0,
+            MinimumX = 0,
+            MaximumX = double.MaxValue,
+            MinimumY = double.MinValue,
+            MaximumY = double.MaxValue,
+            Layer = AnnotationLayer.AboveSeries,
+            XAxisKey = "MinimapTime",
+            YAxisKey = "MinimapY"
+        };
+
+        // Selection rectangle border
+        _minimapSelectionRect = new RectangleAnnotation
+        {
+            Fill = OxyColor.FromArgb(20, 0, 120, 215),
+            Stroke = OxyColor.FromRgb(0, 120, 215),
+            StrokeThickness = 2,
+            MinimumY = double.MinValue,
+            MaximumY = double.MaxValue,
+            Layer = AnnotationLayer.AboveSeries,
+            XAxisKey = "MinimapTime",
+            YAxisKey = "MinimapY"
+        };
+
+        MinimapPlotModel.Annotations.Add(_minimapDimLeft);
+        MinimapPlotModel.Annotations.Add(_minimapDimRight);
         MinimapPlotModel.Annotations.Add(_minimapSelectionRect);
 
         _minimapInteraction = new MinimapInteractionController(
             PlotModel,
             MinimapPlotModel,
-            _minimapSelectionRect);
+            _minimapSelectionRect,
+            _minimapDimLeft,
+            _minimapDimRight);
     }
     #endregion
 
@@ -471,6 +507,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger
                     var dataMaxX = minimapSeriesData.Where(d => d.downsampled.Count > 0).Max(d => d.downsampled[^1].X);
                     _minimapSelectionRect.MinimumX = dataMinX;
                     _minimapSelectionRect.MaximumX = dataMaxX;
+                    _minimapDimLeft.MaximumX = dataMinX;
+                    _minimapDimRight.MinimumX = dataMaxX;
                 }
 
                 MinimapPlotModel.InvalidatePlot(true);
@@ -608,6 +646,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger
 
         _minimapSelectionRect.MinimumX = timeAxis.ActualMinimum;
         _minimapSelectionRect.MaximumX = timeAxis.ActualMaximum;
+        _minimapDimLeft.MaximumX = timeAxis.ActualMinimum;
+        _minimapDimRight.MinimumX = timeAxis.ActualMaximum;
         MinimapPlotModel.InvalidatePlot(false);
     }
 

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -97,6 +97,14 @@ public partial class LoggedSeriesLegendItem : ObservableObject
     /// <summary>
     /// Initializes a new legend item linked to a plot series and optional minimap sync.
     /// </summary>
+    /// <param name="displayName">Full display name including channel and device info.</param>
+    /// <param name="channelName">Channel identifier (e.g., "AI0").</param>
+    /// <param name="deviceSerialNo">Device serial number for grouping.</param>
+    /// <param name="seriesColor">Color of the associated plot series.</param>
+    /// <param name="isVisible">Initial visibility state of the series.</param>
+    /// <param name="actualSeries">The OxyPlot LineSeries this legend item controls.</param>
+    /// <param name="plotModel">The main PlotModel to invalidate on visibility changes.</param>
+    /// <param name="databaseLogger">Optional logger for syncing minimap series visibility.</param>
     public LoggedSeriesLegendItem(
         string displayName,
         string channelName,

--- a/Daqifi.Desktop/Loggers/DeviceLegendGroup.cs
+++ b/Daqifi.Desktop/Loggers/DeviceLegendGroup.cs
@@ -1,0 +1,36 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
+
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// Groups legend items by device for compact display in the legend panel.
+/// </summary>
+public partial class DeviceLegendGroup : ObservableObject
+{
+    /// <summary>
+    /// Full device serial number.
+    /// </summary>
+    public string DeviceSerialNo { get; }
+
+    /// <summary>
+    /// Truncated serial for display (e.g., "...4104").
+    /// </summary>
+    public string TruncatedSerialNo => DeviceSerialNo?.Length > 4
+        ? $"...{DeviceSerialNo[^4..]}"
+        : DeviceSerialNo ?? string.Empty;
+
+    /// <summary>
+    /// Channel legend items belonging to this device.
+    /// </summary>
+    public ObservableCollection<LoggedSeriesLegendItem> Channels { get; } = new();
+
+    /// <summary>
+    /// Initializes a new device legend group.
+    /// </summary>
+    /// <param name="deviceSerialNo">The device serial number for this group.</param>
+    public DeviceLegendGroup(string deviceSerialNo)
+    {
+        DeviceSerialNo = deviceSerialNo;
+    }
+}

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -469,18 +469,73 @@
                                     <Grid Grid.Column="0">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="*"/>
-                                            <RowDefinition Height="80"/>
+                                            <RowDefinition Height="Auto"/>
                                         </Grid.RowDefinitions>
 
-                                        <oxy:PlotView Grid.Row="0" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0"/>
+                                        <oxy:PlotView Grid.Row="0" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0">
+                                            <oxy:PlotView.Style>
+                                                <Style TargetType="oxy:PlotView">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                            <Setter Property="Visibility" Value="Hidden"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </oxy:PlotView.Style>
+                                        </oxy:PlotView>
+
+                                        <!-- Empty State Placeholder -->
+                                        <StackPanel Grid.Row="0"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center">
+                                            <StackPanel.Style>
+                                                <Style TargetType="StackPanel">
+                                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </StackPanel.Style>
+                                            <iconPacks:PackIconMaterial Kind="ChartLine" Width="48" Height="48"
+                                                                        HorizontalAlignment="Center"
+                                                                        Opacity="0.25"
+                                                                        Margin="0,0,0,12"/>
+                                            <TextBlock Text="Select a session to view data"
+                                                       FontSize="14"
+                                                       Opacity="0.4"
+                                                       HorizontalAlignment="Center"/>
+                                        </StackPanel>
 
                                         <!-- Save/Zoom button overlays on the main plot -->
                                         <DockPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top">
+                                            <DockPanel.Style>
+                                                <Style TargetType="DockPanel">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </DockPanel.Style>
                                             <Button Command="{Binding DbLogger.SaveGraphCommand }" CommandParameter="{Binding}" ToolTip="Save as Image" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
                                                 <iconPacks:PackIconMaterial Kind="ImageOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
                                             </Button>
                                         </DockPanel>
                                         <DockPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+                                            <DockPanel.Style>
+                                                <Style TargetType="DockPanel">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </DockPanel.Style>
                                             <Button Command="{Binding DbLogger.ZoomOutXCommand}" ToolTip="Zoom Out (Time)" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
                                                 <Button.Content>
                                                     <iconPacks:PackIconMaterial Kind="MagnifyMinusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
@@ -510,16 +565,36 @@
                                             </StackPanel>
                                         </DockPanel>
 
-                                        <!-- Overview Minimap -->
+                                        <!-- Overview Minimap (hidden when no data) -->
                                         <oxy:PlotView Grid.Row="1"
                                                        Model="{Binding DbLogger.MinimapPlotModel}"
                                                        Margin="5,0,20,5"
-                                                       MinHeight="60"
-                                                       MaxHeight="100"/>
+                                                       Height="80">
+                                            <oxy:PlotView.Style>
+                                                <Style TargetType="oxy:PlotView">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </oxy:PlotView.Style>
+                                        </oxy:PlotView>
                                     </Grid>
 
-                                    <!-- Legend Panel with Collapse Toggle -->
+                                    <!-- Legend Panel with Collapse Toggle (hidden when no data) -->
                                     <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                        <StackPanel.Style>
+                                            <Style TargetType="StackPanel">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </StackPanel.Style>
                                         <!-- Collapse/Expand Toggle Button -->
                                         <Button Command="{Binding DbLogger.ToggleLegendPanelCommand}"
                                                 VerticalAlignment="Top"

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -466,7 +466,57 @@
                                         <ColumnDefinition Width="Auto"/>   <!-- New Legend -->
                                     </Grid.ColumnDefinitions>
 
-                                    <oxy:PlotView Grid.Column="0" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0"/>
+                                    <Grid Grid.Column="0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*"/>
+                                            <RowDefinition Height="80"/>
+                                        </Grid.RowDefinitions>
+
+                                        <oxy:PlotView Grid.Row="0" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0"/>
+
+                                        <!-- Save/Zoom button overlays on the main plot -->
+                                        <DockPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top">
+                                            <Button Command="{Binding DbLogger.SaveGraphCommand }" CommandParameter="{Binding}" ToolTip="Save as Image" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
+                                                <iconPacks:PackIconMaterial Kind="ImageOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
+                                            </Button>
+                                        </DockPanel>
+                                        <DockPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+                                            <Button Command="{Binding DbLogger.ZoomOutXCommand}" ToolTip="Zoom Out (Time)" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
+                                                <Button.Content>
+                                                    <iconPacks:PackIconMaterial Kind="MagnifyMinusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Command="{Binding DbLogger.ZoomInXCommand}" ToolTip="Zoom In (Time)" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
+                                                <Button.Content>
+                                                    <iconPacks:PackIconMaterial Kind="MagnifyPlusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <StackPanel>
+                                                <Button Command="{Binding DbLogger.ZoomInYCommand}" ToolTip="Zoom In (Analog)" Style="{StaticResource FadeButton}">
+                                                    <Button.Content>
+                                                        <iconPacks:PackIconMaterial Kind="MagnifyPlusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
+                                                    </Button.Content>
+                                                </Button>
+                                                <Button Command="{Binding DbLogger.ZoomOutYCommand}" ToolTip="Zoom Out (Analog)" Style="{StaticResource FadeButton}">
+                                                    <Button.Content>
+                                                        <iconPacks:PackIconMaterial Kind="MagnifyMinusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
+                                                    </Button.Content>
+                                                </Button>
+                                                <Button Command="{Binding DbLogger.ResetZoomCommand }" CommandParameter="{Binding}" Style="{StaticResource FadeButton}" ToolTip="Reset Zoom" VerticalAlignment="Bottom" >
+                                                    <Button.Content>
+                                                        <iconPacks:PackIconMaterial Kind="Crosshairs" HorizontalAlignment="Center" Height="15" Width="15"/>
+                                                    </Button.Content>
+                                                </Button>
+                                            </StackPanel>
+                                        </DockPanel>
+
+                                        <!-- Overview Minimap -->
+                                        <oxy:PlotView Grid.Row="1"
+                                                       Model="{Binding DbLogger.MinimapPlotModel}"
+                                                       Margin="5,0,20,5"
+                                                       MinHeight="60"
+                                                       MaxHeight="100"/>
+                                    </Grid>
 
                                     <ListView Grid.Column="1"
                                               ItemsSource="{Binding DbLogger.LegendItems}"
@@ -573,40 +623,6 @@
                                         </ListView.ItemTemplate>
                                     </ListView>
 
-                                    <DockPanel Grid.Column="0" Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top">
-                                        <Button Command="{Binding DbLogger.SaveGraphCommand }" CommandParameter="{Binding}" ToolTip="Save as Image" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
-                                            <iconPacks:PackIconMaterial Kind="ImageOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
-                                        </Button>
-                                    </DockPanel>
-                                    <DockPanel HorizontalAlignment="Right" VerticalAlignment="Bottom">
-                                        <Button Command="{Binding DbLogger.ZoomOutXCommand}" ToolTip="Zoom Out (Time)" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
-                                            <Button.Content>
-                                                <iconPacks:PackIconMaterial Kind="MagnifyMinusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
-                                            </Button.Content>
-                                        </Button>
-                                        <Button Command="{Binding DbLogger.ZoomInXCommand}" ToolTip="Zoom In (Time)" VerticalAlignment="Bottom" Style="{StaticResource FadeButton}">
-                                            <Button.Content>
-                                                <iconPacks:PackIconMaterial Kind="MagnifyPlusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
-                                            </Button.Content>
-                                        </Button>
-                                        <StackPanel>
-                                            <Button Command="{Binding DbLogger.ZoomInYCommand}" ToolTip="Zoom In (Analog)" Style="{StaticResource FadeButton}">
-                                                <Button.Content>
-                                                    <iconPacks:PackIconMaterial Kind="MagnifyPlusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Command="{Binding DbLogger.ZoomOutYCommand}" ToolTip="Zoom Out (Analog)" Style="{StaticResource FadeButton}">
-                                                <Button.Content>
-                                                    <iconPacks:PackIconMaterial Kind="MagnifyMinusOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Command="{Binding DbLogger.ResetZoomCommand }" CommandParameter="{Binding}" Style="{StaticResource FadeButton}" ToolTip="Reset Zoom" VerticalAlignment="Bottom" >
-                                                <Button.Content>
-                                                    <iconPacks:PackIconMaterial Kind="Crosshairs" HorizontalAlignment="Center" Height="15" Width="15"/>
-                                                </Button.Content>
-                                            </Button>
-                                        </StackPanel>
-                                    </DockPanel>
                                 </Grid>
 
                                 <!-- Logged Data List -->

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -540,18 +540,13 @@
                                             </iconPacks:PackIconMaterial>
                                         </Button>
 
-                                        <!-- Collapsible Legend ListView -->
-                                        <ListView ItemsSource="{Binding DbLogger.LegendItems}"
-                                                  Background="Transparent"
-                                                  BorderThickness="0"
-                                                  HorizontalContentAlignment="Stretch"
-                                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                                  MaxHeight="400"
-                                                  MinWidth="120"
-                                                  MaxWidth="160">
-                                            <ListView.Style>
-                                                <Style TargetType="ListView">
+                                        <!-- Collapsible Grouped Legend -->
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                                      HorizontalScrollBarVisibility="Disabled"
+                                                      MaxHeight="500"
+                                                      Margin="4,0,4,0">
+                                            <ScrollViewer.Style>
+                                                <Style TargetType="ScrollViewer">
                                                     <Setter Property="Visibility" Value="Visible"/>
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding DbLogger.IsLegendPanelVisible}" Value="False">
@@ -559,101 +554,83 @@
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
-                                            </ListView.Style>
-                                            <ListView.ItemContainerStyle>
-                                                <Style TargetType="ListViewItem">
-                                                    <Setter Property="Focusable" Value="False"/>
-                                                    <Setter Property="Background" Value="Transparent"/>
-                                                    <Setter Property="Template">
-                                                        <Setter.Value>
-                                                            <ControlTemplate TargetType="ListViewItem">
-                                                                <ContentPresenter/>
-                                                            </ControlTemplate>
-                                                        </Setter.Value>
-                                                    </Setter>
-                                                </Style>
-                                            </ListView.ItemContainerStyle>
-                                            <ListView.ItemTemplate>
-                                                <DataTemplate DataType="{x:Type logger:LoggedSeriesLegendItem}">
-                                                    <Button Command="{Binding DataContext.ToggleLoggedSeriesVisibilityCommand, RelativeSource={RelativeSource AncestorType=controls:MetroWindow}}"
-                                                            CommandParameter="{Binding}"
-                                                            Padding="4,4">
-                                                        <Button.ToolTip>
-                                                            <ToolTip>
-                                                                <TextBlock Text="{Binding DeviceSerialNo, StringFormat='Click to show/hide channel ({0})'}" FontSize="10" FontStyle="Italic"/>
-                                                            </ToolTip>
-                                                        </Button.ToolTip>
-                                                        <Button.Style>
-                                                            <Style TargetType="Button" BasedOn="{StaticResource TransparentButtonStyle}">
-                                                                <Setter Property="Cursor" Value="Hand"/>
-                                                                <Style.Triggers>
-                                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                                        <Setter Property="Background" Value="#15FFFFFF"/>
-                                                                    </Trigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </Button.Style>
-                                                        <Grid>
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                                <ColumnDefinition Width="*"/>
-                                                            </Grid.ColumnDefinitions>
+                                            </ScrollViewer.Style>
+                                            <ItemsControl ItemsSource="{Binding DbLogger.DeviceLegendGroups}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type logger:DeviceLegendGroup}">
+                                                        <StackPanel Margin="0,2,0,4">
+                                                            <!-- Device Header -->
+                                                            <TextBlock FontSize="9" Opacity="0.6" Margin="0,0,0,2"
+                                                                       ToolTip="{Binding DeviceSerialNo}">
+                                                                <Run Text="Device: "/><Run Text="{Binding TruncatedSerialNo, Mode=OneWay}"/>
+                                                            </TextBlock>
 
-                                                            <!-- Color Indicator -->
-                                                            <Rectangle Grid.Column="0"
-                                                                      Width="14" Height="14"
-                                                                      Fill="{Binding SeriesColor, Converter={StaticResource OxyColorToBrushConverter}}"
-                                                                      Margin="0,0,6,0"
-                                                                      VerticalAlignment="Center">
-                                                                <Rectangle.Style>
-                                                                    <Style TargetType="Rectangle">
-                                                                        <Setter Property="Opacity" Value="1.0"/>
-                                                                        <Style.Triggers>
-                                                                            <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                                                <Setter Property="Opacity" Value="0.3"/>
-                                                                            </DataTrigger>
-                                                                        </Style.Triggers>
-                                                                    </Style>
-                                                                </Rectangle.Style>
-                                                            </Rectangle>
-
-                                                            <!-- Channel Info -->
-                                                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                                                <TextBlock Text="{Binding ChannelName}"
-                                                                          FontSize="11"
-                                                                          FontWeight="Medium">
-                                                                    <TextBlock.Style>
-                                                                        <Style TargetType="TextBlock">
-                                                                            <Setter Property="Opacity" Value="1.0"/>
-                                                                            <Style.Triggers>
-                                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                                                    <Setter Property="Opacity" Value="0.4"/>
-                                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
-                                                                                </DataTrigger>
-                                                                            </Style.Triggers>
-                                                                        </Style>
-                                                                    </TextBlock.Style>
-                                                                </TextBlock>
-                                                                <TextBlock Text="{Binding TruncatedSerialNo}"
-                                                                          FontSize="9"
-                                                                          Opacity="0.5"
-                                                                          Margin="0,0,0,0">
-                                                                    <TextBlock.Style>
-                                                                        <Style TargetType="TextBlock">
-                                                                            <Style.Triggers>
-                                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                                                    <Setter Property="Opacity" Value="0.3"/>
-                                                                                </DataTrigger>
-                                                                            </Style.Triggers>
-                                                                        </Style>
-                                                                    </TextBlock.Style>
-                                                                </TextBlock>
-                                                            </StackPanel>
-                                                        </Grid>
-                                                    </Button>
-                                                </DataTemplate>
-                                            </ListView.ItemTemplate>
-                                        </ListView>
+                                                            <!-- Channel Grid (2 columns) -->
+                                                            <ItemsControl ItemsSource="{Binding Channels}">
+                                                                <ItemsControl.ItemsPanel>
+                                                                    <ItemsPanelTemplate>
+                                                                        <UniformGrid Columns="2"/>
+                                                                    </ItemsPanelTemplate>
+                                                                </ItemsControl.ItemsPanel>
+                                                                <ItemsControl.ItemTemplate>
+                                                                    <DataTemplate DataType="{x:Type logger:LoggedSeriesLegendItem}">
+                                                                        <Button Command="{Binding DataContext.ToggleLoggedSeriesVisibilityCommand, RelativeSource={RelativeSource AncestorType=controls:MetroWindow}}"
+                                                                                CommandParameter="{Binding}"
+                                                                                Padding="3,3"
+                                                                                ToolTip="Click to show/hide channel">
+                                                                            <Button.Style>
+                                                                                <Style TargetType="Button" BasedOn="{StaticResource TransparentButtonStyle}">
+                                                                                    <Setter Property="Cursor" Value="Hand"/>
+                                                                                    <Style.Triggers>
+                                                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                                                            <Setter Property="Background" Value="#15FFFFFF"/>
+                                                                                        </Trigger>
+                                                                                    </Style.Triggers>
+                                                                                </Style>
+                                                                            </Button.Style>
+                                                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                                                <!-- Color Swatch -->
+                                                                                <Rectangle Width="12" Height="12"
+                                                                                           Fill="{Binding SeriesColor, Converter={StaticResource OxyColorToBrushConverter}}"
+                                                                                           Margin="0,0,4,0"
+                                                                                           VerticalAlignment="Center">
+                                                                                    <Rectangle.Style>
+                                                                                        <Style TargetType="Rectangle">
+                                                                                            <Setter Property="Opacity" Value="1.0"/>
+                                                                                            <Style.Triggers>
+                                                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                                                                    <Setter Property="Opacity" Value="0.3"/>
+                                                                                                </DataTrigger>
+                                                                                            </Style.Triggers>
+                                                                                        </Style>
+                                                                                    </Rectangle.Style>
+                                                                                </Rectangle>
+                                                                                <!-- Channel Name -->
+                                                                                <TextBlock Text="{Binding ChannelName}"
+                                                                                           FontSize="11"
+                                                                                           VerticalAlignment="Center">
+                                                                                    <TextBlock.Style>
+                                                                                        <Style TargetType="TextBlock">
+                                                                                            <Setter Property="Opacity" Value="1.0"/>
+                                                                                            <Style.Triggers>
+                                                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                                                                    <Setter Property="Opacity" Value="0.4"/>
+                                                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                                                </DataTrigger>
+                                                                                            </Style.Triggers>
+                                                                                        </Style>
+                                                                                    </TextBlock.Style>
+                                                                                </TextBlock>
+                                                                            </StackPanel>
+                                                                        </Button>
+                                                                    </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                            </ItemsControl>
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
                                     </StackPanel>
 
                                 </Grid>

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -518,110 +518,143 @@
                                                        MaxHeight="100"/>
                                     </Grid>
 
-                                    <ListView Grid.Column="1"
-                                              ItemsSource="{Binding DbLogger.LegendItems}"
-                                              Background="Transparent"
-                                              BorderThickness="0"
-                                              HorizontalContentAlignment="Stretch"
-                                              ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                              MaxHeight="400"
-                                              MinWidth="180"
-                                              MaxWidth="220">
-                                        <ListView.ItemContainerStyle>
-                                            <Style TargetType="ListViewItem">
-                                                <Setter Property="Focusable" Value="False"/>
-                                                <Setter Property="Background" Value="Transparent"/>
-                                                <Setter Property="Template">
-                                                    <Setter.Value>
-                                                        <ControlTemplate TargetType="ListViewItem">
-                                                            <ContentPresenter/>
-                                                        </ControlTemplate>
-                                                    </Setter.Value>
-                                                </Setter>
-                                            </Style>
-                                        </ListView.ItemContainerStyle>
-                                        <ListView.ItemTemplate>
-                                            <DataTemplate DataType="{x:Type logger:LoggedSeriesLegendItem}">
-                                                <Button Command="{Binding DataContext.ToggleLoggedSeriesVisibilityCommand, RelativeSource={RelativeSource AncestorType=controls:MetroWindow}}"
-                                                        CommandParameter="{Binding}"
-                                                        Padding="4,6">
-                                                    <Button.ToolTip>
-                                                        <ToolTip>
-                                                            <TextBlock Text="Click to show/hide channel" FontSize="10" FontStyle="Italic"/>
-                                                        </ToolTip>
-                                                    </Button.ToolTip>
-                                                    <Button.Style>
-                                                        <Style TargetType="Button" BasedOn="{StaticResource TransparentButtonStyle}">
-                                                            <Setter Property="Cursor" Value="Hand"/>
-                                                            <Style.Triggers>
-                                                                <Trigger Property="IsMouseOver" Value="True">
-                                                                    <Setter Property="Background" Value="#15FFFFFF"/>
-                                                                </Trigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </Button.Style>
-                                                    <Grid>
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition Width="Auto"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
+                                    <!-- Legend Panel with Collapse Toggle -->
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                        <!-- Collapse/Expand Toggle Button -->
+                                        <Button Command="{Binding DbLogger.ToggleLegendPanelCommand}"
+                                                VerticalAlignment="Top"
+                                                Margin="0,5,0,0"
+                                                Style="{StaticResource FadeButton}"
+                                                ToolTip="Toggle legend">
+                                            <iconPacks:PackIconMaterial Height="12" Width="12" HorizontalAlignment="Center">
+                                                <iconPacks:PackIconMaterial.Style>
+                                                    <Style TargetType="iconPacks:PackIconMaterial">
+                                                        <Setter Property="Kind" Value="ChevronRight"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding DbLogger.IsLegendPanelVisible}" Value="True">
+                                                                <Setter Property="Kind" Value="ChevronLeft"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </iconPacks:PackIconMaterial.Style>
+                                            </iconPacks:PackIconMaterial>
+                                        </Button>
 
-                                                        <!-- Color Indicator -->
-                                                        <Rectangle Grid.Column="0"
-                                                                  Width="16" Height="16"
-                                                                  Fill="{Binding SeriesColor, Converter={StaticResource OxyColorToBrushConverter}}"
-                                                                  Margin="0,0,8,0"
-                                                                  VerticalAlignment="Center">
-                                                            <Rectangle.Style>
-                                                                <Style TargetType="Rectangle">
-                                                                    <Setter Property="Opacity" Value="1.0"/>
-                                                                    <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                                            <Setter Property="Opacity" Value="0.3"/>
-                                                                        </DataTrigger>
-                                                                    </Style.Triggers>
-                                                                </Style>
-                                                            </Rectangle.Style>
-                                                        </Rectangle>
+                                        <!-- Collapsible Legend ListView -->
+                                        <ListView ItemsSource="{Binding DbLogger.LegendItems}"
+                                                  Background="Transparent"
+                                                  BorderThickness="0"
+                                                  HorizontalContentAlignment="Stretch"
+                                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                                  MaxHeight="400"
+                                                  MinWidth="120"
+                                                  MaxWidth="160">
+                                            <ListView.Style>
+                                                <Style TargetType="ListView">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.IsLegendPanelVisible}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </ListView.Style>
+                                            <ListView.ItemContainerStyle>
+                                                <Style TargetType="ListViewItem">
+                                                    <Setter Property="Focusable" Value="False"/>
+                                                    <Setter Property="Background" Value="Transparent"/>
+                                                    <Setter Property="Template">
+                                                        <Setter.Value>
+                                                            <ControlTemplate TargetType="ListViewItem">
+                                                                <ContentPresenter/>
+                                                            </ControlTemplate>
+                                                        </Setter.Value>
+                                                    </Setter>
+                                                </Style>
+                                            </ListView.ItemContainerStyle>
+                                            <ListView.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type logger:LoggedSeriesLegendItem}">
+                                                    <Button Command="{Binding DataContext.ToggleLoggedSeriesVisibilityCommand, RelativeSource={RelativeSource AncestorType=controls:MetroWindow}}"
+                                                            CommandParameter="{Binding}"
+                                                            Padding="4,4">
+                                                        <Button.ToolTip>
+                                                            <ToolTip>
+                                                                <TextBlock Text="{Binding DeviceSerialNo, StringFormat='Click to show/hide channel ({0})'}" FontSize="10" FontStyle="Italic"/>
+                                                            </ToolTip>
+                                                        </Button.ToolTip>
+                                                        <Button.Style>
+                                                            <Style TargetType="Button" BasedOn="{StaticResource TransparentButtonStyle}">
+                                                                <Setter Property="Cursor" Value="Hand"/>
+                                                                <Style.Triggers>
+                                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                                        <Setter Property="Background" Value="#15FFFFFF"/>
+                                                                    </Trigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Button.Style>
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
 
-                                                        <!-- Channel Info -->
-                                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                                            <TextBlock Text="{Binding ChannelName}"
-                                                                      FontSize="12"
-                                                                      FontWeight="Medium">
-                                                                <TextBlock.Style>
-                                                                    <Style TargetType="TextBlock">
+                                                            <!-- Color Indicator -->
+                                                            <Rectangle Grid.Column="0"
+                                                                      Width="14" Height="14"
+                                                                      Fill="{Binding SeriesColor, Converter={StaticResource OxyColorToBrushConverter}}"
+                                                                      Margin="0,0,6,0"
+                                                                      VerticalAlignment="Center">
+                                                                <Rectangle.Style>
+                                                                    <Style TargetType="Rectangle">
                                                                         <Setter Property="Opacity" Value="1.0"/>
-                                                                        <Style.Triggers>
-                                                                            <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                                                <Setter Property="Opacity" Value="0.4"/>
-                                                                                <Setter Property="TextDecorations" Value="Strikethrough"/>
-                                                                            </DataTrigger>
-                                                                        </Style.Triggers>
-                                                                    </Style>
-                                                                </TextBlock.Style>
-                                                            </TextBlock>
-                                                            <TextBlock Text="{Binding DeviceSerialNo}"
-                                                                      FontSize="9"
-                                                                      Opacity="0.6"
-                                                                      Margin="0,1,0,0">
-                                                                <TextBlock.Style>
-                                                                    <Style TargetType="TextBlock">
                                                                         <Style.Triggers>
                                                                             <DataTrigger Binding="{Binding IsVisible}" Value="False">
                                                                                 <Setter Property="Opacity" Value="0.3"/>
                                                                             </DataTrigger>
                                                                         </Style.Triggers>
                                                                     </Style>
-                                                                </TextBlock.Style>
-                                                            </TextBlock>
-                                                        </StackPanel>
-                                                    </Grid>
-                                                </Button>
-                                            </DataTemplate>
-                                        </ListView.ItemTemplate>
-                                    </ListView>
+                                                                </Rectangle.Style>
+                                                            </Rectangle>
+
+                                                            <!-- Channel Info -->
+                                                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                                                <TextBlock Text="{Binding ChannelName}"
+                                                                          FontSize="11"
+                                                                          FontWeight="Medium">
+                                                                    <TextBlock.Style>
+                                                                        <Style TargetType="TextBlock">
+                                                                            <Setter Property="Opacity" Value="1.0"/>
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                                                    <Setter Property="Opacity" Value="0.4"/>
+                                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </TextBlock.Style>
+                                                                </TextBlock>
+                                                                <TextBlock Text="{Binding TruncatedSerialNo}"
+                                                                          FontSize="9"
+                                                                          Opacity="0.5"
+                                                                          Margin="0,0,0,0">
+                                                                    <TextBlock.Style>
+                                                                        <Style TargetType="TextBlock">
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                                                    <Setter Property="Opacity" Value="0.3"/>
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </TextBlock.Style>
+                                                                </TextBlock>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </Button>
+                                                </DataTemplate>
+                                            </ListView.ItemTemplate>
+                                        </ListView>
+                                    </StackPanel>
 
                                 </Grid>
 

--- a/Daqifi.Desktop/View/MinimapInteractionController.cs
+++ b/Daqifi.Desktop/View/MinimapInteractionController.cs
@@ -14,6 +14,8 @@ public class MinimapInteractionController
     private readonly PlotModel _mainPlotModel;
     private readonly PlotModel _minimapPlotModel;
     private readonly RectangleAnnotation _selectionRect;
+    private readonly RectangleAnnotation _dimLeft;
+    private readonly RectangleAnnotation _dimRight;
     private readonly string _mainTimeAxisKey;
     private readonly string _minimapTimeAxisKey;
 
@@ -31,12 +33,16 @@ public class MinimapInteractionController
         PlotModel mainPlotModel,
         PlotModel minimapPlotModel,
         RectangleAnnotation selectionRect,
+        RectangleAnnotation dimLeft,
+        RectangleAnnotation dimRight,
         string mainTimeAxisKey = "Time",
         string minimapTimeAxisKey = "MinimapTime")
     {
         _mainPlotModel = mainPlotModel;
         _minimapPlotModel = minimapPlotModel;
         _selectionRect = selectionRect;
+        _dimLeft = dimLeft;
+        _dimRight = dimRight;
         _mainTimeAxisKey = mainTimeAxisKey;
         _minimapTimeAxisKey = minimapTimeAxisKey;
 
@@ -92,6 +98,8 @@ public class MinimapInteractionController
 
             _selectionRect.MinimumX = newMin;
             _selectionRect.MaximumX = newMax;
+            _dimLeft.MaximumX = newMin;
+            _dimRight.MinimumX = newMax;
             ApplyToMainPlot(newMin, newMax);
             _dragMode = DragMode.Pan;
         }
@@ -209,6 +217,8 @@ public class MinimapInteractionController
         }
 
         mainTimeAxis.Zoom(min, max);
+        _dimLeft.MaximumX = min;
+        _dimRight.MinimumX = max;
         _mainPlotModel.InvalidatePlot(false);
         _minimapPlotModel.InvalidatePlot(false);
     }

--- a/Daqifi.Desktop/View/MinimapInteractionController.cs
+++ b/Daqifi.Desktop/View/MinimapInteractionController.cs
@@ -14,7 +14,7 @@ namespace Daqifi.Desktop.View;
 /// Provides cursor feedback: resize arrows on edges, grab hand inside selection,
 /// and pointer outside.
 /// </summary>
-public class MinimapInteractionController
+public class MinimapInteractionController : IDisposable
 {
     #region Private Fields
     private readonly PlotModel _mainPlotModel;
@@ -302,6 +302,18 @@ public class MinimapInteractionController
     {
         var axis = GetMinimapTimeAxis();
         return axis?.DataMinimum ?? 0;
+    }
+    #endregion
+
+    #region IDisposable
+    /// <summary>
+    /// Unsubscribes all event handlers from the minimap PlotModel.
+    /// </summary>
+    public void Dispose()
+    {
+        _minimapPlotModel.MouseDown -= OnMouseDown;
+        _minimapPlotModel.MouseMove -= OnMouseMove;
+        _minimapPlotModel.MouseUp -= OnMouseUp;
     }
     #endregion
 }

--- a/Daqifi.Desktop/View/MinimapInteractionController.cs
+++ b/Daqifi.Desktop/View/MinimapInteractionController.cs
@@ -30,6 +30,7 @@ public class MinimapInteractionController : IDisposable
     private double _dragStartDataX;
     private double _dragStartRectMin;
     private double _dragStartRectMax;
+    private Cursor _lastCursor;
 
     private const double EDGE_TOLERANCE_FRACTION = 0.02;
     #endregion
@@ -84,13 +85,20 @@ public class MinimapInteractionController : IDisposable
     }
 
     /// <summary>
-    /// Sets the cursor on the WPF PlotView element.
+    /// Sets the cursor on the WPF PlotView element. Skips if unchanged from last value.
     /// </summary>
     private void SetCursor(Cursor cursor)
     {
+        if (cursor == _lastCursor)
+        {
+            return;
+        }
+
+        _lastCursor = cursor;
+
         if (_minimapPlotModel.PlotView is FrameworkElement element)
         {
-            Application.Current?.Dispatcher.Invoke(() => element.Cursor = cursor);
+            Application.Current?.Dispatcher.BeginInvoke(() => element.Cursor = cursor);
         }
     }
     #endregion
@@ -295,7 +303,8 @@ public class MinimapInteractionController : IDisposable
             return 1;
         }
 
-        return axis.DataMaximum - axis.DataMinimum;
+        var range = axis.DataMaximum - axis.DataMinimum;
+        return double.IsNaN(range) || double.IsInfinity(range) || range <= 0 ? 1 : range;
     }
 
     private double GetMinimapDataMin()

--- a/Daqifi.Desktop/View/MinimapInteractionController.cs
+++ b/Daqifi.Desktop/View/MinimapInteractionController.cs
@@ -1,0 +1,238 @@
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.Axes;
+
+namespace Daqifi.Desktop.View;
+
+/// <summary>
+/// Handles mouse interactions on the minimap PlotModel to enable drag/resize
+/// of the selection rectangle, synchronized with the main plot's time axis.
+/// </summary>
+public class MinimapInteractionController
+{
+    #region Private Fields
+    private readonly PlotModel _mainPlotModel;
+    private readonly PlotModel _minimapPlotModel;
+    private readonly RectangleAnnotation _selectionRect;
+    private readonly string _mainTimeAxisKey;
+    private readonly string _minimapTimeAxisKey;
+
+    private enum DragMode { None, Pan, ResizeLeft, ResizeRight }
+    private DragMode _dragMode = DragMode.None;
+    private double _dragStartDataX;
+    private double _dragStartRectMin;
+    private double _dragStartRectMax;
+
+    private const double EDGE_TOLERANCE_FRACTION = 0.02;
+    #endregion
+
+    #region Constructor
+    public MinimapInteractionController(
+        PlotModel mainPlotModel,
+        PlotModel minimapPlotModel,
+        RectangleAnnotation selectionRect,
+        string mainTimeAxisKey = "Time",
+        string minimapTimeAxisKey = "MinimapTime")
+    {
+        _mainPlotModel = mainPlotModel;
+        _minimapPlotModel = minimapPlotModel;
+        _selectionRect = selectionRect;
+        _mainTimeAxisKey = mainTimeAxisKey;
+        _minimapTimeAxisKey = minimapTimeAxisKey;
+
+        _minimapPlotModel.MouseDown += OnMouseDown;
+        _minimapPlotModel.MouseMove += OnMouseMove;
+        _minimapPlotModel.MouseUp += OnMouseUp;
+    }
+    #endregion
+
+    #region Mouse Handlers
+    private void OnMouseDown(object? sender, OxyMouseDownEventArgs e)
+    {
+        if (e.ChangedButton != OxyMouseButton.Left)
+        {
+            return;
+        }
+
+        var minimapTimeAxis = GetMinimapTimeAxis();
+        if (minimapTimeAxis == null)
+        {
+            return;
+        }
+
+        var dataX = minimapTimeAxis.InverseTransform(e.Position.X);
+        var rectMin = _selectionRect.MinimumX;
+        var rectMax = _selectionRect.MaximumX;
+        var rectRange = rectMax - rectMin;
+        var edgeTolerance = Math.Max(rectRange * EDGE_TOLERANCE_FRACTION, GetMinimapDataRange() * 0.005);
+
+        if (Math.Abs(dataX - rectMin) < edgeTolerance)
+        {
+            _dragMode = DragMode.ResizeLeft;
+        }
+        else if (Math.Abs(dataX - rectMax) < edgeTolerance)
+        {
+            _dragMode = DragMode.ResizeRight;
+        }
+        else if (dataX >= rectMin && dataX <= rectMax)
+        {
+            _dragMode = DragMode.Pan;
+        }
+        else
+        {
+            // Click outside: jump rectangle center to click position, then start panning
+            var halfRange = rectRange / 2;
+            var fullRange = GetMinimapDataRange();
+            var fullMin = GetMinimapDataMin();
+            var fullMax = fullMin + fullRange;
+
+            var newMin = Math.Max(fullMin, dataX - halfRange);
+            var newMax = Math.Min(fullMax, newMin + rectRange);
+            newMin = newMax - rectRange;
+
+            _selectionRect.MinimumX = newMin;
+            _selectionRect.MaximumX = newMax;
+            ApplyToMainPlot(newMin, newMax);
+            _dragMode = DragMode.Pan;
+        }
+
+        _dragStartDataX = dataX;
+        _dragStartRectMin = _selectionRect.MinimumX;
+        _dragStartRectMax = _selectionRect.MaximumX;
+
+        e.Handled = true;
+    }
+
+    private void OnMouseMove(object? sender, OxyMouseEventArgs e)
+    {
+        if (_dragMode == DragMode.None)
+        {
+            return;
+        }
+
+        var minimapTimeAxis = GetMinimapTimeAxis();
+        if (minimapTimeAxis == null)
+        {
+            return;
+        }
+
+        var dataX = minimapTimeAxis.InverseTransform(e.Position.X);
+        var delta = dataX - _dragStartDataX;
+        var fullRange = GetMinimapDataRange();
+        var fullMin = GetMinimapDataMin();
+        var fullMax = fullMin + fullRange;
+
+        double newMin, newMax;
+
+        switch (_dragMode)
+        {
+            case DragMode.Pan:
+                newMin = _dragStartRectMin + delta;
+                newMax = _dragStartRectMax + delta;
+
+                // Clamp to minimap bounds
+                if (newMin < fullMin)
+                {
+                    newMax += fullMin - newMin;
+                    newMin = fullMin;
+                }
+                if (newMax > fullMax)
+                {
+                    newMin -= newMax - fullMax;
+                    newMax = fullMax;
+                }
+
+                _selectionRect.MinimumX = newMin;
+                _selectionRect.MaximumX = newMax;
+                ApplyToMainPlot(newMin, newMax);
+                break;
+
+            case DragMode.ResizeLeft:
+                newMin = _dragStartRectMin + delta;
+                newMax = _dragStartRectMax;
+                var minWidth = fullRange * 0.005;
+
+                if (newMin > newMax - minWidth)
+                {
+                    newMin = newMax - minWidth;
+                }
+                if (newMin < fullMin)
+                {
+                    newMin = fullMin;
+                }
+
+                _selectionRect.MinimumX = newMin;
+                _selectionRect.MaximumX = newMax;
+                ApplyToMainPlot(newMin, newMax);
+                break;
+
+            case DragMode.ResizeRight:
+                newMin = _dragStartRectMin;
+                newMax = _dragStartRectMax + delta;
+                minWidth = fullRange * 0.005;
+
+                if (newMax < newMin + minWidth)
+                {
+                    newMax = newMin + minWidth;
+                }
+                if (newMax > fullMax)
+                {
+                    newMax = fullMax;
+                }
+
+                _selectionRect.MinimumX = newMin;
+                _selectionRect.MaximumX = newMax;
+                ApplyToMainPlot(newMin, newMax);
+                break;
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnMouseUp(object? sender, OxyMouseEventArgs e)
+    {
+        if (_dragMode != DragMode.None)
+        {
+            _dragMode = DragMode.None;
+            e.Handled = true;
+        }
+    }
+    #endregion
+
+    #region Private Methods
+    private void ApplyToMainPlot(double min, double max)
+    {
+        var mainTimeAxis = _mainPlotModel.Axes.FirstOrDefault(a => a.Key == _mainTimeAxisKey);
+        if (mainTimeAxis == null)
+        {
+            return;
+        }
+
+        mainTimeAxis.Zoom(min, max);
+        _mainPlotModel.InvalidatePlot(false);
+        _minimapPlotModel.InvalidatePlot(false);
+    }
+
+    private LinearAxis? GetMinimapTimeAxis()
+    {
+        return _minimapPlotModel.Axes.FirstOrDefault(a => a.Key == _minimapTimeAxisKey) as LinearAxis;
+    }
+
+    private double GetMinimapDataRange()
+    {
+        var axis = GetMinimapTimeAxis();
+        if (axis == null)
+        {
+            return 1;
+        }
+
+        return axis.DataMaximum - axis.DataMinimum;
+    }
+
+    private double GetMinimapDataMin()
+    {
+        var axis = GetMinimapTimeAxis();
+        return axis?.DataMinimum ?? 0;
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/View/MinimapInteractionController.cs
+++ b/Daqifi.Desktop/View/MinimapInteractionController.cs
@@ -1,12 +1,18 @@
 using OxyPlot;
 using OxyPlot.Annotations;
 using OxyPlot.Axes;
+using Cursor = System.Windows.Input.Cursor;
+using Cursors = System.Windows.Input.Cursors;
+using Application = System.Windows.Application;
+using FrameworkElement = System.Windows.FrameworkElement;
 
 namespace Daqifi.Desktop.View;
 
 /// <summary>
 /// Handles mouse interactions on the minimap PlotModel to enable drag/resize
 /// of the selection rectangle, synchronized with the main plot's time axis.
+/// Provides cursor feedback: resize arrows on edges, grab hand inside selection,
+/// and pointer outside.
 /// </summary>
 public class MinimapInteractionController
 {
@@ -52,6 +58,43 @@ public class MinimapInteractionController
     }
     #endregion
 
+    #region Cursor Management
+    /// <summary>
+    /// Determines the appropriate cursor based on the mouse position relative
+    /// to the selection rectangle edges and interior.
+    /// </summary>
+    private Cursor GetCursorForPosition(double dataX)
+    {
+        var rectMin = _selectionRect.MinimumX;
+        var rectMax = _selectionRect.MaximumX;
+        var rectRange = rectMax - rectMin;
+        var edgeTolerance = Math.Max(rectRange * EDGE_TOLERANCE_FRACTION, GetMinimapDataRange() * 0.005);
+
+        if (Math.Abs(dataX - rectMin) < edgeTolerance || Math.Abs(dataX - rectMax) < edgeTolerance)
+        {
+            return Cursors.SizeWE;
+        }
+
+        if (dataX >= rectMin && dataX <= rectMax)
+        {
+            return Cursors.Hand;
+        }
+
+        return Cursors.Arrow;
+    }
+
+    /// <summary>
+    /// Sets the cursor on the WPF PlotView element.
+    /// </summary>
+    private void SetCursor(Cursor cursor)
+    {
+        if (_minimapPlotModel.PlotView is FrameworkElement element)
+        {
+            Application.Current?.Dispatcher.Invoke(() => element.Cursor = cursor);
+        }
+    }
+    #endregion
+
     #region Mouse Handlers
     private void OnMouseDown(object? sender, OxyMouseDownEventArgs e)
     {
@@ -75,14 +118,17 @@ public class MinimapInteractionController
         if (Math.Abs(dataX - rectMin) < edgeTolerance)
         {
             _dragMode = DragMode.ResizeLeft;
+            SetCursor(Cursors.SizeWE);
         }
         else if (Math.Abs(dataX - rectMax) < edgeTolerance)
         {
             _dragMode = DragMode.ResizeRight;
+            SetCursor(Cursors.SizeWE);
         }
         else if (dataX >= rectMin && dataX <= rectMax)
         {
             _dragMode = DragMode.Pan;
+            SetCursor(Cursors.ScrollAll);
         }
         else
         {
@@ -102,6 +148,7 @@ public class MinimapInteractionController
             _dimRight.MinimumX = newMax;
             ApplyToMainPlot(newMin, newMax);
             _dragMode = DragMode.Pan;
+            SetCursor(Cursors.ScrollAll);
         }
 
         _dragStartDataX = dataX;
@@ -113,11 +160,6 @@ public class MinimapInteractionController
 
     private void OnMouseMove(object? sender, OxyMouseEventArgs e)
     {
-        if (_dragMode == DragMode.None)
-        {
-            return;
-        }
-
         var minimapTimeAxis = GetMinimapTimeAxis();
         if (minimapTimeAxis == null)
         {
@@ -125,6 +167,14 @@ public class MinimapInteractionController
         }
 
         var dataX = minimapTimeAxis.InverseTransform(e.Position.X);
+
+        // Update cursor on hover when not dragging
+        if (_dragMode == DragMode.None)
+        {
+            SetCursor(GetCursorForPosition(dataX));
+            return;
+        }
+
         var delta = dataX - _dragStartDataX;
         var fullRange = GetMinimapDataRange();
         var fullMin = GetMinimapDataMin();
@@ -202,6 +252,15 @@ public class MinimapInteractionController
         if (_dragMode != DragMode.None)
         {
             _dragMode = DragMode.None;
+
+            // Update cursor based on final position
+            var minimapTimeAxis = GetMinimapTimeAxis();
+            if (minimapTimeAxis != null)
+            {
+                var dataX = minimapTimeAxis.InverseTransform(e.Position.X);
+                SetCursor(GetCursorForPosition(dataX));
+            }
+
             e.Handled = true;
         }
     }


### PR DESCRIPTION
## Summary
- Adds a minimap control below the logged data plot showing a downsampled overview of the full dataset with a draggable/resizable selection rectangle
- Min/Max downsampling (800 buckets, ~1600 output points) enables instant rendering even for 10M+ point datasets
- Two-way synchronization: zooming/panning the main plot updates the minimap indicator, and dragging/resizing the minimap indicator controls the main plot
- Channel visibility toggles sync between main plot and minimap

Closes #147

### New files
- `Daqifi.Desktop/Helpers/MinMaxDownsampler.cs` — O(N) single-pass min/max downsampler
- `Daqifi.Desktop/View/MinimapInteractionController.cs` — Mouse interaction handler for drag (pan), edge-resize (zoom), and click-to-jump on the minimap

### Modified files
- `Daqifi.Desktop/Loggers/DatabaseLogger.cs` — Added MinimapPlotModel, downsampled data population, axis change sync, legend visibility sync
- `Daqifi.Desktop/MainWindow.xaml` — Added 80px minimap PlotView below the main plot, relocated zoom button overlays into inner grid

## Test plan
- [ ] Load a session with data and verify the minimap appears below the main plot with downsampled series
- [ ] Zoom/pan the main plot and verify the selection rectangle updates position/size in real-time
- [ ] Drag the selection rectangle on the minimap and verify the main plot pans accordingly
- [ ] Drag the left/right edges of the selection rectangle and verify the main plot zooms
- [ ] Click outside the rectangle on the minimap and verify it jumps to the click position
- [ ] Reset zoom and verify the rectangle expands to fill the full minimap range
- [ ] Toggle channel visibility in the legend and verify the minimap series visibility matches
- [ ] Load sessions with varying sizes (small, 100K, 1M points) and verify performance
- [ ] Verify zoom/save button overlays remain correctly positioned over the main plot only

🤖 Generated with [Claude Code](https://claude.com/claude-code)