### PR TITLE
fix: Connect Device dialog close race + empty-selection close

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
@@ -1,0 +1,119 @@
+using Daqifi.Desktop;
+using Daqifi.Desktop.Device.SerialDevice;
+using Daqifi.Desktop.DialogService;
+using Daqifi.Desktop.ViewModels;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+[TestClass]
+public class ConnectionDialogViewModelCloseTests
+{
+    private Func<DuplicateDeviceCheckResult, DuplicateDeviceAction>? _originalDuplicateDeviceHandler;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _originalDuplicateDeviceHandler = ConnectionManager.Instance.DuplicateDeviceHandler;
+        ConnectionManager.Instance.DuplicateDeviceHandler = null;
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        ConnectionManager.Instance.DuplicateDeviceHandler = _originalDuplicateDeviceHandler;
+    }
+
+    [TestMethod]
+    public async Task ConnectCommand_WithEmptySelection_DoesNotRaiseCloseRequested()
+    {
+        var viewModel = CreateViewModel();
+        var closeRaised = SubscribeToClose(viewModel);
+
+        await viewModel.ConnectCommand.ExecuteAsync(new List<object>());
+
+        Assert.IsFalse(closeRaised(), "CloseRequested should not fire when no devices are selected.");
+    }
+
+    [TestMethod]
+    public async Task ConnectCommand_WithNullParameter_DoesNotRaiseCloseRequested()
+    {
+        var viewModel = CreateViewModel();
+        var closeRaised = SubscribeToClose(viewModel);
+
+        await viewModel.ConnectCommand.ExecuteAsync(null);
+
+        Assert.IsFalse(closeRaised(), "CloseRequested should not fire when command parameter is null.");
+    }
+
+    [TestMethod]
+    public async Task ConnectSerialCommand_WithEmptySelection_DoesNotRaiseCloseRequested()
+    {
+        var viewModel = CreateViewModel();
+        var closeRaised = SubscribeToClose(viewModel);
+
+        await viewModel.ConnectSerialCommand.ExecuteAsync(Array.Empty<SerialStreamingDevice>());
+
+        Assert.IsFalse(closeRaised(), "CloseRequested should not fire when no serial devices are selected.");
+    }
+
+    [TestMethod]
+    public async Task ConnectManualSerialCommand_WithBlankPort_DoesNotRaiseCloseRequested()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.ManualPortName = "   ";
+        var closeRaised = SubscribeToClose(viewModel);
+
+        await viewModel.ConnectManualSerialCommand.ExecuteAsync(null);
+
+        Assert.IsFalse(closeRaised(), "CloseRequested should not fire when the manual port is blank.");
+    }
+
+    [TestMethod]
+    public async Task ConnectManualWifiCommand_WithBlankAddress_DoesNotRaiseCloseRequested()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.ManualIpAddress = "";
+        var closeRaised = SubscribeToClose(viewModel);
+
+        await viewModel.ConnectManualWifiCommand.ExecuteAsync(null);
+
+        Assert.IsFalse(closeRaised(), "CloseRequested should not fire when the manual IP is blank.");
+    }
+
+    [TestMethod]
+    public async Task ConnectManualWifiCommand_WithInvalidAddress_DoesNotRaiseCloseRequested()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.ManualIpAddress = "not a valid hostname or ip !@#";
+        var closeRaised = SubscribeToClose(viewModel);
+
+        await viewModel.ConnectManualWifiCommand.ExecuteAsync(null);
+
+        Assert.IsFalse(closeRaised(), "CloseRequested should not fire when the manual endpoint fails to resolve.");
+    }
+
+    [TestMethod]
+    public void Close_CalledMultipleTimes_IsIdempotent()
+    {
+        var viewModel = CreateViewModel();
+
+        viewModel.Close();
+        viewModel.Close();
+        viewModel.Close();
+        // Must not throw — discovery finders are only disposed once.
+    }
+
+    private static ConnectionDialogViewModel CreateViewModel()
+    {
+        var dialogService = new Mock<IDialogService>();
+        return new ConnectionDialogViewModel(dialogService.Object);
+    }
+
+    private static Func<bool> SubscribeToClose(ConnectionDialogViewModel viewModel)
+    {
+        var raised = false;
+        viewModel.CloseRequested += (_, _) => raised = true;
+        return () => raised;
+    }
+}

--- a/Daqifi.Desktop/View/ConnectionDialog.xaml
+++ b/Daqifi.Desktop/View/ConnectionDialog.xaml
@@ -18,7 +18,7 @@
                     <Border>
                         <DockPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" LastChildFill="True" Margin="5" >
                             <!-- Connect Button -->
-                            <Button DockPanel.Dock="Bottom" CommandParameter="{Binding ElementName=DeviceList, Path=SelectedItems}" Command="{Binding ConnectCommand}" Click="btnConnect_Click" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right"  Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                            <Button DockPanel.Dock="Bottom" CommandParameter="{Binding ElementName=DeviceList, Path=SelectedItems}" Command="{Binding ConnectCommand}" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right"  Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
 
                             <!-- Device List -->
                             <ListView Name="DeviceList" ItemsSource="{Binding AvailableWiFiDevices}" SelectionMode="Extended" Margin="5" Background="Transparent" BorderThickness="0">
@@ -54,7 +54,7 @@
                     <Border>
                         <DockPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" LastChildFill="True" Margin="5" >
                             <!-- Connect Button -->
-                            <Button DockPanel.Dock="Bottom" Command="{Binding ConnectManualWifiCommand}" Click="btnConnect_Click" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                            <Button DockPanel.Dock="Bottom" Command="{Binding ConnectManualWifiCommand}" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
 
                             <!-- Manual IP Address -->
                             <StackPanel>
@@ -71,7 +71,7 @@
                     <Border>
                         <DockPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" LastChildFill="True" Margin="5" >
                             <!-- Connect Button -->
-                            <Button DockPanel.Dock="Bottom" CommandParameter="{Binding ElementName=SerialList, Path=SelectedItems}" Command="{Binding ConnectSerialCommand}" Click="btnConnect_Click" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                            <Button DockPanel.Dock="Bottom" CommandParameter="{Binding ElementName=SerialList, Path=SelectedItems}" Command="{Binding ConnectSerialCommand}" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
 
                             <!-- Device List -->
                             <ListView Name="SerialList" ItemsSource="{Binding AvailableSerialDevices}" SelectionMode="Extended" Margin="5" Background="Transparent" BorderThickness="0">
@@ -107,7 +107,7 @@
                     <Border>
                         <DockPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" LastChildFill="True" Margin="5" >
                             <!-- Connect Button -->
-                            <Button DockPanel.Dock="Bottom" CommandParameter="{Binding ElementName=SerialList, Path=SelectedItems}" Command="{Binding ConnectManualSerialCommand}" Click="btnConnect_Click" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                            <Button DockPanel.Dock="Bottom" CommandParameter="{Binding ElementName=SerialList, Path=SelectedItems}" Command="{Binding ConnectManualSerialCommand}" Content="Connect" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
 
                             <!-- Manual COM Port -->
                             <StackPanel>

--- a/Daqifi.Desktop/View/ConnectionDialog.xaml.cs
+++ b/Daqifi.Desktop/View/ConnectionDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using Daqifi.Desktop.ViewModels;
 
 namespace Daqifi.Desktop.View;
@@ -8,19 +8,49 @@ namespace Daqifi.Desktop.View;
 /// </summary>
 public partial class ConnectionDialog
 {
+    private ConnectionDialogViewModel? _subscribedViewModel;
+
     public ConnectionDialog()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
     }
 
-    private void btnConnect_Click(object sender, RoutedEventArgs e)
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
-        Close();
+        if (_subscribedViewModel != null)
+        {
+            _subscribedViewModel.CloseRequested -= OnCloseRequested;
+            _subscribedViewModel = null;
+        }
+
+        if (e.NewValue is ConnectionDialogViewModel viewModel)
+        {
+            _subscribedViewModel = viewModel;
+            viewModel.CloseRequested += OnCloseRequested;
+        }
+    }
+
+    private void OnCloseRequested(object? sender, System.EventArgs e)
+    {
+        // Marshal to the UI thread — connect commands complete on a worker thread.
+        Dispatcher.BeginInvoke(new System.Action(() =>
+        {
+            if (IsLoaded) { Close(); }
+        }));
     }
 
     private void MetroWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
     {
-        var vm = DataContext as ConnectionDialogViewModel;
-        vm.Close();
+        if (_subscribedViewModel != null)
+        {
+            _subscribedViewModel.CloseRequested -= OnCloseRequested;
+            _subscribedViewModel = null;
+        }
+
+        if (DataContext is ConnectionDialogViewModel vm)
+        {
+            vm.Close();
+        }
     }
 }

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -38,6 +38,16 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _hasNoHidDevices = true;
+
+    private bool _closed;
+    #endregion
+
+    #region Events
+    /// <summary>
+    /// Raised when a connect command has completed successfully and the dialog should close.
+    /// The view subscribes and closes itself. Not raised on empty input or failed connect.
+    /// </summary>
+    public event EventHandler? CloseRequested;
     #endregion
 
     #region Properties
@@ -173,27 +183,34 @@ public partial class ConnectionDialogViewModel : ObservableObject
     public IAsyncRelayCommand ConnectManualSerialCommand { get; }
     public IAsyncRelayCommand ConnectManualWifiCommand { get; }
 
-    private async Task ConnectAsync(object selectedItems)
+    private async Task ConnectAsync(object? selectedItems)
     {
+        var selectedDevices = ToStreamingDevices(selectedItems);
+        if (selectedDevices.Count == 0) { return; }
+
         StopWiFiDiscovery();
 
-        var selectedDevices = ((IEnumerable)selectedItems).Cast<IStreamingDevice>();
-
         foreach (var device in selectedDevices)
         {
             await ConnectionManager.Instance.Connect(device);
         }
+
+        RaiseCloseRequested();
     }
 
-    private async Task ConnectSerialAsync(object selectedItems)
+    private async Task ConnectSerialAsync(object? selectedItems)
     {
+        var selectedDevices = ToStreamingDevices(selectedItems);
+        if (selectedDevices.Count == 0) { return; }
+
         await StopSerialDiscoveryAsync();
 
-        var selectedDevices = ((IEnumerable)selectedItems).Cast<IStreamingDevice>();
         foreach (var device in selectedDevices)
         {
             await ConnectionManager.Instance.Connect(device);
         }
+
+        RaiseCloseRequested();
     }
 
     private async Task ConnectManualSerialAsync()
@@ -202,6 +219,8 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         ManualSerialDevice = new SerialStreamingDevice(ManualPortName);
         await ConnectionManager.Instance.Connect(ManualSerialDevice);
+
+        RaiseCloseRequested();
     }
 
     private async Task ConnectManualWifiAsync()
@@ -253,6 +272,19 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         var device = new DaqifiStreamingDevice(deviceInfo);
         await ConnectionManager.Instance.Connect(device);
+
+        RaiseCloseRequested();
+    }
+
+    private static List<IStreamingDevice> ToStreamingDevices(object? selectedItems)
+    {
+        if (selectedItems is not IEnumerable enumerable) { return []; }
+        return enumerable.Cast<IStreamingDevice>().ToList();
+    }
+
+    private void RaiseCloseRequested()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 
     private static async Task<IPAddress?> ResolveManualWifiEndpointAsync(string endpointInput)
@@ -423,6 +455,11 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     public void Close()
     {
+        // Guards against concurrent/double dispose when the window closes while
+        // a connect command is still in flight (either path may call this).
+        if (_closed) { return; }
+        _closed = true;
+
         StopWiFiDiscovery();
         // Fire-and-forget: cancel discovery and clean up without waiting for task completion
         _ = StopSerialDiscoveryAsync();


### PR DESCRIPTION
## Summary
- Fixes two pre-existing bugs in the Connect Device dialog flagged by Qodo on [#488](https://github.com/daqifi/daqifi-desktop/pull/488) and scoped out of that visual redesign. Both date back to the SVN migration (`ec6602d`).
- **Close race:** Connect buttons wired both `Command="{Binding …Command}"` (async) and `Click="btnConnect_Click"` (sync `Close()`). The window closed while the connect task was still running; the `Closing` handler then ran `vm.Close()` which disposed discovery concurrently with the in-flight connect.
- **Connect closes with no selection:** Connect buttons were always enabled — clicking with an empty `SelectedItems` list no-op'd on the VM side but still closed the dialog, so the user thought they'd connected when they hadn't.

## Approach
- `ConnectionDialogViewModel` raises a new `CloseRequested` event **only after** a connect command's awaited work completes successfully. Empty input or failed connect → no event → dialog stays open.
- `ConnectionDialog.xaml.cs` subscribes to `CloseRequested` and marshals to the UI thread before closing the window.
- Removed `Click="btnConnect_Click"` from the 4 action buttons (WiFi, Manual WiFi, USB, Manual USB). The Firmware button was already a no-close case.
- `ConnectionDialogViewModel.Close` is now idempotent — double-invocation (once from the connect path, once from the Closing handler) can't double-dispose discovery finders.
- Added a `ToStreamingDevices` helper that safely casts/lists `SelectedItems` and makes the empty-check explicit.

## Test plan
- [ ] Happy path: pick a WiFi/USB device, click Connect — dialog closes after the VM's connect completes, device shows up connected.
- [ ] Empty selection: click Connect on WiFi tab with no tiles selected — dialog stays open.
- [ ] Manual WiFi / Manual USB: blank field + Connect → dialog stays open; populated field → connects and closes.
- [ ] Firmware tab: select HID device → Firmware dialog opens without closing the Connect dialog (unchanged behavior).
- [ ] Close via X during a slow connect — no double-dispose exceptions in the NLog output at `%CommonApplicationData%\DAQifi\Logs`.
- [ ] New unit tests under `Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs` pass on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)