### PR TITLE
fix: logging status label stays stale while a session is active

### DIFF
--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -685,6 +685,33 @@ public abstract class DaqifiAppFixture
     }
 
     /// <summary>
+    /// Strictly waits (polling) until the user-visible <c>LoggingStatusText</c> label
+    /// reads <paramref name="expectedText"/> — reading ONLY the label's UIA Name, with
+    /// <b>no</b> fallback to the toggle's state. Use this for assertions where the label
+    /// itself is the thing under test: the toggle is the binding source so it always
+    /// flips, but the label only updates when <c>IsLogging</c> raises a change
+    /// notification. This catches the "toggle is On but the label still says LOGGING
+    /// OFF" regression that <see cref="WaitForLoggingStatus"/>'s toggle fallback hides.
+    /// </summary>
+    protected void WaitForLoggingStatusLabel(string expectedText, TimeSpan timeout)
+    {
+        Retry.WhileFalse(
+            () =>
+            {
+                var status = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(LOGGING_STATUS_TEXT_ID));
+                return status != null && string.Equals(status.Name, expectedText, StringComparison.Ordinal);
+            },
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(200),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                $"The logging status label never read '{expectedText}'. If the toggle " +
+                "flipped but the label stayed stale, the IsLogging setter is not raising " +
+                "PropertyChanged on the start/stop path, so bindings to IsLogging never refresh.");
+    }
+
+    /// <summary>
     /// Reads the number of logged-session rows currently shown on the Logged Data pane.
     /// Empty sessions (no samples) are deleted by the app on stop, so a row appearing
     /// here is an out-of-process signal that data actually accrued during the run.

--- a/Daqifi.Desktop.UITest/LoggingSessionTests.cs
+++ b/Daqifi.Desktop.UITest/LoggingSessionTests.cs
@@ -55,8 +55,13 @@ public class LoggingSessionTests : DaqifiAppFixture
         // Act — start the logging session.
         StartLogging();
 
-        // Assert — the UI reports the session is running.
-        WaitForLoggingStatus("LOGGING ON", TimeSpan.FromSeconds(15));
+        // Assert — the user-visible status LABEL (not just the toggle) reads "LOGGING
+        // ON". Regression guard: the toggle is the binding source so it always flips,
+        // but the "LOGGING ON/OFF" label and the LIVE/MODE/RATE chips only refresh when
+        // the IsLogging setter raises PropertyChanged. A bug where it didn't left the
+        // toggle On while the label still read "LOGGING OFF". This reads only the label
+        // (no toggle-state fallback), so it fails if the label goes stale.
+        WaitForLoggingStatusLabel("LOGGING ON", TimeSpan.FromSeconds(15));
 
         // Run — poll (not sleep) for an accrual signal. The session-finalize path only
         // keeps the session if samples were recorded, so a new logged-session row
@@ -72,8 +77,8 @@ public class LoggingSessionTests : DaqifiAppFixture
         // Stop — toggle logging off.
         StopLogging();
 
-        // Assert — the UI reports the session has stopped.
-        WaitForLoggingStatus("LOGGING OFF", TimeSpan.FromSeconds(15));
+        // Assert — the user-visible label (not just the toggle) reads "LOGGING OFF".
+        WaitForLoggingStatusLabel("LOGGING OFF", TimeSpan.FromSeconds(15));
 
         // Assert (out-of-process) — a new logged session exists, proving the session
         // ran and accrued data. If the row had not yet rendered during the run window,

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -223,6 +223,12 @@ public partial class DaqifiViewModel : ObservableObject
             }
 
             _isLogging = value;
+            // Notify bindings on the normal start/stop path. The toggle is the binding
+            // source so it flips on its own, but the "LOGGING ON/OFF" status label and
+            // the LIVE/MODE/RATE header chips are consumers that only refresh on this
+            // change notification — without it the label goes stale (toggle reads On
+            // while the label still says "LOGGING OFF").
+            OnPropertyChanged(nameof(IsLogging));
             LoggingManager.Instance.Active = value;
             if (_isLogging)
             {
@@ -2047,7 +2053,6 @@ public partial class DaqifiViewModel : ObservableObject
         {
             _appLogger.Warning($"Disk space critical ({e.AvailableMegabytes} MB) — automatically stopping logging");
             IsLogging = false;
-            OnPropertyChanged(nameof(IsLogging));
 
             _ = ShowDiskSpaceMessage(
                 "Logging Stopped — Disk Space Critical",

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -190,6 +190,14 @@ public partial class DaqifiViewModel : ObservableObject
     public DatabaseLogger DbLogger { get; private set; }
     public SummaryLogger SummaryLogger { get; private set; }
 
+    /// <summary>
+    /// Gets or sets whether a logging session is active. The setter is the single
+    /// entry point for starting/stopping logging: it gates startup on available disk
+    /// space, starts or stops disk-space monitoring, and starts or stops streaming
+    /// (or SD-card logging) on every connected device. It also raises a change
+    /// notification so all bindings — the logging toggle, the "LOGGING ON/OFF" status
+    /// label, and the LIVE/MODE/RATE header chips — reflect the current session state.
+    /// </summary>
     public bool IsLogging
     {
         get => _isLogging;


### PR DESCRIPTION
## Problem

While a session is actively logging, the toolbar still reads **LOGGING OFF** even though the toggle is switched on (green). Reported from the Live Graph pane.

## Root cause

`DaqifiViewModel.IsLogging` is a hand-written property. Its setter raised `OnPropertyChanged(nameof(IsLogging))` only on the disk-space early-return paths — **not on the normal start/stop path**.

The logging toggle and the `LOGGING ON/OFF` label both bind to `IsLogging`, but:
- the **toggle** is the binding *source*, so clicking it updates its own visual state directly;
- the **label** (via a `Style` `DataTrigger`) and the **LIVE / MODE / RATE** header chips are *consumers* — they only refresh when a change notification fires.

No notification on the happy path means the label (and chips) went stale: toggle On, label still says "LOGGING OFF".

## Fix

- Raise `OnPropertyChanged(nameof(IsLogging))` on the normal start/stop path so all consumers refresh.
- Remove the now-redundant explicit notify in the disk-critical stop path (the setter raises it).

## Test

Strengthened the FlaUI integration smoke test so it catches this:

- Added `WaitForLoggingStatusLabel` to `DaqifiAppFixture` — reads **only** the label's UIA text, with **no** toggle-state fallback. The existing `WaitForLoggingStatus` fell back to the toggle state and masked the stale label.
- `LoggingSessionTests.StartLoggingSession_RunsAndStops` now asserts the label reads the on/off text after start and stop.

### Verification (against an attached device, COM3)

| Scenario | Result |
|---|---|
| Strengthened test, **before** fix | Failed — "The logging status label never read 'LOGGING ON'" (reproduces the bug) |
| Strengthened test, **after** fix | Passed |
| Fast unit gate (`TestCategory!=Ui`) | 274 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
