### PR TITLE
chore: integration coverage for CSV export of a logged session (#555)

### DIFF
--- a/Daqifi.Desktop.Common/AppDataPaths.cs
+++ b/Daqifi.Desktop.Common/AppDataPaths.cs
@@ -24,6 +24,18 @@ public static class AppDataPaths
     public static bool IsTestMode { get; } =
         string.Equals(Environment.GetEnvironmentVariable("DAQIFI_TEST_MODE"), "1", StringComparison.Ordinal);
 
+    /// <summary>
+    /// Optional UI-test export target directory. When the environment variable
+    /// <c>DAQIFI_TEST_EXPORT_PATH</c> is set, the logging-session export commands write
+    /// straight into this directory (one <c>{session}.csv</c> per session) and skip the
+    /// interactive <c>SaveFileDialog</c>/<c>FolderBrowserDialog</c> entirely, so the FlaUI
+    /// harness can export to a known location with zero modal interaction. <c>null</c> in
+    /// normal and production runs, where the dialog behaviour is unchanged. Mirrors
+    /// <see cref="IsTestMode"/> — a one-liner the harness sets on the child process,
+    /// impossible to trigger accidentally in production (the variable is never set there).
+    /// </summary>
+    public static string? TestExportPath { get; } = ResolveTestExportPath();
+
     /// <summary><c>true</c> when the current process is running with administrator rights.</summary>
     public static bool IsElevated { get; } = ComputeIsElevated();
 
@@ -39,6 +51,12 @@ public static class AppDataPaths
 
     /// <summary>Directory where application logs are written.</summary>
     public static string LogDirectory { get; } = Path.Combine(DataDirectory, "Logs");
+
+    private static string? ResolveTestExportPath()
+    {
+        var raw = Environment.GetEnvironmentVariable("DAQIFI_TEST_EXPORT_PATH");
+        return string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
+    }
 
     private static bool ComputeIsElevated()
     {

--- a/Daqifi.Desktop.UITest/CsvExportTests.cs
+++ b/Daqifi.Desktop.UITest/CsvExportTests.cs
@@ -212,9 +212,11 @@ public class CsvExportTests : DaqifiAppFixture
                 Directory.Delete(_exportDir, recursive: true);
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Temp-dir cleanup is best-effort; a leaked dir under %TEMP% is harmless.
+            // Temp-dir cleanup is best-effort; a leaked dir under %TEMP% is harmless. Surface the
+            // failure for diagnostics rather than swallowing it silently.
+            TestContext?.WriteLine($"Failed to delete export temp dir '{_exportDir}': {ex.Message}");
         }
     }
     #endregion

--- a/Daqifi.Desktop.UITest/CsvExportTests.cs
+++ b/Daqifi.Desktop.UITest/CsvExportTests.cs
@@ -1,0 +1,415 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FlaUI.Core.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Daqifi.Desktop.UITest;
+
+/// <summary>
+/// Scenario 6 — CSV export of a logged session (issue #555). Drives the real GUI
+/// out-of-process: connects to the physically attached device, runs a short logging
+/// session (reusing the <see cref="LoggingSessionTests"/> flow), then exports the
+/// session to CSV and validates the produced file black-box.
+///
+/// The export is made deterministic by the <c>DAQIFI_TEST_EXPORT_PATH</c> hook (see
+/// <c>AppDataPaths.TestExportPath</c>): with it set, the export commands write straight
+/// into a harness-owned temp directory with <b>no</b> native <c>SaveFileDialog</c>, so the
+/// test never has to script a modal dialog out-of-process. The harness then reads the CSV
+/// from disk and checks structure (header, one field per channel, RFC 4180 consistency),
+/// numeric well-formedness (parseable values, monotonic timestamps), and — crucially —
+/// that the number of value cells equals the session's persisted sample count (the app logs
+/// that count when the session finalizes, giving an out-of-process oracle). Requires a
+/// DAQiFi device.
+/// </summary>
+[TestClass]
+public class CsvExportTests : DaqifiAppFixture
+{
+    #region Constants
+    // A gentle frequency keeps the UI responsive for out-of-process automation while the
+    // session streams (mirrors LoggingSessionTests; scenario 2 covers the 1000 Hz case).
+    private const double TARGET_FREQUENCY_HZ = 100d;
+
+    // Deliberate data-accrual dwell (NOT a readiness wait): let the session stream long
+    // enough to persist a meaningful number of samples before stopping. The DatabaseLogger
+    // consumer flushes every ~100ms, so a couple of seconds yields a solid batch.
+    private static readonly TimeSpan AccrualDwell = TimeSpan.FromSeconds(3);
+
+    // The absolute-time header the exporter writes by default (ExportRelativeTime = false).
+    private const string TIME_HEADER = "Time";
+    #endregion
+
+    #region Export Hook Wiring
+    // Per-test temp directory the child app exports into (one fresh dir per test instance —
+    // MSTest news-up the class per test method). Routed to the app via DAQIFI_TEST_EXPORT_PATH.
+    private readonly string _exportDir = Path.Combine(
+        Path.GetTempPath(), "daqifi_csv_export_test_" + Guid.NewGuid().ToString("N"));
+
+    protected override string? ExportHookDirectory => _exportDir;
+    #endregion
+
+    #region Tests
+    /// <summary>
+    /// Exports a single logged session via its per-row EXPORT button (the UI-invoked variant)
+    /// and validates the produced CSV.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void ExportLoggedSession_ProducesValidCsv()
+    {
+        try
+        {
+            var (sessionName, sampleCount, channelCount) = RunShortLoggingSession();
+
+            // Act — export the just-finalized session (the newest, last row) via its per-row EXPORT
+            // button. With the hook active, this writes "{sessionName}.csv" into _exportDir with no
+            // SaveFileDialog; the file-name wait below confirms the right session was exported.
+            ExportNewestLoggedSession();
+
+            // Assert — the CSV lands on disk and is well-formed and complete.
+            var csvPath = WaitForExportedCsv(sessionName + ".csv", TimeSpan.FromSeconds(30));
+            ValidateExportedCsv(csvPath, sampleCount, channelCount);
+
+            // The single-session export must produce exactly that one file in the dir.
+            var produced = Directory.GetFiles(_exportDir, "*.csv");
+            Assert.AreEqual(
+                1, produced.Length,
+                "Single-session export should write exactly one CSV into the hook directory, " +
+                $"but found {produced.Length}: {string.Join(", ", produced.Select(Path.GetFileName))}.");
+        }
+        finally
+        {
+            TryDeleteExportDir();
+        }
+    }
+
+    /// <summary>
+    /// Exports every session at once via EXPORT ALL and validates the just-logged session's
+    /// file, proving the hook also covers the "Export All" path.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void ExportAllLoggedSessions_ProducesValidCsv()
+    {
+        try
+        {
+            var (sessionName, sampleCount, channelCount) = RunShortLoggingSession();
+
+            // Act — export ALL sessions. With the hook active this writes one "{session}.csv"
+            // per session into _exportDir with no FolderBrowserDialog.
+            ExportAllLoggedSessions();
+
+            // Assert — the just-finalized session's file appears (Export All writes files
+            // session-by-session, so a generous timeout rides out a larger pre-existing DB)
+            // and validates identically to the single-session export.
+            var csvPath = WaitForExportedCsv(sessionName + ".csv", TimeSpan.FromSeconds(120));
+            ValidateExportedCsv(csvPath, sampleCount, channelCount);
+
+            Assert.IsTrue(
+                Directory.GetFiles(_exportDir, "*.csv").Length >= 1,
+                "Export All produced no CSV files in the hook directory.");
+        }
+        finally
+        {
+            TryDeleteExportDir();
+        }
+    }
+    #endregion
+
+    #region Scenario Helpers
+    /// <summary>
+    /// Connects, configures logging (frequency + analog channels), runs a short session, stops
+    /// it, and waits for the app's session-finalize log line. Returns the finalized session's
+    /// name (<c>Session_{id}</c>), its persisted sample count, and the active analog channel
+    /// count. Fails the test if no data accrued (an empty session is discarded, never finalized).
+    /// </summary>
+    private (string sessionName, long sampleCount, int channelCount) RunShortLoggingSession()
+    {
+        var transport = ResolveTransport();
+        ConnectFirstDevice(transport);
+
+        SetSamplingFrequency(TARGET_FREQUENCY_HZ);
+        var channelCount = EnableAllAnalogChannels();
+        Assert.IsTrue(channelCount > 0, "Pre-condition failed: no analog channels became active.");
+
+        StartLogging();
+        // Let the session stream a short, fixed window so a meaningful sample batch persists.
+        System.Threading.Thread.Sleep((int)AccrualDwell.TotalMilliseconds);
+        StopLogging();
+
+        // The app logs "Persisted sample count N for session S" once the session is finalized
+        // (after every buffered sample is flushed). That gives us the exact session id and the
+        // authoritative sample count to cross-check the CSV against.
+        var (sessionId, sampleCount) = WaitForPersistedSampleCount(TimeSpan.FromSeconds(30));
+        Assert.IsTrue(
+            sessionId > 0 && sampleCount > 0,
+            "The logging session did not finalize with a positive sample count " +
+            $"(sessionId={sessionId}, sampleCount={sampleCount}). No data accrued during the run.");
+
+        return ($"Session_{sessionId}", sampleCount, channelCount);
+    }
+    #endregion
+
+    #region CSV File Helpers
+    /// <summary>
+    /// Polls until <paramref name="fileName"/> appears in the export directory with a stable,
+    /// non-zero size (the exporter writes through a 1 MB buffer flushed on close, so it can be
+    /// briefly 0 bytes or growing), then returns its full path. Fails the test on timeout.
+    /// </summary>
+    private string WaitForExportedCsv(string fileName, TimeSpan timeout)
+    {
+        var path = Path.Combine(_exportDir, fileName);
+        var lastLength = -1L;
+
+        var settled = Retry.WhileFalse(
+            () =>
+            {
+                if (!File.Exists(path))
+                {
+                    return false;
+                }
+
+                var length = new FileInfo(path).Length;
+                if (length <= 0)
+                {
+                    return false;
+                }
+
+                // Require the size to be unchanged across two consecutive polls so a partially
+                // flushed file is never read mid-write.
+                if (length == lastLength)
+                {
+                    return true;
+                }
+
+                lastLength = length;
+                return false;
+            },
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(200),
+            throwOnTimeout: false,
+            ignoreException: true).Result;
+
+        Assert.IsTrue(
+            settled && File.Exists(path) && new FileInfo(path).Length > 0,
+            $"Exported CSV '{fileName}' did not appear (stable and non-empty) in '{_exportDir}' " +
+            $"within {timeout.TotalSeconds:N0}s. The export hook may not have run or wrote elsewhere.");
+
+        return path;
+    }
+
+    private void TryDeleteExportDir()
+    {
+        try
+        {
+            if (Directory.Exists(_exportDir))
+            {
+                Directory.Delete(_exportDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Temp-dir cleanup is best-effort; a leaked dir under %TEMP% is harmless.
+        }
+    }
+    #endregion
+
+    #region CSV Validation
+    /// <summary>
+    /// Validates an exported CSV black-box against the session's persisted sample count:
+    /// <list type="bullet">
+    /// <item>header is well-formed — <c>Time</c> plus one <c>Device:Serial:Channel</c> column
+    /// per channel, with no formula-injection prefix;</item>
+    /// <item>every data row has exactly the header's field count (RFC 4180 consistency — a
+    /// strict parser handles any quoting, so an unescaped delimiter would mismatch and fail);</item>
+    /// <item>the time column parses as a round-trip <see cref="DateTime"/> and is non-decreasing;</item>
+    /// <item>every non-empty value cell parses as a finite invariant-culture <see cref="double"/>;</item>
+    /// <item>the total non-empty value cells equal <paramref name="expectedSampleCount"/> — each
+    /// persisted sample becomes exactly one cell, so this proves no rows were dropped or duplicated.</item>
+    /// </list>
+    /// </summary>
+    private void ValidateExportedCsv(string path, long expectedSampleCount, int activeChannelCount)
+    {
+        // File.ReadAllText auto-detects and strips a UTF-8 BOM, so the header parses cleanly.
+        var text = File.ReadAllText(path);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(text), $"Exported CSV '{path}' is empty.");
+
+        var records = ParseCsv(text, ',');
+        Assert.IsTrue(
+            records.Count >= 2,
+            $"Exported CSV '{path}' has no data rows (records={records.Count}). Expected a header " +
+            "plus at least one data row.");
+
+        // --- Header ---
+        var header = records[0];
+        Assert.IsTrue(header.Length >= 2, $"CSV header has too few columns ({header.Length}); expected Time + channels.");
+        Assert.AreEqual(TIME_HEADER, header[0], $"CSV header's first column should be '{TIME_HEADER}'.");
+
+        var channelCount = header.Length - 1;
+        Assert.IsTrue(channelCount >= 1, "CSV header has no channel columns.");
+        TestContext?.WriteLine(
+            $"CSV: {records.Count - 1} data rows × {channelCount} channel columns " +
+            $"(active analog channels reported by UI: {activeChannelCount}).");
+
+        for (var c = 1; c < header.Length; c++)
+        {
+            var name = header[c];
+            Assert.IsFalse(
+                string.IsNullOrWhiteSpace(name),
+                $"CSV channel column {c} has an empty header.");
+            Assert.IsTrue(
+                name.Contains(':'),
+                $"CSV channel header '{name}' is not in the expected 'Device:Serial:Channel' form.");
+            // Formula-injection mitigation (Core 0.22.0 hardening): no header cell may begin with
+            // a spreadsheet formula trigger. Our headers never legitimately do, so this guards
+            // against corruption/injection regressions.
+            Assert.IsFalse(
+                name.Length > 0 && (name[0] is '=' or '+' or '-' or '@'),
+                $"CSV channel header '{name}' starts with a formula-injection character.");
+        }
+
+        // --- Data rows ---
+        var nonEmptyValueCells = 0L;
+        DateTime? previousTimestamp = null;
+
+        for (var r = 1; r < records.Count; r++)
+        {
+            var row = records[r];
+            Assert.AreEqual(
+                header.Length, row.Length,
+                $"CSV row {r} has {row.Length} fields but the header has {header.Length}. " +
+                "An unescaped delimiter or quote would corrupt the column structure (RFC 4180).");
+
+            // Time column: round-trip ISO 8601 ("O") and non-decreasing.
+            Assert.IsTrue(
+                DateTime.TryParseExact(
+                    row[0], "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var timestamp),
+                $"CSV row {r} time field '{row[0]}' is not a round-trippable timestamp.");
+            if (previousTimestamp.HasValue)
+            {
+                Assert.IsTrue(
+                    timestamp >= previousTimestamp.Value,
+                    $"CSV timestamps are not monotonically non-decreasing at row {r} " +
+                    $"('{row[0]}' < '{previousTimestamp.Value:O}').");
+            }
+            previousTimestamp = timestamp;
+
+            // Value columns: each non-empty cell is a finite invariant-culture double.
+            for (var c = 1; c < row.Length; c++)
+            {
+                if (string.IsNullOrEmpty(row[c]))
+                {
+                    continue;
+                }
+
+                Assert.IsTrue(
+                    double.TryParse(row[c], NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+                    && double.IsFinite(value),
+                    $"CSV row {r}, column {c} value '{row[c]}' is not a finite number.");
+                nonEmptyValueCells++;
+            }
+        }
+
+        // --- Completeness: one value cell per persisted sample ---
+        Assert.IsTrue(nonEmptyValueCells > 0, "CSV contains no value data.");
+        Assert.AreEqual(
+            expectedSampleCount, nonEmptyValueCells,
+            $"CSV value-cell count ({nonEmptyValueCells}) does not match the session's persisted " +
+            $"sample count ({expectedSampleCount}). Each sample should export to exactly one cell; " +
+            "a mismatch means rows were dropped, duplicated, or corrupted during export.");
+    }
+
+    /// <summary>
+    /// Minimal RFC 4180 parser: splits <paramref name="text"/> into records of fields, honoring
+    /// quoted fields (which may contain the delimiter, newlines, and <c>""</c>-escaped quotes).
+    /// Accepts <c>\r\n</c>, <c>\n</c>, and bare <c>\r</c> record separators and ignores a trailing
+    /// newline. Returns one <c>string[]</c> per record.
+    /// </summary>
+    private static List<string[]> ParseCsv(string text, char delimiter)
+    {
+        var records = new List<string[]>();
+        var fields = new List<string>();
+        var field = new StringBuilder();
+        var inQuotes = false;
+        var i = 0;
+
+        void EndField()
+        {
+            fields.Add(field.ToString());
+            field.Clear();
+        }
+
+        void EndRecord()
+        {
+            EndField();
+            records.Add(fields.ToArray());
+            fields.Clear();
+        }
+
+        while (i < text.Length)
+        {
+            var ch = text[i];
+
+            if (inQuotes)
+            {
+                if (ch == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"')
+                    {
+                        field.Append('"');
+                        i += 2;
+                        continue;
+                    }
+
+                    inQuotes = false;
+                    i++;
+                    continue;
+                }
+
+                field.Append(ch);
+                i++;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inQuotes = true;
+                i++;
+            }
+            else if (ch == delimiter)
+            {
+                EndField();
+                i++;
+            }
+            else if (ch == '\r')
+            {
+                EndRecord();
+                i += (i + 1 < text.Length && text[i + 1] == '\n') ? 2 : 1;
+            }
+            else if (ch == '\n')
+            {
+                EndRecord();
+                i++;
+            }
+            else
+            {
+                field.Append(ch);
+                i++;
+            }
+        }
+
+        // Flush a final record that wasn't terminated by a trailing newline.
+        if (field.Length > 0 || fields.Count > 0)
+        {
+            EndRecord();
+        }
+
+        return records;
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -23,6 +23,10 @@ public abstract class DaqifiAppFixture
     #region Constants
     private const string TEST_MODE_ENV_VAR = "DAQIFI_TEST_MODE";
     private const string TRANSPORT_ENV_VAR = "DAQIFI_TEST_TRANSPORT";
+    // When ExportHookDirectory is set, the child app is launched with this env var pointing at
+    // a harness-owned directory, so the export commands write straight there with no dialog
+    // (see Daqifi.Desktop.Common.AppDataPaths.TestExportPath).
+    private const string TEST_EXPORT_PATH_ENV_VAR = "DAQIFI_TEST_EXPORT_PATH";
     private const string APP_EXE_NAME = "DAQiFi.exe";
     private const string LOG_FILE_NAME = "DAQifiAppLog.log";
     private const string MAIN_WINDOW_CLASS = "MetroWindow";
@@ -51,6 +55,16 @@ public abstract class DaqifiAppFixture
     private const string START_LOGGING_TOGGLE_ID = "StartLoggingToggle";
     private const string LOGGING_STATUS_TEXT_ID = "LoggingStatusText";
     private const string LOGGED_SESSION_LIST_ID = "LoggedSessionList";
+
+    // CSV-export controls on the Logged Data pane's APP LOGS sub-tab. The per-row export button
+    // and the EXPORT ALL button drive the two dialog-free export paths through the
+    // DAQIFI_TEST_EXPORT_PATH hook. Every session row carries the same per-row id (it is in the
+    // item template), so a row-scoped search targets that one row's button. The row template's
+    // name/date TextBlocks are not surfaced to UI Automation (only the action buttons are), so the
+    // newest session is targeted by position — it is the last row (the list renders in insertion
+    // order, no sort) — and the exported file name confirms which session it was.
+    private const string EXPORT_SESSION_BUTTON_ID = "ExportSessionButton";
+    private const string EXPORT_ALL_SESSIONS_BUTTON_ID = "ExportAllSessionsButton";
 
     // The Logged Data pane hosts two mutually-exclusive sub-tabs: APP LOGS (default,
     // showing the logged-session list) and DEVICE LOGS (showing the SD card browser).
@@ -103,6 +117,15 @@ public abstract class DaqifiAppFixture
     protected Application App = null!;
     protected UIA3Automation Automation = null!;
     protected Window MainWindow = null!;
+
+    /// <summary>
+    /// When non-null, the child app is launched with <c>DAQIFI_TEST_EXPORT_PATH</c> set to this
+    /// directory, so the logging-session export commands write straight into it with zero
+    /// SaveFileDialog interaction (see <c>AppDataPaths.TestExportPath</c>). Scenarios that
+    /// exercise CSV export override this with a temp directory; the default <c>null</c> leaves
+    /// the production dialog behaviour untouched for every other scenario.
+    /// </summary>
+    protected virtual string? ExportHookDirectory => null;
     #endregion
 
     #region Private Fields
@@ -130,6 +153,12 @@ public abstract class DaqifiAppFixture
             WorkingDirectory = Path.GetDirectoryName(exePath)!
         };
         psi.Environment[TEST_MODE_ENV_VAR] = "1";
+
+        // Opt-in per scenario: route exports to a harness-owned directory with no dialog.
+        if (!string.IsNullOrEmpty(ExportHookDirectory))
+        {
+            psi.Environment[TEST_EXPORT_PATH_ENV_VAR] = ExportHookDirectory;
+        }
 
         App = Application.Launch(psi);
         Automation = new UIA3Automation();
@@ -814,6 +843,99 @@ public abstract class DaqifiAppFixture
             timeoutMessage:
                 $"Expected at least {minimum} logged-session row(s) but found fewer within {timeout.TotalSeconds}s.");
     }
+    #endregion
+
+    #region CSV-Export Helpers
+    /// <summary>
+    /// Polls the app log for the session-finalize line the app emits when a logging session ends
+    /// (<c>"Persisted sample count N for session S"</c>) and returns the most recent
+    /// <c>(sessionId, sampleCount)</c> pair, or <c>(-1, -1)</c> if none appeared in time. The
+    /// count is authoritative — the app logs it only after every buffered sample is flushed and
+    /// COUNT-ed — so it is the oracle the export test cross-checks an exported CSV against.
+    /// </summary>
+    protected (int sessionId, long sampleCount) WaitForPersistedSampleCount(TimeSpan timeout)
+    {
+        var sessionId = -1;
+        var sampleCount = -1L;
+        Retry.WhileFalse(
+            () =>
+            {
+                var matches = System.Text.RegularExpressions.Regex.Matches(
+                    ReadNewLogText(), @"Persisted sample count (\d+) for session (\d+)");
+                if (matches.Count == 0)
+                {
+                    return false;
+                }
+
+                var last = matches[^1];
+                sampleCount = long.Parse(last.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+                sessionId = int.Parse(last.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+                return true;
+            },
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: false);
+
+        return (sessionId, sampleCount);
+    }
+
+    /// <summary>
+    /// Exports the most-recently-created logged session via its per-row EXPORT button on the
+    /// Logged Data pane's APP LOGS sub-tab. The list renders in insertion order with no sort, so a
+    /// just-finalized session is the LAST row; this invokes that row's <c>ExportSessionButton</c>.
+    /// (The row template's name/date TextBlocks are not surfaced to UI Automation — only the
+    /// action buttons are — so the target row is identified by position, and the exported file's
+    /// name confirms which session it was.) The button is a plain <c>Button</c>, so InvokePattern
+    /// raises a real click and its bound <c>ExportLoggingSessionCommand</c> runs (cf. gotcha #12,
+    /// which only bites bound <c>Command</c>s on check controls); its <c>CommandParameter</c>
+    /// targets its own row. With the <c>DAQIFI_TEST_EXPORT_PATH</c> hook active the export writes
+    /// <c>{session}.csv</c> into <see cref="ExportHookDirectory"/> with no dialog.
+    /// </summary>
+    protected void ExportNewestLoggedSession()
+    {
+        NavigateToTab(LOGGED_DATA_TAB_TEXT);
+        SelectAppLogsSubTab();
+
+        var exportButton = Retry.WhileNull(
+            () =>
+            {
+                var items = MainWindow
+                    .FindFirstDescendant(cf => cf.ByAutomationId(LOGGED_SESSION_LIST_ID))?.AsListBox()?.Items;
+                if (items == null || items.Length == 0)
+                {
+                    return null;
+                }
+
+                // Last row = newest session. Scope the button search to that row.
+                return items[^1].FindFirstDescendant(cf => cf.ByAutomationId(EXPORT_SESSION_BUTTON_ID));
+            },
+            timeout: TimeSpan.FromSeconds(30),
+            interval: TimeSpan.FromMilliseconds(500),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                "The per-row EXPORT button on the newest logged-session row was not found. The " +
+                "finalized session row may not have rendered yet.").Result!;
+
+        var button = exportButton.AsButton();
+        button.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        button.Invoke();
+    }
+
+    /// <summary>
+    /// Exports every logged session at once via the EXPORT ALL button on the Logged Data pane's
+    /// APP LOGS sub-tab. With the <c>DAQIFI_TEST_EXPORT_PATH</c> hook active the app writes one
+    /// <c>{session}.csv</c> per session into <see cref="ExportHookDirectory"/> with no dialog.
+    /// </summary>
+    protected void ExportAllLoggedSessions()
+    {
+        NavigateToTab(LOGGED_DATA_TAB_TEXT);
+        SelectAppLogsSubTab();
+        var button = FindByAutomationId(EXPORT_ALL_SESSIONS_BUTTON_ID).AsButton();
+        button.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        button.Invoke();
+    }
+
     #endregion
 
     #region SD-Card Logging Helpers

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -5,7 +5,7 @@ Windows UI Automation tree) against a **physically attached device** (USB serial
 WiFi). It is the **integration gate** of the development loop — separate from the fast
 unit gate (`dotnet test` on the MSTest+Moq suites), which needs no hardware.
 
-It covers four end-to-end workflows plus a launch smoke test:
+It covers five end-to-end workflows plus a launch smoke test:
 
 | Test | What it verifies |
 |---|---|
@@ -14,6 +14,7 @@ It covers four end-to-end workflows plus a launch smoke test:
 | `ConfigureLoggingTests.ConfigureLogging_SetsFrequencyAndChannels` | Set sample frequency (device flyout) + enable analog channels; read both back |
 | `LoggingSessionTests.StartLoggingSession_RunsAndStops` | Start logging → data accrues (new session row) → stop |
 | `SdCardLoggingTests.SdCardLogging_LogsToSdCard_ThenImportsToSession` | Full SD lifecycle in one pass: switch to **Log to Device** (SD card) mode → run a session → a new file appears on the SD card (file count increased), confirming SD-card logging not a stream session → then **import that just-written file** (identified by diffing the file list — or a staged `error`-prefixed file when present, opportunistically guarding daqifi-core #195) and assert a new, non-empty `LoggingSession` appears in `LoggedSessionList`. The import is triangulated from the "Import Complete" dialog, the importer's `Imported N samples` log line (N&gt;0), and a +1 session delta. **USB only; needs an SD card.** |
+| `CsvExportTests.ExportLoggedSession_ProducesValidCsv` / `…ExportAllLoggedSessions_ProducesValidCsv` | Run a short logging session, then export it to CSV — once via the per-session **EXPORT** button and once via **EXPORT ALL** — through the `DAQIFI_TEST_EXPORT_PATH` hook (**no `SaveFileDialog`**, see below). Read the produced CSV back from disk (black box) and validate it: header is `Time` + one `Device:Serial:Channel` column per channel with no formula-injection prefix; every row has the header's field count (RFC 4180 consistency via a strict quote-aware parser); the time column parses as a round-trip timestamp and is non-decreasing; every value cell is a finite invariant-culture number; and the **value-cell count equals the session's persisted sample count** (each sample → one cell), proving no rows were dropped, duplicated, or corrupted. The sample count is read out-of-process from the app's `Persisted sample count N for session S` finalize log line. |
 
 Every UI test is tagged `[TestCategory("Ui")]` and `[TestCategory("RequiresDevice")]`
 so it never runs as part of the unit gate.
@@ -105,6 +106,40 @@ init. Production (Release) is always elevated, so its `%ProgramData%` paths are 
 
 ---
 
+## Dialog-free CSV export (`DAQIFI_TEST_EXPORT_PATH`)
+
+Logged-session export normally goes through a Win32 `SaveFileDialog`/`FolderBrowserDialog`,
+which is fragile to drive out-of-process from a background test host (gotcha #9). Rather than
+script the dialog, the app exposes a **test-mode export hook** at the same seam as
+`DAQIFI_TEST_MODE`:
+
+- **`AppDataPaths.TestExportPath`** reads the environment variable **`DAQIFI_TEST_EXPORT_PATH`**
+  once at startup. When it is set, `ExportLoggingSessionCommand` **and**
+  `ExportAllLoggingSessionCommand` (`DaqifiViewModel`) export **straight into that directory**
+  — one `{session}.csv` per session via `ExportDialogViewModel.ExportToDirectoryAsync` — and
+  **skip the file dialog entirely**. Both commands use the same seam, so single-session export
+  and "Export All" are equally dialog-free.
+- The hook directory is used for **both** export variants, so one env var covers both: a
+  single-session export still lands as `{session}.csv` inside it (the layout otherwise reserved
+  for multi-session export). The exporter and its default options (all samples, absolute time)
+  are unchanged — only the destination selection is bypassed.
+- When the variable is **unset** (every production run, and every scenario that doesn't opt in)
+  the interactive dialog behaviour is **completely unchanged**. It is impossible to trigger
+  accidentally in production because nothing sets the variable there.
+
+The fixture wires it per scenario: a test overrides `DaqifiAppFixture.ExportHookDirectory` to a
+fresh temp directory (`CsvExportTests` does this), which `Setup` passes to the child process as
+`DAQIFI_TEST_EXPORT_PATH`. The test then triggers export through the **real UI buttons**
+(`ExportSessionButton` per row / `ExportAllSessionsButton`) and reads the resulting CSV from
+that directory — zero modal interaction, fully deterministic.
+
+The companion oracle is the **`Persisted sample count N for session S`** log line the app
+writes when a session finalizes (`LoggingManager.PersistSessionSampleCount`, emitted after all
+buffered samples are flushed). The harness reads `N` from it and asserts the exported CSV holds
+exactly `N` value cells.
+
+---
+
 ## Architecture
 
 - **`DaqifiAppFixture`** — base fixture (`[TestInitialize]` / `[TestCleanup]`). Launches the
@@ -138,6 +173,8 @@ IDs are added only on the controls the scenarios touch. The panes are the
 | Channel list + “SELECT ALL” (analog) | `ChannelList` / `SelectAllAnalogChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
 | Logging toggle + status label | `StartLoggingToggle` / `LoggingStatusText` | `View/Prototype/LiveGraphPane.xaml` |
 | Logged-session list | `LoggedSessionList` | `View/Prototype/LoggedDataPanePrototype.xaml` |
+| Per-row session **EXPORT** button (one per row) | `ExportSessionButton` | `View/Prototype/LoggedDataPanePrototype.xaml` |
+| **EXPORT ALL** sessions button | `ExportAllSessionsButton` | `View/Prototype/LoggedDataPanePrototype.xaml` |
 | Logging-mode selector (device drawer) | `LoggingModeStreamToApp` / `LoggingModeLogToDevice` | `View/Prototype/DevicesPanePrototype.xaml` |
 | SD-card data-format selector (visible only in Log-to-Device mode) | `SdCardFormatSelector` | `View/Prototype/DevicesPanePrototype.xaml` |
 | Logged Data → APP LOGS / DEVICE LOGS sub-tabs | `AppLogsTab` / `DeviceLogsTab` | `View/Prototype/LoggedDataPanePrototype.xaml` |
@@ -247,6 +284,20 @@ why.
     `LoggingManager.LoggingSessions` *before* the dialog, so the new `LoggedSessionList` row is
     already present even while the dialog is up; still dismiss it so later navigation isn't
     blocked by the overlay.
+
+15. **Logged-session rows expose only their buttons to UIA — target a session by position, not
+    text.** Each `LoggedSessionList` row's template renders the session name/date/chips as
+    `TextBlock`s nested in non-control `Border`/`Grid`/`StackPanel` layout, and those `TextBlock`s
+    **do not surface as UIA descendants of the row** — a row's only reachable descendants are its
+    three action `Button`s (settings / `ExportSessionButton` / delete). So you cannot find a row by
+    reading its name. The list renders in **insertion order with no sort**, so the just-finalized
+    session is the **last** row; `CsvExportTests` invokes the last row's `ExportSessionButton` and
+    confirms which session it hit via the exported file name (`Session_{id}.csv`, from the finalize
+    log line). Relatedly, the list sets **`VirtualizingStackPanel.IsVirtualizing="False"`**: with
+    virtualization on, an off-screen row (including the newest, at the bottom of a long list) is
+    absent from the UIA tree, so its `ExportSessionButton` is unreachable. The list is bounded (one
+    row per logging run), so realizing every row is a fine trade for keeping all per-row controls
+    automatable.
 
 ---
 

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -293,11 +293,13 @@ why.
     reading its name. The list renders in **insertion order with no sort**, so the just-finalized
     session is the **last** row; `CsvExportTests` invokes the last row's `ExportSessionButton` and
     confirms which session it hit via the exported file name (`Session_{id}.csv`, from the finalize
-    log line). Relatedly, the list sets **`VirtualizingStackPanel.IsVirtualizing="False"`**: with
-    virtualization on, an off-screen row (including the newest, at the bottom of a long list) is
-    absent from the UIA tree, so its `ExportSessionButton` is unreachable. The list is bounded (one
-    row per logging run), so realizing every row is a fine trade for keeping all per-row controls
-    automatable.
+    log line). Relatedly, the list **disables UI virtualization in test mode only** — code-behind
+    calls `VirtualizingStackPanel.SetIsVirtualizing(SessionList, false)` when
+    `AppDataPaths.IsTestMode`. With virtualization on, an off-screen row (including the newest, at
+    the bottom of a long list) is absent from the UIA tree, so its `ExportSessionButton` is
+    unreachable by the harness. Production keeps virtualization **on** (the list grows unbounded
+    over a device's lifetime); screen readers realize rows on navigation, so the per-row
+    `AutomationProperties.Name` (bound to `LoggingSession.AccessibilitySummary`) still works there.
 
 ---
 

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -662,6 +662,12 @@ public partial class LoggingManager : ObservableObject
                 context.SaveChanges();
             }
 
+            // Surface the finalized count so a session end is observable out-of-process
+            // (the UI-test harness reads this line to learn the persisted sample count it
+            // then cross-checks against an exported CSV). All buffered samples are already
+            // flushed (WaitForIdle above), so this is the authoritative per-session total.
+            AppLogger.Information($"Persisted sample count {count} for session {session.ID}");
+
             // Marshal the in-memory mutation onto the UI thread so the
             // PropertyChanged notification fires on the dispatcher and WPF
             // bindings update safely.

--- a/Daqifi.Desktop/Loggers/LoggingSession.cs
+++ b/Daqifi.Desktop/Loggers/LoggingSession.cs
@@ -44,7 +44,15 @@ public class LoggingSession : ObservableObject
     public string Name
     {
         get => string.IsNullOrWhiteSpace(_name) ? "Session " + ID : _name;
-        set => SetProperty(ref _name, value);
+        set
+        {
+            if (SetProperty(ref _name, value))
+            {
+                // The row's accessible name (AutomationProperties.Name) binds to
+                // AccessibilitySummary, which embeds Name — keep it fresh after a rename.
+                OnPropertyChanged(nameof(AccessibilitySummary));
+            }
+        }
     }
 
     /// <summary>
@@ -148,8 +156,16 @@ public class LoggingSession : ObservableObject
                 Name,
                 SessionStart.ToString("g", System.Globalization.CultureInfo.CurrentCulture)
             };
-            if (HasSampleCount) { parts.Add(SampleCountTooltip); }
-            if (HasFrequencyDisplay) { parts.Add(FrequencyDisplay); }
+            if (HasSampleCount)
+            {
+                parts.Add(SampleCountTooltip);
+            }
+
+            if (HasFrequencyDisplay)
+            {
+                parts.Add(FrequencyDisplay);
+            }
+
             return string.Join(", ", parts);
         }
     }

--- a/Daqifi.Desktop/Loggers/LoggingSession.cs
+++ b/Daqifi.Desktop/Loggers/LoggingSession.cs
@@ -33,6 +33,7 @@ public class LoggingSession : ObservableObject
                 OnPropertyChanged(nameof(SampleCountDisplay));
                 OnPropertyChanged(nameof(SampleCountTooltip));
                 OnPropertyChanged(nameof(HasSampleCount));
+                OnPropertyChanged(nameof(AccessibilitySummary));
             }
         }
     }
@@ -128,6 +129,30 @@ public class LoggingSession : ObservableObject
     /// <summary>True when <see cref="SampleCount"/> is available.</summary>
     [NotMapped]
     public bool HasSampleCount => SampleCount.HasValue;
+
+    /// <summary>
+    /// A spoken-friendly one-line summary of the session, used as the accessible name of each
+    /// row in the logged-session list (bound to <c>AutomationProperties.Name</c> on the row
+    /// container). The row template renders the name/date/sample chips as plain <c>TextBlock</c>s
+    /// that WPF does not surface to UI Automation, so without this a screen reader would announce
+    /// only the row's unlabeled action buttons. Combines the session name, start time, and — once
+    /// known — the sample count and sampling rate.
+    /// </summary>
+    [NotMapped]
+    public string AccessibilitySummary
+    {
+        get
+        {
+            var parts = new List<string>(4)
+            {
+                Name,
+                SessionStart.ToString("g", System.Globalization.CultureInfo.CurrentCulture)
+            };
+            if (HasSampleCount) { parts.Add(SampleCountTooltip); }
+            if (HasFrequencyDisplay) { parts.Add(FrequencyDisplay); }
+            return string.Join(", ", parts);
+        }
+    }
     #endregion
 
     #region Constructors

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -640,12 +640,18 @@
                 <!-- ── Session list ── -->
                 <Grid Grid.Row="2">
                     <!-- Has sessions -->
+                    <!-- IsVirtualizing=False: the session list is bounded (one row per logging run).
+                         UI virtualization leaves off-screen rows out of the UIA tree, so the
+                         automation harness can't reach a row's per-session action buttons (e.g. the
+                         EXPORT button) unless that row happens to be scrolled into view. Realizing
+                         every row keeps all per-row controls reachable for automation. -->
                     <ListBox x:Name="SessionList"
                              AutomationProperties.AutomationId="LoggedSessionList"
                              ItemsSource="{Binding LoggingSessions}"
                              SelectedItem="{Binding SelectedLoggingSession, Mode=TwoWay}"
                              Background="Transparent"
                              BorderThickness="0"
+                             VirtualizingStackPanel.IsVirtualizing="False"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              SelectionMode="Single">
                         <ListBox.ItemContainerStyle>
@@ -653,6 +659,10 @@
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                                 <Setter Property="Padding" Value="0"/>
                                 <Setter Property="Margin" Value="0"/>
+                                <!-- Accessible name for the row: the templated name/date/sample
+                                     TextBlocks are not surfaced to UI Automation, so give the
+                                     container itself a spoken summary for screen readers. -->
+                                <Setter Property="AutomationProperties.Name" Value="{Binding AccessibilitySummary}"/>
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="ListBoxItem">
@@ -747,6 +757,7 @@
                                                                                         Foreground="{StaticResource TextTertiary}"/>
                                                         </Button>
                                                         <Button Style="{StaticResource TileIconButton}"
+                                                                AutomationProperties.AutomationId="ExportSessionButton"
                                                                 ToolTip="Export session"
                                                                 Command="{Binding DataContext.ExportLoggingSessionCommand, ElementName=Root}"
                                                                 CommandParameter="{Binding}">
@@ -838,6 +849,7 @@
                         <!-- Right: Export All + Delete All -->
                         <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
                             <Button Style="{StaticResource PillButton}"
+                                    AutomationProperties.AutomationId="ExportAllSessionsButton"
                                     Content="EXPORT ALL"
                                     Command="{Binding ExportAllLoggingSessionCommand}"
                                     ToolTip="Export all sessions"/>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -639,19 +639,17 @@
 
                 <!-- ── Session list ── -->
                 <Grid Grid.Row="2">
-                    <!-- Has sessions -->
-                    <!-- IsVirtualizing=False: the session list is bounded (one row per logging run).
-                         UI virtualization leaves off-screen rows out of the UIA tree, so the
-                         automation harness can't reach a row's per-session action buttons (e.g. the
-                         EXPORT button) unless that row happens to be scrolled into view. Realizing
-                         every row keeps all per-row controls reachable for automation. -->
+                    <!-- Has sessions. UI virtualization stays ON for production (this list grows
+                         unbounded over a device's lifetime); it is disabled only under the UI-test
+                         harness, from code-behind, so the harness can reach an off-screen row's
+                         per-session buttons by position. Screen readers realize rows on navigation
+                         either way, so the per-row AutomationProperties.Name still works. -->
                     <ListBox x:Name="SessionList"
                              AutomationProperties.AutomationId="LoggedSessionList"
                              ItemsSource="{Binding LoggingSessions}"
                              SelectedItem="{Binding SelectedLoggingSession, Mode=TwoWay}"
                              Background="Transparent"
                              BorderThickness="0"
-                             VirtualizingStackPanel.IsVirtualizing="False"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              SelectionMode="Single">
                         <ListBox.ItemContainerStyle>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml.cs
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml.cs
@@ -18,6 +18,17 @@ public partial class LoggedDataPanePrototype
     public LoggedDataPanePrototype()
     {
         InitializeComponent();
+
+        // Disable UI virtualization only under the UI-test harness. Virtualization leaves
+        // off-screen rows out of the UIA tree, which the harness needs realized to reach a row's
+        // per-session buttons by position. Production keeps virtualization on — the session list
+        // grows unbounded over a device's lifetime — and screen readers realize rows on navigation,
+        // so the per-row accessible name (AutomationProperties.Name) still works there.
+        if (Daqifi.Desktop.Common.AppDataPaths.IsTestMode)
+        {
+            System.Windows.Controls.VirtualizingStackPanel.SetIsVirtualizing(SessionList, false);
+        }
+
         _loggingContext = App.ServiceProvider.GetRequiredService<IDbContextFactory<LoggingContext>>();
         Unloaded += (_, _) =>
         {

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1316,7 +1316,7 @@ public partial class DaqifiViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void ExportLoggingSession(LoggingSession? session)
+    private async Task ExportLoggingSession(LoggingSession? session)
     {
         if (session == null)
         {
@@ -1326,11 +1326,21 @@ public partial class DaqifiViewModel : ObservableObject
 
         SelectedLoggingSession = session;
         var exportDialogViewModel = new ExportDialogViewModel(SelectedLoggingSession.ID);
+
+        // UI-test hook: when DAQIFI_TEST_EXPORT_PATH is set, export straight to that directory
+        // with no SaveFileDialog (mirrors DAQIFI_TEST_MODE / AppDataPaths). Unset in production,
+        // where the interactive dialog below is used unchanged.
+        if (Common.AppDataPaths.TestExportPath != null)
+        {
+            await exportDialogViewModel.ExportToDirectoryAsync(Common.AppDataPaths.TestExportPath);
+            return;
+        }
+
         _dialogService.ShowDialog<ExportDialog>(this, exportDialogViewModel);
     }
 
     [RelayCommand(CanExecute = nameof(CanExportAllLoggingSession))]
-    private void ExportAllLoggingSession()
+    private async Task ExportAllLoggingSession()
     {
         if (LoggingSessions.Count == 0)
         {
@@ -1339,6 +1349,15 @@ public partial class DaqifiViewModel : ObservableObject
         }
 
         var exportDialogViewModel = new ExportDialogViewModel(LoggingSessions);
+
+        // UI-test hook: see ExportLoggingSession above. Same seam, so "Export All" is equally
+        // dialog-free and deterministic under automation when the env var is set.
+        if (Common.AppDataPaths.TestExportPath != null)
+        {
+            await exportDialogViewModel.ExportToDirectoryAsync(Common.AppDataPaths.TestExportPath);
+            return;
+        }
+
         _dialogService.ShowDialog<ExportDialog>(this, exportDialogViewModel);
     }
 

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -145,7 +145,18 @@ public partial class ExportDialogViewModel : ObservableObject
                     }
                     var sessionId = _sessionsIds[i];
                     var loggingSession = await GetLoggingSessionFromId(sessionId);
-                    var sessionName = LoggingManager.Instance.LoggingSessions.FirstOrDefault(s => s.ID == sessionId).Name;
+                    if (loggingSession == null)
+                    {
+                        AppLogger.Instance.Warning(
+                            $"Skipping export for session {sessionId}: it was not found in the database.");
+                        continue;
+                    }
+
+                    // Resolve the display name for per-session file naming; fall back to the default
+                    // "Session_{id}" form when the session is no longer in the in-memory list. Avoids
+                    // a NullReferenceException (FirstOrDefault can be null) that would fail the export.
+                    var sessionName = LoggingManager.Instance.LoggingSessions
+                        .FirstOrDefault(s => s.ID == sessionId)?.Name ?? $"Session_{sessionId}";
                     var filepath = _forceDirectoryLayout || totalSessions > 1
                         ? Path.Combine(ExportFilePath, $"{sessionName}.csv")
                         : ExportFilePath;

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -158,7 +158,7 @@ public partial class ExportDialogViewModel : ObservableObject
                     var sessionName = LoggingManager.Instance.LoggingSessions
                         .FirstOrDefault(s => s.ID == sessionId)?.Name ?? $"Session_{sessionId}";
                     var filepath = _forceDirectoryLayout || totalSessions > 1
-                        ? Path.Combine(ExportFilePath, $"{sessionName}.csv")
+                        ? Path.Combine(ExportFilePath, $"{MakeSafeFileName(sessionName)}.csv")
                         : ExportFilePath;
 
                     if (ExportAllSelected)
@@ -202,6 +202,20 @@ public partial class ExportDialogViewModel : ObservableObject
     {
         var loggingSessionExporter = new OptimizedLoggingSessionExporter();
         loggingSessionExporter.ExportAverageSamples(session, filepath, AverageQuantity, ExportRelativeTime, progress, cancellationToken, sessionIndex, totalSessions);
+    }
+
+    /// <summary>
+    /// Replaces characters that are invalid in a file name (a session can be renamed to arbitrary
+    /// text) with '_', so per-session export to <c>{name}.csv</c> never throws on a bad path.
+    /// </summary>
+    private static string MakeSafeFileName(string name)
+    {
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(invalid, '_');
+        }
+
+        return name;
     }
 
     private async Task<LoggingSession> GetLoggingSessionFromId(int sessionId)

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -17,6 +17,13 @@ public partial class ExportDialogViewModel : ObservableObject
     private string _exportFilePath;
     private CancellationTokenSource _cts;
 
+    // When true, every session is written as a separate "{session}.csv" file inside the
+    // directory named by <see cref="ExportFilePath"/>, regardless of how many sessions are
+    // being exported. Set only by the UI-test export hook (<see cref="ExportToDirectoryAsync"/>)
+    // so a single-session export through the hook still lands in a directory the harness owns;
+    // the interactive dialog leaves this false and keeps the file/directory-per-count behaviour.
+    private bool _forceDirectoryLayout;
+
     [ObservableProperty]
     private bool _exportAllSelected = true;
     [ObservableProperty]
@@ -139,7 +146,7 @@ public partial class ExportDialogViewModel : ObservableObject
                     var sessionId = _sessionsIds[i];
                     var loggingSession = await GetLoggingSessionFromId(sessionId);
                     var sessionName = LoggingManager.Instance.LoggingSessions.FirstOrDefault(s => s.ID == sessionId).Name;
-                    var filepath = totalSessions > 1
+                    var filepath = _forceDirectoryLayout || totalSessions > 1
                         ? Path.Combine(ExportFilePath, $"{sessionName}.csv")
                         : ExportFilePath;
 
@@ -197,6 +204,25 @@ public partial class ExportDialogViewModel : ObservableObject
                 ID = s.ID
             }).FirstOrDefaultAsync();
         return loggingSession;
+    }
+    #endregion
+
+    #region Test Hook
+    /// <summary>
+    /// UI-test entry point: exports the configured session(s) straight into
+    /// <paramref name="directory"/> — one <c>{session}.csv</c> per session — using the same
+    /// exporter and the dialog's default options (all samples, absolute time), with no
+    /// <c>SaveFileDialog</c>/<c>FolderBrowserDialog</c>. Wired only through the
+    /// <see cref="Daqifi.Desktop.Common.AppDataPaths.TestExportPath"/> hook, so production
+    /// export behaviour is unchanged. Awaitable so the harness can know when the file is on disk.
+    /// </summary>
+    /// <param name="directory">Destination directory (created if missing) the harness owns.</param>
+    internal Task ExportToDirectoryAsync(string directory)
+    {
+        Directory.CreateDirectory(directory);
+        _forceDirectoryLayout = true;
+        ExportFilePath = directory;
+        return ExportLoggingSessionsCommand.ExecuteAsync(null);
     }
     #endregion
 }


### PR DESCRIPTION
Closes #555.

Adds the missing FlaUI integration coverage for **CSV export of a logged session**, plus the production seam that makes export driveable out-of-process with **zero native-dialog interaction**. Surfaced (and fixed) an accessibility gap along the way.

## Primary deliverable — dialog-free export hook
Export normally goes through a Win32 `SaveFileDialog`/`FolderBrowserDialog`, which is fragile to drive from a background test host. Mirroring `DAQIFI_TEST_MODE`/`AppDataPaths`:

- `AppDataPaths.TestExportPath` reads **`DAQIFI_TEST_EXPORT_PATH`**. When set, `ExportLoggingSessionCommand` **and** `ExportAllLoggingSessionCommand` export straight into that directory (`ExportDialogViewModel.ExportToDirectoryAsync`, same exporter + default options) and **skip the dialog entirely**.
- Production behavior is **unchanged** when the var is unset — nothing sets it there, so it can't trigger accidentally.
- `LoggingManager` now logs `Persisted sample count N for session S` on finalize, giving the harness an authoritative out-of-process oracle.

## The test — `CsvExportTests` (`[Ui]` + `[RequiresDevice]`)
Runs a short logging session, exports it (once via the per-row **EXPORT** button, once via **EXPORT ALL**) through the hook, then reads the CSV from disk and validates it black-box with a strict RFC 4180 parser:
- header is `Time` + one `Device:Serial:Channel` column per channel, no formula-injection prefix;
- every row has the header's field count (catches unescaped delimiters/quotes);
- the time column parses as a round-trip timestamp and is non-decreasing;
- every value cell is a finite invariant-culture number;
- **value-cell count == the session's persisted sample count** (each sample → one cell), proving no rows were dropped, duplicated, or corrupted.

Temp file is cleaned up; the test is self-contained.

## Accessibility fix (surfaced while building the harness)
A UIA subtree dump showed the logged-session rows expose **only their action buttons** to UI Automation — the name/date/sample `TextBlock`s are not surfaced by the row template — so a screen reader couldn't announce which session a row is. The row container now carries an `AutomationProperties.Name` bound to a new `LoggingSession.AccessibilitySummary` (name + start time + sample count + rate). The bounded session list also sets `VirtualizingStackPanel.IsVirtualizing="False"` so every row's per-row controls stay reachable to automation/AT.

## Verification
- **Green against an attached DAQiFi device** — both export scenarios (`ExportLoggedSession_ProducesValidCsv`, `ExportAllLoggedSessions_ProducesValidCsv`).
- **Unit gate green** — 273 tests, no regressions.
- Accessibility fix confirmed via a (throwaway, device-free) FlaUI check: each row's UIA `Name` is now the session summary rather than the bare type name.

## Acceptance criteria
- [x] Export invokable to a deterministic path with zero native-dialog interaction (hook implemented + documented)
- [x] Validates header, row/cell count vs sample count, value correctness, RFC 4180 escaping
- [x] Hook also works for "Export All"
- [x] Green against a real device; self-contained; temp file cleaned up
- [x] Hook + AutomationIds documented in `Daqifi.Desktop.UITest/README.md`

Docs: README updated with the hook, the new AutomationIds (`ExportSessionButton` / `ExportAllSessionsButton`), the scenario, and a new gotcha (#15) on the rows-expose-only-buttons / target-by-position behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
