### PR TITLE
feat(device-logs): surface SD card error states inline (#510)

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelTests.cs
@@ -182,7 +182,8 @@ public class DeviceLogsViewModelTests
         _viewModel.DeviceFiles.Add(new SdCardFile { FileName = "LOG001.bin" });
         _viewModel.DeviceFiles.Add(new SdCardFile { FileName = "LOG002.bin" });
 
-        Assert.IsTrue(_viewModel.SdCardStatusLine.Contains("2 files"), $"Expected '2 files' in '{_viewModel.SdCardStatusLine}'");
+        var statusLine = _viewModel.SdCardStatusLine;
+        Assert.IsTrue(statusLine.Contains("2 files"), $"Expected '2 files' in '{statusLine}'");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelTests.cs
@@ -1,0 +1,229 @@
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Models;
+using Daqifi.Desktop.ViewModels;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+[TestClass]
+public class DeviceLogsViewModelTests
+{
+    private Mock<IStreamingDevice> _mockDevice;
+    private DeviceLogsViewModel _viewModel;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockDevice = new Mock<IStreamingDevice>();
+        _mockDevice.Setup(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        _mockDevice.Setup(d => d.DeviceSerialNo).Returns("DAQ-TEST-001");
+        _mockDevice.Setup(d => d.DeviceVersion).Returns("1.0.0");
+        _mockDevice.Setup(d => d.SdCardFiles).Returns(new List<SdCardFile>().AsReadOnly());
+        _mockDevice.Setup(d => d.DeviceDisplayName).Returns("DAQ-TEST-001");
+
+        _viewModel = new DeviceLogsViewModel();
+        _viewModel.SelectedDevice = _mockDevice.Object;
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_Success_SetsSdCardStateOk()
+    {
+        _mockDevice.Setup(d => d.RefreshSdCardFiles()); // no-op
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_Success_WithFiles_HasFilesIsTrue()
+    {
+        var files = new List<SdCardFile>
+        {
+            new SdCardFile { FileName = "LOG001.bin", CreatedDate = DateTime.UtcNow }
+        };
+        _mockDevice.Setup(d => d.SdCardFiles).Returns(files.AsReadOnly());
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasFiles);
+        Assert.IsFalse(_viewModel.HasNoFiles);
+        Assert.IsFalse(_viewModel.HasSdCardError);
+        Assert.IsFalse(_viewModel.HasSdCardNotPresent);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_Success_EmptyCard_HasNoFilesIsTrue()
+    {
+        _mockDevice.Setup(d => d.SdCardFiles).Returns(new List<SdCardFile>().AsReadOnly());
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasNoFiles);
+        Assert.IsFalse(_viewModel.HasFiles);
+        Assert.IsFalse(_viewModel.HasSdCardError);
+        Assert.IsFalse(_viewModel.HasSdCardNotPresent);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_SdCardNotPresent_SetsSdCardStateNotPresent()
+    {
+        _mockDevice
+            .Setup(d => d.RefreshSdCardFiles())
+            .Throws(new SdCardNotPresentException(new List<string>(), "No card"));
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.NotPresent, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasSdCardNotPresent);
+        Assert.IsFalse(_viewModel.HasSdCardError);
+        Assert.IsFalse(_viewModel.HasNoFiles);
+        Assert.IsFalse(_viewModel.HasFiles);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_SdCardFilesystemException_SetsSdCardStateError()
+    {
+        const string deviceMessage = "FS corrupt";
+        _mockDevice
+            .Setup(d => d.RefreshSdCardFiles())
+            .Throws(new SdCardFilesystemException(new List<string>(), "Filesystem error", deviceMessage));
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.Error, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasSdCardError);
+        Assert.AreEqual(deviceMessage, _viewModel.SdCardErrorMessage);
+        Assert.IsFalse(_viewModel.HasSdCardNotPresent);
+        Assert.IsFalse(_viewModel.HasNoFiles);
+        Assert.IsFalse(_viewModel.HasFiles);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_SdCardOperationException_SetsSdCardStateError()
+    {
+        const string scpiError = "-200,\"Execution error\"";
+        _mockDevice
+            .Setup(d => d.RefreshSdCardFiles())
+            .Throws(new SdCardOperationException("SCPI error", new List<string>(), scpiError, null));
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.Error, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasSdCardError);
+        Assert.AreEqual(scpiError, _viewModel.SdCardErrorMessage);
+        Assert.IsFalse(_viewModel.HasSdCardNotPresent);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_GenericException_SetsSdCardStateError()
+    {
+        const string errorMessage = "Connection lost";
+        _mockDevice
+            .Setup(d => d.RefreshSdCardFiles())
+            .Throws(new InvalidOperationException(errorMessage));
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.Error, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasSdCardError);
+        Assert.AreEqual(errorMessage, _viewModel.SdCardErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_AfterError_SuccessResetsErrorState()
+    {
+        _mockDevice
+            .Setup(d => d.RefreshSdCardFiles())
+            .Throws(new SdCardNotPresentException(new List<string>(), "No card"));
+
+        await _viewModel.RefreshFilesAsync();
+        Assert.AreEqual(SdCardState.NotPresent, _viewModel.SdCardState);
+
+        _mockDevice.Setup(d => d.RefreshSdCardFiles()); // no-op on second call
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState);
+        Assert.IsFalse(_viewModel.HasSdCardNotPresent);
+        Assert.IsFalse(_viewModel.HasSdCardError);
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_IsBusyIsFalseAfterCompletion()
+    {
+        _mockDevice.Setup(d => d.RefreshSdCardFiles());
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.IsFalse(_viewModel.IsBusy);
+        Assert.IsTrue(string.IsNullOrEmpty(_viewModel.BusyMessage));
+    }
+
+    [TestMethod]
+    public async Task RefreshFiles_IsBusyIsFalseAfterException()
+    {
+        _mockDevice
+            .Setup(d => d.RefreshSdCardFiles())
+            .Throws(new SdCardFilesystemException(new List<string>(), "error", "FS error"));
+
+        await _viewModel.RefreshFilesAsync();
+
+        Assert.IsFalse(_viewModel.IsBusy);
+        Assert.IsTrue(string.IsNullOrEmpty(_viewModel.BusyMessage));
+    }
+
+    [TestMethod]
+    public void SdCardStatusLine_WhenOkWithFiles_ShowsFileCount()
+    {
+        _viewModel.SdCardState = SdCardState.Ok;
+        _viewModel.DeviceFiles.Add(new SdCardFile { FileName = "LOG001.bin" });
+        _viewModel.DeviceFiles.Add(new SdCardFile { FileName = "LOG002.bin" });
+
+        Assert.IsTrue(_viewModel.SdCardStatusLine.Contains("2 files"), $"Expected '2 files' in '{_viewModel.SdCardStatusLine}'");
+    }
+
+    [TestMethod]
+    public void SdCardStatusLine_WhenNotPresent_ShowsMessage()
+    {
+        _viewModel.SdCardState = SdCardState.NotPresent;
+
+        Assert.IsTrue(_viewModel.SdCardStatusLine.Contains("No SD card"));
+    }
+
+    [TestMethod]
+    public void SdCardStatusLine_WhenError_IncludesErrorMessage()
+    {
+        _viewModel.SdCardState = SdCardState.Error;
+        _viewModel.SdCardErrorMessage = "-200 Execution error";
+
+        Assert.IsTrue(_viewModel.SdCardStatusLine.Contains("-200 Execution error"));
+    }
+
+    [TestMethod]
+    public void RefreshFiles_SkipsWhenNoDeviceSelected()
+    {
+        _viewModel.SelectedDevice = null;
+
+        // Should not throw; state stays Unknown
+        var task = _viewModel.RefreshFilesAsync();
+        Assert.AreEqual(SdCardState.Unknown, _viewModel.SdCardState);
+    }
+
+    [TestMethod]
+    public void CanAccessSdCard_WhenUsbConnected_IsTrue()
+    {
+        Assert.IsTrue(_viewModel.CanAccessSdCard);
+    }
+
+    [TestMethod]
+    public void CanAccessSdCard_WhenWifiConnected_IsFalse()
+    {
+        _mockDevice.Setup(d => d.ConnectionType).Returns(ConnectionType.Wifi);
+        _viewModel.SelectedDevice = _mockDevice.Object;
+
+        Assert.IsFalse(_viewModel.CanAccessSdCard);
+    }
+}

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -149,6 +149,13 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     };
 
     /// <summary>
+    /// Gets the best available human-readable name for this device.
+    /// Returns the serial number when populated, otherwise falls back to DisplayIdentifier.
+    /// </summary>
+    public string DeviceDisplayName =>
+        !string.IsNullOrWhiteSpace(DeviceSerialNo) ? DeviceSerialNo : DisplayIdentifier;
+
+    /// <summary>
     /// Gets the COM port identifier for USB devices. Override in derived classes.
     /// </summary>
     /// <returns>COM port name for USB devices</returns>

--- a/Daqifi.Desktop/Device/IStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/IStreamingDevice.cs
@@ -64,6 +64,12 @@ public interface IStreamingDevice : IDevice
     /// </summary>
     string DisplayIdentifier { get; }
 
+    /// <summary>
+    /// Gets the best available human-readable name for this device.
+    /// Returns the serial number when populated, otherwise falls back to DisplayIdentifier.
+    /// </summary>
+    string DeviceDisplayName { get; }
+
     List<IChannel> DataChannels { get; set; }
 
     void InitializeStreaming();

--- a/Daqifi.Desktop/View/DeviceLogsView.xaml
+++ b/Daqifi.Desktop/View/DeviceLogsView.xaml
@@ -414,7 +414,10 @@
                         HorizontalAlignment="Center"
                         Margin="0">
                     <StackPanel Orientation="Horizontal">
-                        <iconPacks:PackIconMaterial Kind="ContentCopy" Width="10" Height="10" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <iconPacks:PackIconMaterial Kind="ContentCopy"
+                                                   Width="10" Height="10"
+                                                   Margin="0,0,5,0"
+                                                   VerticalAlignment="Center"/>
                         <TextBlock Text="COPY DIAGNOSTICS"/>
                     </StackPanel>
                 </Button>
@@ -471,7 +474,10 @@
                         HorizontalAlignment="Center"
                         Margin="0">
                     <StackPanel Orientation="Horizontal">
-                        <iconPacks:PackIconMaterial Kind="ContentCopy" Width="10" Height="10" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <iconPacks:PackIconMaterial Kind="ContentCopy"
+                                                   Width="10" Height="10"
+                                                   Margin="0,0,5,0"
+                                                   VerticalAlignment="Center"/>
                         <TextBlock Text="COPY DIAGNOSTICS"/>
                     </StackPanel>
                 </Button>

--- a/Daqifi.Desktop/View/DeviceLogsView.xaml
+++ b/Daqifi.Desktop/View/DeviceLogsView.xaml
@@ -260,7 +260,7 @@
                       Style="{StaticResource DarkComboBox}"
                       ItemsSource="{Binding ConnectedDevices}"
                       SelectedItem="{Binding SelectedDevice}"
-                      DisplayMemberPath="DeviceSerialNo"
+                      DisplayMemberPath="DeviceDisplayName"
                       Margin="0,0,12,0"/>
 
             <Button Grid.Column="2"
@@ -286,7 +286,7 @@
             </Button>
         </Grid>
 
-        <!-- Connection status -->
+        <!-- Connection + SD card status -->
         <Border Grid.Row="1"
                 Margin="20,0,20,8"
                 Padding="10,6"
@@ -305,6 +305,25 @@
                            FontWeight="SemiBold"
                            Foreground="{StaticResource TextSecondary}"
                            VerticalAlignment="Center"/>
+                <!-- SD card status — includes its own " · " prefix; hidden when empty -->
+                <TextBlock Text="{Binding SdCardStatusLine}"
+                           FontSize="11"
+                           VerticalAlignment="Center">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+                            <Setter Property="Visibility" Value="Visible"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SdCardStatusLine}" Value="">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding HasSdCardError}" Value="True">
+                                    <Setter Property="Foreground" Value="#E05555"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
             </StackPanel>
         </Border>
 
@@ -364,6 +383,100 @@
                            MaxWidth="320"/>
             </StackPanel>
 
+            <!-- Empty state: SD card not installed -->
+            <StackPanel VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Visibility="{Binding HasSdCardNotPresent, Converter={StaticResource BoolToVis}}">
+                <iconPacks:PackIconMaterial Kind="SdStorage"
+                                            Width="40"
+                                            Height="40"
+                                            Foreground="{StaticResource TextTertiary}"
+                                            Opacity="0.5"
+                                            HorizontalAlignment="Center"
+                                            Margin="0,0,0,12"/>
+                <TextBlock Text="NO SD CARD"
+                           FontSize="11"
+                           FontWeight="Bold"
+                           Foreground="{StaticResource TextTertiary}"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,6"/>
+                <TextBlock Text="No SD card installed. Insert a FAT32-formatted card and click Refresh."
+                           FontSize="13"
+                           FontWeight="Light"
+                           Foreground="{StaticResource TextPrimary}"
+                           HorizontalAlignment="Center"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           MaxWidth="320"
+                           Margin="0,0,0,16"/>
+                <Button Style="{StaticResource PillButton}"
+                        Command="{Binding CopyDiagnosticInfoCommand}"
+                        HorizontalAlignment="Center"
+                        Margin="0">
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="ContentCopy" Width="10" Height="10" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="COPY DIAGNOSTICS"/>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+
+            <!-- Empty state: SD card error -->
+            <StackPanel VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Visibility="{Binding HasSdCardError, Converter={StaticResource BoolToVis}}">
+                <iconPacks:PackIconMaterial Kind="AlertCircleOutline"
+                                            Width="40"
+                                            Height="40"
+                                            Foreground="#E05555"
+                                            Opacity="0.8"
+                                            HorizontalAlignment="Center"
+                                            Margin="0,0,0,12"/>
+                <TextBlock Text="SD CARD ERROR"
+                           FontSize="11"
+                           FontWeight="Bold"
+                           Foreground="#E05555"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,6"/>
+                <TextBlock Text="{Binding SdCardErrorMessage}"
+                           FontSize="12"
+                           FontFamily="Consolas"
+                           Foreground="{StaticResource TextSecondary}"
+                           HorizontalAlignment="Center"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           MaxWidth="360"
+                           Margin="0,0,0,8">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Visible"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SdCardErrorMessage}" Value="">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+                <TextBlock Text="The card may be corrupt or busy. Try a different card or reformat (FAT32)."
+                           FontSize="13"
+                           FontWeight="Light"
+                           Foreground="{StaticResource TextPrimary}"
+                           HorizontalAlignment="Center"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           MaxWidth="320"
+                           Margin="0,0,0,16"/>
+                <Button Style="{StaticResource PillButton}"
+                        Command="{Binding CopyDiagnosticInfoCommand}"
+                        HorizontalAlignment="Center"
+                        Margin="0">
+                    <StackPanel Orientation="Horizontal">
+                        <iconPacks:PackIconMaterial Kind="ContentCopy" Width="10" Height="10" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                        <TextBlock Text="COPY DIAGNOSTICS"/>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+
             <!-- File list (visible only when USB device has at least one file) -->
             <ListView Name="DeviceFilesList"
                       ItemsSource="{Binding DeviceFiles}"
@@ -376,13 +489,9 @@
                     <Style TargetType="ListView">
                         <Setter Property="Visibility" Value="Collapsed"/>
                         <Style.Triggers>
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding CanAccessSdCard}" Value="True"/>
-                                    <Condition Binding="{Binding HasNoFiles}" Value="False"/>
-                                </MultiDataTrigger.Conditions>
+                            <DataTrigger Binding="{Binding HasFiles}" Value="True">
                                 <Setter Property="Visibility" Value="Visible"/>
-                            </MultiDataTrigger>
+                            </DataTrigger>
                         </Style.Triggers>
                     </Style>
                 </ListView.Style>

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -1,5 +1,8 @@
 using System.Collections.ObjectModel;
+using System.Text;
+using System.Windows;
 using Application = System.Windows.Application;
+using Clipboard = System.Windows.Clipboard;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Controls.Dialogs;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -9,11 +12,19 @@ using Daqifi.Desktop.Device;
 using Daqifi.Desktop.Logger;
 using Daqifi.Desktop.Loggers;
 using Daqifi.Desktop.Models;
+using Daqifi.Core.Device.SdCard;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using System.Windows.Input;
 
 namespace Daqifi.Desktop.ViewModels;
+
+public enum SdCardState
+{
+    Unknown,
+    Ok,
+    NotPresent,
+    Error
+}
 
 public partial class DeviceLogsViewModel : ObservableObject
 {
@@ -30,6 +41,12 @@ public partial class DeviceLogsViewModel : ObservableObject
 
     [ObservableProperty]
     private IStreamingDevice _selectedDevice;
+
+    [ObservableProperty]
+    private SdCardState _sdCardState = SdCardState.Unknown;
+
+    [ObservableProperty]
+    private string _sdCardErrorMessage = string.Empty;
 
     private ObservableCollection<SdCardFile> _deviceFiles;
 
@@ -52,23 +69,35 @@ public partial class DeviceLogsViewModel : ObservableObject
                     _deviceFiles.CollectionChanged += OnDeviceFilesCollectionChanged;
                 }
                 OnPropertyChanged(nameof(HasNoFiles));
+                OnPropertyChanged(nameof(HasFiles));
             }
         }
     }
 
-    [ObservableProperty]
-    private bool _canRefreshFiles;
-
     public bool CanAccessSdCard => SelectedDevice?.ConnectionType == ConnectionType.Usb;
 
-    public bool HasNoFiles => (DeviceFiles?.Any() != true) && CanAccessSdCard;
+    public bool HasNoFiles => (DeviceFiles?.Any() != true) && CanAccessSdCard && SdCardState == SdCardState.Ok;
+
+    public bool HasFiles => CanAccessSdCard && (DeviceFiles?.Any() == true) && SdCardState == SdCardState.Ok;
+
+    public bool HasSdCardNotPresent => CanAccessSdCard && SdCardState == SdCardState.NotPresent;
+
+    public bool HasSdCardError => CanAccessSdCard && SdCardState == SdCardState.Error;
 
     public string ConnectionTypeMessage => SelectedDevice == null ? string.Empty :
         SelectedDevice.ConnectionType == ConnectionType.Usb ?
             "USB Connected - SD Card Access Available" :
             "WiFi Connected - SD Card Access Requires USB Connection";
 
-    public ICommand RefreshFilesCommand { get; }
+    public string SdCardStatusLine => SdCardState switch
+    {
+        SdCardState.Ok => $" · SD card OK · {DeviceFiles?.Count ?? 0} {(DeviceFiles?.Count == 1 ? "file" : "files")}",
+        SdCardState.NotPresent => " · No SD card installed",
+        SdCardState.Error => $" · SD card error{(!string.IsNullOrEmpty(SdCardErrorMessage) ? $": {SdCardErrorMessage}" : string.Empty)}",
+        _ => string.Empty
+    };
+
+    public IAsyncRelayCommand RefreshFilesCommand { get; }
 
     public DeviceLogsViewModel()
     {
@@ -76,10 +105,8 @@ public partial class DeviceLogsViewModel : ObservableObject
         DeviceFiles = new ObservableCollection<SdCardFile>();
         DeviceFiles.CollectionChanged += OnDeviceFilesCollectionChanged;
 
-        // Initialize commands
-        RefreshFilesCommand = new RelayCommand(RefreshFiles, () => CanAccessSdCard);
+        RefreshFilesCommand = new AsyncRelayCommand(RefreshFilesAsync, () => CanAccessSdCard);
 
-        // Subscribe to device connection changes
         ConnectionManager.Instance.PropertyChanged += (s, e) =>
         {
             if (e.PropertyName == "ConnectedDevices")
@@ -88,18 +115,28 @@ public partial class DeviceLogsViewModel : ObservableObject
             }
         };
 
-        // Initial load
         UpdateConnectedDevices();
     }
 
     private void OnDeviceFilesCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
         OnPropertyChanged(nameof(HasNoFiles));
+        OnPropertyChanged(nameof(HasFiles));
+        OnPropertyChanged(nameof(SdCardStatusLine));
+    }
+
+    partial void OnSdCardStateChanged(SdCardState value)
+    {
+        OnPropertyChanged(nameof(HasNoFiles));
+        OnPropertyChanged(nameof(HasFiles));
+        OnPropertyChanged(nameof(HasSdCardNotPresent));
+        OnPropertyChanged(nameof(HasSdCardError));
+        OnPropertyChanged(nameof(SdCardStatusLine));
     }
 
     private void UpdateConnectedDevices()
     {
-        Application.Current.Dispatcher.Invoke(() =>
+        void Update()
         {
             ConnectedDevices.Clear();
             foreach (var device in ConnectionManager.Instance.ConnectedDevices)
@@ -107,22 +144,33 @@ public partial class DeviceLogsViewModel : ObservableObject
                 ConnectedDevices.Add(device);
             }
 
-            // If we have devices but none selected, select the first one
             if (SelectedDevice == null && ConnectedDevices.Any())
             {
                 SelectedDevice = ConnectedDevices.First();
             }
-        });
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher != null)
+        {
+            dispatcher.Invoke(Update);
+        }
+        else
+        {
+            Update();
+        }
     }
 
     partial void OnSelectedDeviceChanged(IStreamingDevice value)
     {
+        SdCardState = SdCardState.Unknown;
+        SdCardErrorMessage = string.Empty;
+
         if (value != null)
         {
-            // Only refresh files if we have USB access
             if (CanAccessSdCard)
             {
-                RefreshFiles();
+                _ = RefreshFilesAsync();
             }
             else
             {
@@ -136,11 +184,14 @@ public partial class DeviceLogsViewModel : ObservableObject
 
         OnPropertyChanged(nameof(CanAccessSdCard));
         OnPropertyChanged(nameof(HasNoFiles));
+        OnPropertyChanged(nameof(HasSdCardNotPresent));
+        OnPropertyChanged(nameof(HasSdCardError));
+        OnPropertyChanged(nameof(HasFiles));
         OnPropertyChanged(nameof(ConnectionTypeMessage));
-        (RefreshFilesCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        RefreshFilesCommand.NotifyCanExecuteChanged();
     }
 
-    private async void RefreshFiles()
+    internal async Task RefreshFilesAsync()
     {
         if (SelectedDevice == null || !CanAccessSdCard)
         {
@@ -151,32 +202,65 @@ public partial class DeviceLogsViewModel : ObservableObject
         {
             IsBusy = true;
             BusyMessage = "Refreshing files...";
+            SdCardState = SdCardState.Unknown;
+            SdCardErrorMessage = string.Empty;
 
-            // Clear existing files
             DeviceFiles.Clear();
 
-            // Request file list from device without blocking the UI thread
             await Task.Run(() => SelectedDevice.RefreshSdCardFiles());
 
-            // Update our list with any files found
             foreach (var file in SelectedDevice.SdCardFiles)
             {
                 DeviceFiles.Add(file);
             }
+
+            SdCardState = SdCardState.Ok;
+        }
+        catch (SdCardNotPresentException)
+        {
+            SdCardState = SdCardState.NotPresent;
+            SdCardErrorMessage = string.Empty;
+            _logger.Warning($"SD card not present in device {SelectedDevice?.DeviceSerialNo}");
+        }
+        catch (SdCardFilesystemException ex)
+        {
+            SdCardState = SdCardState.Error;
+            SdCardErrorMessage = ex.DeviceMessage ?? ex.Message;
+            _logger.Error(ex, "SD card filesystem error");
+        }
+        catch (SdCardOperationException ex)
+        {
+            SdCardState = SdCardState.Error;
+            SdCardErrorMessage = ex.LastScpiError ?? ex.Message;
+            _logger.Error(ex, "SD card operation error");
         }
         catch (Exception ex)
         {
+            SdCardState = SdCardState.Error;
+            SdCardErrorMessage = ex.Message;
             _logger.Error(ex, "Failed to refresh SD card files");
-            await Application.Current.Dispatcher.InvokeAsync(async () =>
-            {
-                await ShowMessage("Error", "Failed to refresh files. Please check the device connection and try again.", MessageDialogStyle.Affirmative);
-            });
         }
         finally
         {
             IsBusy = false;
             BusyMessage = string.Empty;
         }
+    }
+
+    [RelayCommand]
+    private void CopyDiagnosticInfo()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Device Serial: {SelectedDevice?.DeviceSerialNo ?? "N/A"}");
+        sb.AppendLine($"Firmware Version: {SelectedDevice?.DeviceVersion ?? "N/A"}");
+        sb.AppendLine($"Connection Type: {SelectedDevice?.ConnectionType}");
+        sb.AppendLine($"SD Card State: {SdCardState}");
+        if (!string.IsNullOrEmpty(SdCardErrorMessage))
+        {
+            sb.AppendLine($"Error: {SdCardErrorMessage}");
+        }
+
+        Clipboard.SetText(sb.ToString());
     }
 
     [RelayCommand]

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -18,11 +18,18 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Daqifi.Desktop.ViewModels;
 
+/// <summary>
+/// Represents the current state of the SD card in the connected device.
+/// </summary>
 public enum SdCardState
 {
+    /// <summary>SD card state has not yet been determined.</summary>
     Unknown,
+    /// <summary>SD card is present and accessible.</summary>
     Ok,
+    /// <summary>No SD card is installed in the device.</summary>
     NotPresent,
+    /// <summary>SD card is present but an error occurred accessing it.</summary>
     Error
 }
 
@@ -43,9 +50,16 @@ public partial class DeviceLogsViewModel : ObservableObject
     private IStreamingDevice _selectedDevice;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasNoFiles))]
+    [NotifyPropertyChangedFor(nameof(HasFiles))]
+    [NotifyPropertyChangedFor(nameof(HasSdCardNotPresent))]
+    [NotifyPropertyChangedFor(nameof(HasSdCardError))]
+    [NotifyPropertyChangedFor(nameof(SdCardStatusLine))]
     private SdCardState _sdCardState = SdCardState.Unknown;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSdCardError))]
+    [NotifyPropertyChangedFor(nameof(SdCardStatusLine))]
     private string _sdCardErrorMessage = string.Empty;
 
     private ObservableCollection<SdCardFile> _deviceFiles;
@@ -76,12 +90,16 @@ public partial class DeviceLogsViewModel : ObservableObject
 
     public bool CanAccessSdCard => SelectedDevice?.ConnectionType == ConnectionType.Usb;
 
+    /// <summary>True when the USB device has an OK SD card but no log files on it.</summary>
     public bool HasNoFiles => (DeviceFiles?.Any() != true) && CanAccessSdCard && SdCardState == SdCardState.Ok;
 
+    /// <summary>True when the USB device has an OK SD card with at least one log file.</summary>
     public bool HasFiles => CanAccessSdCard && (DeviceFiles?.Any() == true) && SdCardState == SdCardState.Ok;
 
+    /// <summary>True when the USB device reports that no SD card is installed.</summary>
     public bool HasSdCardNotPresent => CanAccessSdCard && SdCardState == SdCardState.NotPresent;
 
+    /// <summary>True when the USB device reports an SD card error.</summary>
     public bool HasSdCardError => CanAccessSdCard && SdCardState == SdCardState.Error;
 
     public string ConnectionTypeMessage => SelectedDevice == null ? string.Empty :
@@ -89,14 +107,21 @@ public partial class DeviceLogsViewModel : ObservableObject
             "USB Connected - SD Card Access Available" :
             "WiFi Connected - SD Card Access Requires USB Connection";
 
+    /// <summary>
+    /// Short status string appended to the connection status bar.
+    /// Returns an empty string when the SD card state is unknown.
+    /// </summary>
     public string SdCardStatusLine => SdCardState switch
     {
-        SdCardState.Ok => $" · SD card OK · {DeviceFiles?.Count ?? 0} {(DeviceFiles?.Count == 1 ? "file" : "files")}",
+        SdCardState.Ok =>
+            $" · SD card OK · {DeviceFiles?.Count ?? 0} {(DeviceFiles?.Count == 1 ? "file" : "files")}",
         SdCardState.NotPresent => " · No SD card installed",
-        SdCardState.Error => $" · SD card error{(!string.IsNullOrEmpty(SdCardErrorMessage) ? $": {SdCardErrorMessage}" : string.Empty)}",
+        SdCardState.Error =>
+            $" · SD card error{(!string.IsNullOrEmpty(SdCardErrorMessage) ? $": {SdCardErrorMessage}" : string.Empty)}",
         _ => string.Empty
     };
 
+    /// <summary>Refreshes the SD card file list from the selected device.</summary>
     public IAsyncRelayCommand RefreshFilesCommand { get; }
 
     public DeviceLogsViewModel()
@@ -122,15 +147,6 @@ public partial class DeviceLogsViewModel : ObservableObject
     {
         OnPropertyChanged(nameof(HasNoFiles));
         OnPropertyChanged(nameof(HasFiles));
-        OnPropertyChanged(nameof(SdCardStatusLine));
-    }
-
-    partial void OnSdCardStateChanged(SdCardState value)
-    {
-        OnPropertyChanged(nameof(HasNoFiles));
-        OnPropertyChanged(nameof(HasFiles));
-        OnPropertyChanged(nameof(HasSdCardNotPresent));
-        OnPropertyChanged(nameof(HasSdCardError));
         OnPropertyChanged(nameof(SdCardStatusLine));
     }
 
@@ -193,7 +209,8 @@ public partial class DeviceLogsViewModel : ObservableObject
 
     internal async Task RefreshFilesAsync()
     {
-        if (SelectedDevice == null || !CanAccessSdCard)
+        var device = SelectedDevice;
+        if (device == null || device.ConnectionType != ConnectionType.Usb)
         {
             return;
         }
@@ -207,20 +224,25 @@ public partial class DeviceLogsViewModel : ObservableObject
 
             DeviceFiles.Clear();
 
-            await Task.Run(() => SelectedDevice.RefreshSdCardFiles());
+            await Task.Run(() => device.RefreshSdCardFiles());
 
-            foreach (var file in SelectedDevice.SdCardFiles)
+            if (SelectedDevice != device)
+            {
+                return;
+            }
+
+            foreach (var file in device.SdCardFiles)
             {
                 DeviceFiles.Add(file);
             }
 
             SdCardState = SdCardState.Ok;
         }
-        catch (SdCardNotPresentException)
+        catch (SdCardNotPresentException ex)
         {
             SdCardState = SdCardState.NotPresent;
             SdCardErrorMessage = string.Empty;
-            _logger.Warning($"SD card not present in device {SelectedDevice?.DeviceSerialNo}");
+            _logger.Warning($"SD card not present in device {device.DeviceSerialNo}: {ex.Message}");
         }
         catch (SdCardFilesystemException ex)
         {
@@ -260,7 +282,14 @@ public partial class DeviceLogsViewModel : ObservableObject
             sb.AppendLine($"Error: {SdCardErrorMessage}");
         }
 
-        Clipboard.SetText(sb.ToString());
+        try
+        {
+            Clipboard.SetText(sb.ToString());
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning($"Failed to copy diagnostic info to clipboard: {ex.Message}");
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary

Fixes #510. Replaces the silent "NO FILES" fallback with actionable inline feedback when Core reports an SD card fault.

- **Typed exception handling**: `RefreshFilesAsync` now catches `SdCardNotPresentException`, `SdCardFilesystemException`, and `SdCardOperationException` from Core (daqifi/daqifi-core#181) and renders state inline — no more fire-and-forget modal dialogs
- **Three inline empty states**: "NO SD CARD" (insert FAT32 card + Refresh), "SD CARD ERROR" (error code + reformat hint), and the existing "NO FILES" (only shown when state is confirmed Ok)
- **Status bar suffix**: connection badge gains `· SD card OK · 3 files` / `· SD card error: -200 Execution error` (red) after refresh
- **Copy Diagnostics button**: in both error panels — writes device serial, firmware version, and last SCPI error to clipboard
- **`DeviceDisplayName` fallback**: ComboBox `DisplayMemberPath` changed from `DeviceSerialNo` to `DeviceDisplayName` (falls back to `DisplayIdentifier`), fixing the class-name label when serial is null
- **`AsyncRelayCommand`**: `RefreshFilesCommand` switched from `RelayCommand` wrapping an async void to a proper `AsyncRelayCommand`; `UpdateConnectedDevices` is null-safe for the dispatcher so the ViewModel is unit-testable

## Test plan

- [ ] USB device with no SD card: "NO SD CARD" panel appears, "Copy Diagnostics" copies device info to clipboard
- [ ] USB device with corrupt SD card (or mock `SdCardOperationException`): "SD CARD ERROR" panel shows the SCPI error code; status bar shows it in red
- [ ] USB device with a healthy SD card and files: file list populates normally; status bar shows "SD card OK · N files"
- [ ] USB device with a healthy but empty SD card: "NO FILES" panel shown (not the error panel)
- [ ] WiFi device selected: "USB REQUIRED" panel shown, SD card states hidden
- [ ] Device with null `DeviceSerialNo`: ComboBox shows COM port / IP instead of class name
- [ ] 14 new unit tests pass on Windows CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)