### PR TITLE
chore(license): add PackageLicenseExpression to .csproj files

### DIFF
--- a/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
+++ b/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 	<PropertyGroup>
 		<AssemblyVersion>3.0.0.0</AssemblyVersion>

--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 	<PropertyGroup>
 		<AssemblyVersion>3.0.0.0</AssemblyVersion>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -3,6 +3,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 	<PropertyGroup>
 		<AssemblyVersion>3.0.0.0</AssemblyVersion>

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -8,6 +8,7 @@
 		<UseWPF>true</UseWPF>
 		<UseWindowsForms>true</UseWindowsForms>
 		<Version>3.1.0</Version>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<InternalsVisibleTo>Daqifi.Desktop.Test</InternalsVisibleTo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<NoWarn>CA1416</NoWarn>


### PR DESCRIPTION
## Summary
- Adds MIT PackageLicenseExpression to Desktop, Common, IO, and DataModel .csproj files

## Context
Part of DAQiFi public repo licensing cleanup. Repo already had MIT LICENSE but .csproj files were missing NuGet license metadata.

## Test plan
- [ ] `dotnet build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)