### PR TITLE
fix(update-check): harden VersionNotification against bad GitHub responses

### DIFF
--- a/Daqifi.Desktop.Test/UpdateVersion/VersionNotificationTests.cs
+++ b/Daqifi.Desktop.Test/UpdateVersion/VersionNotificationTests.cs
@@ -9,9 +9,9 @@ public class VersionNotificationTests
 {
     #region Helpers
 
-    private const string CurrentVersion = "3.2.0.0";
+    private const string CURRENT_VERSION = "3.2.0.0";
 
-    private static VersionNotification CreateSut(HttpStatusCode statusCode, string? body, string currentVersion = CurrentVersion)
+    private static VersionNotification CreateSut(HttpStatusCode statusCode, string? body, string currentVersion = CURRENT_VERSION)
     {
         var handler = new FakeHttpMessageHandler(statusCode, body ?? string.Empty);
         return new VersionNotification(handler, currentVersion);
@@ -163,7 +163,7 @@ public class VersionNotificationTests
     {
         // Arrange
         var handler = new ThrowingHttpMessageHandler();
-        var sut = new VersionNotification(handler, CurrentVersion);
+        var sut = new VersionNotification(handler, CURRENT_VERSION);
 
         // Act — must not throw
         await sut.CheckForUpdatesAsync();

--- a/Daqifi.Desktop.Test/UpdateVersion/VersionNotificationTests.cs
+++ b/Daqifi.Desktop.Test/UpdateVersion/VersionNotificationTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Net.Http;
+using Daqifi.Desktop.UpdateVersion;
+
+namespace Daqifi.Desktop.Test.UpdateVersion;
+
+[TestClass]
+public class VersionNotificationTests
+{
+    #region Helpers
+
+    private const string CurrentVersion = "3.2.0.0";
+
+    private static VersionNotification CreateSut(HttpStatusCode statusCode, string? body, string currentVersion = CurrentVersion)
+    {
+        var handler = new FakeHttpMessageHandler(statusCode, body ?? string.Empty);
+        return new VersionNotification(handler, currentVersion);
+    }
+
+    private static string ReleaseJson(string tagName) =>
+        $"{{\"tag_name\":\"{tagName}\",\"name\":\"Release {tagName}\"}}";
+
+    #endregion
+
+    #region Non-success HTTP response
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_NonSuccessStatusCode_DoesNotThrow()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.NotFound, "<html>not found</html>");
+
+        // Act — must not throw
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_RateLimitResponse_DoesNotThrow()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.Forbidden, "{\"message\":\"API rate limit exceeded\"}");
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    #endregion
+
+    #region Null / missing tag_name
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_NullTagName_DoesNotThrow()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.OK, "{\"tag_name\":null,\"name\":\"Draft\"}");
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_MissingTagName_DoesNotThrow()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.OK, "{\"name\":\"Draft\"}");
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    #endregion
+
+    #region Pre-release / unparseable tag
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_PrereleaseTag_DoesNotThrow()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.OK, ReleaseJson("v3.2.0-rc1"));
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_TagWithBuildMetadata_DoesNotThrow()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.OK, ReleaseJson("v3.2.0+hotfix"));
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    #endregion
+
+    #region Happy path
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_NewerVersionAvailable_SetsNotificationCount()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.OK, ReleaseJson("v3.3.0"), currentVersion: "3.2.0.0");
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(1, sut.NotificationCount);
+        Assert.AreEqual("v3.3.0", sut.VersionNumber);
+    }
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_SameVersion_DoesNotSetNotificationCount()
+    {
+        // Arrange — 3-part tag v3.2.0 matches 4-part assembly 3.2.0.0 (same release, no notification expected)
+        var sut = CreateSut(HttpStatusCode.OK, ReleaseJson("v3.2.0"), currentVersion: "3.2.0.0");
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_OlderVersion_DoesNotSetNotificationCount()
+    {
+        // Arrange
+        var sut = CreateSut(HttpStatusCode.OK, ReleaseJson("v3.1.0"), currentVersion: "3.2.0.0");
+
+        // Act
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    #endregion
+
+    #region Network failure
+
+    [TestMethod]
+    public async Task CheckForUpdatesAsync_NetworkException_DoesNotThrow()
+    {
+        // Arrange
+        var handler = new ThrowingHttpMessageHandler();
+        var sut = new VersionNotification(handler, CurrentVersion);
+
+        // Act — must not throw
+        await sut.CheckForUpdatesAsync();
+
+        // Assert
+        Assert.AreEqual(0, sut.NotificationCount);
+    }
+
+    #endregion
+
+    #region Fake handlers
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _body;
+
+        public FakeHttpMessageHandler(HttpStatusCode statusCode, string body)
+        {
+            _statusCode = statusCode;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_body)
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Simulated network failure");
+        }
+    }
+
+    #endregion
+}

--- a/Daqifi.Desktop/UpdateVersion/VersionNotification.cs
+++ b/Daqifi.Desktop/UpdateVersion/VersionNotification.cs
@@ -6,6 +6,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Daqifi.Desktop.UpdateVersion;
 
+/// <summary>
+/// Checks GitHub for a newer application release and surfaces a notification badge when one is found.
+/// </summary>
 public partial class VersionNotification : ObservableObject, IDisposable
 {
     private readonly AppLogger _appLogger = AppLogger.Instance;
@@ -23,6 +26,17 @@ public partial class VersionNotification : ObservableObject, IDisposable
     #endregion
 
     #region Constructor
+    /// <summary>
+    /// Initializes a new instance of <see cref="VersionNotification"/>.
+    /// </summary>
+    /// <param name="httpMessageHandler">
+    /// Optional HTTP handler used for the GitHub API request. When <c>null</c> a default
+    /// <see cref="HttpClientHandler"/> is created and owned by this instance.
+    /// </param>
+    /// <param name="currentVersion">
+    /// Optional override for the running application version string. Defaults to the executing
+    /// assembly version. Useful for testing without relying on the test-assembly version.
+    /// </param>
     public VersionNotification(HttpMessageHandler? httpMessageHandler = null, string? currentVersion = null)
     {
         _ownsHandler = httpMessageHandler == null;
@@ -32,6 +46,9 @@ public partial class VersionNotification : ObservableObject, IDisposable
     #endregion
 
     #region IDisposable
+    /// <summary>
+    /// Releases the <see cref="HttpClientHandler"/> when this instance owns it.
+    /// </summary>
     public void Dispose()
     {
         if (_ownsHandler && _httpMessageHandler is IDisposable disposable)
@@ -40,6 +57,11 @@ public partial class VersionNotification : ObservableObject, IDisposable
     #endregion
 
     #region Version Checking Function
+    /// <summary>
+    /// Queries the GitHub Releases API and sets <see cref="NotificationCount"/> to 1 when a newer
+    /// version than <see cref="_currentVersion"/> is available. All failures are logged and swallowed
+    /// so a transient network issue or malformed response never crashes the application on startup.
+    /// </summary>
     public async Task CheckForUpdatesAsync()
     {
         var githubApiUrl = "https://api.github.com/repos/daqifi/daqifi-desktop/releases/latest";
@@ -72,6 +94,8 @@ public partial class VersionNotification : ObservableObject, IDisposable
             }
             if (!Version.TryParse(_currentVersion, out var current))
             {
+                _appLogger.Error(new FormatException($"Could not parse current version '{_currentVersion}'."),
+                    $"Error checking for updates: unparseable currentVersion '{_currentVersion}'");
                 return;
             }
             if (latest > current)

--- a/Daqifi.Desktop/UpdateVersion/VersionNotification.cs
+++ b/Daqifi.Desktop/UpdateVersion/VersionNotification.cs
@@ -6,9 +6,13 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Daqifi.Desktop.UpdateVersion;
 
-public partial class VersionNotification : ObservableObject
+public partial class VersionNotification : ObservableObject, IDisposable
 {
     private readonly AppLogger _appLogger = AppLogger.Instance;
+    private readonly HttpMessageHandler _httpMessageHandler;
+    private readonly bool _ownsHandler;
+    private readonly string _currentVersion;
+
     #region Properties
 
     [ObservableProperty]
@@ -18,30 +22,62 @@ public partial class VersionNotification : ObservableObject
     private string _versionNumber;
     #endregion
 
-    #region Version Checking Function 
+    #region Constructor
+    public VersionNotification(HttpMessageHandler? httpMessageHandler = null, string? currentVersion = null)
+    {
+        _ownsHandler = httpMessageHandler == null;
+        _httpMessageHandler = httpMessageHandler ?? new HttpClientHandler();
+        _currentVersion = currentVersion ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0.0";
+    }
+    #endregion
+
+    #region IDisposable
+    public void Dispose()
+    {
+        if (_ownsHandler && _httpMessageHandler is IDisposable disposable)
+            disposable.Dispose();
+    }
+    #endregion
+
+    #region Version Checking Function
     public async Task CheckForUpdatesAsync()
     {
-        var currentVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         var githubApiUrl = "https://api.github.com/repos/daqifi/daqifi-desktop/releases/latest";
         try
         {
-            using var client = new HttpClient();
+            using var client = new HttpClient(_httpMessageHandler, disposeHandler: false);
             client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
             var response = await client.GetAsync(githubApiUrl);
             if (!response.IsSuccessStatusCode)
             {
-                var ex= new HttpRequestException("Unable to fetch release information from GitHub.");
-                _appLogger.Error(ex, $"Error checking for updates: {ex.Message}");
+                _appLogger.Error(new HttpRequestException("Unable to fetch release information from GitHub."),
+                    $"Error checking for updates: non-success status {(int)response.StatusCode}");
+                return;
             }
             var jsonResponse = await response.Content.ReadAsStringAsync();
             var releaseData = JObject.Parse(jsonResponse);
-            var latestVersion = releaseData["tag_name"].ToString().Trim();
-            var current = new Version(currentVersion);
-            var latest = new Version(latestVersion.TrimStart('v'));
+            var tagToken = releaseData["tag_name"];
+            if (tagToken == null || tagToken.Type == JTokenType.Null)
+            {
+                _appLogger.Error(new InvalidOperationException("GitHub response missing tag_name."),
+                    "Error checking for updates: tag_name was null or missing");
+                return;
+            }
+            var latestVersionTag = tagToken.ToString().Trim();
+            if (!Version.TryParse(latestVersionTag.TrimStart('v'), out var latest))
+            {
+                _appLogger.Error(new FormatException($"Could not parse version from tag '{latestVersionTag}'."),
+                    $"Error checking for updates: unparseable tag '{latestVersionTag}'");
+                return;
+            }
+            if (!Version.TryParse(_currentVersion, out var current))
+            {
+                return;
+            }
             if (latest > current)
             {
                 NotificationCount = 1;
-                VersionNumber = latestVersion;
+                VersionNumber = latestVersionTag;
             }
             else
             {


### PR DESCRIPTION
## Summary

Fixes three latent startup crashes in `VersionNotification.CheckForUpdatesAsync` (closes #513):

- **Non-success HTTP response fell through to JSON parsing** — added early `return` after logging any non-2xx status code
- **Null `tag_name` threw NullReferenceException** — explicit `null`/`JTokenType.Null` guard before calling `.ToString()`
- **Pre-release tags threw FormatException** — replaced `new Version(...)` with `Version.TryParse`; tags like `v3.2.0-rc1` or `v3.2.0+hotfix` now log quietly and return

Also addressed two issues surfaced during review:

- `VersionNotification` now implements `IDisposable` and disposes its `HttpClientHandler` when it owns it
- `currentVersion` is resolved at construction time (defaults to assembly version) and injectable, so tests no longer rely on the test assembly's implicit `0.0.0.0` version

## Test plan

- [ ] `CheckForUpdatesAsync_NonSuccessStatusCode_DoesNotThrow` — 404 response returns silently
- [ ] `CheckForUpdatesAsync_RateLimitResponse_DoesNotThrow` — 403 response returns silently
- [ ] `CheckForUpdatesAsync_NullTagName_DoesNotThrow` — JSON `null` tag_name returns silently
- [ ] `CheckForUpdatesAsync_MissingTagName_DoesNotThrow` — absent tag_name key returns silently
- [ ] `CheckForUpdatesAsync_PrereleaseTag_DoesNotThrow` — `v3.2.0-rc1` returns silently
- [ ] `CheckForUpdatesAsync_TagWithBuildMetadata_DoesNotThrow` — `v3.2.0+hotfix` returns silently
- [ ] `CheckForUpdatesAsync_NewerVersionAvailable_SetsNotificationCount` — `v3.3.0` against `3.2.0.0` sets count to 1
- [ ] `CheckForUpdatesAsync_SameVersion_DoesNotSetNotificationCount` — `v3.2.0` against `3.2.0.0` stays at 0
- [ ] `CheckForUpdatesAsync_OlderVersion_DoesNotSetNotificationCount` — `v3.1.0` against `3.2.0.0` stays at 0
- [ ] `CheckForUpdatesAsync_NetworkException_DoesNotThrow` — network failure returns silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)