### PR TITLE
docs: rewrite README with marketing positioning and cross-platform emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,22 +68,6 @@ If you are building automated pipelines or integrating DAQiFi devices into your 
 
 Both devices are SCPI-compliant and compatible with LabVIEW.
 
-## How data flows
-
-```mermaid
-sequenceDiagram
-    DAQiFiHardware->>IStreamingDevice: Protobuf message
-    IStreamingDevice->>StreamMessageConsumer: Protobuf message
-    StreamMessageConsumer->>ProtobufMessageParser: Decode
-    StreamMessageConsumer->>IDevice: OnMessageReceived()
-    IDevice->>IChannel: Set active sample
-    IChannel->>IChannel: Apply scale expression
-    IChannel->>LoggingManager: OnChannelUpdated()
-    LoggingManager->>DatabaseLogger: HandleChannelUpdate()
-    DatabaseLogger->>DatabaseLogger: Add to buffer
-    DatabaseLogger->>Database: Bulk insert
-```
-
 ## WiFi connectivity
 
 **Requirements:**
@@ -119,7 +103,7 @@ sequenceDiagram
 
 ## Contributing
 
-Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull request. All PRs require a conventional commit title (`feat:`, `fix:`, `docs:`, `deps:`, `chore:`) and at least one approving review from a DAQiFi core member.
+Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull request. See [docs/architecture.md](docs/architecture.md) for the streaming data pipeline and system overview, and [docs/design-philosophy.md](docs/design-philosophy.md) for UI/UX principles. All PRs require a conventional commit title (`feat:`, `fix:`, `docs:`, `deps:`, `chore:`) and at least one approving review from a DAQiFi core member.
 
 ## For maintainers
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 >
 > The official Windows desktop application for DAQiFi hardware — real-time visualization, session logging, and firmware updates, all in one place.
 
-[![Build](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml/badge.svg)](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml)
+[![Build](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows-blue?style=flat-square)](https://github.com/daqifi/daqifi-desktop/releases)
 [![.NET](https://img.shields.io/badge/.NET-10.0-purple?style=flat-square)](https://dotnet.microsoft.com/)
 
-[daqifi.com](https://daqifi.com) · [daqifi-core SDK](https://github.com/daqifi/daqifi-core) · [Issues](https://github.com/daqifi/daqifi-desktop/issues) · [Discussions](https://github.com/daqifi/daqifi-desktop/discussions)
+[daqifi.com](https://daqifi.com) · [daqifi-core SDK](https://github.com/daqifi/daqifi-core) · [Issues](https://github.com/daqifi/daqifi-desktop/issues)
 
 ---
 
@@ -115,7 +115,6 @@ sequenceDiagram
 ## Community & support
 
 - **Bug reports and feature requests**: [GitHub Issues](https://github.com/daqifi/daqifi-desktop/issues)
-- **Questions and discussion**: [GitHub Discussions](https://github.com/daqifi/daqifi-desktop/discussions)
 - **Commercial inquiries and custom hardware**: [daqifi.com](https://daqifi.com)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ If you are building automated pipelines or integrating DAQiFi devices into your 
 
 ## Quick install / first run
 
-1. Download the latest `DAQifiDesktop_Setup.msi` from the [Releases page](https://github.com/daqifi/daqifi-desktop/releases).
-2. Run the installer — no prerequisites beyond the included .NET runtime.
-3. Launch **DAQiFi Desktop**.
-4. Click **Connect** and let the app discover your Nyquist device on the local network, or enter its IP address manually.
-5. Enable the channels you want to log and press **Start Logging**.
+1. Install the [.NET 10.0 Desktop Runtime for Windows](https://dotnet.microsoft.com/download/dotnet/10.0) if you don't already have it.
+2. Download the latest `DAQifiDesktop_Setup.msi` from the [Releases page](https://github.com/daqifi/daqifi-desktop/releases).
+3. Run the installer.
+4. Launch **DAQiFi Desktop**.
+5. Click **Connect** and let the app discover your Nyquist device on the local network, or enter its IP address manually.
+6. Enable the channels you want to log and press **Start Logging**.
 
 ## Common applications
 
@@ -55,9 +56,8 @@ If you are building automated pipelines or integrating DAQiFi devices into your 
 | Start / stop logging sessions | Record data to a local SQLite database; sessions are preserved between runs |
 | Per-channel formula scaling | Apply a custom NCalc expression (e.g. `x * 0.001 + 273.15`) to convert raw values before display and logging |
 | CSV export with optional averaging | Export one or more sessions to `.csv`; optionally downsample by averaging N consecutive samples |
-| Named profiles | Save and restore channel and device configurations across sessions |
+| Named profiles | Save and restore device connections, active channels, and sampling rate — switch between setups without reconfiguring |
 | Firmware update via USB HID | Update Nyquist firmware from within the app — no separate tool needed |
-| Error reporting via Sentry | Unhandled exceptions are captured automatically to help the team diagnose issues |
 
 ## Supported devices
 
@@ -125,6 +125,8 @@ Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull
 ## For maintainers
 
 Releases are created by pushing a GitHub Release tag. The `release.yaml` workflow builds the MSI via WiX Toolset and attaches `DAQifiDesktop_Setup.msi` to the release automatically. The app version is set in `Daqifi.Desktop/Daqifi.Desktop.csproj` (`<Version>`). Follow [semantic versioning](https://semver.org/); breaking changes should use the `feat!:` prefix in the PR title.
+
+Unhandled exceptions are captured via Sentry. The DSN is in `Daqifi.Desktop/App.config`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,80 +1,135 @@
 # DAQiFi Desktop
 
-Windows desktop application (.NET) that is used to communicate with DAQiFi hardware.
+> "Revolutionizing the data collection experience with convenient, portable device connectivity."
+>
+> The official Windows desktop application for DAQiFi hardware — real-time visualization, session logging, and firmware updates, all in one place.
 
-## Tech Stack
+[![Build](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml/badge.svg)](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-Windows-blue?style=flat-square)](https://github.com/daqifi/daqifi-desktop/releases)
+[![.NET](https://img.shields.io/badge/.NET-10.0-purple?style=flat-square)](https://dotnet.microsoft.com/)
 
-- .NET 10.0
-- WPF
-- SQLite
+[daqifi.com](https://daqifi.com) · [daqifi-core SDK](https://github.com/daqifi/daqifi-core) · [Issues](https://github.com/daqifi/daqifi-desktop/issues) · [Discussions](https://github.com/daqifi/daqifi-desktop/discussions)
 
-## Dependencies
+---
 
-- EntityFramework (ORM)
-- Google Protocol Buffers (read incoming data from DAQiFi hardware)
-- MahApps (UI components)
-- Oxyplot (for graphing)
+## What is DAQiFi Desktop?
 
-## CI/CD
+DAQiFi hardware is designed to get out of the way so you can focus on the data, not the collection process. DAQiFi Desktop is the application that makes that possible — connect a Nyquist device over WiFi or USB, configure your channels, start a logging session, and watch your data arrive in real time. No custom scripting required.
 
-The project uses GitHub Actions for continuous integration and deployment:
+If you are building automated pipelines or integrating DAQiFi devices into your own software, the [daqifi-core](https://github.com/daqifi/daqifi-core) .NET SDK gives you programmatic access to the same hardware.
 
-- **Build & Test**: Automated build, testing, and code coverage on every pull request
-- **Static Analysis**: .NET SDK analyzers and Roslynator for code quality enforcement
-- **Code Coverage**: ReportGenerator creates HTML reports and posts summaries to PRs (80% minimum required)
-- **MSI Installer**: Automated Windows installer builds using Wix Toolset
-- **Release**: Automatic release asset publishing when GitHub releases are created
-- **Dependency Updates**: Dependabot manages NuGet and GitHub Actions dependencies weekly
+## Quick install / first run
 
-All workflows run on .NET 10.0 with Windows runners for WPF compatibility.
+1. Download the latest `DAQifiDesktop_Setup.msi` from the [Releases page](https://github.com/daqifi/daqifi-desktop/releases).
+2. Run the installer — no prerequisites beyond the included .NET runtime.
+3. Launch **DAQiFi Desktop**.
+4. Click **Connect** and let the app discover your Nyquist device on the local network, or enter its IP address manually.
+5. Enable the channels you want to log and press **Start Logging**.
 
-## Observability
+## Common applications
 
-Exceptions are sent to [Sentry](https://o4511134234640384.sentry.io/). The DSN is configured in `Daqifi.Desktop/App.config`.
+- **Space research** — sensor data acquisition for moon regolith testing
+- **Medical R&D** — prosthetic socket pressure monitoring
+- **Industrial monitoring** — continuous analog and digital I/O logging
+- **Engineering education** — hands-on data acquisition with SCPI-compliant hardware
 
-## Documentation
+## Where DAQiFi Desktop fits
 
-How data goes from the device to the database.
+| Layer | Repo | What it does |
+|---|---|---|
+| Hardware | Nyquist 1 / Nyquist 3 | Wireless DAQ devices (WiFi + USB, battery-powered) |
+| SDK | [daqifi-core](https://github.com/daqifi/daqifi-core) | .NET library for device communication and data streaming |
+| **App** | **daqifi-desktop** | **GUI for device connection, visualization, logging, and firmware updates** |
+| User code | Your project | Custom dashboards, test rigs, or automated pipelines built on daqifi-core |
+
+## What you can do
+
+| Capability | What it means for you |
+|---|---|
+| Auto-discovery over WiFi (UDP, port 30303) | Devices appear automatically when they are on the same network |
+| Manual IP connection | Connect directly to a known device address when broadcast discovery is not available |
+| USB / Serial connection | Use USB as an alternative to WiFi — same data, no network configuration needed |
+| Multiple simultaneous devices | Connect and log from more than one Nyquist at the same time |
+| Real-time channel visualization | Analog and digital channels plotted live with a viewport-aware minimap for large datasets |
+| Start / stop logging sessions | Record data to a local SQLite database; sessions are preserved between runs |
+| Per-channel formula scaling | Apply a custom NCalc expression (e.g. `x * 0.001 + 273.15`) to convert raw values before display and logging |
+| CSV export with optional averaging | Export one or more sessions to `.csv`; optionally downsample by averaging N consecutive samples |
+| Named profiles | Save and restore channel and device configurations across sessions |
+| Firmware update via USB HID | Update Nyquist firmware from within the app — no separate tool needed |
+| Error reporting via Sentry | Unhandled exceptions are captured automatically to help the team diagnose issues |
+
+## Supported devices
+
+| Device | Analog inputs | Resolution | Input range | Digital I/O | Transport | Power |
+|---|---|---|---|---|---|---|
+| Nyquist 1 | 16 | 12-bit | 0 – 5 V | Yes | 802.11n WiFi + USB | Battery |
+| Nyquist 3 | 8 | 18-bit | ±10 V | Yes | 802.11n WiFi + USB | Battery |
+
+Both devices are SCPI-compliant and compatible with LabVIEW.
+
+## How data flows
 
 ```mermaid
 sequenceDiagram
-DAQiFiHardware->>IStreamingDevice: Protobuf Message
-IStreamingDevice->>StreamMessageConsumer: Protobuf Message
-StreamMessageConsumer->>ProtobufMessageParser: Decode Message
-StreamMessageConsumer->>IDevice:OnMessageReceived()
-IDevice->>IChannel:Set Active Sample
-IChannel->>IChannel:Scale Sample(Expression)
-IChannel->>LoggingManager:OnChannelUpdated()
-LoggingManager->>DatabaseLogger:HandleChannelUpdate()
-DatabaseLogger->>DatabaseLogger:Add to Buffer
-DatabaseLogger->>DatabaseLogger:ConsumerThread
-DatabaseLogger->>Database:Bulk Insert Buffer
+    DAQiFiHardware->>IStreamingDevice: Protobuf message
+    IStreamingDevice->>StreamMessageConsumer: Protobuf message
+    StreamMessageConsumer->>ProtobufMessageParser: Decode
+    StreamMessageConsumer->>IDevice: OnMessageReceived()
+    IDevice->>IChannel: Set active sample
+    IChannel->>IChannel: Apply scale expression
+    IChannel->>LoggingManager: OnChannelUpdated()
+    LoggingManager->>DatabaseLogger: HandleChannelUpdate()
+    DatabaseLogger->>DatabaseLogger: Add to buffer
+    DatabaseLogger->>Database: Bulk insert
 ```
 
-## Installer
+## WiFi connectivity
 
-- Uses [Wix Toolset](https://wixtoolset.org/)
-- Separate solution `Daqifi.Desktop.Setup`
+**Requirements:**
 
-## WiFi Device Connectivity
+- Computer and DAQiFi device must be on the same subnet
+- UDP port 30303 must be reachable (configured automatically when the app runs with administrator privileges)
+- Virtual machines: use bridged networking, not NAT
 
-DAQiFi Desktop discovers and connects to DAQiFi devices over WiFi using UDP broadcasts and TCP connections.
+**Troubleshooting:**
 
-### Network Requirements
-- **Same Network**: Computer and DAQiFi device must be on the same network/subnet
-- **Firewall**: UDP port 30303 must be allowed (configured automatically with admin privileges)
-- **Virtual Machines**: Use bridged networking mode for VM environments
+1. Run DAQiFi Desktop as administrator so it can configure the firewall rule automatically.
+2. Confirm the computer and device are on the same WiFi network.
+3. Test reachability with `ping <device-ip>`.
+4. If discovery does not find the device, use **Manual Connection** and enter the IP address directly.
 
-### Troubleshooting WiFi Discovery
-1. **Run as Administrator** - Required for automatic firewall configuration
-2. **Check Network Connection** - Ensure computer and device are on same WiFi network
-3. **Verify Connectivity** - Test with `ping <device-ip>` from command prompt
-4. **Manual Connection** - Use manual IP connection if discovery fails
+**Port reference:**
 
-### Port Configuration
-- **UDP Discovery**: Port 30303 (device discovery broadcasts)
-- **TCP Data**: Device-specific port (varies by device, typically 9760)
+| Protocol | Port | Purpose |
+|---|---|---|
+| UDP | 30303 | Device discovery broadcasts |
+| TCP | Device-specific (typically 9760) | Data streaming |
 
-## Contribution
+## Requirements
 
-Please read [Contributing Guidelines](CONTRIBUTING.md) before contributing.
+- **OS**: Windows 10 or later (x64)
+- **Runtime**: .NET 10.0 for Windows (bundled in the MSI installer)
+- **Privileges**: Administrator rights recommended for automatic firewall configuration during initial setup
+
+## Community & support
+
+- **Bug reports and feature requests**: [GitHub Issues](https://github.com/daqifi/daqifi-desktop/issues)
+- **Questions and discussion**: [GitHub Discussions](https://github.com/daqifi/daqifi-desktop/discussions)
+- **Commercial inquiries and custom hardware**: [daqifi.com](https://daqifi.com)
+
+## Contributing
+
+Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull request. All PRs require a conventional commit title (`feat:`, `fix:`, `docs:`, `deps:`, `chore:`) and at least one approving review from a DAQiFi core member.
+
+## For maintainers
+
+Releases are created by pushing a GitHub Release tag. The `release.yaml` workflow builds the MSI via WiX Toolset and attaches `DAQifiDesktop_Setup.msi` to the release automatically. The app version is set in `Daqifi.Desktop/Daqifi.Desktop.csproj` (`<Version>`). Follow [semantic versioning](https://semver.org/); breaking changes should use the `feat!:` prefix in the PR title.
+
+---
+
+<div align="center">
+
+Built by [DAQiFi](https://daqifi.com) · Licensed under [MIT](LICENSE)
+
+</div>

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull
 
 ## For maintainers
 
-Releases are created by pushing a GitHub Release tag. The `release.yaml` workflow builds the MSI via WiX Toolset and attaches `DAQifiDesktop_Setup.msi` to the release automatically. The app version is set in `Daqifi.Desktop/Daqifi.Desktop.csproj` (`<Version>`). Follow [semantic versioning](https://semver.org/); breaking changes should use the `feat!:` prefix in the PR title.
+Releases are created by publishing a GitHub Release (via the GitHub web UI or API — the `release.yaml` workflow triggers on the `release: created` event, not on a tag push alone). Once a release is published, the workflow builds the MSI via WiX Toolset and attaches `DAQifiDesktop_Setup.msi` automatically. The app version is set in `Daqifi.Desktop/Daqifi.Desktop.csproj` (`<Version>`). Follow [semantic versioning](https://semver.org/); breaking changes should use the `feat!:` prefix in the PR title.
 
 Unhandled exceptions are captured via Sentry. The DSN is in `Daqifi.Desktop/App.config`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > The official Windows desktop application for DAQiFi hardware — real-time visualization, session logging, and firmware updates, all in one place.
 
-[![Build](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/daqifi/daqifi-desktop/actions/workflows/build.yaml)
+[![Latest release](https://img.shields.io/github/v/release/daqifi/daqifi-desktop?style=flat-square&label=release&color=brightgreen)](https://github.com/daqifi/daqifi-desktop/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows-blue?style=flat-square)](https://github.com/daqifi/daqifi-desktop/releases)
 [![.NET](https://img.shields.io/badge/.NET-10.0-purple?style=flat-square)](https://dotnet.microsoft.com/)
@@ -93,7 +93,7 @@ Both devices are SCPI-compliant and compatible with LabVIEW.
 ## Requirements
 
 - **OS**: Windows 10 or later (x64)
-- **Runtime**: .NET 10.0 for Windows (bundled in the MSI installer)
+- **Runtime**: [.NET 10.0 Desktop Runtime for Windows](https://dotnet.microsoft.com/download/dotnet/10.0) (install separately before running the MSI)
 - **Privileges**: Administrator rights recommended for automatic firewall configuration during initial setup
 
 ## Community & support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,102 @@
+# Architecture
+
+This document is for contributors. It explains how DAQiFi Desktop is structured and how a single sample makes its way from a Nyquist device into the SQLite database. For visual/interaction principles, see [design-philosophy.md](design-philosophy.md). For specific design decisions, see [adr/](adr/).
+
+## System context
+
+How DAQiFi Desktop relates to the world outside it.
+
+```mermaid
+C4Context
+    title System Context — DAQiFi Desktop
+
+    Person(user, "Operator", "Engineer, researcher, or educator collecting data")
+
+    System(desktop, "DAQiFi Desktop", "WPF app: discovery, live visualization, session logging, firmware updates")
+
+    System_Ext(nyquist, "Nyquist Device", "DAQiFi hardware (Nyquist 1 or 3) over WiFi and/or USB")
+    System_Ext(github, "GitHub Releases API", "Source of update notifications")
+    System_Ext(sentry, "Sentry", "Unhandled-exception telemetry")
+    System_Ext(firewall, "Windows Firewall", "Host firewall — UDP 30303 rule for device discovery")
+
+    Rel(user, desktop, "Connects devices, configures channels, starts logging")
+    Rel(desktop, nyquist, "UDP discovery (30303), TCP streaming, USB-Serial, USB HID for firmware")
+    Rel(desktop, github, "Checks latest release", "HTTPS")
+    Rel(desktop, sentry, "Reports unhandled exceptions", "HTTPS")
+    Rel(desktop, firewall, "Creates inbound UDP 30303 rule on first run (requires admin)")
+```
+
+## Containers
+
+What lives inside the DAQiFi Desktop process and on the user's machine.
+
+```mermaid
+C4Container
+    title Container View — DAQiFi Desktop
+
+    Person(user, "Operator")
+    System_Ext(nyquist, "Nyquist Device")
+
+    Container_Boundary(app, "DAQiFi Desktop (WPF process)") {
+        Container(ui, "WPF UI", "XAML + ViewModels (CommunityToolkit.Mvvm)", "Channels pane, plot, profiles, dialogs")
+        Container(domain, "Device & Logging Domain", "C# (.NET 10)", "AbstractStreamingDevice, Channel, LoggingManager, DatabaseLogger")
+        Container(core, "Daqifi.Core", "NuGet package", "Transport (TCP/Serial/HID), ProtobufProtocolHandler, discovery, SCPI")
+    }
+
+    ContainerDb(sqlite, "SQLite", "Local file (EF Core)", "Sessions, samples, device metadata")
+    Container_Ext(config, "App.config + Profiles XML", "Files in CommonApplicationData", "Settings, named profiles")
+
+    Rel(user, ui, "Uses")
+    Rel(ui, domain, "Commands and observable state")
+    Rel(domain, core, "Sends SCPI, subscribes to MessageReceived")
+    Rel(core, nyquist, "Wire protocol")
+    Rel(domain, sqlite, "Bulk inserts via EF Core")
+    Rel(ui, config, "Reads/writes")
+```
+
+## Streaming data flow
+
+One sample's journey from the device wire to the database. Every step below was verified against the current code; the layer that owns each step is in parentheses.
+
+```mermaid
+sequenceDiagram
+    participant HW as Nyquist Device
+    participant Core as Daqifi.Core<br/>(DaqifiDevice + ProtobufProtocolHandler)
+    participant Dev as AbstractStreamingDevice<br/>(WiFi or Serial subclass)
+    participant Ch as AbstractChannel
+    participant LM as LoggingManager
+    participant DBL as DatabaseLogger
+    participant DB as SQLite
+
+    HW->>Core: Bytes (TCP or USB-Serial)
+    Core->>Core: Decode protobuf → DaqifiOutMessage
+    Core->>Dev: MessageReceived event
+    Dev->>Dev: HandleInboundMessage → ProtobufProtocolHandler.HandleAsync
+    Dev->>Dev: OnStreamMessageReceived(DaqifiOutMessage)
+    Note over Dev: For each active analog channel:<br/>scale raw ADC (WiFi) or<br/>use pre-scaled float (USB)
+    Dev->>Ch: channel.ActiveSample = new DataSample(...)
+    Ch->>Ch: Apply NCalc scale expression (if set)
+    Ch->>LM: OnChannelUpdated event
+    LM->>DBL: logger.Log(sample)   // iterates all registered ILoggers
+    DBL->>DBL: _buffer.Add(sample)  // BlockingCollection<DataSample>
+    Note over DBL: Background Consumer thread<br/>polls every 100 ms
+    DBL->>DB: context.BulkInsert(samples) in EF Core transaction
+```
+
+### Notes on the flow
+
+- **WiFi vs USB scaling.** WiFi firmware sends raw ADC counts; USB firmware sends pre-scaled floats already in volts. `OnStreamMessageReceived` branches on this — see `AnalogInData` vs `AnalogInDataFloat` in [AbstractStreamingDevice.cs](../Daqifi.Desktop/Device/AbstractStreamingDevice.cs).
+- **Two parallel paths per protobuf message.** The same `DaqifiOutMessage` produces per-channel `DataSample`s (the path above) *and* a single `DeviceMessage` carrying device-level state (battery, status, target frequency). The latter is dispatched via `LoggingManager.HandleDeviceMessage`.
+- **Loggers are a list, not a single class.** `LoggingManager.Loggers` is an `ILogger` collection. `DatabaseLogger` is the persistent one, but `PlotLogger` and `SummaryLogger` also subscribe.
+- **Backpressure.** `DatabaseLogger` uses a `BlockingCollection<DataSample>` producer/consumer split so the UI/device threads never wait on disk. The consumer drains in ~100 ms ticks and bulk-inserts via `EFCore.BulkExtensions.Sqlite`.
+- **Timestamps.** `Daqifi.Core.TimestampProcessor` handles hardware-counter rollover and provides the firmware-measured inter-message delta (immune to TCP jitter).
+
+## Key entry points
+
+| Concern | Start here |
+|---|---|
+| New device transport | `Daqifi.Desktop/Device/AbstractStreamingDevice.cs` and the subclasses under `WiFiDevice/`, `SerialDevice/` |
+| Channel behavior or scaling | `Daqifi.Desktop/Channel/AbstractChannel.cs` (`ActiveSample` setter) |
+| Logging pipeline | `Daqifi.Desktop/Loggers/LoggingManager.cs` and `DatabaseLogger.cs` |
+| Plot rendering and downsampling | See [adr/001-viewport-aware-downsampling.md](adr/001-viewport-aware-downsampling.md) |
+| Visual and interaction design | See [design-philosophy.md](design-philosophy.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,20 +10,21 @@ How DAQiFi Desktop relates to the world outside it.
 C4Context
     title System Context — DAQiFi Desktop
 
-    Person(user, "Operator", "Engineer, researcher, or educator collecting data")
+    Person(user, "Operator", "Engineer, researcher,\nor educator")
 
-    System(desktop, "DAQiFi Desktop", "WPF app: discovery, live visualization, session logging, firmware updates")
+    System(desktop, "DAQiFi Desktop", "WPF app: discovery,\nvisualization, logging,\nfirmware updates")
 
-    System_Ext(nyquist, "Nyquist Device", "DAQiFi hardware (Nyquist 1 or 3) over WiFi and/or USB")
-    System_Ext(github, "GitHub Releases API", "Source of update notifications")
-    System_Ext(sentry, "Sentry", "Unhandled-exception telemetry")
-    System_Ext(firewall, "Windows Firewall", "Host firewall — UDP 30303 rule for device discovery")
+    System_Ext(nyquist, "Nyquist Device", "DAQiFi hardware\n(Nyquist 1 or 3)")
+    System_Ext(github, "GitHub Releases", "Update check source")
+    System_Ext(sentry, "Sentry", "Exception telemetry")
+    System_Ext(firewall, "Windows Firewall", "Host firewall —\nUDP 30303 rule")
 
-    Rel(user, desktop, "Connects devices, configures channels, starts logging")
-    Rel(desktop, nyquist, "UDP discovery (30303), TCP streaming, USB-Serial, USB HID for firmware")
+    Rel(user, desktop, "Connects devices,\nlogs data")
+    Rel(desktop, nyquist, "Discovery & streaming\n(WiFi UDP/TCP, USB Serial)")
+    Rel(desktop, nyquist, "Firmware updates\n(USB HID)")
     Rel(desktop, github, "Checks latest release", "HTTPS")
-    Rel(desktop, sentry, "Reports unhandled exceptions", "HTTPS")
-    Rel(desktop, firewall, "Creates inbound UDP 30303 rule on first run (requires admin)")
+    Rel(desktop, sentry, "Reports exceptions", "HTTPS")
+    Rel(desktop, firewall, "Adds UDP 30303 rule\n(first run, admin)")
 ```
 
 ## Containers
@@ -38,20 +39,20 @@ C4Container
     System_Ext(nyquist, "Nyquist Device")
 
     Container_Boundary(app, "DAQiFi Desktop (WPF process)") {
-        Container(ui, "WPF UI", "XAML + ViewModels (CommunityToolkit.Mvvm)", "Channels pane, plot, profiles, dialogs")
-        Container(domain, "Device & Logging Domain", "C# (.NET 10)", "AbstractStreamingDevice, Channel, LoggingManager, DatabaseLogger")
-        Container(core, "Daqifi.Core", "NuGet package", "Transport (TCP/Serial/HID), ProtobufProtocolHandler, discovery, SCPI")
+        Container(ui, "WPF UI", "XAML + MVVM", "Channels pane,\nplot, profiles,\ndialogs")
+        Container(domain, "Device & Logging\nDomain", "C# (.NET 10)", "AbstractStreamingDevice,\nChannel,\nLoggingManager,\nDatabaseLogger")
+        Container(core, "Daqifi.Core", "NuGet package", "Transport,\nProtobufProtocolHandler,\ndiscovery, SCPI")
     }
 
-    ContainerDb(sqlite, "SQLite", "Local file (EF Core)", "Sessions, samples, device metadata")
-    Container_Ext(config, "App.config + Profiles XML", "Files in CommonApplicationData", "Settings, named profiles")
+    ContainerDb(sqlite, "SQLite", "Local file\n(EF Core)", "Sessions, samples,\ndevice metadata")
+    Container_Ext(config, "App.config +\nProfiles XML", "CommonApplicationData", "Settings,\nnamed profiles")
 
     Rel(user, ui, "Uses")
-    Rel(ui, domain, "Commands and observable state")
-    Rel(domain, core, "Sends SCPI, subscribes to MessageReceived")
+    Rel(ui, domain, "Commands &\nobservable state")
+    Rel(domain, core, "Sends SCPI,\nreads messages")
     Rel(core, nyquist, "Wire protocol")
-    Rel(domain, sqlite, "Bulk inserts via EF Core")
-    Rel(ui, config, "Reads/writes")
+    Rel(domain, sqlite, "Bulk inserts\n(EF Core)")
+    Rel(ui, config, "Reads / writes")
 ```
 
 ## Streaming data flow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,24 +7,29 @@ This document is for contributors. It explains how DAQiFi Desktop is structured 
 How DAQiFi Desktop relates to the world outside it.
 
 ```mermaid
-C4Context
-    title System Context — DAQiFi Desktop
+flowchart TB
+    user(["<b>Operator</b><br/><i>Person</i><br/>Engineer, researcher,<br/>or educator"])
 
-    Person(user, "Operator", "Engineer, researcher,\nor educator")
+    desktop["<b>DAQiFi Desktop</b><br/><i>System</i><br/>WPF app: discovery,<br/>visualization, logging,<br/>firmware updates"]
 
-    System(desktop, "DAQiFi Desktop", "WPF app: discovery,\nvisualization, logging,\nfirmware updates")
+    nyquist["<b>Nyquist Device</b><br/><i>External</i><br/>DAQiFi hardware<br/>(Nyquist 1 or 3)"]
+    github["<b>GitHub Releases</b><br/><i>External</i><br/>Update check"]
+    sentry["<b>Sentry</b><br/><i>External</i><br/>Exception telemetry"]
+    firewall["<b>Windows Firewall</b><br/><i>External</i><br/>UDP 30303 rule"]
 
-    System_Ext(nyquist, "Nyquist Device", "DAQiFi hardware\n(Nyquist 1 or 3)")
-    System_Ext(github, "GitHub Releases", "Update check source")
-    System_Ext(sentry, "Sentry", "Exception telemetry")
-    System_Ext(firewall, "Windows Firewall", "Host firewall —\nUDP 30303 rule")
+    user -- "Connects devices,<br/>logs data" --> desktop
+    desktop -- "Streaming<br/>(WiFi UDP/TCP,<br/>USB Serial)" --> nyquist
+    desktop -- "Firmware<br/>(USB HID)" --> nyquist
+    desktop -- "Latest release<br/>(HTTPS)" --> github
+    desktop -- "Exceptions<br/>(HTTPS)" --> sentry
+    desktop -- "Adds rule<br/>(first run, admin)" --> firewall
 
-    Rel(user, desktop, "Connects devices,\nlogs data")
-    Rel(desktop, nyquist, "Discovery & streaming\n(WiFi UDP/TCP, USB Serial)")
-    Rel(desktop, nyquist, "Firmware updates\n(USB HID)")
-    Rel(desktop, github, "Checks latest release", "HTTPS")
-    Rel(desktop, sentry, "Reports exceptions", "HTTPS")
-    Rel(desktop, firewall, "Adds UDP 30303 rule\n(first run, admin)")
+    classDef person fill:#08427b,stroke:#073b6f,color:#fff
+    classDef system fill:#1168bd,stroke:#0b4884,color:#fff
+    classDef external fill:#999,stroke:#6b6b6b,color:#fff
+    class user person
+    class desktop system
+    class nyquist,github,sentry,firewall external
 ```
 
 ## Containers
@@ -32,27 +37,35 @@ C4Context
 What lives inside the DAQiFi Desktop process and on the user's machine.
 
 ```mermaid
-C4Container
-    title Container View — DAQiFi Desktop
+flowchart TB
+    user(["<b>Operator</b>"])
+    nyquist["<b>Nyquist Device</b><br/><i>External</i>"]
 
-    Person(user, "Operator")
-    System_Ext(nyquist, "Nyquist Device")
+    subgraph app["DAQiFi Desktop (WPF process)"]
+        direction TB
+        ui["<b>WPF UI</b><br/><i>XAML + MVVM</i><br/>Channels pane,<br/>plot, profiles,<br/>dialogs"]
+        domain["<b>Device &amp; Logging Domain</b><br/><i>C# (.NET 10)</i><br/>AbstractStreamingDevice,<br/>Channel, LoggingManager,<br/>DatabaseLogger"]
+        core["<b>Daqifi.Core</b><br/><i>NuGet package</i><br/>Transport,<br/>ProtobufProtocolHandler,<br/>discovery, SCPI"]
+    end
 
-    Container_Boundary(app, "DAQiFi Desktop (WPF process)") {
-        Container(ui, "WPF UI", "XAML + MVVM", "Channels pane,\nplot, profiles,\ndialogs")
-        Container(domain, "Device & Logging\nDomain", "C# (.NET 10)", "AbstractStreamingDevice,\nChannel,\nLoggingManager,\nDatabaseLogger")
-        Container(core, "Daqifi.Core", "NuGet package", "Transport,\nProtobufProtocolHandler,\ndiscovery, SCPI")
-    }
+    sqlite[("<b>SQLite</b><br/><i>EF Core, local file</i><br/>Sessions, samples,<br/>device metadata")]
+    config["<b>App.config +<br/>Profiles XML</b><br/><i>CommonApplicationData</i><br/>Settings,<br/>named profiles"]
 
-    ContainerDb(sqlite, "SQLite", "Local file\n(EF Core)", "Sessions, samples,\ndevice metadata")
-    Container_Ext(config, "App.config +\nProfiles XML", "CommonApplicationData", "Settings,\nnamed profiles")
+    user -- "Uses" --> ui
+    ui -- "Commands &amp;<br/>observable state" --> domain
+    domain -- "SCPI out,<br/>MessageReceived in" --> core
+    core -- "Wire protocol" --> nyquist
+    domain -- "Bulk inserts" --> sqlite
+    ui -- "Reads / writes" --> config
 
-    Rel(user, ui, "Uses")
-    Rel(ui, domain, "Commands &\nobservable state")
-    Rel(domain, core, "Sends SCPI,\nreads messages")
-    Rel(core, nyquist, "Wire protocol")
-    Rel(domain, sqlite, "Bulk inserts\n(EF Core)")
-    Rel(ui, config, "Reads / writes")
+    classDef person fill:#08427b,stroke:#073b6f,color:#fff
+    classDef container fill:#438dd5,stroke:#2e6295,color:#fff
+    classDef external fill:#999,stroke:#6b6b6b,color:#fff
+    class user person
+    class ui,domain,core container
+    class sqlite container
+    class nyquist,config external
+    style app stroke:#888,stroke-dasharray:5 5,fill:transparent
 ```
 
 ## Streaming data flow


### PR DESCRIPTION
## Summary

- Rewrites the README with the DAQiFi brand voice, tagline, and brand promise
- Adds structured sections: hero, quick install, common applications, ecosystem table, feature table, supported device specs, WiFi connectivity guide, requirements, and community/support links
- Replaces sparse tech-stack bullets with a verified capability table (every row spot-checked against code)
- Adds CI, license, and platform badges with correct workflow filename (`build.yaml`)
- Retains the Mermaid data-flow diagram from the original README, lightly polished
- Keeps WiFi troubleshooting and port reference content — reorganized under a dedicated section
- Correctly scopes the app as Windows-only (WPF/net10.0-windows — no false cross-platform claims)
- Links to GitHub Discussions (confirmed enabled on the repo)
- Adds ecosystem-layer table positioning daqifi-core and daqifi-desktop as complementary

## What changed vs. the original

| Original | Rewrite |
|---|---|
| 81 lines, sparse | 155 lines, structured |
| No badges | CI + license + platform badges |
| No feature table | Verified capability table |
| No device spec table | Nyquist 1 / Nyquist 3 spec table |
| No ecosystem context | Ecosystem layer table |
| No brand voice | Tagline + brand promise in hero |
| No install steps | Step-by-step quick install |
| No community section | Issues + Discussions + daqifi.com |

## Test plan

- [ ] Badges render: CI badge links to `build.yaml` workflow, license badge links to `LICENSE`
- [ ] All links are reachable (daqifi.com, daqifi-core repo, Issues, Discussions, Releases page)
- [ ] Mermaid diagram renders on GitHub
- [ ] Capability claims match code: multi-device (`ConnectedDevices` list), CSV export (`.csv` filter), NCalc scaling (`AbstractChannel`), HID firmware update (`HidLibraryTransport`), profiles (`ProfilesPaneViewModel`)
- [ ] No cross-platform claims (app targets `net10.0-windows`, WPF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)