### PR TITLE
chore: remove redundant Google.Protobuf package references

### DIFF
--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -9,7 +9,6 @@
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 	  <PackageReference Include="Daqifi.Core" Version="0.21.0" />
-	  <PackageReference Include="Google.Protobuf" Version="3.34.1" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -8,7 +8,6 @@
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.8" />
 		<PackageReference Include="Daqifi.Core" Version="0.21.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.34.1" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
+++ b/Daqifi.Desktop.Test/Daqifi.Desktop.Test.csproj
@@ -11,7 +11,6 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Google.Protobuf" Version="3.34.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />


### PR DESCRIPTION
## What

Removes the direct `Google.Protobuf` PackageReference from three projects that do not use it directly:

- `Daqifi.Desktop.DataModel`
- `Daqifi.Desktop.IO`
- `Daqifi.Desktop.Test`

## Why

Protobuf handling lives in the external **Daqifi.Core** package, which declares `Google.Protobuf` as a public dependency — so it already flows transitively to every project that references Core. These three direct references were leftover cruft from when this repo had its own `.proto` codegen, which is now fully removed (no `.proto` files, no `Grpc.Tools`, no `<Protobuf>` MSBuild items remain).

- **DataModel** and **IO** contain no code that touches `Google.Protobuf` types.
- **Test** consumes the protobuf-generated `DaqifiOutMessage` (and its `RepeatedField` / `ByteString` members) transitively from Core — exactly like the main `Daqifi.Desktop` app and `Daqifi.Desktop.IO.Test`, neither of which carries a direct reference.

## Fixes the failure in #533

These stale pins are the root cause of the `NU1605` package-downgrade error in #533. The grouped Dependabot bump moved Protobuf `3.34.1 -> 3.35.0` in DataModel and IO but left `Daqifi.Desktop.Test` at `3.34.1`. Because a direct reference always overrides a transitive one, NuGet treated the Test pin as a downgrade of the version Core requires and failed `dotnet restore`.

With the direct references gone, `Google.Protobuf` simply tracks whatever version Daqifi.Core ships, and this class of Dependabot desync cannot recur. After this merges, #533 should rebase down to just the `coverlet.collector` and `System.Management` bumps and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
