### PR TITLE
fix: write settings, profiles, and firmware under the elevation-aware data dir

### DIFF
--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -16,7 +16,10 @@ public partial class LoggingManager : ObservableObject
 {
     #region Private Variables
     private readonly AppLogger AppLogger = AppLogger.Instance;
-    private static string ProfileAppDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + "\\DAQifi";
+    // Use the shared, elevation-aware data directory (AppDataPaths) so the profiles XML is
+    // written to a location the process can actually write (per-user when un-elevated),
+    // instead of failing on the admin-owned %ProgramData% file.
+    private static string ProfileAppDirectory = Daqifi.Desktop.Common.AppDataPaths.DataDirectory;
     private static readonly string ProfileSettingsXmlPath = ProfileAppDirectory + "\\DAQifiProfilesConfiguration.xml";
     private readonly IDbContextFactory<LoggingContext> _loggingContext;
     private bool _hasActiveApplicationSession;

--- a/Daqifi.Desktop/Models/DaqifiSettings.cs
+++ b/Daqifi.Desktop/Models/DaqifiSettings.cs
@@ -9,7 +9,10 @@ public class DaqifiSettings
 {
     #region Private Data
     private string _csvDelimiter = ",";
-    private static readonly string AppDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + "\\DAQifi";
+    // Use the shared, elevation-aware data directory (AppDataPaths): machine-wide for
+    // elevated production runs, per-user for un-elevated runs. Keeps settings writable
+    // (and consistent with the database/logs) instead of failing on an admin-owned file.
+    private static readonly string AppDirectory = Daqifi.Desktop.Common.AppDataPaths.DataDirectory;
     private static readonly string SettingsXmlPath = AppDirectory + "\\DAQifiConfiguration.xml";
     #endregion
 

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1035,8 +1035,7 @@ public partial class DaqifiViewModel : ObservableObject
     private static string GetFirmwareDownloadDirectory()
     {
         var firmwareDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "DAQiFi",
+            App.DaqifiDataDirectory,
             "Firmware",
             "PIC32");
         Directory.CreateDirectory(firmwareDirectory);
@@ -1046,8 +1045,7 @@ public partial class DaqifiViewModel : ObservableObject
     private static string GetWifiDownloadDirectory()
     {
         var wifiDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "DAQiFi",
+            App.DaqifiDataDirectory,
             "Firmware",
             "WiFi");
         Directory.CreateDirectory(wifiDirectory);


### PR DESCRIPTION
﻿Follow-up to #548. That PR introduced `AppDataPaths` (elevation-aware app-data location) and routed the **database** and **logs** through it. A few app-data paths were still hardcoded to `%ProgramData%`, so an un-elevated run still threw when writing the admin-owned files.

This routes the remaining ones through `AppDataPaths.DataDirectory`, so **every** app-data file lives in one elevation-aware location — machine-wide `%ProgramData%` for elevated production runs, per-user `%LocalAppData%` otherwise:

- `DaqifiSettings` → `DAQifiConfiguration.xml`
- `LoggingManager` → `DAQifiProfilesConfiguration.xml` (the exact source of the Sentry crash below)
- The PIC32 / WiFi firmware-download directories

### Fixes
`Fixes #535` — `System.UnauthorizedAccessException: Access to the path 'C:\ProgramData\DAQifi\DAQifiProfilesConfiguration.xml' is denied` (`LoggingManager.AddAndRemoveProfileXml`), which fired on un-elevated runs (the Debug `asInvoker` launch / the UI-test harness). Production is elevated and writes `%ProgramData%`, so it was never user-facing — but it left the profiles XML unwritten on non-admin runs.

### Verification
- Confirmed `DAQifiConfiguration.xml` and `DAQifiProfilesConfiguration.xml` now write under `%LocalAppData%\DAQiFi` on an un-elevated run.
- All 4 device-gated UI scenarios pass against an attached device; fast unit gate (274 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
