### PR TITLE
chore: bump sub-project assembly versions to 3.2.0 and fix WiX ICE61

### DIFF
--- a/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
+++ b/Daqifi.Desktop.Common/Daqifi.Desktop.Common.csproj
@@ -6,10 +6,6 @@
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
-	<PropertyGroup>
-		<AssemblyVersion>3.0.0.0</AssemblyVersion>
-		<FileVersion>3.0.0.0</FileVersion>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NLog" Version="6.1.2" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">

--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -6,10 +6,6 @@
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
-	<PropertyGroup>
-		<AssemblyVersion>3.0.0.0</AssemblyVersion>
-		<FileVersion>3.0.0.0</FileVersion>
-	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 	  <PackageReference Include="Daqifi.Core" Version="0.21.0" />

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -5,10 +5,6 @@
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
-	<PropertyGroup>
-		<AssemblyVersion>3.0.0.0</AssemblyVersion>
-		<FileVersion>3.0.0.0</FileVersion>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.7" />
 		<PackageReference Include="Daqifi.Core" Version="0.21.0" />

--- a/Daqifi.Desktop.Setup/DAQifiDesktopSetup/Product.wxs
+++ b/Daqifi.Desktop.Setup/DAQifiDesktopSetup/Product.wxs
@@ -25,17 +25,6 @@
     <MediaTemplate EmbedCab="yes" />
     <Icon Id="Icon.exe" SourceFile="$(var.SourceDir)\$(var.MainExeName)"/>
 
-    <!-- Force upgrade if already installed-->
-    <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />
-    <Upgrade Id="ACA4F4E1-6DBB-47C0-A829-84AA1536C147">
-      <UpgradeVersion Minimum="0.1.0.0"
-                      Maximum="99.0.0.0"
-                      Property="PREVIOUSVERSIONSINSTALLED"
-                      IncludeMinimum="yes"
-                      IncludeMaximum="no"
-                      OnlyDetect="no"/>
-    </Upgrade>
-
     <Feature Id="ProductFeature" Title="DAQiFiDesktop_Setup" Level="1" Display="expand">
       <ComponentRef Id="MainExecutable"/>
       <ComponentRef Id="UninstallProgramMenuItems"/>

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -19,10 +19,6 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 	</PropertyGroup>
-	<PropertyGroup>
-		<AssemblyVersion>3.2.0.0</AssemblyVersion>
-		<FileVersion>3.2.0.0</FileVersion>
-	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
 	  <PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,18 @@
 <Project>
   <PropertyGroup>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
+    <FileVersion>3.2.0.0</FileVersion>
+
     <!-- Enable .NET code analysis -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    
+
     <!-- Code quality settings -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <WarningsNotAsErrors />
-    
+
     <!-- Common settings -->
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Closes #512

## Summary
- **Assembly versions:** Lifted `AssemblyVersion`/`FileVersion` (`3.2.0.0`) into `Directory.Build.props` so all projects inherit from one place. Removed the per-project `<PropertyGroup>` blocks from `Common`, `DataModel`, `IO`, and `Desktop` that had drifted to `3.0.0.0`. Version drift is no longer possible — one edit in `Directory.Build.props` updates every DLL.
- **WiX ICE61:** Deleted the redundant `<Property Id="PREVIOUSVERSIONSINSTALLED">` + `<Upgrade>` block from `Product.wxs`. The wide `Maximum="99.0.0.0"` bound was the root cause of `WIX1076`. The existing `<MajorUpgrade>` on line 24 already covers upgrade detection correctly.

## Test plan
- [ ] `dotnet build` completes with 0 errors and no `WIX1076` warning
- [ ] All four assemblies report `3.2.0.0` in file properties after build
- [ ] Installer upgrade from 3.1.0 → 3.2.0 still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)