### PR TITLE
deps: bump Daqifi.Core to 0.20.0

### DIFF
--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-	  <PackageReference Include="Daqifi.Core" Version="0.19.7" />
+	  <PackageReference Include="Daqifi.Core" Version="0.20.0" />
 	  <PackageReference Include="Google.Protobuf" Version="3.34.1" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.7" />
-		<PackageReference Include="Daqifi.Core" Version="0.19.7" />
+		<PackageReference Include="Daqifi.Core" Version="0.20.0" />
 		<PackageReference Include="Google.Protobuf" Version="3.34.1" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -57,7 +57,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-		<PackageReference Include="Daqifi.Core" Version="0.19.7" />
+		<PackageReference Include="Daqifi.Core" Version="0.20.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />


### PR DESCRIPTION
## Summary

Bumps the [`Daqifi.Core`](https://github.com/daqifi/daqifi-core) device-protocol/HAL package from **0.19.7 → 0.20.0** in the three csproj files that reference it (`Daqifi.Desktop`, `Daqifi.Desktop.DataModel`, `Daqifi.Desktop.IO`). All three were kept in lockstep.

Upstream release notes: https://github.com/daqifi/daqifi-core/releases/tag/v0.20.0

## What's in 0.19.7 → 0.20.0

There are no intermediate releases between 0.19.7 and 0.20.0, so this is a single release-note hop.

| Change | Type | Impact on desktop |
| --- | --- | --- |
| New `Daqifi.Core.Logging.Export` namespace (`ISampleSource`, `ChannelDescriptor`, `SampleRow`, `CsvExporter`, etc.) — storage-agnostic CSV export pipeline ([core#167](https://github.com/daqifi/daqifi-core/pull/167)) | ✨ Additive | None — purely new API surface, no name collisions with our exporter code |
| **Dropped `net8.0` support** — package now ships `net9.0` and `net10.0` only ([core#175](https://github.com/daqifi/daqifi-core/pull/175)) | ⚠ Breaking | None — every project here targets `net10.0` or `net10.0-windows` (PR #499 / PR #503 already migrated us off net9) |
| README refresh for current API surface and target frameworks ([core#176](https://github.com/daqifi/daqifi-core/pull/176)) | docs | None |
| Coverlet packages 8.0.1 → 10.0.0 ([core#177](https://github.com/daqifi/daqifi-core/pull/177)) | chore (test-only, internal to core) | None |
| Minor/patch transitive bumps ([core#178](https://github.com/daqifi/daqifi-core/pull/178)) | chore | None |

**Net result:** zero code changes required here. Single bump commit; no follow-up `refactor:` / `fix:` commit was needed.

## Verification

- Grepped the desktop solution for `ISampleSource` / `ChannelDescriptor` / `SampleRow` / `CsvExporter` / `Logging.Export` — no collisions with existing types.
- Existing `Daqifi.Core` consumption (`Communication.*`, `Device.*`, `Channel.*`, `Firmware.*`) is untouched by 0.20.0.
- `dotnet restore` ✅
- `dotnet build --configuration Release /p:EnforceCodeStyleInBuild=true` ✅ — 0 errors. Warning count unchanged from `main` (all pre-existing CS86xx/CA*/MSTEST0032 in test code).
- `dotnet test --configuration Release --no-build` partial: `Daqifi.Desktop.IO.Test` ran on macOS-arm64 and passed (1/1). The other three test assemblies need an x64 .NET host (the main app is `<PlatformTarget>x64</PlatformTarget>` for Windows/WPF), which isn't available on this dev machine — the full suite needs to run in CI on Windows.

## Test plan

`Daqifi.Core` is the device-protocol/HAL library — high blast radius. Please verify on Windows hardware:

- [ ] Device discovery — UDP broadcast on port 30303 finds at least one device on the LAN
- [ ] TCP streaming — connect to a discovered device and start/stop streaming cleanly
- [ ] Channel toggle — enable/disable analog and digital channels mid-session
- [ ] Logging session — start a logging session, capture data, stop, confirm row count in DB matches expectations
- [ ] SD card import — import a `.bin` log session from an SD card and confirm samples land in the desktop DB
- [ ] Firmware update flow — kick off a firmware update against a PIC32 device and confirm progress reporting works end-to-end
- [ ] CI: Windows build + full `dotnet test` go green

## Notes / risks

- `Daqifi.Core` is the highest-blast-radius dependency in the project, so even though the diff is three lines, please prioritise the on-hardware checks above before merging.
- Do **not** bump the desktop app version with this PR — v3.2.0 was already cut in #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)