### PR TITLE
feat: display per-device sampling frequency in session legend

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/DeviceLegendGroupTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/DeviceLegendGroupTests.cs
@@ -1,0 +1,109 @@
+using Daqifi.Desktop.Logger;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+[TestClass]
+public class DeviceLegendGroupTests
+{
+    #region FormatFrequency
+    [TestMethod]
+    public void FormatFrequency_NullOrZero_ReturnsEmptyString()
+    {
+        Assert.AreEqual(string.Empty, DeviceLegendGroup.FormatFrequency(null));
+        Assert.AreEqual(string.Empty, DeviceLegendGroup.FormatFrequency(0));
+        Assert.AreEqual(string.Empty, DeviceLegendGroup.FormatFrequency(-5));
+    }
+
+    [TestMethod]
+    public void FormatFrequency_LessThanOneKilohertz_ReturnsHz()
+    {
+        Assert.AreEqual("1 Hz", DeviceLegendGroup.FormatFrequency(1));
+        Assert.AreEqual("100 Hz", DeviceLegendGroup.FormatFrequency(100));
+        Assert.AreEqual("999 Hz", DeviceLegendGroup.FormatFrequency(999));
+    }
+
+    [TestMethod]
+    public void FormatFrequency_ExactKilohertz_ReturnsWholeKHz()
+    {
+        Assert.AreEqual("1 kHz", DeviceLegendGroup.FormatFrequency(1_000));
+        Assert.AreEqual("10 kHz", DeviceLegendGroup.FormatFrequency(10_000));
+        Assert.AreEqual("100 kHz", DeviceLegendGroup.FormatFrequency(100_000));
+    }
+
+    [TestMethod]
+    public void FormatFrequency_FractionalKilohertz_ReturnsFractionalKHz()
+    {
+        Assert.AreEqual("1.5 kHz", DeviceLegendGroup.FormatFrequency(1_500));
+        Assert.AreEqual("2.25 kHz", DeviceLegendGroup.FormatFrequency(2_250));
+    }
+
+    [TestMethod]
+    public void FormatFrequency_ExactMegahertz_ReturnsWholeMHz()
+    {
+        Assert.AreEqual("1 MHz", DeviceLegendGroup.FormatFrequency(1_000_000));
+        Assert.AreEqual("2 MHz", DeviceLegendGroup.FormatFrequency(2_000_000));
+    }
+
+    [TestMethod]
+    public void FormatFrequency_FractionalMegahertz_ReturnsFractionalMHz()
+    {
+        Assert.AreEqual("1.5 MHz", DeviceLegendGroup.FormatFrequency(1_500_000));
+    }
+    #endregion
+
+    #region SamplingFrequencyHz property
+    [TestMethod]
+    public void SamplingFrequencyHz_Setter_UpdatesDisplayAndHasFrequency()
+    {
+        var group = new DeviceLegendGroup("DAQ-12345");
+
+        Assert.IsFalse(group.HasSamplingFrequency);
+        Assert.AreEqual(string.Empty, group.SamplingFrequencyDisplay);
+
+        group.SamplingFrequencyHz = 1_000;
+
+        Assert.IsTrue(group.HasSamplingFrequency);
+        Assert.AreEqual("1 kHz", group.SamplingFrequencyDisplay);
+    }
+
+    [TestMethod]
+    public void SamplingFrequencyHz_Setter_RaisesPropertyChangedForDependents()
+    {
+        var group = new DeviceLegendGroup("DAQ-12345");
+        var changed = new HashSet<string>();
+        group.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != null) { changed.Add(e.PropertyName); }
+        };
+
+        group.SamplingFrequencyHz = 100;
+
+        Assert.IsTrue(changed.Contains(nameof(DeviceLegendGroup.SamplingFrequencyHz)));
+        Assert.IsTrue(changed.Contains(nameof(DeviceLegendGroup.SamplingFrequencyDisplay)));
+        Assert.IsTrue(changed.Contains(nameof(DeviceLegendGroup.HasSamplingFrequency)));
+    }
+    #endregion
+
+    #region TruncatedSerialNo
+    [TestMethod]
+    public void TruncatedSerialNo_LongSerial_ReturnsLastFourWithEllipsis()
+    {
+        var group = new DeviceLegendGroup("DAQ-1234567890");
+        Assert.AreEqual("...7890", group.TruncatedSerialNo);
+    }
+
+    [TestMethod]
+    public void TruncatedSerialNo_ShortSerial_ReturnsAsIs()
+    {
+        var group = new DeviceLegendGroup("ABCD");
+        Assert.AreEqual("ABCD", group.TruncatedSerialNo);
+    }
+
+    [TestMethod]
+    public void TruncatedSerialNo_NullSerial_ReturnsEmpty()
+    {
+        var group = new DeviceLegendGroup(null);
+        Assert.AreEqual(string.Empty, group.TruncatedSerialNo);
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.Test/Loggers/SessionDeviceMetadataTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SessionDeviceMetadataTests.cs
@@ -1,0 +1,150 @@
+using Daqifi.Desktop.Logger;
+using Microsoft.EntityFrameworkCore;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+[TestClass]
+public class SessionDeviceMetadataTests
+{
+    private string _dbPath;
+    private DbContextOptions<LoggingContext> _options;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"daqifi_metadata_{Guid.NewGuid():N}.db");
+        _options = new DbContextOptionsBuilder<LoggingContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+
+        using var ctx = new LoggingContext(_options);
+        ctx.Database.EnsureCreated();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (File.Exists(_dbPath)) { File.Delete(_dbPath); }
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    [TestMethod]
+    public void DeletingSession_CascadesToSessionDeviceMetadata()
+    {
+        // Arrange — create a session with two device metadata rows
+        using (var ctx = new LoggingContext(_options))
+        {
+            var session = new LoggingSession { ID = 1, Name = "Multi-Device Session" };
+            ctx.Sessions.Add(session);
+            ctx.SessionDeviceMetadata.Add(new SessionDeviceMetadata
+            {
+                LoggingSessionID = 1,
+                DeviceSerialNo = "DAQ-001",
+                DeviceName = "Nyquist 1",
+                SamplingFrequencyHz = 1000
+            });
+            ctx.SessionDeviceMetadata.Add(new SessionDeviceMetadata
+            {
+                LoggingSessionID = 1,
+                DeviceSerialNo = "DAQ-002",
+                DeviceName = "Nyquist 2",
+                SamplingFrequencyHz = 100
+            });
+            ctx.SaveChanges();
+        }
+
+        // Act — delete the parent session via EF, which should cascade
+        using (var ctx = new LoggingContext(_options))
+        {
+            var session = ctx.Sessions.Single(s => s.ID == 1);
+            ctx.Sessions.Remove(session);
+            ctx.SaveChanges();
+        }
+
+        // Assert — no metadata rows remain
+        using (var ctx = new LoggingContext(_options))
+        {
+            Assert.AreEqual(0, ctx.SessionDeviceMetadata.Count(m => m.LoggingSessionID == 1));
+            Assert.AreEqual(0, ctx.Sessions.Count(s => s.ID == 1));
+        }
+    }
+
+    [TestMethod]
+    public void SessionDeviceMetadata_SupportsMultipleDevicesPerSession()
+    {
+        // Arrange
+        using (var ctx = new LoggingContext(_options))
+        {
+            var session = new LoggingSession { ID = 42, Name = "Multi-Device Session" };
+            ctx.Sessions.Add(session);
+            ctx.SessionDeviceMetadata.Add(new SessionDeviceMetadata
+            {
+                LoggingSessionID = 42,
+                DeviceSerialNo = "DAQ-A",
+                DeviceName = "Device A",
+                SamplingFrequencyHz = 1000
+            });
+            ctx.SessionDeviceMetadata.Add(new SessionDeviceMetadata
+            {
+                LoggingSessionID = 42,
+                DeviceSerialNo = "DAQ-B",
+                DeviceName = "Device B",
+                SamplingFrequencyHz = 100
+            });
+            ctx.SaveChanges();
+        }
+
+        // Assert — both rows persist with their distinct frequencies
+        using (var ctx = new LoggingContext(_options))
+        {
+            var rows = ctx.SessionDeviceMetadata
+                .Where(m => m.LoggingSessionID == 42)
+                .OrderBy(m => m.DeviceSerialNo)
+                .ToList();
+
+            Assert.AreEqual(2, rows.Count);
+            Assert.AreEqual("DAQ-A", rows[0].DeviceSerialNo);
+            Assert.AreEqual(1000, rows[0].SamplingFrequencyHz);
+            Assert.AreEqual("DAQ-B", rows[1].DeviceSerialNo);
+            Assert.AreEqual(100, rows[1].SamplingFrequencyHz);
+        }
+    }
+
+    [TestMethod]
+    public void SessionDeviceMetadata_CompositeKey_PreventsDuplicates()
+    {
+        using (var ctx = new LoggingContext(_options))
+        {
+            ctx.Sessions.Add(new LoggingSession { ID = 5, Name = "Dup Test" });
+            ctx.SessionDeviceMetadata.Add(new SessionDeviceMetadata
+            {
+                LoggingSessionID = 5,
+                DeviceSerialNo = "DAQ-DUP",
+                DeviceName = "Original",
+                SamplingFrequencyHz = 100
+            });
+            ctx.SaveChanges();
+        }
+
+        // Inserting a row with the same (sessionId, serial) should fail
+        Assert.ThrowsExactly<DbUpdateException>(() =>
+        {
+            using var ctx = new LoggingContext(_options);
+            ctx.SessionDeviceMetadata.Add(new SessionDeviceMetadata
+            {
+                LoggingSessionID = 5,
+                DeviceSerialNo = "DAQ-DUP",
+                DeviceName = "Duplicate",
+                SamplingFrequencyHz = 200
+            });
+            ctx.SaveChanges();
+        });
+    }
+}

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -617,7 +617,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                 PlotModel.Subtitle = totalSamplesCount > INITIAL_LOAD_POINTS
                     ? "\nLoading full dataset..."
                     : string.Empty;
-                CurrentSessionSampleCount = totalSamplesCount;
+                // Prefer the persisted SampleCount when available; fall back to
+                // the live count computed during this load for sessions that
+                // haven't been finalized yet.
+                CurrentSessionSampleCount = session.SampleCount ?? totalSamplesCount;
 
                 SetupUiCollections(tempSeriesList, tempLegendItemsList);
                 SetupMinimapSeries(initialMinimapData);

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -137,6 +137,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     private readonly CancellationTokenSource _consumerCts = new();
     private Thread _consumerThread;
     private volatile bool _disposed;
+    private volatile bool _consumerBusy;
 
     [ObservableProperty]
     private PlotModel _plotModel;
@@ -167,6 +168,24 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     /// </summary>
     [ObservableProperty]
     private long _currentSessionSampleCount;
+
+    /// <summary>
+    /// Compact magnitude rendering of <see cref="CurrentSessionSampleCount"/>
+    /// (e.g. <c>1.23M</c>) for the chart header. Reuses the same formatter as
+    /// <see cref="LoggingSession.SampleCountDisplay"/> so the header and the
+    /// session list rows stay visually consistent.
+    /// </summary>
+    public string CurrentSessionSampleCountDisplay =>
+        LoggingSession.FormatAbbreviated(CurrentSessionSampleCount);
+
+    public string CurrentSessionSampleCountTooltip =>
+        CurrentSessionSampleCount.ToString("N0", System.Globalization.CultureInfo.CurrentCulture) + " samples";
+
+    partial void OnCurrentSessionSampleCountChanged(long value)
+    {
+        OnPropertyChanged(nameof(CurrentSessionSampleCountDisplay));
+        OnPropertyChanged(nameof(CurrentSessionSampleCountTooltip));
+    }
 
     /// <summary>
     /// Indicates whether a session with data is currently loaded.
@@ -429,6 +448,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                 // Wait if the consumer is suspended (e.g. during delete-all)
                 _consumerGate.Wait(_consumerCts.Token);
 
+                _consumerBusy = true;
+
                 // Remove the samples from the collection
                 for (var i = 0; i < bufferCount; i++)
                 {
@@ -447,13 +468,16 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                     transaction.Commit();
                 }
                 samples.Clear();
+                _consumerBusy = false;
             }
             catch (OperationCanceledException)
             {
+                _consumerBusy = false;
                 break;
             }
             catch (Exception ex)
             {
+                _consumerBusy = false;
                 if (_consumerCts.IsCancellationRequested) { break; }
                 _appLogger.Error(ex, "Failed in Consumer Thread");
             }
@@ -1033,6 +1057,29 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     {
         while (_buffer.TryTake(out _))
         {
+        }
+    }
+
+    /// <summary>
+    /// Blocks until the buffered samples have been flushed to the database, or
+    /// the timeout elapses. Used by <c>LoggingManager</c> when finalizing a
+    /// session so the persisted <c>SampleCount</c> reflects every row that was
+    /// actually written, not just the rows the consumer happened to have
+    /// drained at the moment Active flipped to false.
+    /// </summary>
+    public void WaitForIdle(TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_buffer.Count == 0 && !_consumerBusy)
+            {
+                // Sleep one consumer poll interval to ensure no in-flight item
+                // slipped between TryTake and the busy flag being set.
+                Thread.Sleep(120);
+                if (_buffer.Count == 0 && !_consumerBusy) { return; }
+            }
+            Thread.Sleep(50);
         }
     }
 

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -112,6 +112,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     #region Private Data
     public ObservableCollection<LoggedSeriesLegendItem> LegendItems { get; } = new();
     public ObservableCollection<DeviceLegendGroup> DeviceLegendGroups { get; } = new();
+    private Dictionary<string, int> _sessionDeviceFrequencyHz = new();
     private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _allSessionPoints = new();
     private readonly Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _downsampledCache = new();
     private readonly BlockingCollection<DataSample> _buffer = new();
@@ -461,6 +462,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             _allSessionPoints.Clear();
             _downsampledCache.Clear();
             _minimapSeries.Clear();
+            _sessionDeviceFrequencyHz = new Dictionary<string, int>();
             PlotModel.Series.Clear();
             LegendItems.Clear();
             DeviceLegendGroups.Clear();
@@ -508,6 +510,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             // This eliminates shared mutable state between threads.
             var localPoints = new Dictionary<(string deviceSerial, string channelName), List<DataPoint>>();
             DateTime? localFirstTime = null;
+
+            // Load per-device sampling frequency from session metadata.
+            // Built on this background thread; swapped to shared state on the UI thread.
+            var localDeviceFrequency = LoadSessionDeviceFrequency(session.ID);
 
             // ── Phase 1: Fast initial load (<1s) ──────────────────────────
             // Get channel metadata from first timestamp (6ms via index)
@@ -582,6 +588,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             {
                 _allSessionPoints = localPoints;
                 _firstTime = localFirstTime;
+                _sessionDeviceFrequencyHz = localDeviceFrequency;
 
                 PlotModel.Title = sessionName;
                 PlotModel.Subtitle = totalSamplesCount > INITIAL_LOAD_POINTS
@@ -802,6 +809,39 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     }
 
     /// <summary>
+    /// Loads per-device sampling frequency for a session from <c>SessionDeviceMetadata</c>.
+    /// Returns an empty dictionary for legacy sessions logged before metadata was persisted —
+    /// the legend will simply omit the frequency line for those.
+    /// </summary>
+    /// <param name="sessionId">The session whose device metadata to load.</param>
+    /// <returns>Map of device serial number to configured sampling frequency in Hz.</returns>
+    private Dictionary<string, int> LoadSessionDeviceFrequency(int sessionId)
+    {
+        var result = new Dictionary<string, int>();
+        try
+        {
+            using var context = _loggingContext.CreateDbContext();
+            var metadata = context.SessionDeviceMetadata.AsNoTracking()
+                .Where(m => m.LoggingSessionID == sessionId)
+                .Select(m => new { m.DeviceSerialNo, m.SamplingFrequencyHz })
+                .ToList();
+
+            foreach (var entry in metadata)
+            {
+                if (!string.IsNullOrEmpty(entry.DeviceSerialNo))
+                {
+                    result[entry.DeviceSerialNo] = entry.SamplingFrequencyHz;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _appLogger.Error(ex, "Failed to load SessionDeviceMetadata");
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Sets up UI collections (legend items, device groups, series) on the UI thread.
     /// </summary>
     private void SetupUiCollections(List<LineSeries> seriesList, List<LoggedSeriesLegendItem> legendItems)
@@ -818,6 +858,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             if (!groupDict.TryGetValue(legendItem.DeviceSerialNo, out var group))
             {
                 group = new DeviceLegendGroup(legendItem.DeviceSerialNo);
+                if (_sessionDeviceFrequencyHz.TryGetValue(legendItem.DeviceSerialNo, out var freqHz) && freqHz > 0)
+                {
+                    group.SamplingFrequencyHz = freqHz;
+                }
                 groupDict[legendItem.DeviceSerialNo] = group;
                 DeviceLegendGroups.Add(group);
             }
@@ -912,6 +956,17 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             {
                 cmd.Transaction = transaction;
                 cmd.CommandText = "DELETE FROM Samples WHERE LoggingSessionID = @id";
+                var param = cmd.CreateParameter();
+                param.ParameterName = "@id";
+                param.Value = session.ID;
+                cmd.Parameters.Add(param);
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.Transaction = transaction;
+                cmd.CommandText = "DELETE FROM SessionDeviceMetadata WHERE LoggingSessionID = @id";
                 var param = cmd.CreateParameter();
                 param.ParameterName = "@id";
                 param.Value = session.ID;

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -155,11 +155,18 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
 
     /// <summary>
     /// The session currently displayed in the plot. Bound by the session info
-    /// footer to surface session-level metadata (frequency, etc.) under the
+    /// header to surface session-level metadata (frequency, etc.) above the
     /// chart. Null when no session is loaded.
     /// </summary>
     [ObservableProperty]
     private LoggingSession _currentSession;
+
+    /// <summary>
+    /// Total number of samples in the currently displayed session. Surfaced
+    /// in the session info header. Zero while no session is loaded.
+    /// </summary>
+    [ObservableProperty]
+    private long _currentSessionSampleCount;
 
     /// <summary>
     /// Indicates whether a session with data is currently loaded.
@@ -472,6 +479,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             _minimapSeries.Clear();
             _sessionDeviceFrequencyHz = new Dictionary<string, int>();
             CurrentSession = null;
+            CurrentSessionSampleCount = 0;
             PlotModel.Series.Clear();
             LegendItems.Clear();
             DeviceLegendGroups.Clear();
@@ -547,7 +555,9 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                     Application.Current.Dispatcher.Invoke(() =>
                     {
                         _sessionDeviceFrequencyHz = localDeviceFrequency;
-                        PlotModel.Title = sessionName;
+                        // Title is rendered in the WPF header strip, not by OxyPlot
+                        PlotModel.Title = string.Empty;
+                        CurrentSessionSampleCount = 0;
                         HasSessionData = false;
                         PlotModel.InvalidatePlot(true);
                     });
@@ -601,10 +611,13 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                 _firstTime = localFirstTime;
                 _sessionDeviceFrequencyHz = localDeviceFrequency;
 
-                PlotModel.Title = sessionName;
+                // Session name is rendered in the WPF header strip; keep the
+                // OxyPlot title clear so we don't double up on it.
+                PlotModel.Title = string.Empty;
                 PlotModel.Subtitle = totalSamplesCount > INITIAL_LOAD_POINTS
                     ? "\nLoading full dataset..."
                     : string.Empty;
+                CurrentSessionSampleCount = totalSamplesCount;
 
                 SetupUiCollections(tempSeriesList, tempLegendItemsList);
                 SetupMinimapSeries(initialMinimapData);

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -154,6 +154,14 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     private bool _isLegendPanelVisible = true;
 
     /// <summary>
+    /// The session currently displayed in the plot. Bound by the session info
+    /// footer to surface session-level metadata (frequency, etc.) under the
+    /// chart. Null when no session is loaded.
+    /// </summary>
+    [ObservableProperty]
+    private LoggingSession _currentSession;
+
+    /// <summary>
     /// Indicates whether a session with data is currently loaded.
     /// Controls visibility of the minimap, legend, and empty state placeholder.
     /// </summary>
@@ -463,6 +471,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             _downsampledCache.Clear();
             _minimapSeries.Clear();
             _sessionDeviceFrequencyHz = new Dictionary<string, int>();
+            CurrentSession = null;
             PlotModel.Series.Clear();
             LegendItems.Clear();
             DeviceLegendGroups.Clear();
@@ -498,6 +507,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             // ClearPlot is already dispatcher-wrapped
             ClearPlot();
             _currentSessionId = session.ID;
+            Application.Current.Dispatcher.Invoke(() => CurrentSession = session);
 
             var sessionName = session.Name;
             var subtitle = string.Empty;
@@ -536,6 +546,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                     // Empty session
                     Application.Current.Dispatcher.Invoke(() =>
                     {
+                        _sessionDeviceFrequencyHz = localDeviceFrequency;
                         PlotModel.Title = sessionName;
                         HasSessionData = false;
                         PlotModel.InvalidatePlot(true);
@@ -840,6 +851,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         }
         return result;
     }
+
 
     /// <summary>
     /// Sets up UI collections (legend items, device groups, series) on the UI thread.

--- a/Daqifi.Desktop/Loggers/DeviceLegendGroup.cs
+++ b/Daqifi.Desktop/Loggers/DeviceLegendGroup.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
+using System.Globalization;
 
 namespace Daqifi.Desktop.Logger;
 
@@ -21,6 +22,32 @@ public partial class DeviceLegendGroup : ObservableObject
         : DeviceSerialNo ?? string.Empty;
 
     /// <summary>
+    /// Configured sampling frequency in Hz for this device, captured at log start.
+    /// Null when the frequency is unknown (e.g., legacy sessions logged before
+    /// device metadata was persisted).
+    /// </summary>
+    [ObservableProperty]
+    private int? _samplingFrequencyHz;
+
+    /// <summary>
+    /// User-facing frequency string (e.g., "100 Hz", "1 kHz", "1.5 kHz").
+    /// Returns an empty string when the frequency is unknown.
+    /// </summary>
+    public string SamplingFrequencyDisplay => FormatFrequency(SamplingFrequencyHz);
+
+    partial void OnSamplingFrequencyHzChanged(int? value)
+    {
+        OnPropertyChanged(nameof(SamplingFrequencyDisplay));
+        OnPropertyChanged(nameof(HasSamplingFrequency));
+    }
+
+    /// <summary>
+    /// Whether a frequency is known and should be shown in the UI.
+    /// Bound by the legend XAML to hide the row for legacy sessions.
+    /// </summary>
+    public bool HasSamplingFrequency => SamplingFrequencyHz.HasValue && SamplingFrequencyHz.Value > 0;
+
+    /// <summary>
     /// Channel legend items belonging to this device.
     /// </summary>
     public ObservableCollection<LoggedSeriesLegendItem> Channels { get; } = new();
@@ -32,5 +59,41 @@ public partial class DeviceLegendGroup : ObservableObject
     public DeviceLegendGroup(string deviceSerialNo)
     {
         DeviceSerialNo = deviceSerialNo;
+    }
+
+    /// <summary>
+    /// Formats a frequency value in Hz as a compact, user-friendly string.
+    /// </summary>
+    /// <param name="frequencyHz">Frequency in Hz, or null if unknown.</param>
+    /// <returns>
+    /// A formatted string like "100 Hz", "1 kHz", "1.5 kHz", or "2 MHz".
+    /// Returns an empty string when <paramref name="frequencyHz"/> is null or non-positive.
+    /// </returns>
+    public static string FormatFrequency(int? frequencyHz)
+    {
+        if (!frequencyHz.HasValue || frequencyHz.Value <= 0)
+        {
+            return string.Empty;
+        }
+
+        var hz = frequencyHz.Value;
+
+        if (hz >= 1_000_000)
+        {
+            var mhz = hz / 1_000_000.0;
+            return mhz % 1 == 0
+                ? string.Format(CultureInfo.InvariantCulture, "{0:0} MHz", mhz)
+                : string.Format(CultureInfo.InvariantCulture, "{0:0.##} MHz", mhz);
+        }
+
+        if (hz >= 1_000)
+        {
+            var khz = hz / 1_000.0;
+            return khz % 1 == 0
+                ? string.Format(CultureInfo.InvariantCulture, "{0:0} kHz", khz)
+                : string.Format(CultureInfo.InvariantCulture, "{0:0.##} kHz", khz);
+        }
+
+        return string.Format(CultureInfo.InvariantCulture, "{0} Hz", hz);
     }
 }

--- a/Daqifi.Desktop/Loggers/LoggingContext.cs
+++ b/Daqifi.Desktop/Loggers/LoggingContext.cs
@@ -15,7 +15,11 @@ public class LoggingContext : DbContext
         {
             entity.ToTable("Sessions");
             entity.HasMany(c => c.DataSamples).WithOne(p => p.LoggingSession).IsRequired().OnDelete(DeleteBehavior.Cascade);
-            entity.HasMany(c => c.DeviceMetadata).WithOne(m => m.LoggingSession).HasForeignKey(m => m.LoggingSessionID).IsRequired().OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(c => c.DeviceMetadata)
+                .WithOne(m => m.LoggingSession)
+                .HasForeignKey(m => m.LoggingSessionID)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
             entity.Property(ls => ls.Name).IsRequired();
         });
 

--- a/Daqifi.Desktop/Loggers/LoggingContext.cs
+++ b/Daqifi.Desktop/Loggers/LoggingContext.cs
@@ -15,7 +15,17 @@ public class LoggingContext : DbContext
         {
             entity.ToTable("Sessions");
             entity.HasMany(c => c.DataSamples).WithOne(p => p.LoggingSession).IsRequired().OnDelete(DeleteBehavior.Cascade);
+            entity.HasMany(c => c.DeviceMetadata).WithOne(m => m.LoggingSession).HasForeignKey(m => m.LoggingSessionID).IsRequired().OnDelete(DeleteBehavior.Cascade);
             entity.Property(ls => ls.Name).IsRequired();
+        });
+
+        modelBuilder.Entity<SessionDeviceMetadata>(entity =>
+        {
+            entity.ToTable("SessionDeviceMetadata");
+            entity.HasKey(m => new { m.LoggingSessionID, m.DeviceSerialNo });
+            entity.Property(m => m.DeviceSerialNo).IsRequired();
+            entity.Property(m => m.DeviceName).IsRequired();
+            entity.Property(m => m.SamplingFrequencyHz);
         });
 
         modelBuilder.Entity<DataSample>(entity =>
@@ -36,4 +46,5 @@ public class LoggingContext : DbContext
 
     public DbSet<LoggingSession> Sessions { get; set; }
     public DbSet<DataSample> Samples { get; set; }
+    public DbSet<SessionDeviceMetadata> SessionDeviceMetadata { get; set; }
 }

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -51,6 +51,11 @@ public partial class LoggingManager : ObservableObject
             {
                 if (_hasActiveApplicationSamples)
                 {
+                    // Finalize the session by recording its sample count so the
+                    // list view never has to count rows. One COUNT(*) per
+                    // session, run at most once when the session ends.
+                    PersistSessionSampleCount(Session);
+
                     if (!LoggingSessions.Any(s => s.ID == Session.ID))
                     {
                         LoggingSessions.Add(Session);
@@ -563,6 +568,11 @@ public partial class LoggingManager : ObservableObject
             context.SaveChanges();
         }
 
+        // One-time backfill: any session created before the SampleCount column
+        // existed (or whose count was lost mid-run) gets counted in a single
+        // GROUP BY query, then UPDATEd. Subsequent loads pay no cost.
+        BackfillMissingSampleCounts(context);
+
         return new ObservableCollection<LoggingSession>(
             context.Sessions
                 .AsNoTracking()
@@ -570,6 +580,74 @@ public partial class LoggingManager : ObservableObject
                 .Where(session => context.Samples.Any(sample => sample.LoggingSessionID == session.ID))
                 .OrderBy(session => session.ID)
                 .ToList());
+    }
+
+    /// <summary>
+    /// Persists <see cref="LoggingSession.SampleCount"/> for the given session
+    /// by running a single COUNT against the Samples table. Called when a
+    /// session ends so the list view can surface the count without a query.
+    /// </summary>
+    private void PersistSessionSampleCount(LoggingSession session)
+    {
+        try
+        {
+            using var context = _loggingContext.CreateDbContext();
+            var count = context.Samples.LongCount(s => s.LoggingSessionID == session.ID);
+
+            var tracked = context.Sessions.FirstOrDefault(s => s.ID == session.ID);
+            if (tracked != null)
+            {
+                tracked.SampleCount = count;
+                context.SaveChanges();
+            }
+            // Also surface immediately on the in-memory entity bound by the UI.
+            session.SampleCount = count;
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error(ex, $"Failed to persist sample count for session {session?.ID}");
+        }
+    }
+
+    /// <summary>
+    /// Lazily backfills <see cref="LoggingSession.SampleCount"/> for any
+    /// session whose count is null. Uses a single GROUP BY query covering all
+    /// missing sessions at once, then issues UPDATEs in one transaction. Runs
+    /// at most once per session over the lifetime of the database.
+    /// </summary>
+    private void BackfillMissingSampleCounts(LoggingContext context)
+    {
+        try
+        {
+            var sessionsMissingCount = context.Sessions
+                .Where(s => s.SampleCount == null)
+                .Select(s => s.ID)
+                .ToList();
+
+            if (sessionsMissingCount.Count == 0) { return; }
+
+            var counts = context.Samples
+                .Where(sample => sessionsMissingCount.Contains(sample.LoggingSessionID))
+                .GroupBy(sample => sample.LoggingSessionID)
+                .Select(g => new { SessionId = g.Key, Count = g.LongCount() })
+                .ToList();
+
+            var trackedSessions = context.Sessions
+                .Where(s => sessionsMissingCount.Contains(s.ID))
+                .ToList();
+
+            foreach (var tracked in trackedSessions)
+            {
+                var match = counts.FirstOrDefault(c => c.SessionId == tracked.ID);
+                tracked.SampleCount = match?.Count ?? 0;
+            }
+
+            context.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error(ex, "Failed to backfill SampleCount for legacy sessions");
+        }
     }
 
     /// <summary>

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -51,15 +51,19 @@ public partial class LoggingManager : ObservableObject
             {
                 if (_hasActiveApplicationSamples)
                 {
-                    // Finalize the session by recording its sample count so the
-                    // list view never has to count rows. One COUNT(*) per
-                    // session, run at most once when the session ends.
-                    PersistSessionSampleCount(Session);
-
                     if (!LoggingSessions.Any(s => s.ID == Session.ID))
                     {
                         LoggingSessions.Add(Session);
                     }
+
+                    // Finalize the session by recording its sample count so the
+                    // list view never has to count rows. Runs on a background
+                    // thread because COUNT(*) on a multi-million-row session
+                    // would otherwise block the UI thread that toggled Active.
+                    // The list row updates automatically when SampleCount is
+                    // set, since LoggingSession is INotifyPropertyChanged.
+                    var sessionToFinalize = Session;
+                    _ = Task.Run(() => PersistSessionSampleCount(sessionToFinalize));
                 }
                 else
                 {

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -9,6 +9,7 @@ using Daqifi.Desktop.UpdateVersion;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Daqifi.Desktop;
 
 namespace Daqifi.Desktop.Logger;
 
@@ -98,6 +99,15 @@ public partial class LoggingManager : ObservableObject
                 var name = $"Session_{newId}";
                 Session = new LoggingSession(newId, name);
                 context.Sessions.Add(Session);
+
+                // Capture per-device metadata (sampling frequency, name) for the
+                // devices that own the subscribed channels, so the session UI can
+                // display configuration without re-deriving it from sample data.
+                foreach (var metadata in BuildDeviceMetadataForSession(newId))
+                {
+                    context.SessionDeviceMetadata.Add(metadata);
+                }
+
                 context.SaveChanges();
             }
 
@@ -404,6 +414,59 @@ public partial class LoggingManager : ObservableObject
     }
     #endregion
 
+    /// <summary>
+    /// Builds <see cref="SessionDeviceMetadata"/> rows for every device that has
+    /// at least one subscribed channel at the start of a logging session.
+    /// </summary>
+    /// <param name="sessionId">The id of the session being created.</param>
+    /// <returns>One metadata entry per distinct device serial number.</returns>
+    private IEnumerable<SessionDeviceMetadata> BuildDeviceMetadataForSession(int sessionId)
+    {
+        var subscribedSerials = SubscribedChannels
+            .Select(c => c.DeviceSerialNo)
+            .Where(s => !string.IsNullOrEmpty(s))
+            .Distinct()
+            .ToHashSet();
+
+        if (subscribedSerials.Count == 0)
+        {
+            yield break;
+        }
+
+        var connectedDevices = ConnectionManager.Instance.ConnectedDevices ?? new List<IStreamingDevice>();
+        var emittedSerials = new HashSet<string>();
+
+        foreach (var device in connectedDevices)
+        {
+            if (device == null || string.IsNullOrEmpty(device.DeviceSerialNo))
+            {
+                continue;
+            }
+
+            if (!subscribedSerials.Contains(device.DeviceSerialNo))
+            {
+                continue;
+            }
+
+            // Defensive: ConnectedDevices can briefly contain two entries with the
+            // same serial (e.g., during USB re-enumeration). The composite primary
+            // key on (LoggingSessionID, DeviceSerialNo) would otherwise reject the
+            // second row and abort the session start.
+            if (!emittedSerials.Add(device.DeviceSerialNo))
+            {
+                continue;
+            }
+
+            yield return new SessionDeviceMetadata
+            {
+                LoggingSessionID = sessionId,
+                DeviceSerialNo = device.DeviceSerialNo,
+                DeviceName = device.Name ?? string.Empty,
+                SamplingFrequencyHz = device.StreamingFrequency
+            };
+        }
+    }
+
     public void HandleDeviceMessage(object sender, DeviceMessage sample)
     {
         if (!Active || CurrentMode != LoggingMode.Stream || !_hasActiveApplicationSession)
@@ -510,6 +573,17 @@ public partial class LoggingManager : ObservableObject
             {
                 cmd.Transaction = transaction;
                 cmd.CommandText = "DELETE FROM Samples WHERE LoggingSessionID = @id";
+                var param = cmd.CreateParameter();
+                param.ParameterName = "@id";
+                param.Value = sessionId;
+                cmd.Parameters.Add(param);
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.Transaction = transaction;
+                cmd.CommandText = "DELETE FROM SessionDeviceMetadata WHERE LoggingSessionID = @id";
                 var param = cmd.CreateParameter();
                 param.ParameterName = "@id";
                 param.Value = sessionId;

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -595,6 +595,13 @@ public partial class LoggingManager : ObservableObject
     {
         try
         {
+            // Wait for any buffered samples in DatabaseLogger to be flushed to
+            // disk before counting. Without this, the COUNT can race the
+            // background consumer and persist a permanent undercount, since
+            // BackfillMissingSampleCounts only repairs null values.
+            var dbLogger = Loggers?.OfType<DatabaseLogger>().FirstOrDefault();
+            dbLogger?.WaitForIdle(TimeSpan.FromSeconds(10));
+
             using var context = _loggingContext.CreateDbContext();
             var count = context.Samples.LongCount(s => s.LoggingSessionID == session.ID);
 
@@ -604,8 +611,19 @@ public partial class LoggingManager : ObservableObject
                 tracked.SampleCount = count;
                 context.SaveChanges();
             }
-            // Also surface immediately on the in-memory entity bound by the UI.
-            session.SampleCount = count;
+
+            // Marshal the in-memory mutation onto the UI thread so the
+            // PropertyChanged notification fires on the dispatcher and WPF
+            // bindings update safely.
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null && !dispatcher.CheckAccess())
+            {
+                dispatcher.Invoke(() => session.SampleCount = count);
+            }
+            else
+            {
+                session.SampleCount = count;
+            }
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -103,9 +103,19 @@ public partial class LoggingManager : ObservableObject
                 // Capture per-device metadata (sampling frequency, name) for the
                 // devices that own the subscribed channels, so the session UI can
                 // display configuration without re-deriving it from sample data.
-                foreach (var metadata in BuildDeviceMetadataForSession(newId))
+                // Failures here must not block session creation — the session is
+                // still usable without metadata; the legend just won't show
+                // sampling frequency.
+                try
                 {
-                    context.SessionDeviceMetadata.Add(metadata);
+                    foreach (var metadata in BuildDeviceMetadataForSession(newId))
+                    {
+                        context.SessionDeviceMetadata.Add(metadata);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Error(ex, $"Failed to capture device metadata for session {newId}; continuing without it.");
                 }
 
                 context.SaveChanges();
@@ -419,24 +429,40 @@ public partial class LoggingManager : ObservableObject
     /// at least one subscribed channel at the start of a logging session.
     /// </summary>
     /// <param name="sessionId">The id of the session being created.</param>
-    /// <returns>One metadata entry per distinct device serial number.</returns>
-    private IEnumerable<SessionDeviceMetadata> BuildDeviceMetadataForSession(int sessionId)
+    /// <returns>One materialized metadata entry per distinct device serial number.</returns>
+    /// <remarks>
+    /// Snapshots <see cref="SubscribedChannels"/> and
+    /// <see cref="ConnectionManager.ConnectedDevices"/> up front so the result is
+    /// computed against stable copies — these collections can otherwise mutate
+    /// concurrently (e.g., from device-connection background threads) and throw
+    /// during enumeration. Returns a fully materialized list rather than yielding
+    /// lazily so the caller is never iterating against the live collections.
+    /// Uses <see cref="StringComparer.Ordinal"/> for serial-number deduplication
+    /// because device serials are opaque identifiers, not culture-sensitive text.
+    /// </remarks>
+    private List<SessionDeviceMetadata> BuildDeviceMetadataForSession(int sessionId)
     {
-        var subscribedSerials = SubscribedChannels
+        var result = new List<SessionDeviceMetadata>();
+
+        // Snapshot inputs before iterating to avoid concurrent-modification
+        // exceptions on the underlying mutable lists.
+        var subscribedChannelsSnapshot = SubscribedChannels?.ToList() ?? new List<IChannel>();
+        var connectedDevicesSnapshot = ConnectionManager.Instance.ConnectedDevices?.ToList()
+            ?? new List<IStreamingDevice>();
+
+        var subscribedSerials = subscribedChannelsSnapshot
             .Select(c => c.DeviceSerialNo)
             .Where(s => !string.IsNullOrEmpty(s))
-            .Distinct()
-            .ToHashSet();
+            .ToHashSet(StringComparer.Ordinal);
 
         if (subscribedSerials.Count == 0)
         {
-            yield break;
+            return result;
         }
 
-        var connectedDevices = ConnectionManager.Instance.ConnectedDevices ?? new List<IStreamingDevice>();
-        var emittedSerials = new HashSet<string>();
+        var emittedSerials = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var device in connectedDevices)
+        foreach (var device in connectedDevicesSnapshot)
         {
             if (device == null || string.IsNullOrEmpty(device.DeviceSerialNo))
             {
@@ -457,14 +483,16 @@ public partial class LoggingManager : ObservableObject
                 continue;
             }
 
-            yield return new SessionDeviceMetadata
+            result.Add(new SessionDeviceMetadata
             {
                 LoggingSessionID = sessionId,
                 DeviceSerialNo = device.DeviceSerialNo,
                 DeviceName = device.Name ?? string.Empty,
                 SamplingFrequencyHz = device.StreamingFrequency
-            };
+            });
         }
+
+        return result;
     }
 
     public void HandleDeviceMessage(object sender, DeviceMessage sample)

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -626,11 +626,11 @@ public partial class LoggingManager : ObservableObject
 
             if (sessionsMissingCount.Count == 0) { return; }
 
-            var counts = context.Samples
+            var countsBySession = context.Samples
                 .Where(sample => sessionsMissingCount.Contains(sample.LoggingSessionID))
                 .GroupBy(sample => sample.LoggingSessionID)
                 .Select(g => new { SessionId = g.Key, Count = g.LongCount() })
-                .ToList();
+                .ToDictionary(g => g.SessionId, g => g.Count);
 
             var trackedSessions = context.Sessions
                 .Where(s => sessionsMissingCount.Contains(s.ID))
@@ -638,8 +638,7 @@ public partial class LoggingManager : ObservableObject
 
             foreach (var tracked in trackedSessions)
             {
-                var match = counts.FirstOrDefault(c => c.SessionId == tracked.ID);
-                tracked.SampleCount = match?.Count ?? 0;
+                tracked.SampleCount = countsBySession.TryGetValue(tracked.ID, out var c) ? c : 0;
             }
 
             context.SaveChanges();

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -111,6 +111,10 @@ public partial class LoggingManager : ObservableObject
                     foreach (var metadata in BuildDeviceMetadataForSession(newId))
                     {
                         context.SessionDeviceMetadata.Add(metadata);
+                        // Also attach to the in-memory session so the list view
+                        // and any header binding picks up FrequencyDisplay
+                        // immediately without waiting for a reload.
+                        Session.DeviceMetadata.Add(metadata);
                     }
                 }
                 catch (Exception ex)
@@ -562,6 +566,7 @@ public partial class LoggingManager : ObservableObject
         return new ObservableCollection<LoggingSession>(
             context.Sessions
                 .AsNoTracking()
+                .Include(session => session.DeviceMetadata)
                 .Where(session => context.Samples.Any(sample => sample.LoggingSessionID == session.ID))
                 .OrderBy(session => session.ID)
                 .ToList());

--- a/Daqifi.Desktop/Loggers/LoggingSession.cs
+++ b/Daqifi.Desktop/Loggers/LoggingSession.cs
@@ -8,6 +8,7 @@ public class LoggingSession : ObservableObject
 {
     #region Private Data
     private string _name;
+    private long? _sampleCount;
     #endregion
 
     #region Properties
@@ -18,9 +19,22 @@ public class LoggingSession : ObservableObject
     /// <summary>
     /// Total number of samples persisted for this session, populated when the
     /// session ends and lazy-backfilled on first list load for legacy sessions.
-    /// Null only for sessions that have not been counted yet.
+    /// Null only for sessions that have not been counted yet. Setter notifies
+    /// dependent computed properties so the list view refreshes if the count
+    /// is updated after the entity is already bound.
     /// </summary>
-    public long? SampleCount { get; set; }
+    public long? SampleCount
+    {
+        get => _sampleCount;
+        set
+        {
+            if (SetProperty(ref _sampleCount, value))
+            {
+                OnPropertyChanged(nameof(SampleCountDisplay));
+                OnPropertyChanged(nameof(HasSampleCount));
+            }
+        }
+    }
     public virtual ICollection<Channel.Channel> Channels { get; set; } = new List<Channel.Channel>();
     public virtual ICollection<DataSample> DataSamples { get; set; } = new List<DataSample>();
     public virtual ICollection<SessionDeviceMetadata> DeviceMetadata { get; set; } = new List<SessionDeviceMetadata>();

--- a/Daqifi.Desktop/Loggers/LoggingSession.cs
+++ b/Daqifi.Desktop/Loggers/LoggingSession.cs
@@ -16,6 +16,7 @@ public class LoggingSession : ObservableObject
     public DateTime SessionStart { get; set; }
     public virtual ICollection<Channel.Channel> Channels { get; set; } = new List<Channel.Channel>();
     public virtual ICollection<DataSample> DataSamples { get; set; } = new List<DataSample>();
+    public virtual ICollection<SessionDeviceMetadata> DeviceMetadata { get; set; } = new List<SessionDeviceMetadata>();
 
     public string Name
     {

--- a/Daqifi.Desktop/Loggers/LoggingSession.cs
+++ b/Daqifi.Desktop/Loggers/LoggingSession.cs
@@ -23,6 +23,56 @@ public class LoggingSession : ObservableObject
         get => string.IsNullOrWhiteSpace(_name) ? "Session " + ID : _name;
         set => SetProperty(ref _name, value);
     }
+
+    /// <summary>
+    /// A compact, human-readable summary of each device's sampling frequency
+    /// for this session. Empty for legacy sessions that lack metadata.
+    /// Single device: "10 Hz". Multi device: "...4106: 10 Hz · ...5678: 1 kHz".
+    /// </summary>
+    [NotMapped]
+    public string FrequencyDisplay
+    {
+        get
+        {
+            if (DeviceMetadata == null || DeviceMetadata.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            if (DeviceMetadata.Count == 1)
+            {
+                var only = DeviceMetadata.First();
+                return DeviceLegendGroup.FormatFrequency(only.SamplingFrequencyHz);
+            }
+
+            var parts = new List<string>(DeviceMetadata.Count);
+            foreach (var entry in DeviceMetadata.OrderBy(m => m.DeviceSerialNo, StringComparer.Ordinal))
+            {
+                var formatted = DeviceLegendGroup.FormatFrequency(entry.SamplingFrequencyHz);
+                if (string.IsNullOrEmpty(formatted)) { continue; }
+                var serialTail = !string.IsNullOrEmpty(entry.DeviceSerialNo) && entry.DeviceSerialNo.Length > 4
+                    ? "..." + entry.DeviceSerialNo[^4..]
+                    : entry.DeviceSerialNo ?? string.Empty;
+                parts.Add($"{serialTail}: {formatted}");
+            }
+            return string.Join(" · ", parts);
+        }
+    }
+
+    /// <summary>
+    /// Number of distinct devices participating in this session, derived from
+    /// device metadata. Zero for legacy sessions without metadata.
+    /// </summary>
+    [NotMapped]
+    public int DeviceCount => DeviceMetadata?.Count ?? 0;
+
+    /// <summary>True when <see cref="FrequencyDisplay"/> has content to show.</summary>
+    [NotMapped]
+    public bool HasFrequencyDisplay => !string.IsNullOrEmpty(FrequencyDisplay);
+
+    /// <summary>True when more than one device participated in the session.</summary>
+    [NotMapped]
+    public bool HasMultipleDevices => DeviceCount > 1;
     #endregion
 
     #region Constructors

--- a/Daqifi.Desktop/Loggers/LoggingSession.cs
+++ b/Daqifi.Desktop/Loggers/LoggingSession.cs
@@ -31,6 +31,7 @@ public class LoggingSession : ObservableObject
             if (SetProperty(ref _sampleCount, value))
             {
                 OnPropertyChanged(nameof(SampleCountDisplay));
+                OnPropertyChanged(nameof(SampleCountTooltip));
                 OnPropertyChanged(nameof(HasSampleCount));
             }
         }
@@ -96,13 +97,33 @@ public class LoggingSession : ObservableObject
     public bool HasMultipleDevices => DeviceCount > 1;
 
     /// <summary>
-    /// Sample count formatted with thousands separators (e.g. "16,000"),
-    /// or empty string when the count has not been recorded yet.
+    /// Sample count rendered in compact magnitude notation (e.g. <c>1.23M</c>,
+    /// <c>16K</c>, <c>2.4B</c>). Empty when no count has been recorded yet.
+    /// The full count with thousands separators is exposed via
+    /// <see cref="SampleCountTooltip"/> for hover details.
     /// </summary>
     [NotMapped]
     public string SampleCountDisplay => SampleCount.HasValue
-        ? SampleCount.Value.ToString("N0", System.Globalization.CultureInfo.CurrentCulture)
+        ? FormatAbbreviated(SampleCount.Value)
         : string.Empty;
+
+    /// <summary>
+    /// Full sample count formatted with thousands separators, intended for
+    /// tooltips so the abbreviated display can be expanded on demand.
+    /// </summary>
+    [NotMapped]
+    public string SampleCountTooltip => SampleCount.HasValue
+        ? SampleCount.Value.ToString("N0", System.Globalization.CultureInfo.CurrentCulture) + " samples"
+        : string.Empty;
+
+    public static string FormatAbbreviated(long value)
+    {
+        var culture = System.Globalization.CultureInfo.CurrentCulture;
+        if (value < 1_000) { return value.ToString(culture); }
+        if (value < 1_000_000) { return (value / 1_000d).ToString(value < 10_000 ? "0.0" : "0", culture) + "K"; }
+        if (value < 1_000_000_000) { return (value / 1_000_000d).ToString(value < 10_000_000 ? "0.00" : "0.0", culture) + "M"; }
+        return (value / 1_000_000_000d).ToString(value < 10_000_000_000L ? "0.00" : "0.0", culture) + "B";
+    }
 
     /// <summary>True when <see cref="SampleCount"/> is available.</summary>
     [NotMapped]

--- a/Daqifi.Desktop/Loggers/LoggingSession.cs
+++ b/Daqifi.Desktop/Loggers/LoggingSession.cs
@@ -14,6 +14,13 @@ public class LoggingSession : ObservableObject
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public int ID { get; set; }
     public DateTime SessionStart { get; set; }
+
+    /// <summary>
+    /// Total number of samples persisted for this session, populated when the
+    /// session ends and lazy-backfilled on first list load for legacy sessions.
+    /// Null only for sessions that have not been counted yet.
+    /// </summary>
+    public long? SampleCount { get; set; }
     public virtual ICollection<Channel.Channel> Channels { get; set; } = new List<Channel.Channel>();
     public virtual ICollection<DataSample> DataSamples { get; set; } = new List<DataSample>();
     public virtual ICollection<SessionDeviceMetadata> DeviceMetadata { get; set; } = new List<SessionDeviceMetadata>();
@@ -73,6 +80,19 @@ public class LoggingSession : ObservableObject
     /// <summary>True when more than one device participated in the session.</summary>
     [NotMapped]
     public bool HasMultipleDevices => DeviceCount > 1;
+
+    /// <summary>
+    /// Sample count formatted with thousands separators (e.g. "16,000"),
+    /// or empty string when the count has not been recorded yet.
+    /// </summary>
+    [NotMapped]
+    public string SampleCountDisplay => SampleCount.HasValue
+        ? SampleCount.Value.ToString("N0", System.Globalization.CultureInfo.CurrentCulture)
+        : string.Empty;
+
+    /// <summary>True when <see cref="SampleCount"/> is available.</summary>
+    [NotMapped]
+    public bool HasSampleCount => SampleCount.HasValue;
     #endregion
 
     #region Constructors

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -276,6 +276,26 @@ public class SdCardSessionImporter
         }
 
         _logger.Information($"Imported {samplesProcessed} samples for session '{session.Name}' (ID={session.ID})");
+
+        // Record the sample count on the session so the list view can show it
+        // without falling back to the lazy backfill on the next reload. We
+        // already have the exact count locally, so no extra query is needed.
+        try
+        {
+            using var ctx = _loggingContext.CreateDbContext();
+            var tracked = ctx.Sessions.FirstOrDefault(s => s.ID == session.ID);
+            if (tracked != null)
+            {
+                tracked.SampleCount = samplesProcessed;
+                ctx.SaveChanges();
+            }
+            session.SampleCount = samplesProcessed;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, $"Failed to persist SampleCount for imported session {session.ID}");
+        }
+
         return session;
     }
 

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -289,7 +289,19 @@ public class SdCardSessionImporter
                 tracked.SampleCount = samplesProcessed;
                 ctx.SaveChanges();
             }
-            session.SampleCount = samplesProcessed;
+
+            // Marshal the in-memory mutation onto the UI thread: this importer
+            // is invoked from background tasks, and SampleCount raises
+            // PropertyChanged for WPF bindings.
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null && !dispatcher.CheckAccess())
+            {
+                dispatcher.Invoke(() => session.SampleCount = samplesProcessed);
+            }
+            else
+            {
+                session.SampleCount = samplesProcessed;
+            }
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/Loggers/SessionDeviceMetadata.cs
+++ b/Daqifi.Desktop/Loggers/SessionDeviceMetadata.cs
@@ -1,0 +1,43 @@
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// Per-device metadata captured at the start of a logging session.
+/// Stores the configured sampling frequency and device identification so
+/// that the session UI can display this information without re-deriving
+/// it from sample timestamps.
+/// </summary>
+/// <remarks>
+/// One row is created per (session, device) at logging start. Rows are
+/// removed via cascade delete when the parent <see cref="LoggingSession"/>
+/// is deleted.
+/// </remarks>
+public class SessionDeviceMetadata
+{
+    #region Properties
+    /// <summary>
+    /// Foreign key to the parent <see cref="LoggingSession"/>. Part of the composite primary key.
+    /// </summary>
+    public int LoggingSessionID { get; set; }
+
+    /// <summary>
+    /// Device serial number. Part of the composite primary key so that
+    /// multi-device sessions get one row per device.
+    /// </summary>
+    public string DeviceSerialNo { get; set; }
+
+    /// <summary>
+    /// Friendly device name captured at log start (e.g., "Nyquist 1").
+    /// </summary>
+    public string DeviceName { get; set; }
+
+    /// <summary>
+    /// Configured sampling frequency in Hz at the time logging started.
+    /// </summary>
+    public int SamplingFrequencyHz { get; set; }
+
+    /// <summary>
+    /// Navigation property to the parent session.
+    /// </summary>
+    public LoggingSession LoggingSession { get; set; }
+    #endregion
+}

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -468,13 +468,75 @@
 
                                     <Grid Grid.Column="0">
                                         <Grid.RowDefinitions>
-                                            <RowDefinition Height="*"/>
                                             <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="*"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                         </Grid.RowDefinitions>
 
-                                        <oxy:PlotView Grid.Row="0" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0">
+                                        <!-- Session Header: title + centered metadata strip (hidden when no data) -->
+                                        <StackPanel Grid.Row="0"
+                                                    HorizontalAlignment="Center"
+                                                    Margin="5,8,20,4">
+                                            <StackPanel.Style>
+                                                <Style TargetType="StackPanel">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </StackPanel.Style>
+
+                                            <!-- Session name -->
+                                            <TextBlock Text="{Binding DbLogger.CurrentSession.Name}"
+                                                       FontSize="16" FontWeight="SemiBold"
+                                                       HorizontalAlignment="Center"/>
+
+                                            <!-- Centered metadata strip -->
+                                            <StackPanel Orientation="Horizontal"
+                                                        HorizontalAlignment="Center"
+                                                        Margin="0,2,0,0">
+                                                <!-- Started -->
+                                                <TextBlock FontSize="9" Opacity="0.55" VerticalAlignment="Center"
+                                                           Margin="0,1,3,0" Text="STARTED"/>
+                                                <TextBlock Text="{Binding DbLogger.CurrentSession.SessionStart, StringFormat='{}{0:M/d h:mm tt}'}"
+                                                           FontSize="11" VerticalAlignment="Center"/>
+
+                                                <!-- Sample rate (only when present) -->
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                                            Visibility="{Binding DbLogger.CurrentSession.HasFrequencyDisplay, Converter={StaticResource BoolToVis}}">
+                                                    <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
+                                                    <TextBlock FontSize="9" Opacity="0.55" VerticalAlignment="Center"
+                                                               Margin="0,1,3,0" Text="SAMPLE RATE"/>
+                                                    <TextBlock Text="{Binding DbLogger.CurrentSession.FrequencyDisplay}"
+                                                               FontSize="11" FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                </StackPanel>
+
+                                                <!-- Sample count -->
+                                                <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
+                                                <TextBlock FontSize="9" Opacity="0.55" VerticalAlignment="Center"
+                                                           Margin="0,1,3,0" Text="SAMPLES"/>
+                                                <TextBlock Text="{Binding DbLogger.CurrentSessionSampleCount, StringFormat='{}{0:N0}'}"
+                                                           FontSize="11" FontWeight="SemiBold"
+                                                           VerticalAlignment="Center"/>
+
+                                                <!-- Devices (only when multi-device) -->
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                                            Visibility="{Binding DbLogger.CurrentSession.HasMultipleDevices, Converter={StaticResource BoolToVis}}">
+                                                    <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
+                                                    <TextBlock FontSize="9" Opacity="0.55" VerticalAlignment="Center"
+                                                               Margin="0,1,3,0" Text="DEVICES"/>
+                                                    <TextBlock Text="{Binding DbLogger.CurrentSession.DeviceCount}"
+                                                               FontSize="11" FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+
+                                        <oxy:PlotView Grid.Row="1" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0">
                                             <oxy:PlotView.Style>
                                                 <Style TargetType="oxy:PlotView">
                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -488,7 +550,7 @@
                                         </oxy:PlotView>
 
                                         <!-- Empty State Placeholder -->
-                                        <StackPanel Grid.Row="0"
+                                        <StackPanel Grid.Row="1"
                                                     HorizontalAlignment="Center"
                                                     VerticalAlignment="Center">
                                             <StackPanel.Style>
@@ -512,7 +574,7 @@
                                         </StackPanel>
 
                                         <!-- Save/Zoom button overlays on the main plot -->
-                                        <DockPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top">
+                                        <DockPanel Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Top">
                                             <DockPanel.Style>
                                                 <Style TargetType="DockPanel">
                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -527,7 +589,7 @@
                                                 <iconPacks:PackIconMaterial Kind="ImageOutline" HorizontalAlignment="Center" Height="15" Width="15"/>
                                             </Button>
                                         </DockPanel>
-                                        <DockPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+                                        <DockPanel Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Bottom">
                                             <DockPanel.Style>
                                                 <Style TargetType="DockPanel">
                                                     <Setter Property="Visibility" Value="Visible"/>
@@ -568,7 +630,7 @@
                                         </DockPanel>
 
                                         <!-- Refining data indicator — thin bar between plot and minimap -->
-                                        <ProgressBar Grid.Row="1"
+                                        <ProgressBar Grid.Row="2"
                                                      IsIndeterminate="{Binding DbLogger.IsRefiningData}"
                                                      Height="2"
                                                      Margin="5,0,20,0"
@@ -588,7 +650,7 @@
                                         </ProgressBar>
 
                                         <!-- Overview Minimap (hidden when no data) -->
-                                        <oxy:PlotView Grid.Row="2"
+                                        <oxy:PlotView Grid.Row="3"
                                                        Model="{Binding DbLogger.MinimapPlotModel}"
                                                        Margin="5,0,20,5"
                                                        Height="80">
@@ -603,70 +665,6 @@
                                                 </Style>
                                             </oxy:PlotView.Style>
                                         </oxy:PlotView>
-
-                                        <!-- Session Info Footer (compact metadata strip; hidden when no data) -->
-                                        <Border Grid.Row="3"
-                                                Margin="5,2,20,5"
-                                                Padding="8,4"
-                                                Background="#0FFFFFFF"
-                                                BorderBrush="#1FFFFFFF"
-                                                BorderThickness="0,1,0,0">
-                                            <Border.Style>
-                                                <Style TargetType="Border">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </Border.Style>
-                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <!-- Session name -->
-                                                <TextBlock Text="{Binding DbLogger.CurrentSession.Name}"
-                                                           FontSize="11" FontWeight="SemiBold"
-                                                           VerticalAlignment="Center"/>
-
-                                                <!-- Separator + Started -->
-                                                <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
-                                                <TextBlock FontSize="9"
-                                                           Opacity="0.55"
-                                                           VerticalAlignment="Center"
-                                                           Margin="0,1,3,0"
-                                                           Text="STARTED"/>
-                                                <TextBlock Text="{Binding DbLogger.CurrentSession.SessionStart, StringFormat='{}{0:M/d h:mm tt}'}"
-                                                           FontSize="11"
-                                                           VerticalAlignment="Center"/>
-
-                                                <!-- Separator + Sample rate (only when present) -->
-                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
-                                                            Visibility="{Binding DbLogger.CurrentSession.HasFrequencyDisplay, Converter={StaticResource BoolToVis}}">
-                                                    <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
-                                                    <TextBlock FontSize="9"
-                                                               Opacity="0.55"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,1,3,0"
-                                                               Text="SAMPLE RATE"/>
-                                                    <TextBlock Text="{Binding DbLogger.CurrentSession.FrequencyDisplay}"
-                                                               FontSize="11" FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
-                                                </StackPanel>
-
-                                                <!-- Separator + Devices (only when multi-device) -->
-                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
-                                                            Visibility="{Binding DbLogger.CurrentSession.HasMultipleDevices, Converter={StaticResource BoolToVis}}">
-                                                    <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
-                                                    <TextBlock FontSize="9"
-                                                               Opacity="0.55"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,1,3,0"
-                                                               Text="DEVICES"/>
-                                                    <TextBlock Text="{Binding DbLogger.CurrentSession.DeviceCount}"
-                                                               FontSize="11" FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
-                                                </StackPanel>
-                                            </StackPanel>
-                                        </Border>
                                     </Grid>
 
                                     <!-- Legend Panel with Collapse Toggle (hidden when no data) -->

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -655,6 +655,12 @@
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate DataType="{x:Type logger:DeviceLegendGroup}">
                                                         <StackPanel Margin="0,2,0,4">
+                                                            <!-- Sampling Frequency (hidden for legacy sessions without metadata) -->
+                                                            <TextBlock FontSize="11" FontWeight="SemiBold" Margin="0,0,0,1"
+                                                                       Text="{Binding SamplingFrequencyDisplay, Mode=OneWay}"
+                                                                       ToolTip="Configured sampling frequency"
+                                                                       Visibility="{Binding HasSamplingFrequency, Converter={StaticResource BoolToVis}}"/>
+
                                                             <!-- Device Header -->
                                                             <TextBlock FontSize="9" Opacity="0.6" Margin="0,0,0,2"
                                                                        ToolTip="{Binding DeviceSerialNo}">

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -817,16 +817,32 @@
                                                                 <DockPanel >
                                                                     <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
                                                                         <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
-                                                                        <StackPanel Orientation="Horizontal" Margin="0,1,0,0"
-                                                                                    Visibility="{Binding HasFrequencyDisplay, Converter={StaticResource BoolToVis}}">
-                                                                            <TextBlock Text="SAMPLE RATE  "
-                                                                                       FontSize="8"
-                                                                                       Opacity="0.5"
-                                                                                       VerticalAlignment="Center"/>
-                                                                            <TextBlock Text="{Binding FrequencyDisplay}"
-                                                                                       FontSize="10"
-                                                                                       Opacity="0.85"
-                                                                                       VerticalAlignment="Center"/>
+                                                                        <StackPanel Orientation="Horizontal" Margin="0,1,0,0">
+                                                                            <!-- Sample rate -->
+                                                                            <StackPanel Orientation="Horizontal"
+                                                                                        Visibility="{Binding HasFrequencyDisplay, Converter={StaticResource BoolToVis}}">
+                                                                                <TextBlock Text="SAMPLE RATE  "
+                                                                                           FontSize="8"
+                                                                                           Opacity="0.5"
+                                                                                           VerticalAlignment="Center"/>
+                                                                                <TextBlock Text="{Binding FrequencyDisplay}"
+                                                                                           FontSize="10"
+                                                                                           Opacity="0.85"
+                                                                                           VerticalAlignment="Center"/>
+                                                                            </StackPanel>
+                                                                            <!-- Samples -->
+                                                                            <StackPanel Orientation="Horizontal"
+                                                                                        Margin="8,0,0,0"
+                                                                                        Visibility="{Binding HasSampleCount, Converter={StaticResource BoolToVis}}">
+                                                                                <TextBlock Text="SAMPLES  "
+                                                                                           FontSize="8"
+                                                                                           Opacity="0.5"
+                                                                                           VerticalAlignment="Center"/>
+                                                                                <TextBlock Text="{Binding SampleCountDisplay}"
+                                                                                           FontSize="10"
+                                                                                           Opacity="0.85"
+                                                                                           VerticalAlignment="Center"/>
+                                                                            </StackPanel>
                                                                         </StackPanel>
                                                                     </StackPanel>
 

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -471,6 +471,7 @@
                                             <RowDefinition Height="*"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
                                         </Grid.RowDefinitions>
 
                                         <oxy:PlotView Grid.Row="0" Model="{Binding DbLogger.PlotModel}" Margin="5,5,20,5" TabIndex="0">
@@ -602,6 +603,70 @@
                                                 </Style>
                                             </oxy:PlotView.Style>
                                         </oxy:PlotView>
+
+                                        <!-- Session Info Footer (compact metadata strip; hidden when no data) -->
+                                        <Border Grid.Row="3"
+                                                Margin="5,2,20,5"
+                                                Padding="8,4"
+                                                Background="#0FFFFFFF"
+                                                BorderBrush="#1FFFFFFF"
+                                                BorderThickness="0,1,0,0">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding DbLogger.HasSessionData}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <!-- Session name -->
+                                                <TextBlock Text="{Binding DbLogger.CurrentSession.Name}"
+                                                           FontSize="11" FontWeight="SemiBold"
+                                                           VerticalAlignment="Center"/>
+
+                                                <!-- Separator + Started -->
+                                                <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
+                                                <TextBlock FontSize="9"
+                                                           Opacity="0.55"
+                                                           VerticalAlignment="Center"
+                                                           Margin="0,1,3,0"
+                                                           Text="STARTED"/>
+                                                <TextBlock Text="{Binding DbLogger.CurrentSession.SessionStart, StringFormat='{}{0:M/d h:mm tt}'}"
+                                                           FontSize="11"
+                                                           VerticalAlignment="Center"/>
+
+                                                <!-- Separator + Sample rate (only when present) -->
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                                            Visibility="{Binding DbLogger.CurrentSession.HasFrequencyDisplay, Converter={StaticResource BoolToVis}}">
+                                                    <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
+                                                    <TextBlock FontSize="9"
+                                                               Opacity="0.55"
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,1,3,0"
+                                                               Text="SAMPLE RATE"/>
+                                                    <TextBlock Text="{Binding DbLogger.CurrentSession.FrequencyDisplay}"
+                                                               FontSize="11" FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                </StackPanel>
+
+                                                <!-- Separator + Devices (only when multi-device) -->
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                                            Visibility="{Binding DbLogger.CurrentSession.HasMultipleDevices, Converter={StaticResource BoolToVis}}">
+                                                    <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
+                                                    <TextBlock FontSize="9"
+                                                               Opacity="0.55"
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,1,3,0"
+                                                               Text="DEVICES"/>
+                                                    <TextBlock Text="{Binding DbLogger.CurrentSession.DeviceCount}"
+                                                               FontSize="11" FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Border>
                                     </Grid>
 
                                     <!-- Legend Panel with Collapse Toggle (hidden when no data) -->
@@ -655,41 +720,11 @@
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate DataType="{x:Type logger:DeviceLegendGroup}">
                                                         <StackPanel Margin="0,4,0,8">
-                                                            <!-- Device header strip: serial on the left, sampling frequency on the right -->
-                                                            <Grid Margin="0,0,0,3">
-                                                                <Grid.ColumnDefinitions>
-                                                                    <ColumnDefinition Width="*"/>
-                                                                    <ColumnDefinition Width="Auto"/>
-                                                                </Grid.ColumnDefinitions>
-                                                                <TextBlock Grid.Column="0"
-                                                                           FontSize="10" Opacity="0.7"
-                                                                           VerticalAlignment="Center"
-                                                                           ToolTip="{Binding DeviceSerialNo}">
-                                                                    <Run Text="Device: "/><Run Text="{Binding TruncatedSerialNo, Mode=OneWay}"/>
-                                                                </TextBlock>
-                                                                <Border Grid.Column="1"
-                                                                        Background="#1F1976D2"
-                                                                        BorderBrush="#401976D2"
-                                                                        BorderThickness="1"
-                                                                        CornerRadius="3"
-                                                                        Padding="5,1"
-                                                                        VerticalAlignment="Center"
-                                                                        ToolTip="Configured sampling frequency"
-                                                                        Visibility="{Binding HasSamplingFrequency, Converter={StaticResource BoolToVis}}">
-                                                                    <StackPanel Orientation="Horizontal">
-                                                                        <TextBlock Text="&#xE916;"
-                                                                                   FontFamily="Segoe MDL2 Assets"
-                                                                                   FontSize="9"
-                                                                                   Opacity="0.85"
-                                                                                   VerticalAlignment="Center"
-                                                                                   Margin="0,0,3,0"/>
-                                                                        <TextBlock Text="{Binding SamplingFrequencyDisplay, Mode=OneWay}"
-                                                                                   FontSize="10"
-                                                                                   FontWeight="SemiBold"
-                                                                                   VerticalAlignment="Center"/>
-                                                                    </StackPanel>
-                                                                </Border>
-                                                            </Grid>
+                                                            <!-- Device Header (sampling frequency now lives in the chart subtitle) -->
+                                                            <TextBlock FontSize="10" Opacity="0.7" Margin="0,0,0,3"
+                                                                       ToolTip="{Binding DeviceSerialNo}">
+                                                                <Run Text="Device: "/><Run Text="{Binding TruncatedSerialNo, Mode=OneWay}"/>
+                                                            </TextBlock>
 
                                                             <!-- Channel Grid (2 columns) -->
                                                             <ItemsControl ItemsSource="{Binding Channels}">
@@ -782,7 +817,20 @@
                                                         <DataTemplate>
                                                             <Border>
                                                                 <DockPanel >
-                                                                    <TextBlock Text="{Binding Name}" DockPanel.Dock="Left" FontWeight="Bold" VerticalAlignment="Center"/>
+                                                                    <StackPanel DockPanel.Dock="Left" VerticalAlignment="Center">
+                                                                        <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+                                                                        <StackPanel Orientation="Horizontal" Margin="0,1,0,0"
+                                                                                    Visibility="{Binding HasFrequencyDisplay, Converter={StaticResource BoolToVis}}">
+                                                                            <TextBlock Text="SAMPLE RATE  "
+                                                                                       FontSize="8"
+                                                                                       Opacity="0.5"
+                                                                                       VerticalAlignment="Center"/>
+                                                                            <TextBlock Text="{Binding FrequencyDisplay}"
+                                                                                       FontSize="10"
+                                                                                       Opacity="0.85"
+                                                                                       VerticalAlignment="Center"/>
+                                                                        </StackPanel>
+                                                                    </StackPanel>
 
                                                                     <!-- Delete Logging Session -->
                                                                     <Button DockPanel.Dock="Right" Command="{Binding ElementName=LoggingSessionList, Path=DataContext.DeleteLoggingSessionCommand}" CommandParameter="{Binding}" Background="#88FFFFFF" ToolTip="Delete" Padding="5">

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -654,18 +654,42 @@
                                             <ItemsControl ItemsSource="{Binding DbLogger.DeviceLegendGroups}">
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate DataType="{x:Type logger:DeviceLegendGroup}">
-                                                        <StackPanel Margin="0,2,0,4">
-                                                            <!-- Sampling Frequency (hidden for legacy sessions without metadata) -->
-                                                            <TextBlock FontSize="11" FontWeight="SemiBold" Margin="0,0,0,1"
-                                                                       Text="{Binding SamplingFrequencyDisplay, Mode=OneWay}"
-                                                                       ToolTip="Configured sampling frequency"
-                                                                       Visibility="{Binding HasSamplingFrequency, Converter={StaticResource BoolToVis}}"/>
-
-                                                            <!-- Device Header -->
-                                                            <TextBlock FontSize="9" Opacity="0.6" Margin="0,0,0,2"
-                                                                       ToolTip="{Binding DeviceSerialNo}">
-                                                                <Run Text="Device: "/><Run Text="{Binding TruncatedSerialNo, Mode=OneWay}"/>
-                                                            </TextBlock>
+                                                        <StackPanel Margin="0,4,0,8">
+                                                            <!-- Device header strip: serial on the left, sampling frequency on the right -->
+                                                            <Grid Margin="0,0,0,3">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="*"/>
+                                                                    <ColumnDefinition Width="Auto"/>
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock Grid.Column="0"
+                                                                           FontSize="10" Opacity="0.7"
+                                                                           VerticalAlignment="Center"
+                                                                           ToolTip="{Binding DeviceSerialNo}">
+                                                                    <Run Text="Device: "/><Run Text="{Binding TruncatedSerialNo, Mode=OneWay}"/>
+                                                                </TextBlock>
+                                                                <Border Grid.Column="1"
+                                                                        Background="#1F1976D2"
+                                                                        BorderBrush="#401976D2"
+                                                                        BorderThickness="1"
+                                                                        CornerRadius="3"
+                                                                        Padding="5,1"
+                                                                        VerticalAlignment="Center"
+                                                                        ToolTip="Configured sampling frequency"
+                                                                        Visibility="{Binding HasSamplingFrequency, Converter={StaticResource BoolToVis}}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <TextBlock Text="&#xE916;"
+                                                                                   FontFamily="Segoe MDL2 Assets"
+                                                                                   FontSize="9"
+                                                                                   Opacity="0.85"
+                                                                                   VerticalAlignment="Center"
+                                                                                   Margin="0,0,3,0"/>
+                                                                        <TextBlock Text="{Binding SamplingFrequencyDisplay, Mode=OneWay}"
+                                                                                   FontSize="10"
+                                                                                   FontWeight="SemiBold"
+                                                                                   VerticalAlignment="Center"/>
+                                                                    </StackPanel>
+                                                                </Border>
+                                                            </Grid>
 
                                                             <!-- Channel Grid (2 columns) -->
                                                             <ItemsControl ItemsSource="{Binding Channels}">
@@ -679,6 +703,7 @@
                                                                         <Button Command="{Binding DataContext.ToggleLoggedSeriesVisibilityCommand, RelativeSource={RelativeSource AncestorType=controls:MetroWindow}}"
                                                                                 CommandParameter="{Binding}"
                                                                                 Padding="3,3"
+                                                                                Margin="0,2,4,2"
                                                                                 ToolTip="Click to show/hide channel">
                                                                             <Button.Style>
                                                                                 <Style TargetType="Button" BasedOn="{StaticResource TransparentButtonStyle}">

--- a/Daqifi.Desktop/MainWindow.xaml
+++ b/Daqifi.Desktop/MainWindow.xaml
@@ -519,7 +519,8 @@
                                                 <TextBlock Text="  ·  " FontSize="11" Opacity="0.4" VerticalAlignment="Center"/>
                                                 <TextBlock FontSize="9" Opacity="0.55" VerticalAlignment="Center"
                                                            Margin="0,1,3,0" Text="SAMPLES"/>
-                                                <TextBlock Text="{Binding DbLogger.CurrentSessionSampleCount, StringFormat='{}{0:N0}'}"
+                                                <TextBlock Text="{Binding DbLogger.CurrentSessionSampleCountDisplay}"
+                                                           ToolTip="{Binding DbLogger.CurrentSessionSampleCountTooltip}"
                                                            FontSize="11" FontWeight="SemiBold"
                                                            VerticalAlignment="Center"/>
 
@@ -833,6 +834,7 @@
                                                                             <!-- Samples -->
                                                                             <StackPanel Orientation="Horizontal"
                                                                                         Margin="8,0,0,0"
+                                                                                        ToolTip="{Binding SampleCountTooltip}"
                                                                                         Visibility="{Binding HasSampleCount, Converter={StaticResource BoolToVis}}">
                                                                                 <TextBlock Text="SAMPLES  "
                                                                                            FontSize="8"

--- a/Daqifi.Desktop/Migrations/20260414120000_AddSessionDeviceMetadata.Designer.cs
+++ b/Daqifi.Desktop/Migrations/20260414120000_AddSessionDeviceMetadata.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Daqifi.Desktop.Logger;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Daqifi.Desktop.Migrations;
 
 [DbContext(typeof(LoggingContext))]
-partial class LoggingContextModelSnapshot : ModelSnapshot
+[Migration("20260414120000_AddSessionDeviceMetadata")]
+partial class AddSessionDeviceMetadata
 {
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    /// <inheritdoc />
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
         modelBuilder.HasAnnotation("ProductVersion", "9.0.14");

--- a/Daqifi.Desktop/Migrations/20260414120000_AddSessionDeviceMetadata.cs
+++ b/Daqifi.Desktop/Migrations/20260414120000_AddSessionDeviceMetadata.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Daqifi.Desktop.Migrations;
+
+/// <inheritdoc />
+public partial class AddSessionDeviceMetadata : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "SessionDeviceMetadata",
+            columns: table => new
+            {
+                LoggingSessionID = table.Column<int>(type: "INTEGER", nullable: false),
+                DeviceSerialNo = table.Column<string>(type: "TEXT", nullable: false),
+                DeviceName = table.Column<string>(type: "TEXT", nullable: false),
+                SamplingFrequencyHz = table.Column<int>(type: "INTEGER", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SessionDeviceMetadata", x => new { x.LoggingSessionID, x.DeviceSerialNo });
+                table.ForeignKey(
+                    name: "FK_SessionDeviceMetadata_Sessions_LoggingSessionID",
+                    column: x => x.LoggingSessionID,
+                    principalTable: "Sessions",
+                    principalColumn: "ID",
+                    onDelete: ReferentialAction.Cascade);
+            });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "SessionDeviceMetadata");
+    }
+}

--- a/Daqifi.Desktop/Migrations/20260415000000_AddSessionSampleCount.Designer.cs
+++ b/Daqifi.Desktop/Migrations/20260415000000_AddSessionSampleCount.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Daqifi.Desktop.Logger;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Daqifi.Desktop.Migrations;
 
 [DbContext(typeof(LoggingContext))]
-partial class LoggingContextModelSnapshot : ModelSnapshot
+[Migration("20260415000000_AddSessionSampleCount")]
+partial class AddSessionSampleCount
 {
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    /// <inheritdoc />
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
         modelBuilder.HasAnnotation("ProductVersion", "9.0.14");

--- a/Daqifi.Desktop/Migrations/20260415000000_AddSessionSampleCount.cs
+++ b/Daqifi.Desktop/Migrations/20260415000000_AddSessionSampleCount.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Daqifi.Desktop.Migrations;
+
+/// <inheritdoc />
+public partial class AddSessionSampleCount : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<long>(
+            name: "SampleCount",
+            table: "Sessions",
+            type: "INTEGER",
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "SampleCount",
+            table: "Sessions");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #199. Adds per-device sampling frequency display to the session legend panel, captured at the start of each logging session.

- New `SessionDeviceMetadata` table (composite PK on `LoggingSessionID` + `DeviceSerialNo`) stores the configured `SamplingFrequencyHz`, `DeviceName`, and serial for every device that owns at least one subscribed channel when streaming starts.
- `DeviceLegendGroup` gains `SamplingFrequencyHz` + a `FormatFrequency` helper that renders `100 Hz` / `1 kHz` / `1.5 kHz` / `2 MHz`. The legend XAML shows it above the device serial; the row is hidden via `BoolToVis` for legacy sessions that have no metadata.
- `DatabaseLogger.DisplayLoggingSession` loads metadata on the background thread and swaps it onto the UI thread atomically with the rest of the session state.
- Cascade deletion is wired through every path: EF cascade for `Sessions.Remove` / `RemoveRange`, plus explicit `DELETE FROM SessionDeviceMetadata` in both raw-SQL deletion sites (`LoggingManager.DeleteLoggingSessionIfPresent`, `DatabaseLogger.DeleteLoggingSession`). The "delete all" path nukes the DB file so it's covered automatically.
- Multi-device sessions naturally produce one metadata row per device, so each device shows its own rate.
- Defensive dedupe by serial when iterating `ConnectedDevices` — a transient duplicate during USB re-enumeration would otherwise hit the composite-PK constraint and abort the session start.

This same table is well-positioned to also hold per-device sample counts when #198 is implemented.

## Test plan
- [ ] Start a single-device streaming session and confirm the legend shows the configured frequency above the device serial
- [ ] Start a multi-device session with each device at a different rate and confirm each legend group shows its own frequency
- [ ] Open a session that was logged before this change and confirm the frequency row is hidden (no layout artifacts)
- [ ] Delete a logging session via the per-row delete and confirm the corresponding `SessionDeviceMetadata` rows are gone
- [ ] Delete all sessions and confirm the database recreates cleanly
- [ ] Run `dotnet test Daqifi.Desktop.Test` on Windows — new tests:
  - `DeviceLegendGroupTests` (11 cases) — `FormatFrequency` edge cases, property-change propagation, truncated serial
  - `SessionDeviceMetadataTests` (3 cases) — cascade delete via EF, multi-device per session, composite-key uniqueness

🤖 Generated with [Claude Code](https://claude.com/claude-code)