### PR TITLE
chore: integration coverage for SD card logging mode

### DIFF
--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -51,6 +51,19 @@ public abstract class DaqifiAppFixture
     private const string LOGGING_STATUS_TEXT_ID = "LoggingStatusText";
     private const string LOGGED_SESSION_LIST_ID = "LoggedSessionList";
 
+    // AutomationIds for SD-card logging mode. The logging-mode selector lives in the
+    // per-device settings drawer (gear icon); the SD-card DATA FORMAT selector is
+    // rendered there only while in "Log to Device" mode, so its presence is an
+    // independent confirmation that the mode switch took effect. The SD file list and
+    // status line live on the Logged Data pane's DEVICE LOGS sub-tab.
+    private const string LOGGING_MODE_STREAM_ID = "LoggingModeStreamToApp";
+    private const string LOGGING_MODE_SDCARD_ID = "LoggingModeLogToDevice";
+    private const string SDCARD_FORMAT_SELECTOR_ID = "SdCardFormatSelector";
+    private const string DEVICE_LOGS_TAB_ID = "DeviceLogsTab";
+    private const string REFRESH_SDCARD_FILES_BUTTON_ID = "RefreshSdCardFilesButton";
+    private const string SDCARD_STATUS_TEXT_ID = "SdCardStatusText";
+    private const string SDCARD_FILE_LIST_ID = "SdCardFileList";
+
     private const string LOGGING_ON_TEXT = "LOGGING ON";
     private const string LOGGING_OFF_TEXT = "LOGGING OFF";
 
@@ -743,6 +756,200 @@ public abstract class DaqifiAppFixture
             throwOnTimeout: true,
             timeoutMessage:
                 $"Expected at least {minimum} logged-session row(s) but found fewer within {timeout.TotalSeconds}s.");
+    }
+    #endregion
+
+    #region SD-Card Logging Helpers
+    /// <summary>
+    /// Switches the connected device's logging mode via the segmented selector in the
+    /// per-device settings drawer. <paramref name="logToDevice"/> true selects
+    /// "Log to Device" (SD card); false selects "Stream to App". Confirms the switch by
+    /// an INDEPENDENT signal — the SD-card DATA FORMAT selector is rendered only while
+    /// <c>Shell.IsLogToDeviceMode</c> is true — rather than the radio's own checked
+    /// state, which the UIA SelectionItem pattern sets directly regardless of whether
+    /// the bound switch command actually ran.
+    /// </summary>
+    /// <param name="logToDevice">True for SD card logging; false for stream-to-app.</param>
+    protected void SetLoggingMode(bool logToDevice)
+    {
+        EnsureDeviceSettingsDrawerOpen();
+
+        var radioId = logToDevice ? LOGGING_MODE_SDCARD_ID : LOGGING_MODE_STREAM_ID;
+        var radio = FindByAutomationId(radioId).AsRadioButton();
+
+        // "Log to Device" is gated on a USB connection (SD card logging requires USB);
+        // WaitUntilEnabled surfaces a clear failure if the device is not USB-connected.
+        radio.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        if (!radio.IsChecked)
+        {
+            // Select() raises Checked, which the view's EventTrigger forwards to the
+            // SetLoggingMode command (a RadioButton's bound Command would not fire from
+            // a background automation host — see the harness gotchas).
+            radio.IsChecked = true;
+        }
+
+        // The DATA FORMAT section's Visibility binds through BooleanToVisibilityConverter
+        // (false -> Collapsed), and a Collapsed subtree is absent from the UIA tree. So
+        // *presence* of the selector is the signal that Shell.IsLogToDeviceMode is true —
+        // independent of scroll position (an on-screen check would falsely time out if the
+        // drawer ever needs scrolling to reveal it).
+        if (logToDevice)
+        {
+            Retry.WhileNull(
+                () => MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(SDCARD_FORMAT_SELECTOR_ID)),
+                timeout: TimeSpan.FromSeconds(15),
+                interval: TimeSpan.FromMilliseconds(300),
+                throwOnTimeout: true,
+                ignoreException: true,
+                timeoutMessage:
+                    "Switching to 'Log to Device' did not take effect: the SD card DATA FORMAT " +
+                    "selector never appeared, so Shell.IsLogToDeviceMode stayed false (the mode " +
+                    "switch command did not run).");
+        }
+        else
+        {
+            Retry.WhileFalse(
+                () => MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(SDCARD_FORMAT_SELECTOR_ID)) == null,
+                timeout: TimeSpan.FromSeconds(15),
+                interval: TimeSpan.FromMilliseconds(300),
+                throwOnTimeout: true,
+                ignoreException: true,
+                timeoutMessage:
+                    "Switching to 'Stream to App' did not take effect: the SD card DATA FORMAT " +
+                    "selector remained visible (Shell.IsLogToDeviceMode stayed true).");
+        }
+    }
+
+    /// <summary>
+    /// Navigates to the Logged Data pane's DEVICE LOGS sub-tab, refreshes the SD card
+    /// file list from the connected USB device, and returns the file count parsed from
+    /// the SD status line ("· SD card OK · N files"). Marks the test inconclusive when
+    /// no SD card is installed and fails on an SD card error. Counting from the status
+    /// line works at zero files (the file list itself is hidden when empty), so it gives
+    /// a stable before/after baseline.
+    /// </summary>
+    protected int GetSdCardFileCount(int timeoutSeconds = 45)
+    {
+        NavigateToTab(LOGGED_DATA_TAB_TEXT);
+        SelectDeviceLogsSubTab();
+        InvokeRefreshSdCardFiles();
+
+        // Wait until the refresh settles into a definitive SD state, capturing the line.
+        var statusText = string.Empty;
+        Retry.WhileFalse(
+            () =>
+            {
+                var status = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(SDCARD_STATUS_TEXT_ID));
+                if (status == null || status.IsOffscreen)
+                {
+                    return false;
+                }
+
+                var name = status.Name ?? string.Empty;
+                if (name.Contains("SD card OK", StringComparison.OrdinalIgnoreCase)
+                    || name.Contains("No SD card", StringComparison.OrdinalIgnoreCase)
+                    || name.Contains("SD card error", StringComparison.OrdinalIgnoreCase))
+                {
+                    statusText = name;
+                    return true;
+                }
+
+                return false;
+            },
+            timeout: TimeSpan.FromSeconds(timeoutSeconds),
+            interval: TimeSpan.FromMilliseconds(400),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                "SD card status did not reach a definitive state after refresh. Ensure the " +
+                "device is USB-connected and reporting its SD card.");
+
+        if (statusText.Contains("No SD card", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Inconclusive(
+                "The attached device reports no SD card installed; SD card logging cannot be " +
+                "exercised. Insert a FAT32-formatted SD card and re-run.");
+        }
+
+        if (statusText.Contains("SD card error", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Fail($"The device reported an SD card error during refresh: '{statusText}'.");
+        }
+
+        // e.g. "· SD card OK · 3 files" / "· SD card OK · 1 file" -> capture the count.
+        var match = System.Text.RegularExpressions.Regex.Match(
+            statusText, @"(\d+)\s*files?", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        Assert.IsTrue(
+            match.Success,
+            $"Could not parse the SD card file count from the status line '{statusText}'.");
+
+        return int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Ensures the per-device settings drawer is open (clicking the gear on the device
+    /// tile if needed) and the logging-mode selector inside it is realized.
+    /// </summary>
+    private void EnsureDeviceSettingsDrawerOpen()
+    {
+        NavigateToTab(DEVICES_TAB_TEXT);
+
+        var probe = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(LOGGING_MODE_SDCARD_ID));
+        if (probe == null || probe.IsOffscreen)
+        {
+            var gear = FindByAutomationId(DEVICE_SETTINGS_BUTTON_ID);
+            gear.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+            gear.AsButton().Invoke();
+        }
+
+        Retry.WhileNull(
+            () =>
+            {
+                var el = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(LOGGING_MODE_SDCARD_ID));
+                return el != null && !el.IsOffscreen ? el : null;
+            },
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "Device settings drawer did not open (logging-mode selector not visible).");
+    }
+
+    /// <summary>
+    /// Selects the DEVICE LOGS sub-tab on the Logged Data pane and waits for its content
+    /// (the SD card file view) to realize. The sub-tab is a RadioButton whose checked
+    /// state drives the view's visibility directly (ElementName binding, no command), so
+    /// the UIA SelectionItem pattern switches it reliably.
+    /// </summary>
+    private void SelectDeviceLogsSubTab()
+    {
+        var tab = FindByAutomationId(DEVICE_LOGS_TAB_ID).AsRadioButton();
+        Retry.WhileFalse(
+            () =>
+            {
+                if (!tab.IsChecked)
+                {
+                    tab.IsChecked = true;
+                }
+
+                return tab.IsChecked;
+            },
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "DEVICE LOGS sub-tab could not be selected on the Logged Data pane.");
+
+        // The refresh button only exists once the DeviceLogsView is realized/visible.
+        FindByAutomationId(REFRESH_SDCARD_FILES_BUTTON_ID);
+    }
+
+    /// <summary>Invokes the REFRESH button on the DEVICE LOGS sub-tab to re-read the SD file list.</summary>
+    private void InvokeRefreshSdCardFiles()
+    {
+        var refresh = FindByAutomationId(REFRESH_SDCARD_FILES_BUTTON_ID).AsButton();
+        refresh.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        refresh.Invoke();
     }
     #endregion
 

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -821,17 +821,56 @@ public abstract class DaqifiAppFixture
     }
 
     /// <summary>
-    /// Navigates to the Logged Data pane's DEVICE LOGS sub-tab, refreshes the SD card
-    /// file list from the connected USB device, and returns the file count parsed from
-    /// the SD status line ("· SD card OK · N files"). Marks the test inconclusive when
-    /// no SD card is installed and fails on an SD card error. Counting from the status
-    /// line works at zero files (the file list itself is hidden when empty), so it gives
-    /// a stable before/after baseline.
+    /// Navigates to the Logged Data pane's DEVICE LOGS sub-tab and returns the current SD
+    /// card file count (refresh + parse of the "· SD card OK · N files" status line). Marks
+    /// the test inconclusive when no SD card is installed and fails on an SD card error.
+    /// Counting from the status line works at zero files (the file list itself is hidden
+    /// when empty), so it gives a stable baseline before a logging run.
     /// </summary>
     protected int GetSdCardFileCount(int timeoutSeconds = 45)
     {
         NavigateToTab(LOGGED_DATA_TAB_TEXT);
         SelectDeviceLogsSubTab();
+        return ReadSdCardFileCountAfterRefresh(timeoutSeconds);
+    }
+
+    /// <summary>
+    /// Polls (re-refreshing the SD file list) until the SD card file count exceeds
+    /// <paramref name="baseline"/> or <paramref name="timeout"/> elapses, returning the last
+    /// count read. Uses a SINGLE overall timeout: it selects the DEVICE LOGS sub-tab once,
+    /// then each attempt refreshes with a short, bounded status-settle wait — so, unlike
+    /// nesting <see cref="GetSdCardFileCount"/> in an outer retry, one slow attempt cannot
+    /// blow past the overall budget. Use after stopping an SD logging run to ride out any
+    /// brief device-side finalize lag before the new file appears.
+    /// </summary>
+    protected int WaitForSdCardFileCountAbove(int baseline, TimeSpan timeout)
+    {
+        NavigateToTab(LOGGED_DATA_TAB_TEXT);
+        SelectDeviceLogsSubTab();
+
+        var latest = baseline;
+        Retry.WhileFalse(
+            () =>
+            {
+                // Short per-attempt settle keeps a single attempt well under the overall timeout.
+                latest = ReadSdCardFileCountAfterRefresh(settleTimeoutSeconds: 10);
+                return latest > baseline;
+            },
+            timeout: timeout,
+            interval: TimeSpan.FromSeconds(1),
+            throwOnTimeout: false);
+
+        return latest;
+    }
+
+    /// <summary>
+    /// Refreshes the SD card file list (assumes the DEVICE LOGS sub-tab is already selected),
+    /// waits up to <paramref name="settleTimeoutSeconds"/> for the SD status line to reach a
+    /// definitive state, and returns the file count parsed from it. Marks the test
+    /// inconclusive when no SD card is installed and fails on an SD card error.
+    /// </summary>
+    private int ReadSdCardFileCountAfterRefresh(int settleTimeoutSeconds)
+    {
         InvokeRefreshSdCardFiles();
 
         // Wait until the refresh settles into a definitive SD state, capturing the line.
@@ -856,7 +895,7 @@ public abstract class DaqifiAppFixture
 
                 return false;
             },
-            timeout: TimeSpan.FromSeconds(timeoutSeconds),
+            timeout: TimeSpan.FromSeconds(settleTimeoutSeconds),
             interval: TimeSpan.FromMilliseconds(400),
             throwOnTimeout: true,
             ignoreException: true,

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -5,7 +5,7 @@ Windows UI Automation tree) against a **physically attached device** (USB serial
 WiFi). It is the **integration gate** of the development loop — separate from the fast
 unit gate (`dotnet test` on the MSTest+Moq suites), which needs no hardware.
 
-It covers three end-to-end workflows plus a launch smoke test:
+It covers four end-to-end workflows plus a launch smoke test:
 
 | Test | What it verifies |
 |---|---|
@@ -13,6 +13,7 @@ It covers three end-to-end workflows plus a launch smoke test:
 | `AddDeviceTests.AddDevice_ConnectsToAttachedDevice` | Open connection dialog → discover → connect; device shows in connected list |
 | `ConfigureLoggingTests.ConfigureLogging_SetsFrequencyAndChannels` | Set sample frequency (device flyout) + enable analog channels; read both back |
 | `LoggingSessionTests.StartLoggingSession_RunsAndStops` | Start logging → data accrues (new session row) → stop |
+| `SdCardLoggingTests.SdCardLogging_LogsToSdCard_NotStream` | Switch to **Log to Device** (SD card) mode → run a session → a new file appears on the SD card (file count increased), confirming SD-card logging, not a stream session. **USB only; needs an SD card.** |
 
 Every UI test is tagged `[TestCategory("Ui")]` and `[TestCategory("RequiresDevice")]`
 so it never runs as part of the unit gate.
@@ -137,6 +138,10 @@ IDs are added only on the controls the scenarios touch. The panes are the
 | Channel list + “SELECT ALL” (analog) | `ChannelList` / `SelectAllAnalogChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
 | Logging toggle + status label | `StartLoggingToggle` / `LoggingStatusText` | `View/Prototype/LiveGraphPane.xaml` |
 | Logged-session list | `LoggedSessionList` | `View/Prototype/LoggedDataPanePrototype.xaml` |
+| Logging-mode selector (device drawer) | `LoggingModeStreamToApp` / `LoggingModeLogToDevice` | `View/Prototype/DevicesPanePrototype.xaml` |
+| SD-card data-format selector (visible only in Log-to-Device mode) | `SdCardFormatSelector` | `View/Prototype/DevicesPanePrototype.xaml` |
+| Logged Data → DEVICE LOGS sub-tab | `DeviceLogsTab` | `View/Prototype/LoggedDataPanePrototype.xaml` |
+| SD refresh button / status line / file list | `RefreshSdCardFilesButton` / `SdCardStatusText` / `SdCardFileList` | `View/DeviceLogsView.xaml` |
 
 ---
 
@@ -200,6 +205,24 @@ why.
 11. **Invalid `PackIconMaterial` Kinds crash panes at load.** Icon `Kind` is parsed at runtime,
     so a bad value (e.g. the former `SdStorage`) throws `XamlParseException` and destabilises
     the app when that pane loads. Use valid Material icon names.
+
+12. **A `RadioButton`/`ToggleButton` bound `Command` does NOT fire from automation — drive it
+    through `IsChecked` instead.** A `ButtonBase.Command` executes only on a real `Click`
+    (mouse/keyboard/access-key). The UIA patterns a background host can raise on a check control —
+    `SelectionItem.Select()` (RadioButton) and `Toggle.Toggle()` (ToggleButton) — set `IsChecked`
+    but never call `OnClick`, so a bound `Command` silently never runs and the action doesn’t
+    happen. Controls whose *effect* is driven by `IsChecked` itself work fine via these patterns:
+    the `StartLoggingToggle` (`IsChecked` TwoWay → `IsLogging` setter) and the Logged-Data
+    `DeviceLogsTab` (its `IsChecked` drives the view’s visibility via an `ElementName` binding)
+    are both automatable as-is. The **logging-mode segmented selector** was the exception — it
+    used `Command="{Binding SetLoggingModeCommand}"`, so `Select()` checked the button visually
+    but the device never switched mode. Fix: the two RadioButtons now forward their `Checked`
+    event to the command via a `Microsoft.Xaml.Behaviors` `EventTrigger`/`InvokeCommandAction`
+    (the `SetLoggingMode` setter is idempotent, so the redundant `Checked` raised when the OneWay
+    `IsChecked` binding refreshes is a harmless no-op). Confirm a mode switch by an **independent**
+    signal — `SetLoggingMode` waits for the `SdCardFormatSelector` (rendered only while
+    `Shell.IsLogToDeviceMode` is true), not the radio’s own checked state, which `Select()` sets
+    directly regardless of whether the command ran.
 
 ---
 

--- a/Daqifi.Desktop.UITest/SdCardLoggingTests.cs
+++ b/Daqifi.Desktop.UITest/SdCardLoggingTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Globalization;
+using System.IO;
+using FlaUI.Core.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Daqifi.Desktop.UITest;
+
+/// <summary>
+/// Scenario 4 — SD card logging mode. Drives the real GUI out-of-process: connects to
+/// the physically attached USB device, switches the logging mode from "Stream to App"
+/// to "Log to Device" (SD card), enables the analog channels, runs a brief logging
+/// session, and stops it. Asserts SD-card-side evidence — the device's "Enabled/Disabled
+/// SD card logging" log lines plus a new file on the SD card (the file count increased) —
+/// confirming the device logged to its SD card rather than to an in-app stream session.
+/// Requires a DAQiFi device with an SD card connected via USB (SD logging is USB-only).
+/// </summary>
+[TestClass]
+public class SdCardLoggingTests : DaqifiAppFixture
+{
+    #region Constants
+    // A gentle frequency keeps the UI responsive for out-of-process automation while the
+    // device streams to its SD card.
+    private const double TARGET_FREQUENCY_HZ = 100d;
+
+    // How long to let the device log to its SD card before stopping. SD file operations
+    // are blocked while logging, so a new file cannot be observed mid-run — this is a
+    // small, deliberate run window (not a readiness wait) long enough to create a file.
+    private static readonly TimeSpan SdRunDuration = TimeSpan.FromSeconds(5);
+    #endregion
+
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void SdCardLogging_LogsToSdCard_NotStream()
+    {
+        // Arrange — connect over Serial/USB. SD card logging requires USB: the
+        // "Log to Device" selector is disabled for WiFi devices, so this scenario
+        // forces Serial regardless of DAQIFI_TEST_TRANSPORT.
+        ConnectFirstDevice(DeviceTransport.Serial);
+
+        // Baseline the SD card file count while the device is still in the default
+        // Stream mode. This also asserts the device actually has an SD card present
+        // (the helper marks the test inconclusive otherwise).
+        var filesBefore = GetSdCardFileCount();
+
+        // Act — switch the device to "Log to Device" (SD card) logging mode.
+        SetLoggingMode(logToDevice: true);
+
+        // Configure a known rate and enable the analog channels (which gate the toggle).
+        SetSamplingFrequency(TARGET_FREQUENCY_HZ);
+        var activeChannels = EnableAllAnalogChannels();
+        Assert.IsTrue(
+            activeChannels > 0,
+            "Pre-condition failed: no analog channels became active.");
+
+        // Start logging. In SD mode the same toolbar toggle calls StartSdCardLogging on
+        // the device; production logs "Enabled SD card logging for device {serial}" — a
+        // mode-specific signal an in-app stream session would never emit.
+        StartLogging();
+        WaitForLoggingStatusLabel("LOGGING ON", TimeSpan.FromSeconds(15));
+        Assert.IsTrue(
+            WaitForLogContains("Enabled SD card logging for device", TimeSpan.FromSeconds(20)),
+            "Expected the device to engage SD card logging, but no 'Enabled SD card logging' " +
+            "log line appeared. Without it the session likely streamed to the app instead of " +
+            "logging to the SD card.");
+
+        // Let the device log to its SD card briefly.
+        System.Threading.Thread.Sleep(SdRunDuration);
+
+        // Stop logging — production logs "Disabled SD card logging for device {serial}".
+        StopLogging();
+        WaitForLoggingStatusLabel("LOGGING OFF", TimeSpan.FromSeconds(15));
+        Assert.IsTrue(
+            WaitForLogContains("Disabled SD card logging for device", TimeSpan.FromSeconds(20)),
+            "Expected the device to stop SD card logging, but no 'Disabled SD card logging' " +
+            "log line appeared.");
+
+        // Assert (out-of-process) — a new file exists on the SD card. The device writes a
+        // log file to its SD card per session, so an increased file count is positive
+        // proof the run logged to the SD card, not to an in-app stream session. Poll
+        // (re-refreshing) to ride out any brief device-side finalize lag after stop.
+        var filesAfter = filesBefore;
+        var sdFileAppeared = Retry.WhileFalse(
+            () =>
+            {
+                filesAfter = GetSdCardFileCount();
+                return filesAfter > filesBefore;
+            },
+            timeout: TimeSpan.FromSeconds(30),
+            interval: TimeSpan.FromSeconds(2),
+            throwOnTimeout: false).Result;
+
+        Assert.IsTrue(
+            sdFileAppeared,
+            $"Expected the SD card file count to increase after an SD logging run " +
+            $"(before={filesBefore}, after={filesAfter}). No new SD file means the device did " +
+            "not log to its SD card.");
+
+        CaptureScreenshot("SdCardLogging_LogsToSdCard_final");
+
+        // Best-effort: leave the device back in Stream mode for the next run. The base
+        // fixture's [TestCleanup] closes the app regardless, so a failure here is benign.
+        try { SetLoggingMode(logToDevice: false); } catch { /* teardown closes the app */ }
+
+        // Per-test independence: the base fixture's [TestCleanup] closes the app, which
+        // disconnects the device. A fresh app instance is launched per test.
+    }
+
+    /// <summary>
+    /// Saves a screenshot of the main window into the test results directory and
+    /// registers it as a result file. Best-effort; never throws into the test.
+    /// </summary>
+    private void CaptureScreenshot(string name)
+    {
+        try
+        {
+            var outDir = TestContext?.TestResultsDirectory ?? AppContext.BaseDirectory;
+            var stamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+            var path = Path.Combine(outDir, $"{name}_{stamp}.png");
+            FlaUI.Core.Capturing.Capture.Element(MainWindow).ToFile(path);
+            TestContext?.AddResultFile(path);
+        }
+        catch
+        {
+            // Screenshot capture must not affect the test outcome.
+        }
+    }
+}

--- a/Daqifi.Desktop.UITest/SdCardLoggingTests.cs
+++ b/Daqifi.Desktop.UITest/SdCardLoggingTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-using FlaUI.Core.Tools;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Daqifi.Desktop.UITest;
@@ -29,6 +28,12 @@ public class SdCardLoggingTests : DaqifiAppFixture
     private static readonly TimeSpan SdRunDuration = TimeSpan.FromSeconds(5);
     #endregion
 
+    /// <summary>
+    /// End-to-end SD card logging scenario: connect over USB, switch to "Log to Device"
+    /// mode, enable channels, run a brief logging session, stop, and assert the device
+    /// logged to its SD card (Enabled/Disabled SD card logging log lines plus an increased
+    /// SD file count) rather than to an in-app stream session.
+    /// </summary>
     [TestMethod]
     [TestCategory("Ui")]
     [TestCategory("RequiresDevice")]
@@ -77,22 +82,13 @@ public class SdCardLoggingTests : DaqifiAppFixture
             "log line appeared.");
 
         // Assert (out-of-process) — a new file exists on the SD card. The device writes a
-        // log file to its SD card per session, so an increased file count is positive
-        // proof the run logged to the SD card, not to an in-app stream session. Poll
-        // (re-refreshing) to ride out any brief device-side finalize lag after stop.
-        var filesAfter = filesBefore;
-        var sdFileAppeared = Retry.WhileFalse(
-            () =>
-            {
-                filesAfter = GetSdCardFileCount();
-                return filesAfter > filesBefore;
-            },
-            timeout: TimeSpan.FromSeconds(30),
-            interval: TimeSpan.FromSeconds(2),
-            throwOnTimeout: false).Result;
-
+        // log file to its SD card per session, so an increased file count is positive proof
+        // the run logged to the SD card, not to an in-app stream session. The helper polls
+        // (re-refreshing) under a single overall timeout to ride out brief device-side
+        // finalize lag after stop.
+        var filesAfter = WaitForSdCardFileCountAbove(filesBefore, TimeSpan.FromSeconds(30));
         Assert.IsTrue(
-            sdFileAppeared,
+            filesAfter > filesBefore,
             $"Expected the SD card file count to increase after an SD logging run " +
             $"(before={filesBefore}, after={filesAfter}). No new SD file means the device did " +
             "not log to its SD card.");

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -66,6 +66,11 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<!-- Used directly by View/Prototype/*.xaml (i:Interaction/EventTrigger/InvokeCommandAction).
+		     Referenced explicitly rather than relying on MahApps.Metro's transitive dependency so a
+		     clean restore cannot drop it out from under the XAML compiler. Version tracks the one
+		     MahApps.Metro 2.4.11 currently resolves. -->
+		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
 		<PackageReference Include="NCalcSync" Version="5.12.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="OxyPlot.Core" Version="2.2.0" />

--- a/Daqifi.Desktop/View/DeviceLogsView.xaml
+++ b/Daqifi.Desktop/View/DeviceLogsView.xaml
@@ -265,6 +265,7 @@
 
             <Button Grid.Column="2"
                     Style="{StaticResource PillButton}"
+                    AutomationProperties.AutomationId="RefreshSdCardFilesButton"
                     Command="{Binding RefreshFilesCommand}"
                     ToolTip="{Binding ConnectionTypeMessage}"
                     IsEnabled="{Binding CanAccessSdCard}">
@@ -305,8 +306,12 @@
                            FontWeight="SemiBold"
                            Foreground="{StaticResource TextSecondary}"
                            VerticalAlignment="Center"/>
-                <!-- SD card status — includes its own " · " prefix; hidden when empty -->
+                <!-- SD card status — includes its own " · " prefix; hidden when empty.
+                     The UIA Name mirrors the bound Text (a direct binding, not a Style
+                     trigger), so the FlaUI harness reads the live "SD card OK · N files"
+                     line from here to assert the SD file count after a logging run. -->
                 <TextBlock Text="{Binding SdCardStatusLine}"
+                           AutomationProperties.AutomationId="SdCardStatusText"
                            FontSize="11"
                            VerticalAlignment="Center">
                     <TextBlock.Style>
@@ -485,6 +490,7 @@
 
             <!-- File list (visible only when USB device has at least one file) -->
             <ListView Name="DeviceFilesList"
+                      AutomationProperties.AutomationId="SdCardFileList"
                       ItemsSource="{Binding DeviceFiles}"
                       Background="Transparent"
                       BorderThickness="0"

--- a/Daqifi.Desktop/View/Prototype/DevicesPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/DevicesPanePrototype.xaml
@@ -9,6 +9,7 @@
              xmlns:vm="clr-namespace:Daqifi.Desktop.ViewModels"
              xmlns:networkDataModel="clr-namespace:Daqifi.Core.Device.Network;assembly=Daqifi.Core"
              xmlns:sdCard="clr-namespace:Daqifi.Core.Device.SdCard;assembly=Daqifi.Core"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance Type=vm:DevicesPaneViewModel}"
              d:DesignHeight="800" d:DesignWidth="1200">
@@ -640,23 +641,42 @@
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
+                                    <!-- Drive the mode switch off Checked rather than Command: a RadioButton's
+                                         bound Command fires only on a real Click, which a background UI-automation
+                                         host cannot raise. Checking the button through the UIA SelectionItem/Toggle
+                                         pattern raises Checked (not Click), so an EventTrigger on Checked keeps the
+                                         control drivable both interactively and from the FlaUI harness. The
+                                         SelectedLoggingMode setter is idempotent, so the extra Checked that fires
+                                         when the OneWay binding refreshes after a switch is a harmless no-op. -->
                                     <RadioButton Grid.Column="0"
                                                  Content="STREAM TO APP"
+                                                 AutomationProperties.AutomationId="LoggingModeStreamToApp"
                                                  GroupName="LoggingMode"
                                                  IsChecked="{Binding Shell.IsLogToDeviceMode,
                                                              Converter={StaticResource BooleanToInverse}, Mode=OneWay}"
-                                                 Style="{StaticResource SegmentedToggle}"
-                                                 Command="{Binding SetLoggingModeCommand}"
-                                                 CommandParameter="Stream to App"/>
+                                                 Style="{StaticResource SegmentedToggle}">
+                                        <i:Interaction.Triggers>
+                                            <i:EventTrigger EventName="Checked">
+                                                <i:InvokeCommandAction Command="{Binding SetLoggingModeCommand}"
+                                                                       CommandParameter="Stream to App"/>
+                                            </i:EventTrigger>
+                                        </i:Interaction.Triggers>
+                                    </RadioButton>
                                     <RadioButton Grid.Column="1"
                                                  Content="LOG TO DEVICE"
+                                                 AutomationProperties.AutomationId="LoggingModeLogToDevice"
                                                  GroupName="LoggingMode"
                                                  IsEnabled="{Binding SelectedTile.IsUsb}"
                                                  IsChecked="{Binding Shell.IsLogToDeviceMode, Mode=OneWay}"
                                                  Style="{StaticResource SegmentedToggle}"
-                                                 Command="{Binding SetLoggingModeCommand}"
-                                                 CommandParameter="Log to Device"
-                                                 ToolTip="SD card logging requires USB. WiFi devices do not support SD card logging."/>
+                                                 ToolTip="SD card logging requires USB. WiFi devices do not support SD card logging.">
+                                        <i:Interaction.Triggers>
+                                            <i:EventTrigger EventName="Checked">
+                                                <i:InvokeCommandAction Command="{Binding SetLoggingModeCommand}"
+                                                                       CommandParameter="Log to Device"/>
+                                            </i:EventTrigger>
+                                        </i:Interaction.Triggers>
+                                    </RadioButton>
                                 </Grid>
                             </Border>
 
@@ -692,6 +712,7 @@
                                                      Converter={StaticResource BoolToVis}}">
                                 <TextBlock Text="DATA FORMAT" Style="{StaticResource InfoLabel}" Margin="0,16,0,6"/>
                                 <ComboBox Style="{StaticResource DrawerComboBox}"
+                                          AutomationProperties.AutomationId="SdCardFormatSelector"
                                           ItemsSource="{Binding Source={StaticResource SdCardLogFormats}}"
                                           SelectedItem="{Binding Shell.SelectedSdCardLogFormat, Mode=TwoWay}"/>
                             </StackPanel>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -225,6 +225,7 @@
                                          Content="APP LOGS"
                                          Style="{StaticResource SegmentedToggle}"/>
                             <RadioButton x:Name="DeviceLogsTab"
+                                         AutomationProperties.AutomationId="DeviceLogsTab"
                                          GroupName="LoggedDataTab"
                                          Content="DEVICE LOGS"
                                          Style="{StaticResource SegmentedToggle}"/>


### PR DESCRIPTION
Closes #553.

Adds the FlaUI hardware-in-the-loop scenario for **SD card logging mode** — one of the gaps surfaced during the Core 0.22.0 validation (#551) — plus the app change and AutomationIds needed to drive it.

## What the test does
`SdCardLoggingTests.SdCardLogging_LogsToSdCard_NotStream` (`[Ui]` + `[RequiresDevice]`) drives the real GUI out-of-process:
1. Connect over Serial/USB (SD logging is USB-only).
2. Baseline the SD card file count (also asserts a card is present → inconclusive otherwise).
3. Switch **Stream to App → Log to Device** via the Devices-pane drawer.
4. Enable the analog channels + set a known rate.
5. Start logging, run briefly, stop.
6. Assert SD-card-side evidence: the device's `Enabled/Disabled SD card logging` log lines **and** a new file on the SD card (file count increased) — confirming SD-card mode was used, **not** an in-app stream session.

## The app fix this surfaced (separate `fix(ui)` commit)
The logging-mode segmented selector bound its switch to a RadioButton **`Command`**. A `ButtonBase.Command` fires only on a real `Click`, which a background UI-automation host cannot raise — checking the button through the UIA `SelectionItem`/`Toggle` pattern raises `Checked`, not `Click` — so the device never switched mode under automation (same class of issue as the channel-tile gotcha).

Fix: forward each RadioButton's `Checked` event to `SetLoggingModeCommand` via a `Microsoft.Xaml.Behaviors` `EventTrigger`/`InvokeCommandAction`. Interactive behavior is unchanged (a click still raises `Checked`); the `SelectedLoggingMode` setter is idempotent, so the redundant `Checked` raised when the OneWay `IsChecked` binding refreshes is a harmless no-op. Controls already driven by `IsChecked` itself (`StartLoggingToggle`, the `DeviceLogsTab` sub-tab) were automatable as-is — now documented as README gotcha #12.

## AutomationIds added (touched controls only)
`LoggingModeStreamToApp` / `LoggingModeLogToDevice` / `SdCardFormatSelector` (Devices drawer), `DeviceLogsTab` (Logged Data), and `RefreshSdCardFilesButton` / `SdCardStatusText` / `SdCardFileList` (DeviceLogsView). All documented in the README AutomationId map.

## Verification
- App + UITest build clean; `dotnet format`-consistent.
- Unit gate: **274/274 pass**.
- Full device-gated UI suite on a **real device with an SD card**: **5/5 pass** (~3m37s) — the new SD scenario plus the 4 existing ones, so the shared device-drawer change caused no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)