### PR TITLE
fix: improve data point tracker overlay readability

### DIFF
--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -1118,13 +1118,17 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         var key = (deviceSerial: deviceSerialNo, channelName);
         localPoints.Add(key, []);
 
+        var serialSuffix = deviceSerialNo?.Length > 4
+            ? $"...{deviceSerialNo[^4..]}"
+            : deviceSerialNo;
+
         var newLineSeries = new LineSeries
         {
             Title = channelName,
             Tag = (deviceSerialNo, channelName),
             Color = OxyColor.Parse(color),
             IsVisible = true,
-            TrackerFormatString = "{0}\n{1}: {2:0.###}\n{3}: {4:0.######}"
+            TrackerFormatString = $"{channelName} ({serialSuffix})\n{{1}}: {{2:0.###}}\n{{3}}: {{4:0.######}}"
         };
 
         var legendItem = new LoggedSeriesLegendItem(

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -1120,10 +1120,11 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
 
         var newLineSeries = new LineSeries
         {
-            Title = $"{channelName} : ({deviceSerialNo})",
+            Title = channelName,
             Tag = (deviceSerialNo, channelName),
             Color = OxyColor.Parse(color),
-            IsVisible = true
+            IsVisible = true,
+            TrackerFormatString = "{0}\n{1}: {2:0.###}\n{3}: {4:0.######}"
         };
 
         var legendItem = new LoggedSeriesLegendItem(

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -242,12 +242,16 @@ public partial class PlotLogger : ObservableObject, ILogger
         var newDataPoints = new List<DataPoint>();
         LoggedPoints.Add(key, newDataPoints);
 
+        var serialSuffix = DeviceSerialNo?.Length > 4
+            ? $"...{DeviceSerialNo[^4..]}"
+            : DeviceSerialNo;
+
         var newLineSeries = new LineSeries
         {
             Title = channelName,
             ItemsSource = newDataPoints,
             Color = OxyColor.Parse(newColor),
-            TrackerFormatString = "{0}\n{1}: {2:0.###}\n{3}: {4:0.######}"
+            TrackerFormatString = $"{channelName} ({serialSuffix})\n{{1}}: {{2:0.###}}\n{{3}}: {{4:0.######}}"
         };
 
         // Synchronize IsVisible with the IChannel

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -246,7 +246,8 @@ public partial class PlotLogger : ObservableObject, ILogger
         {
             Title = channelName,
             ItemsSource = newDataPoints,
-            Color = OxyColor.Parse(newColor)
+            Color = OxyColor.Parse(newColor),
+            TrackerFormatString = "{0}\n{1}: {2:0.###}\n{3}: {4:0.######}"
         };
 
         // Synchronize IsVisible with the IChannel

--- a/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
+++ b/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
@@ -328,7 +328,26 @@
             <Grid Grid.Column="0">
                 <oxy:PlotView x:Name="DataLog"
                               Model="{Binding Plotter.PlotModel}"
-                              TabIndex="0"/>
+                              TabIndex="0">
+                    <oxy:PlotView.DefaultTrackerTemplate>
+                        <ControlTemplate>
+                            <oxy:TrackerControl Position="{Binding Position}"
+                                                LineExtents="{Binding PlotModel.PlotArea}"
+                                                Background="#1E2530"
+                                                BorderBrush="#3A4252"
+                                                BorderThickness="1"
+                                                LineStroke="#3A4252"
+                                                CornerRadius="4">
+                                <TextBlock Text="{Binding Text}"
+                                           Foreground="#F5F5F7"
+                                           FontFamily="Segoe UI"
+                                           FontSize="11"
+                                           LineHeight="18"
+                                           Margin="10,7"/>
+                            </oxy:TrackerControl>
+                        </ControlTemplate>
+                    </oxy:PlotView.DefaultTrackerTemplate>
+                </oxy:PlotView>
 
                 <!-- Empty-state overlay: shown when no channels are streaming -->
                 <Border IsHitTestVisible="False"

--- a/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
+++ b/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
@@ -333,14 +333,14 @@
                         <ControlTemplate>
                             <oxy:TrackerControl Position="{Binding Position}"
                                                 LineExtents="{Binding PlotModel.PlotArea}"
-                                                Background="#1E2530"
-                                                BorderBrush="#3A4252"
+                                                Background="{StaticResource SurfaceActive}"
+                                                BorderBrush="{StaticResource BorderBright}"
                                                 BorderThickness="1"
-                                                LineStroke="#3A4252"
+                                                LineStroke="{StaticResource BorderBright}"
                                                 CornerRadius="4">
                                 <TextBlock Text="{Binding Text}"
-                                           Foreground="#F5F5F7"
-                                           FontFamily="Segoe UI"
+                                           Foreground="{StaticResource TextPrimary}"
+                                           FontFamily="Consolas"
                                            FontSize="11"
                                            LineHeight="18"
                                            Margin="10,7"/>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -413,14 +413,14 @@
                                 <ControlTemplate>
                                     <oxy:TrackerControl Position="{Binding Position}"
                                                         LineExtents="{Binding PlotModel.PlotArea}"
-                                                        Background="#1E2530"
-                                                        BorderBrush="#3A4252"
+                                                        Background="{StaticResource SurfaceActive}"
+                                                        BorderBrush="{StaticResource BorderBright}"
                                                         BorderThickness="1"
-                                                        LineStroke="#3A4252"
+                                                        LineStroke="{StaticResource BorderBright}"
                                                         CornerRadius="4">
                                         <TextBlock Text="{Binding Text}"
-                                                   Foreground="#F5F5F7"
-                                                   FontFamily="Segoe UI"
+                                                   Foreground="{StaticResource TextPrimary}"
+                                                   FontFamily="Consolas"
                                                    FontSize="11"
                                                    LineHeight="18"
                                                    Margin="10,7"/>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -409,6 +409,24 @@
                         <oxy:PlotView Grid.Row="1"
                                       Model="{Binding DbLogger.PlotModel}"
                                       Margin="16,8,16,0">
+                            <oxy:PlotView.DefaultTrackerTemplate>
+                                <ControlTemplate>
+                                    <oxy:TrackerControl Position="{Binding Position}"
+                                                        LineExtents="{Binding PlotModel.PlotArea}"
+                                                        Background="#1E2530"
+                                                        BorderBrush="#3A4252"
+                                                        BorderThickness="1"
+                                                        LineStroke="#3A4252"
+                                                        CornerRadius="4">
+                                        <TextBlock Text="{Binding Text}"
+                                                   Foreground="#F5F5F7"
+                                                   FontFamily="Segoe UI"
+                                                   FontSize="11"
+                                                   LineHeight="18"
+                                                   Margin="10,7"/>
+                                    </oxy:TrackerControl>
+                                </ControlTemplate>
+                            </oxy:PlotView.DefaultTrackerTemplate>
                             <oxy:PlotView.Style>
                                 <Style TargetType="oxy:PlotView">
                                     <Setter Property="Visibility" Value="Visible"/>


### PR DESCRIPTION
## Summary

- Stripped the device serial number from the series `Title` (was showing as `AI9 : (9090539562006014104)` in the tracker — unreadably long and noisy)
- Added a `TrackerFormatString` with sensible decimal precision (`0.###` for time, `0.######` for voltage)
- Added a `DefaultTrackerTemplate` to the main `PlotView` that matches the app's dark design tokens: `#1E2530` background, `#3A4252` border/crosshair lines, `#F5F5F7` text, 4px corner radius

The custom legend items already store `ChannelName` and `DeviceSerialNo` separately and render them independently, so removing the serial from the series title has no effect on the legend panel.

## Test plan

- [ ] Open a session in Logged Data — hover over any trace and confirm the overlay shows dark background with white text (no more light-yellow tooltip)
- [ ] Confirm tracker title shows just the channel name (e.g. `AI9`) not the serial number
- [ ] Confirm Time and Analog values show with reasonable decimal places
- [ ] Confirm the legend panel still shows the correct channel names with their device grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)