### PR TITLE
feat(logged-data): in-pane dark confirm dialog for delete actions

### DIFF
--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -1022,5 +1022,57 @@
             </StackPanel>
         </Grid>
 
+        <!-- ========== CONFIRM DIALOG (over everything) ========== -->
+        <Grid Visibility="{Binding IsConfirmOpen, Converter={StaticResource BoolToVis}}"
+              Panel.ZIndex="30">
+            <!-- Scrim. Click = cancel (same pattern as the drawer). -->
+            <Rectangle Fill="#A0000000">
+                <Rectangle.InputBindings>
+                    <MouseBinding MouseAction="LeftClick" Command="{Binding ConfirmNegativeCommand}"/>
+                </Rectangle.InputBindings>
+            </Rectangle>
+
+            <!-- Card -->
+            <Border Width="420"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Background="{StaticResource SurfaceRaised}"
+                    BorderBrush="{StaticResource BorderDim}"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="24">
+                <StackPanel>
+                    <TextBlock Text="{Binding ConfirmTitle}"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Foreground="{StaticResource TextPrimary}"/>
+                    <TextBlock Text="{Binding ConfirmMessage}"
+                               FontSize="13"
+                               Foreground="{StaticResource TextSecondary}"
+                               TextWrapping="Wrap"
+                               Margin="0,10,0,20"/>
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Right">
+                        <Button Content="CANCEL"
+                                Style="{StaticResource PillButton}"
+                                IsCancel="True"
+                                Command="{Binding ConfirmNegativeCommand}"/>
+                        <!-- Affirmative is one of two styles depending on whether the
+                             confirmed action is destructive; only one is visible at a time. -->
+                        <Button Content="{Binding ConfirmAffirmativeLabel}"
+                                Style="{StaticResource AccentPillButton}"
+                                Margin="10,0,0,0"
+                                Command="{Binding ConfirmAffirmativeCommand}"
+                                Visibility="{Binding ConfirmAffirmativeIsDestructive, Converter={StaticResource InvertedBoolToVis}}"/>
+                        <Button Content="{Binding ConfirmAffirmativeLabel}"
+                                Style="{StaticResource DangerPillButton}"
+                                Margin="10,0,0,0"
+                                Command="{Binding ConfirmAffirmativeCommand}"
+                                Visibility="{Binding ConfirmAffirmativeIsDestructive, Converter={StaticResource BoolToVis}}"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Grid>
+
     </Grid>
 </UserControl>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -1023,8 +1023,15 @@
         </Grid>
 
         <!-- ========== CONFIRM DIALOG (over everything) ========== -->
-        <Grid Visibility="{Binding IsConfirmOpen, Converter={StaticResource BoolToVis}}"
-              Panel.ZIndex="30">
+        <!-- Focusable + Cycle traps Tab inside the overlay so keyboard focus can't reach
+             the now-scrim-covered controls behind. Initial focus is moved to the Cancel
+             button by code-behind on IsVisibleChanged so the safe option is the default. -->
+        <Grid x:Name="ConfirmOverlay"
+              Visibility="{Binding IsConfirmOpen, Converter={StaticResource BoolToVis}}"
+              Panel.ZIndex="30"
+              Focusable="True"
+              KeyboardNavigation.TabNavigation="Cycle"
+              IsVisibleChanged="OnConfirmOverlayIsVisibleChanged">
             <!-- Scrim. Click = cancel (same pattern as the drawer). -->
             <Rectangle Fill="#A0000000">
                 <Rectangle.InputBindings>
@@ -1053,7 +1060,8 @@
                                Margin="0,10,0,20"/>
                     <StackPanel Orientation="Horizontal"
                                 HorizontalAlignment="Right">
-                        <Button Content="CANCEL"
+                        <Button x:Name="ConfirmCancelButton"
+                                Content="CANCEL"
                                 Style="{StaticResource PillButton}"
                                 IsCancel="True"
                                 Command="{Binding ConfirmNegativeCommand}"/>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml.cs
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml.cs
@@ -27,6 +27,22 @@ public partial class LoggedDataPanePrototype
         };
     }
 
+    /// <summary>
+    /// Moves keyboard focus to the Cancel button when the confirm overlay becomes visible,
+    /// so Enter/Space activates the safe option by default. The TabNavigation="Cycle" on
+    /// the overlay grid then traps subsequent Tab navigation inside the dialog.
+    /// </summary>
+    private void OnConfirmOverlayIsVisibleChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
+    {
+        if (e.NewValue is true)
+        {
+            // Defer until the visual tree has finished switching states; calling Focus
+            // directly inside the change handler can race the visibility transition.
+            Dispatcher.BeginInvoke(new Action(() => ConfirmCancelButton.Focus()),
+                System.Windows.Threading.DispatcherPriority.Input);
+        }
+    }
+
     private async void OnSessionNameChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
     {
         if ((DataContext as DaqifiViewModel)?.SelectedLoggingSession is not LoggingSession session ||

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -78,6 +78,16 @@ public partial class DaqifiViewModel : ObservableObject
     [ObservableProperty]
     private bool _isAppSettingsOpen;
 
+    // In-pane confirm dialog state (used by ShowConfirm for delete confirmations, etc.).
+    // Bound by the LoggedDataPane confirm overlay; replaces the MahApps MessageDialog
+    // (white card / blue theme) which clashed with the dark, tile-based design system.
+    [ObservableProperty] private bool _isConfirmOpen;
+    [ObservableProperty] private string _confirmTitle = string.Empty;
+    [ObservableProperty] private string _confirmMessage = string.Empty;
+    [ObservableProperty] private string _confirmAffirmativeLabel = "OK";
+    [ObservableProperty] private bool _confirmAffirmativeIsDestructive;
+    private TaskCompletionSource<bool>? _confirmTcs;
+
     private SettingsViewModel? _appSettings;
 
     /// <summary>
@@ -413,6 +423,8 @@ public partial class DaqifiViewModel : ObservableObject
     public AsyncRelayCommand DeleteAllLoggingSessionCommand { get; private set; }
     public ICommand ToggleChannelVisibilityCommand { get; private set; }
     public ICommand ToggleLoggedSeriesVisibilityCommand { get; private set; }
+    public IRelayCommand ConfirmAffirmativeCommand { get; }
+    public IRelayCommand ConfirmNegativeCommand { get; }
     #endregion
 
     #region Constructor
@@ -452,6 +464,9 @@ public partial class DaqifiViewModel : ObservableObject
         _firmwareUpdateService = firmwareUpdateService ?? CreateDefaultFirmwareUpdateService(_firmwareDownloadService, resolvedLogger);
         _loggingContextFactory = loggingContextFactory;
         _wifiFirmwareUpdateServiceFactory = wifiFirmwareUpdateServiceFactory ?? CreateWifiFirmwareUpdateService;
+
+        ConfirmAffirmativeCommand = new RelayCommand(() => CompleteConfirm(true));
+        ConfirmNegativeCommand = new RelayCommand(() => CompleteConfirm(false));
 
         var app = Application.Current as App;
         if (app != null)
@@ -1345,8 +1360,12 @@ public partial class DaqifiViewModel : ObservableObject
 
             SelectedLoggingSession = session;
 
-            var result = await ShowMessage("Delete Confirmation", $"Are you sure you want to delete {SelectedLoggingSession.Name}?", MessageDialogStyle.AffirmativeAndNegative);
-            if (result != MessageDialogResult.Affirmative)
+            var confirmed = await ShowConfirm(
+                "Delete Confirmation",
+                $"Are you sure you want to delete {SelectedLoggingSession.Name}?",
+                affirmativeLabel: "DELETE",
+                isDestructive: true);
+            if (!confirmed)
             {
                 return;
             }
@@ -1410,11 +1429,12 @@ public partial class DaqifiViewModel : ObservableObject
                 return;
             }
 
-            var result = await ShowMessage(
+            var confirmed = await ShowConfirm(
                 "Delete Confirmation",
                 "Are you sure you want to delete all logging sessions? This cannot be undone.",
-                MessageDialogStyle.AffirmativeAndNegative);
-            if (result != MessageDialogResult.Affirmative)
+                affirmativeLabel: "DELETE ALL",
+                isDestructive: true);
+            if (!confirmed)
             {
                 return;
             }
@@ -1836,6 +1856,37 @@ public partial class DaqifiViewModel : ObservableObject
     {
         var metroWindow = Application.Current.MainWindow as MetroWindow;
         return await metroWindow.ShowMessageAsync(title, message, dialogStyle, metroWindow.MetroDialogOptions);
+    }
+
+    /// <summary>
+    /// Displays the in-pane dark confirm overlay and returns true if the user
+    /// chose the affirmative button. Bound by the LoggedDataPane confirm overlay
+    /// via <see cref="IsConfirmOpen"/>, <see cref="ConfirmTitle"/>,
+    /// <see cref="ConfirmMessage"/>, and <see cref="ConfirmAffirmativeLabel"/>;
+    /// the two button commands complete the underlying
+    /// <see cref="TaskCompletionSource{TResult}"/>.
+    /// </summary>
+    private Task<bool> ShowConfirm(string title, string message, string affirmativeLabel = "OK", bool isDestructive = false)
+    {
+        // Defensive: if a prior confirm is somehow still pending, cancel it
+        // with a negative so the previous awaiter unwinds cleanly.
+        _confirmTcs?.TrySetResult(false);
+
+        _confirmTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        ConfirmTitle = title;
+        ConfirmMessage = message;
+        ConfirmAffirmativeLabel = affirmativeLabel;
+        ConfirmAffirmativeIsDestructive = isDestructive;
+        IsConfirmOpen = true;
+        return _confirmTcs.Task;
+    }
+
+    private void CompleteConfirm(bool result)
+    {
+        IsConfirmOpen = false;
+        var tcs = _confirmTcs;
+        _confirmTcs = null;
+        tcs?.TrySetResult(result);
     }
     public void CloseFlyouts()
     {

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -81,11 +81,26 @@ public partial class DaqifiViewModel : ObservableObject
     // In-pane confirm dialog state (used by ShowConfirm for delete confirmations, etc.).
     // Bound by the LoggedDataPane confirm overlay; replaces the MahApps MessageDialog
     // (white card / blue theme) which clashed with the dark, tile-based design system.
+
+    /// <summary>True while the in-pane confirm overlay is visible.</summary>
     [ObservableProperty] private bool _isConfirmOpen;
+
+    /// <summary>Title shown at the top of the confirm overlay card.</summary>
     [ObservableProperty] private string _confirmTitle = string.Empty;
+
+    /// <summary>Body message shown in the confirm overlay card.</summary>
     [ObservableProperty] private string _confirmMessage = string.Empty;
+
+    /// <summary>Label shown on the affirmative button of the confirm overlay (e.g. "DELETE").</summary>
     [ObservableProperty] private string _confirmAffirmativeLabel = "OK";
+
+    /// <summary>
+    /// When true, the confirm overlay's affirmative button uses the danger style
+    /// (red outline) instead of the accent style (filled blue). Set by destructive
+    /// callers of <see cref="ShowConfirm"/>.
+    /// </summary>
     [ObservableProperty] private bool _confirmAffirmativeIsDestructive;
+
     private TaskCompletionSource<bool>? _confirmTcs;
 
     private SettingsViewModel? _appSettings;
@@ -267,6 +282,10 @@ public partial class DaqifiViewModel : ObservableObject
         {
             _selectedIndex = value;
             CloseFlyouts();
+            // Cancel any pending confirm overlay so its awaiter (e.g. an in-flight
+            // delete) doesn't get stranded when the user navigates away from the
+            // pane that owns the overlay.
+            CompleteConfirm(false);
             OnPropertyChanged();
         }
     }
@@ -423,7 +442,16 @@ public partial class DaqifiViewModel : ObservableObject
     public AsyncRelayCommand DeleteAllLoggingSessionCommand { get; private set; }
     public ICommand ToggleChannelVisibilityCommand { get; private set; }
     public ICommand ToggleLoggedSeriesVisibilityCommand { get; private set; }
+    /// <summary>
+    /// Resolves the confirm overlay's awaitable Task with <c>true</c>.
+    /// Bound to the affirmative button.
+    /// </summary>
     public IRelayCommand ConfirmAffirmativeCommand { get; }
+
+    /// <summary>
+    /// Resolves the confirm overlay's awaitable Task with <c>false</c>.
+    /// Bound to the cancel button and the scrim.
+    /// </summary>
     public IRelayCommand ConfirmNegativeCommand { get; }
     #endregion
 
@@ -1866,7 +1894,11 @@ public partial class DaqifiViewModel : ObservableObject
     /// the two button commands complete the underlying
     /// <see cref="TaskCompletionSource{TResult}"/>.
     /// </summary>
-    private Task<bool> ShowConfirm(string title, string message, string affirmativeLabel = "OK", bool isDestructive = false)
+    private Task<bool> ShowConfirm(
+        string title,
+        string message,
+        string affirmativeLabel = "OK",
+        bool isDestructive = false)
     {
         // Defensive: if a prior confirm is somehow still pending, cancel it
         // with a negative so the previous awaiter unwinds cleanly.


### PR DESCRIPTION
## Summary

- Replaces the white MahApps Delete Confirmation dialog (single-session and "delete all") with the same dark in-pane overlay pattern the Profiles pane adopted in 18b7f04 — scrim + 420px card on `SurfaceRaised`, matching the rest of the Logged Data pane.
- Adds an `isDestructive` flag to `ShowConfirm` so destructive affirmatives use `DangerPillButton` (red) instead of `AccentPillButton` (blue). The pattern source (Profiles "switch") was non-destructive; both delete confirms here are destructive and pass `isDestructive: true`.
- `IsCancel="True"` on Cancel so Escape dismisses the dialog. `IsDefault` on the affirmative was deliberately skipped — a global Enter triggering an irreversible delete is exactly the kind of accidental data loss the confirm step exists to prevent.

The "Cannot Delete" logging-active alert still uses MahApps. It's a single-button info dialog, different shape, separate follow-up.

## Before / after

The screenshot in the originating thread shows the white MahApps card sitting on top of the dark Logged Data pane. After this PR, the confirm renders as a 420px `SurfaceRaised` card with `BorderDim` stroke, `TextPrimary` title, `TextSecondary` body, and a red `DangerPillButton` "DELETE ALL" / "DELETE" affirmative.

## Test plan

- [ ] Open Logged Data → click DELETE ALL on the bottom action bar → confirm renders as a dark card; affirmative is red and labeled "DELETE ALL"
- [ ] Click Cancel → dialog closes, no sessions deleted
- [ ] Click the scrim (outside the card) → dialog closes, no sessions deleted
- [ ] Press Escape → dialog closes, no sessions deleted
- [ ] Click DELETE ALL → DELETE ALL → loading overlay appears, all sessions are removed
- [ ] Open the session settings drawer → click the trash icon on a single session → confirm shows the session name; affirmative is red and labeled "DELETE"
- [ ] Confirm single delete → only that session is removed
- [ ] Start logging → click DELETE ALL → "Cannot Delete" info dialog still appears (still MahApps, intentional out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)