### PR TITLE
fix(logged-data): recreate schema after Delete All sessions

### DIFF
--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1509,8 +1509,12 @@ public partial class DaqifiViewModel : ObservableObject
             DeleteFileIfExists(dbPath + "-wal");
             DeleteFileIfExists(dbPath + "-shm");
 
-            // Recreate the database schema by creating a fresh context.
+            // Recreate the database schema. Constructing a context does not
+            // create tables — only Migrate() (or EnsureCreated) does. Without
+            // this, the next session-start query against Samples/Sessions
+            // throws "no such table: Samples".
             using var context = contextFactory.CreateDbContext();
+            context.Database.Migrate();
         }
         finally
         {


### PR DESCRIPTION
## Summary

- After **Delete All Logging Sessions** the next attempt to start a logging session crashed with `SQLite Error 1: 'no such table: Samples'`.
- `DeleteAllLoggingSessionsFromStorage` deletes the SQLite file (and `-wal`/`-shm`) and then constructed a fresh `LoggingContext`, but constructing a context does **not** create tables — that requires `Migrate()` or `EnsureCreated()`. So the file was recreated empty, and the next `OnActiveChanged` SQL probe (`SELECT MAX … FROM Sessions UNION ALL … FROM SessionDeviceMetadata UNION ALL … FROM Samples`) threw.
- Fix: call `context.Database.Migrate()` after recreating the context, matching the startup path in `App.xaml.cs` (which also uses `Migrate()` so `__EFMigrationsHistory` is seeded correctly — `EnsureCreated()` would skip that table and break future migration runs).

## Test plan

- [ ] Start the app, create one or more logging sessions with samples
- [ ] Click **Delete All** and confirm
- [ ] Toggle **Start Logging** on a subscribed channel — verify the session starts cleanly with no exception
- [ ] Stop logging, restart the app, confirm the new session loads from disk
- [ ] (Regression) Delete-All with no sessions present still works without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)