### PR TITLE
deps: upgrade from .NET 9 to .NET 10

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore
@@ -23,7 +23,7 @@ jobs:
       run: dotnet build --no-restore --configuration Release
 
     - name: Publish Application
-      run: dotnet publish Daqifi.Desktop/Daqifi.Desktop.csproj --configuration Release --output Daqifi.Desktop/bin/Release/net9.0-windows/publish --no-build
+      run: dotnet publish Daqifi.Desktop/Daqifi.Desktop.csproj --configuration Release --output Daqifi.Desktop/bin/Release/net10.0-windows/publish --no-build
 
     - name: Build MSI Installer
       run: |

--- a/Daqifi.Desktop.Common.Test/Daqifi.Desktop.Common.Test.csproj
+++ b/Daqifi.Desktop.Common.Test/Daqifi.Desktop.Common.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>CA1707;CA1416</NoWarn>
   </PropertyGroup>

--- a/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
+++ b/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Daqifi.Desktop.DataModel.Test/Daqifi.Desktop.DataModel.Test.csproj
+++ b/Daqifi.Desktop.DataModel.Test/Daqifi.Desktop.DataModel.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>CA1707;CA1416</NoWarn>
   </PropertyGroup>

--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
+++ b/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
@@ -13,8 +13,6 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Daqifi.Desktop.IO\Daqifi.Desktop.IO.csproj" />

--- a/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
+++ b/Daqifi.Desktop.IO.Test/Daqifi.Desktop.IO.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>CA1707;CA1416</NoWarn>
   </PropertyGroup>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Daqifi.Desktop.Setup/DAQifiDesktopSetup/DAQifiDesktop_Setup.wixproj
+++ b/Daqifi.Desktop.Setup/DAQifiDesktopSetup/DAQifiDesktop_Setup.wixproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <!-- Use published output so all dependencies are present -->
-    <DaqifiSourceDir>$(SolutionDir)..\Daqifi.Desktop\bin\$(Configuration)\net9.0-windows\publish</DaqifiSourceDir>
+    <DaqifiSourceDir>$(SolutionDir)..\Daqifi.Desktop\bin\$(Configuration)\net10.0-windows\publish</DaqifiSourceDir>
     <DaqifiSourceDirShort>$([System.IO.Path]::GetFullPath('$(DaqifiSourceDir)'))</DaqifiSourceDirShort>
     <MainExeName>DAQiFi.exe</MainExeName>
   </PropertyGroup>

--- a/Daqifi.Desktop.Setup/global.json
+++ b/Daqifi.Desktop.Setup/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "10.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
+++ b/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<PlatformTarget>x64</PlatformTarget>

--- a/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
+++ b/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
@@ -16,9 +16,7 @@
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-		<PackageReference Include="System.ValueTuple" Version="4.6.2" />
-		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.5" />
+<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Daqifi.Desktop.DataModel\Daqifi.Desktop.DataModel.csproj" />

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>
@@ -58,14 +58,14 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="Daqifi.Core" Version="0.19.7" />
-		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="9.0.2" />
+		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.14" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.14" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.14">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.0",
+    "version": "10.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
## Summary

- Bumps `TargetFramework` to `net10.0` / `net10.0-windows` across all 8 projects
- Upgrades EF Core packages (`Microsoft.EntityFrameworkCore`, `.Sqlite`, `.Tools`) from `9.0.14` → `10.0.7`
- Upgrades `EFCore.BulkExtensions.Sqlite` from `9.0.2` → `10.0.1`
- Updates both `global.json` files (root and `Daqifi.Desktop.Setup`) to require SDK `10.0.0` minimum

Closes #498 — Dependabot's PR only bumped the Tools package to v10 while leaving the runtime packages on v9, which would have caused a version mismatch. This PR completes the full upgrade together.

## Test plan

- [ ] Install .NET 10 SDK locally (`winget install Microsoft.DotNet.SDK.10` on Windows or `brew install --cask dotnet-sdk` on macOS)
- [ ] `dotnet build` succeeds with no errors
- [ ] `dotnet test` passes all existing tests
- [ ] Run app on Windows and verify device connectivity still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)