### PR TITLE
fix: update sidebar navigation icons for clarity and consistency

### DIFF
--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -168,7 +168,7 @@
                     <Label>
                         <Label.Content>
                             <StackPanel Width="75" Margin="0,10,0,10">
-                                <iconPacks:PackIconMaterial Kind="ChartLineVariant" HorizontalAlignment="Center" Height="30" Width="30"/>
+                                <iconPacks:PackIconMaterial Kind="ChartTimelineVariant" HorizontalAlignment="Center" Height="30" Width="30"/>
                                 <TextBlock TextWrapping="WrapWithOverflow" Text="Live Graph" TextAlignment="Center" IsEnabled="False"/>
                             </StackPanel>
                         </Label.Content>

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -834,7 +834,7 @@
                     <Label>
                         <Label.Content>
                             <StackPanel Width="75" Margin="0,10,0,10">
-                                <iconPacks:PackIconMaterial Kind="SineWave" HorizontalAlignment="Center" Height="30" Width="30"/>
+                                <iconPacks:PackIconMaterial Kind="HubOutline" HorizontalAlignment="Center" Height="30" Width="30"/>
                                 <TextBlock TextWrapping="WrapWithOverflow" Text="Channels" TextAlignment="Center" IsEnabled="False"/>
                             </StackPanel>
                         </Label.Content>

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -168,7 +168,7 @@
                     <Label>
                         <Label.Content>
                             <StackPanel Width="75" Margin="0,10,0,10">
-                                <iconPacks:PackIconMaterial Kind="ChartLine" HorizontalAlignment="Center" Height="30" Width="30"/>
+                                <iconPacks:PackIconMaterial Kind="ChartLineVariant" HorizontalAlignment="Center" Height="30" Width="30"/>
                                 <TextBlock TextWrapping="WrapWithOverflow" Text="Live Graph" TextAlignment="Center" IsEnabled="False"/>
                             </StackPanel>
                         </Label.Content>
@@ -733,7 +733,7 @@
                     <Label>
                         <Label.Content>
                             <StackPanel Width="75" Margin="0,10,0,10">
-                                <iconPacks:PackIconMaterial Kind="HexagonMultipleOutline" HorizontalAlignment="Center" Height="30" Width="30"/>
+                                <iconPacks:PackIconMaterial Kind="SineWave" HorizontalAlignment="Center" Height="30" Width="30"/>
                                 <TextBlock TextWrapping="WrapWithOverflow" Text="Channels" TextAlignment="Center" IsEnabled="False"/>
                             </StackPanel>
                         </Label.Content>
@@ -930,7 +930,7 @@
                     <Label>
                         <Label.Content>
                             <StackPanel Width="75" Margin="0,10,0,10">
-                                <iconPacks:PackIconMaterial Kind="FaceWomanProfile" HorizontalAlignment="Center" Height="30" Width="30"/>
+                                <iconPacks:PackIconMaterial Kind="TuneVariant" HorizontalAlignment="Center" Height="30" Width="30"/>
                                 <TextBlock TextWrapping="WrapWithOverflow" Text="Profiles" TextAlignment="Center" IsEnabled="False"/>
                             </StackPanel>
                         </Label.Content>


### PR DESCRIPTION
## Summary
- **Live Graph**: `ChartLine` → `ChartLineVariant` (outline style, consistent with other icons)
- **Channels**: `HexagonMultipleOutline` → `SineWave` (waveform icon better represents data acquisition channels)
- **Profiles**: `FaceWomanProfile` → `TuneVariant` (sliders icon conveys saved configuration presets, not user accounts)

## Test plan
- [ ] Build and launch the app
- [ ] Verify all 5 sidebar icons render correctly
- [ ] Confirm icons are visually consistent in style

🤖 Generated with [Claude Code](https://claude.com/claude-code)