### PR TITLE
chore: bump version to 3.2.0 and refresh .NET 10 docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
     - name: Cache NuGet packages
       uses: actions/cache@v5
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This document provides context for Claude to assist with the DAQiFi Desktop appl
 DAQiFi Desktop is a Windows desktop application for communicating with DAQiFi hardware products. Our goal is to modernize data acquisition with user-friendly and intuitive products.
 
 ### Technology Stack
-- .NET 9.0 and WPF for the desktop application
+- .NET 10.0 and WPF for the desktop application
 - SQLite for local data storage
 - Google Protocol Buffers for device communication
 - EntityFramework for database operations

--- a/Daqifi.Desktop.Setup/DAQifiDesktopSetup/Product.wxs
+++ b/Daqifi.Desktop.Setup/DAQifiDesktopSetup/Product.wxs
@@ -3,7 +3,7 @@
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
   <Package Name="DAQiFi"
            Manufacturer="DAQiFi"
-           Version="3.1.0.0"
+           Version="3.2.0.0"
            UpgradeCode="ACA4F4E1-6DBB-47C0-A829-84AA1536C147"
            Language="1033">
 

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -7,7 +7,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>
 		<UseWindowsForms>true</UseWindowsForms>
-		<Version>3.1.0</Version>
+		<Version>3.2.0</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<InternalsVisibleTo>Daqifi.Desktop.Test</InternalsVisibleTo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -20,8 +20,8 @@
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AssemblyVersion>3.1.0.0</AssemblyVersion>
-		<FileVersion>3.1.0.0</FileVersion>
+		<AssemblyVersion>3.2.0.0</AssemblyVersion>
+		<FileVersion>3.2.0.0</FileVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
 	  <PlatformTarget>x64</PlatformTarget>

--- a/Daqifi.Desktop/app.manifest
+++ b/Daqifi.Desktop/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="3.1.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="3.2.0.0" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Windows desktop application (.NET) that is used to communicate with DAQiFi hardw
 
 ## Tech Stack
 
-- .NET 9.0
+- .NET 10.0
 - WPF
 - SQLite
 
@@ -26,7 +26,7 @@ The project uses GitHub Actions for continuous integration and deployment:
 - **Release**: Automatic release asset publishing when GitHub releases are created
 - **Dependency Updates**: Dependabot manages NuGet and GitHub Actions dependencies weekly
 
-All workflows run on .NET 9.0 with Windows runners for WPF compatibility.
+All workflows run on .NET 10.0 with Windows runners for WPF compatibility.
 
 ## Observability
 


### PR DESCRIPTION
## Summary
- Bump desktop app and WiX installer from 3.1.0 → 3.2.0 ahead of the v3.2.0 release.
- Refresh README.md and CLAUDE.md to reflect the .NET 9 → .NET 10 upgrade from #499; project files have targeted `net10.0-windows` since that PR but the docs hadn't caught up.
- Submodule assemblies (Common, DataModel, IO) remain at 3.0.0.0 — they were not bumped on prior releases either, so leaving as-is for this release.

## Test plan
- [ ] CI build & tests pass on the PR
- [ ] Verify the produced binary reports `FileVersion 3.2.0.0` (right-click → Properties → Details on the built `DAQiFi.exe`)
- [ ] Verify the MSI installer's product version reads `3.2.0.0` and that an upgrade from a 3.1.x install replaces it cleanly
- [ ] Spot-check README.md and CLAUDE.md render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)