### PR TITLE
deps: bump Daqifi.Core to 0.21.0

### DIFF
--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-	  <PackageReference Include="Daqifi.Core" Version="0.20.0" />
+	  <PackageReference Include="Daqifi.Core" Version="0.21.0" />
 	  <PackageReference Include="Google.Protobuf" Version="3.34.1" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.7" />
-		<PackageReference Include="Daqifi.Core" Version="0.20.0" />
+		<PackageReference Include="Daqifi.Core" Version="0.21.0" />
 		<PackageReference Include="Google.Protobuf" Version="3.34.1" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -57,7 +57,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-		<PackageReference Include="Daqifi.Core" Version="0.20.0" />
+		<PackageReference Include="Daqifi.Core" Version="0.21.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -443,14 +443,12 @@ public partial class ConnectionDialogViewModel : ObservableObject
             return;
         }
 
-        if (AvailableWiFiDevices.FirstOrDefault(d => d.MacAddress == wifiDevice.MacAddress) == null)
+        InvokeOnUiThread(() =>
         {
-            InvokeOnUiThread(() =>
-            {
-                AvailableWiFiDevices.Add(wifiDevice);
-                if (HasNoWiFiDevices) { HasNoWiFiDevices = false; }
-            });
-        }
+            if (AvailableWiFiDevices.Any(d => d.MacAddress == wifiDevice.MacAddress)) return;
+            AvailableWiFiDevices.Add(wifiDevice);
+            if (HasNoWiFiDevices) { HasNoWiFiDevices = false; }
+        });
     }
 
     public void Close()


### PR DESCRIPTION
## Summary

Bumps `Daqifi.Core` from `0.20.0` → `0.21.0` in all three projects.

## What's new in 0.21.0 ([release notes](https://github.com/daqifi/daqifi-core/releases/tag/v0.21.0))

- **Typed SD card exception hierarchy** — `GetSdCardFilesAsync` now throws `SdCardNotPresentException`, `SdCardFilesystemException`, or `SdCardOperationException` instead of silently returning an empty list when the SD card is absent or errored. Empty directory still returns empty list (no behavior change for the happy path).
- **UDP discovery fix for hosts with virtual NICs** — fixes silent zero-device discovery on Windows machines running WSL2/Hyper-V/VPN/VirtualBox. `WiFiDeviceFinder` now binds one socket per physical NIC and skips virtual adapters. Note: `DeviceDiscovered` may now fire concurrently from multiple NIC receive loops.

## Test plan

- [ ] Build passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)