### PR TITLE
fix: add cancellation support to DatabaseLogger consumer thread

### DIFF
--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -133,6 +133,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     private DispatcherTimer _settleTimer;
     private int? _currentSessionId;
     private CancellationTokenSource _fetchCts;
+    private readonly CancellationTokenSource _consumerCts = new();
 
     [ObservableProperty]
     private PlotModel _plotModel;
@@ -388,18 +389,20 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     {
         var samples = new List<DataSample>();
         int bufferCount;
-        while (true)
+        while (!_consumerCts.IsCancellationRequested)
         {
             try
             {
                 Thread.Sleep(100);
+
+                if (_consumerCts.IsCancellationRequested) { break; }
 
                 bufferCount = _buffer.Count;
 
                 if (bufferCount < 1) { continue; }
 
                 // Wait if the consumer is suspended (e.g. during delete-all)
-                _consumerGate.Wait();
+                _consumerGate.Wait(_consumerCts.Token);
 
                 // Remove the samples from the collection
                 for (var i = 0; i < bufferCount; i++)
@@ -420,8 +423,13 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                 }
                 samples.Clear();
             }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
             catch (Exception ex)
             {
+                if (_consumerCts.IsCancellationRequested) { break; }
                 _appLogger.Error(ex, "Failed in Consumer Thread");
             }
         }
@@ -1481,7 +1489,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         }
 
         _minimapInteraction?.Dispose();
+        _consumerCts.Cancel();
+        _buffer.CompleteAdding();
         _buffer.Dispose();
+        _consumerCts.Dispose();
         _consumerGate.Dispose();
     }
     #endregion

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -134,6 +134,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     private int? _currentSessionId;
     private CancellationTokenSource _fetchCts;
     private readonly CancellationTokenSource _consumerCts = new();
+    private Thread _consumerThread;
+    private volatile bool _disposed;
 
     [ObservableProperty]
     private PlotModel _plotModel;
@@ -264,8 +266,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         // Initialize minimap PlotModel
         InitializeMinimapPlotModel();
 
-        var consumerThread = new Thread(Consumer) { IsBackground = true };
-        consumerThread.Start();
+        _consumerThread = new Thread(Consumer) { IsBackground = true };
+        _consumerThread.Start();
     }
     #endregion
 
@@ -372,7 +374,14 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     /// <param name="dataSample"></param>
     public void Log(DataSample dataSample)
     {
-        _buffer.Add(dataSample);
+        if (_disposed) { return; }
+
+        try
+        {
+            _buffer.Add(dataSample);
+        }
+        catch (ObjectDisposedException) { }
+        catch (InvalidOperationException) { }
     }
 
     /// <summary>
@@ -1489,8 +1498,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         }
 
         _minimapInteraction?.Dispose();
+        _disposed = true;
         _consumerCts.Cancel();
         _buffer.CompleteAdding();
+        _consumerThread?.Join(TimeSpan.FromSeconds(2));
         _buffer.Dispose();
         _consumerCts.Dispose();
         _consumerGate.Dispose();


### PR DESCRIPTION
## Summary
- Add `CancellationTokenSource` to cleanly shut down the `Consumer()` background thread when `Dispose()` is called
- Replace `while (true)` with cancellation-aware loop that exits on token signal
- Call `CompleteAdding()` and cancel the token **before** disposing the `BlockingCollection`, preventing the infinite error-log loop

Closes #472

## Test plan
- [x] Start a logging session with a connected device, then stop logging and close the application — verify clean shutdown with no error log spam
- [x] Start logging, then navigate away from the logged data view (triggers `Dispose()`) — verify the consumer thread exits and no `ObjectDisposedException` appears in logs
- [ ] Use `SuspendConsumer()` (e.g. delete-all operation) and then dispose — verify the thread is not stuck waiting on the gate and exits promptly
- [ ] Check `%CommonApplicationData%\DAQifi\Logs` after each scenario for unexpected errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)