### PR TITLE
chore(.net10): refresh EF snapshot stamps and drop duplicate SQLitePCLRaw bundle

### DIFF
--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -74,7 +74,6 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
-		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
 		<PackageReference Include="System.IO.Ports" Version="10.0.7" />
 		<PackageReference Include="System.Management" Version="10.0.7" />

--- a/Daqifi.Desktop/Loggers/DatabaseMigrator.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseMigrator.cs
@@ -13,7 +13,7 @@ public static class DatabaseMigrator
 {
     #region Constants
     private const string INITIAL_MIGRATION_ID = "20250812090000_InitialSQLiteMigration";
-    private const string EF_PRODUCT_VERSION = "9.0.14";
+    private const string EF_PRODUCT_VERSION = "10.0.7";
     #endregion
 
     #region Public Methods

--- a/Daqifi.Desktop/Migrations/20250812090000_InitialSQLiteMigration.Designer.cs
+++ b/Daqifi.Desktop/Migrations/20250812090000_InitialSQLiteMigration.Designer.cs
@@ -18,7 +18,7 @@ partial class InitialSQLiteMigration
     protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
-        modelBuilder.HasAnnotation("ProductVersion", "9.0.14");
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
         modelBuilder.Entity("Daqifi.Desktop.Channel.Channel", b =>
             {

--- a/Daqifi.Desktop/Migrations/20250812100000_AddSamplesSessionTimeIndex.Designer.cs
+++ b/Daqifi.Desktop/Migrations/20250812100000_AddSamplesSessionTimeIndex.Designer.cs
@@ -18,7 +18,7 @@ partial class AddSamplesSessionTimeIndex
     protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
-        modelBuilder.HasAnnotation("ProductVersion", "9.0.14");
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
         modelBuilder.Entity("Daqifi.Desktop.Channel.Channel", b =>
             {

--- a/Daqifi.Desktop/Migrations/20260414120000_AddSessionDeviceMetadata.Designer.cs
+++ b/Daqifi.Desktop/Migrations/20260414120000_AddSessionDeviceMetadata.Designer.cs
@@ -18,7 +18,7 @@ partial class AddSessionDeviceMetadata
     protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
-        modelBuilder.HasAnnotation("ProductVersion", "9.0.14");
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
         modelBuilder.Entity("Daqifi.Desktop.Channel.Channel", b =>
             {

--- a/Daqifi.Desktop/Migrations/20260415000000_AddSessionSampleCount.Designer.cs
+++ b/Daqifi.Desktop/Migrations/20260415000000_AddSessionSampleCount.Designer.cs
@@ -18,7 +18,7 @@ partial class AddSessionSampleCount
     protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
-        modelBuilder.HasAnnotation("ProductVersion", "9.0.14");
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
         modelBuilder.Entity("Daqifi.Desktop.Channel.Channel", b =>
             {

--- a/Daqifi.Desktop/Migrations/LoggingContextModelSnapshot.cs
+++ b/Daqifi.Desktop/Migrations/LoggingContextModelSnapshot.cs
@@ -15,7 +15,7 @@ partial class LoggingContextModelSnapshot : ModelSnapshot
     protected override void BuildModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
-        modelBuilder.HasAnnotation("ProductVersion", "9.0.14");
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
         modelBuilder.Entity("Daqifi.Desktop.Channel.Channel", b =>
             {


### PR DESCRIPTION
## Summary

Closes #514 — two leftovers from the .NET 9 → .NET 10 upgrade.

- Bumped EF migration `ProductVersion` annotations across all 5 migration files and the `EF_PRODUCT_VERSION` seed constant in `DatabaseMigrator.cs` from `9.0.14` → `10.0.7` to match the EF Core 10.0.7 packages. Future `dotnet ef migrations add` runs no longer produce a noisy unrelated snapshot diff.
- Dropped the redundant `SQLitePCLRaw.bundle_green` 2.1.11 reference. `bundle_e_sqlite3` 3.0.2 (already required by `Microsoft.EntityFrameworkCore.Sqlite` 10.0.7) is sufficient. Verified no code uses `System.Data.SQLite`, `Mono.Data.Sqlite`, or any direct `SQLitePCL` API — everything goes through `Microsoft.Data.Sqlite`.

After the bundle removal, all SQLitePCLRaw transitive packages now resolve to a consistent 3.0.2 chain (previously mixed 2.1.11 / 3.0.2).

## Test plan

- [x] `dotnet build` — passes with 0 errors
- [x] `dotnet list package --include-transitive` — only `bundle_e_sqlite3` 3.0.2 remains; no `bundle_green`, no mismatched `lib.e_sqlite3` 2.1.11
- [x] `dotnet test` on the IO project — passes
- [ ] **Windows manual smoke test**: clean install opens, reads, and writes a SQLite session DB (acceptance criterion #4 — requires Windows host, not coverable from this dev environment)

## Notes / follow-ups

- Followed the issue's "manual bump" path rather than re-scaffolding the snapshot. If EF 10 emits any subtly different snapshot patterns vs. EF 9, a future scaffold will still produce a small diff — but no longer the giant `ProductVersion` one.
- Out of scope but noticed: `Daqifi.Desktop/e_sqlite3.dll` is a manually checked-in native lib (added in #97) referenced as `<Content Include="e_sqlite3.dll">`. It overrides the bundle's own `runtimes/win-x64/native/e_sqlite3.dll` at the output root. Same family of redundant native-init plumbing as #514 but not listed in its acceptance criteria — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)