### PR TITLE
chore: integration coverage for profiles (save, activate, delete)

### DIFF
--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -102,6 +102,34 @@ public abstract class DaqifiAppFixture
     private const string IMPORT_DIALOG_OK_BUTTON_TEXT = "OK";
     private const string IMPORT_FAILED_TITLE = "Import Failed";
 
+    // AutomationIds for the Profiles pane (save / activate / delete round-trip). Profiles are
+    // saved experiment presets that re-apply a captured channel + frequency configuration to a
+    // matching connected device. The tile name/date TextBlocks are not reliably surfaced to UI
+    // Automation (like the logged-session rows), so a profile is targeted by POSITION — the
+    // newest is the LAST tile (SubscribedProfiles appends; the list renders in insertion order)
+    // — via its per-tile settings (gear) button, which opens the edit drawer holding ACTIVATE /
+    // DELETE. The "+ ADD PROFILE" button opens the new-profile drawer (status-bar id when
+    // profiles exist, empty-state id otherwise).
+    private const string PROFILE_LIST_ID = "ProfileList";
+    private const string PROFILE_SETTINGS_BUTTON_ID = "ProfileSettingsButton";
+    private const string ADD_PROFILE_BUTTON_ID = "AddProfileButton";
+    private const string ADD_PROFILE_BUTTON_EMPTY_ID = "AddProfileButtonEmpty";
+    private const string NEW_PROFILE_NAME_INPUT_ID = "NewProfileNameInput";
+    private const string SAVE_CURRENT_SETTINGS_BUTTON_ID = "SaveCurrentSettingsButton";
+    private const string SAVE_NEW_PROFILE_BUTTON_ID = "SaveNewProfileButton";
+    private const string NEW_PROFILE_DEVICE_CHECKBOX_ID = "NewProfileDeviceCheckbox";
+    private const string ACTIVATE_PROFILE_BUTTON_ID = "ActivateProfileButton";
+    private const string DELETE_PROFILE_BUTTON_ID = "DeleteProfileButton";
+
+    // "ACTIVE" appears on the Profiles pane only in the status-bar "· {name} ACTIVE" indicator
+    // (the activate button reads "ACTIVATE"/"DEACTIVATE", neither of which contains "ACTIVE"),
+    // so its presence is an independent profile-active signal used to confirm deactivation.
+    private const string PROFILE_ACTIVE_INDICATOR_TEXT = "ACTIVE";
+
+    // Channels pane CLEAR ALL — used to move the device to a known-different state between
+    // saving a profile and activating it, so the re-application is observable.
+    private const string CLEAR_ALL_CHANNELS_ID = "ClearAllChannels";
+
     private const string LOGGING_ON_TEXT = "LOGGING ON";
     private const string LOGGING_OFF_TEXT = "LOGGING OFF";
 
@@ -652,6 +680,48 @@ public abstract class DaqifiAppFixture
         }
 
         return -1;
+    }
+
+    /// <summary>
+    /// Clears every active channel via the Channels pane's CLEAR ALL button, then waits until
+    /// the analog "n / N ACTIVE" indicator reads zero. Navigates to the Channels tab first.
+    /// Used to move the device to a known-different state before activating a profile, so the
+    /// profile's re-application of channels is observable (0 active -> N active).
+    /// </summary>
+    protected void ClearAllChannels()
+    {
+        NavigateToTab(CHANNELS_TAB_TEXT);
+        var clear = FindByAutomationId(CLEAR_ALL_CHANNELS_ID).AsButton();
+        clear.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        clear.Invoke();
+
+        Retry.WhileFalse(
+            () => ReadActiveAnalogCount() == 0,
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "Channels did not clear: the analog active count did not reach 0 after CLEAR ALL.");
+    }
+
+    /// <summary>
+    /// Navigates to the Channels pane (rebuilding it from current device state) and waits until
+    /// the analog "n / N ACTIVE" indicator reads <paramref name="expected"/>. The pane is
+    /// recreated on tab entry, so it reflects channels a profile activation added to the device
+    /// directly (bypassing the pane), making this a faithful ground-truth re-application check.
+    /// </summary>
+    protected void WaitForActiveAnalogChannelCount(int expected, TimeSpan timeout)
+    {
+        NavigateToTab(CHANNELS_TAB_TEXT);
+        Retry.WhileFalse(
+            () => ReadActiveAnalogCount() == expected,
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                $"Analog active channel count did not reach {expected} (last read " +
+                $"{ReadActiveAnalogCount()}). Expected the activated profile to re-apply its channels.");
     }
     #endregion
 
@@ -1407,6 +1477,288 @@ public abstract class DaqifiAppFixture
         }
 
         return max;
+    }
+    #endregion
+
+    #region Profiles Helpers
+    /// <summary>
+    /// Reads the number of saved profiles on the Profiles pane by counting the per-tile settings
+    /// (gear) buttons under the profile list — each tile renders exactly one. This is robust to
+    /// the tile's inner layout (its name/date TextBlocks are not reliably surfaced to UI
+    /// Automation, like the logged-session rows). Returns 0 when no profiles exist (the
+    /// empty-state view renders instead of the list, so the list element is absent from the
+    /// tree). Navigates to the Profiles tab first.
+    /// </summary>
+    protected int GetProfileCount()
+    {
+        NavigateToTab(PROFILES_TAB_TEXT);
+        var list = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(PROFILE_LIST_ID));
+        if (list == null)
+        {
+            return 0;
+        }
+
+        return list.FindAllDescendants(cf => cf.ByAutomationId(PROFILE_SETTINGS_BUTTON_ID)).Length;
+    }
+
+    /// <summary>Waits (polling) until the saved-profile count equals <paramref name="expected"/>.</summary>
+    protected void WaitForProfileCount(int expected, TimeSpan timeout)
+    {
+        Retry.WhileFalse(
+            () => GetProfileCount() == expected,
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                $"Saved-profile count did not reach {expected} within {timeout.TotalSeconds}s " +
+                $"(last read {GetProfileCount()}).");
+    }
+
+    /// <summary>
+    /// Opens the new-profile drawer by invoking the "+ ADD PROFILE" button — the status-bar
+    /// button when profiles already exist, or the empty-state button otherwise. Waits until the
+    /// new-profile NAME field is realized, confirming the drawer opened in new-profile mode.
+    /// </summary>
+    protected void OpenNewProfileDrawer()
+    {
+        NavigateToTab(PROFILES_TAB_TEXT);
+
+        var addButton = Retry.WhileNull(
+            () => MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(ADD_PROFILE_BUTTON_ID))
+                  ?? MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(ADD_PROFILE_BUTTON_EMPTY_ID)),
+            timeout: TimeSpan.FromSeconds(30),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "Add Profile button not found on the Profiles pane.").Result!;
+
+        var button = addButton.AsButton();
+        button.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        button.Invoke();
+
+        // The NAME field exists only while the drawer is open in new-profile mode.
+        FindByAutomationId(NEW_PROFILE_NAME_INPUT_ID);
+    }
+
+    /// <summary>
+    /// Types <paramref name="name"/> into the new-profile NAME field via the ValuePattern and
+    /// waits until the field reads it back. Assumes the new-profile drawer is open.
+    /// </summary>
+    protected void SetNewProfileName(string name)
+    {
+        FindByAutomationId(NEW_PROFILE_NAME_INPUT_ID).Patterns.Value.Pattern.SetValue(name);
+
+        Retry.WhileFalse(
+            () => string.Equals(
+                MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(NEW_PROFILE_NAME_INPUT_ID))
+                    ?.Patterns.Value.Pattern.Value.Value,
+                name,
+                StringComparison.Ordinal),
+            timeout: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMilliseconds(200),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: $"The new-profile NAME field did not accept the value '{name}'.");
+    }
+
+    /// <summary>
+    /// Invokes "CAPTURE FROM CURRENT SETTINGS" in the new-profile drawer
+    /// (<c>SaveCurrentSettingsCommand</c>), which snapshots every connected device's currently
+    /// active channels + sampling frequency into a new profile and closes the drawer. Waits
+    /// until the drawer closes. A plain Button's InvokePattern raises a real click, so its bound
+    /// command runs.
+    /// </summary>
+    protected void SaveCurrentSettingsAsProfile()
+    {
+        var capture = FindByAutomationId(SAVE_CURRENT_SETTINGS_BUTTON_ID).AsButton();
+        capture.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        capture.Invoke();
+        WaitForNewProfileDrawerClosed();
+    }
+
+    /// <summary>
+    /// Ticks the first connected-device checkbox in the new-profile form via the TogglePattern.
+    /// The checkbox's <c>IsChecked</c> binding drives selection directly (no bound command), so
+    /// the pattern works from a background host. Selecting a device satisfies
+    /// <c>CanSaveNewProfile</c>, enabling the SAVE PROFILE button.
+    /// </summary>
+    protected void SelectFirstNewProfileDevice()
+    {
+        Retry.WhileFalse(
+            () =>
+            {
+                var checkbox = MainWindow
+                    .FindFirstDescendant(cf => cf.ByAutomationId(NEW_PROFILE_DEVICE_CHECKBOX_ID))?.AsCheckBox();
+                if (checkbox == null)
+                {
+                    return false;
+                }
+
+                if (checkbox.IsChecked != true)
+                {
+                    checkbox.IsChecked = true;
+                }
+
+                return checkbox.IsChecked == true;
+            },
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "Could not select a device in the new-profile form (checkbox never became checked).");
+    }
+
+    /// <summary>
+    /// Invokes "SAVE PROFILE" in the new-profile drawer (<c>SaveNewProfileCommand</c>), which
+    /// persists the form's selections as a new profile and closes the drawer. Requires a name
+    /// (auto-populated) and at least one selected device. Waits until the drawer closes.
+    /// </summary>
+    protected void SaveNewProfileFromForm()
+    {
+        var save = FindByAutomationId(SAVE_NEW_PROFILE_BUTTON_ID).AsButton();
+        save.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        save.Invoke();
+        WaitForNewProfileDrawerClosed();
+    }
+
+    /// <summary>Waits until the new-profile drawer closes (its NAME field leaves the UIA tree).</summary>
+    private void WaitForNewProfileDrawerClosed()
+    {
+        Retry.WhileFalse(
+            () => MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(NEW_PROFILE_NAME_INPUT_ID)) == null,
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "The new-profile drawer did not close after saving.");
+    }
+
+    /// <summary>
+    /// Opens the edit drawer for the most-recently-created profile by invoking the settings
+    /// (gear) button on the LAST profile tile. Profiles render in insertion order with no sort,
+    /// so the newest — the one a test just created — is last. Waits until the drawer's
+    /// ACTIVATE/DEACTIVATE button is realized. Navigates to the Profiles tab first; entering the
+    /// tab rebuilds the pane with the drawer closed, so the gear is reachable underneath.
+    /// </summary>
+    protected void OpenLastProfileEditDrawer()
+    {
+        NavigateToTab(PROFILES_TAB_TEXT);
+
+        var gear = Retry.WhileNull(
+            () =>
+            {
+                var gears = MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(PROFILE_LIST_ID))
+                    ?.FindAllDescendants(cf => cf.ByAutomationId(PROFILE_SETTINGS_BUTTON_ID));
+                return gears is { Length: > 0 } ? gears[^1] : null;
+            },
+            timeout: TimeSpan.FromSeconds(30),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "No profile tiles were found on the Profiles pane.").Result!;
+
+        var button = gear.AsButton();
+        button.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        button.Invoke();
+
+        // The ACTIVATE/DELETE buttons exist only while the edit drawer is open.
+        FindByAutomationId(ACTIVATE_PROFILE_BUTTON_ID);
+    }
+
+    /// <summary>
+    /// Invokes the ACTIVATE PROFILE button in the open edit drawer (the profile must be
+    /// inactive). The command re-applies the profile's captured sampling frequency + channels to
+    /// the matching connected device; the caller verifies that via the Devices flyout and the
+    /// Channels pane "n / N ACTIVE" indicator.
+    /// </summary>
+    protected void ActivateSelectedProfile()
+    {
+        var button = FindByAutomationId(ACTIVATE_PROFILE_BUTTON_ID).AsButton();
+        button.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        button.Invoke();
+    }
+
+    /// <summary>
+    /// Deactivates the active profile by invoking the (same) activate/deactivate button in the
+    /// open edit drawer, then waits until no profile reports active. Deactivation is confirmed by
+    /// the Profiles status-bar "ACTIVE" indicator leaving the tree — an INDEPENDENT signal driven
+    /// by a Visibility binding on the active-profile name, not the button's own swapped label
+    /// (a DataTrigger-driven content swap may not surface as a UIA name change). A profile must
+    /// be deactivated before it can be deleted.
+    /// </summary>
+    protected void DeactivateSelectedProfile()
+    {
+        var button = FindByAutomationId(ACTIVATE_PROFILE_BUTTON_ID).AsButton();
+        button.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        button.Invoke();
+
+        Retry.WhileTrue(
+            () => IsAnyProfileActiveIndicatorPresent(),
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                "The profile did not deactivate: the Profiles status-bar 'ACTIVE' indicator " +
+                "stayed visible after invoking the deactivate button.");
+    }
+
+    /// <summary>
+    /// Invokes the DELETE PROFILE button in the open edit drawer (<c>DeleteProfileCommand</c>).
+    /// The profile must already be deactivated — the command refuses (and surfaces an inline
+    /// error) while any profile is active. The command removes the profile and closes the drawer.
+    /// </summary>
+    protected void DeleteSelectedProfile()
+    {
+        var button = FindByAutomationId(DELETE_PROFILE_BUTTON_ID).AsButton();
+        button.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        button.Invoke();
+    }
+
+    /// <summary>
+    /// True when the Profiles pane shows its "· {name} ACTIVE" status-bar indicator, i.e. some
+    /// profile is active. The indicator's Visibility binds to the active-profile name (collapsed,
+    /// and so absent from the UIA tree, when none is active), making its presence a reliable
+    /// signal. "ACTIVE" appears only here on the Profiles pane (the ACTIVATE/DEACTIVATE button
+    /// label contains "ACTIVATE"/"DEACTIVATE", neither of which contains the substring "ACTIVE").
+    /// </summary>
+    private bool IsAnyProfileActiveIndicatorPresent()
+    {
+        foreach (var text in MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Text)))
+        {
+            if ((text.Name ?? string.Empty).Contains(PROFILE_ACTIVE_INDICATOR_TEXT, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Waits (polling) until the per-device sampling frequency flyout reads
+    /// <paramref name="expectedHz"/> (within 0.5 Hz) and returns the value read back. Used to
+    /// confirm a profile activation re-applied its captured frequency to the device.
+    /// </summary>
+    protected double WaitForSamplingFrequency(double expectedHz, TimeSpan timeout)
+    {
+        var last = double.NaN;
+        Retry.WhileFalse(
+            () =>
+            {
+                last = GetSamplingFrequency();
+                return Math.Abs(last - expectedHz) < 0.5;
+            },
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                $"Sampling frequency did not reach {expectedHz} Hz (last read {last}). Expected " +
+                "the activated profile to re-apply its captured frequency.");
+
+        return last;
     }
     #endregion
 

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -121,10 +121,12 @@ public abstract class DaqifiAppFixture
     private const string ACTIVATE_PROFILE_BUTTON_ID = "ActivateProfileButton";
     private const string DELETE_PROFILE_BUTTON_ID = "DeleteProfileButton";
 
-    // "ACTIVE" appears on the Profiles pane only in the status-bar "· {name} ACTIVE" indicator
-    // (the activate button reads "ACTIVATE"/"DEACTIVATE", neither of which contains "ACTIVE"),
-    // so its presence is an independent profile-active signal used to confirm deactivation.
-    private const string PROFILE_ACTIVE_INDICATOR_TEXT = "ACTIVE";
+    // The Profiles status-bar "· {name} ACTIVE" indicator carries this AutomationId. Its
+    // Visibility binds to the active-profile name (collapsed, and so absent from the UIA tree,
+    // when none is active), so looking it up by id is a deterministic profile-active signal used
+    // to confirm deactivation — independent of any profile name text (a profile named "...ACTIVE"
+    // would defeat a substring scan).
+    private const string ACTIVE_PROFILE_INDICATOR_ID = "ActiveProfileIndicator";
 
     // Channels pane CLEAR ALL — used to move the device to a known-different state between
     // saving a profile and activating it, so the re-application is observable.
@@ -1718,23 +1720,13 @@ public abstract class DaqifiAppFixture
 
     /// <summary>
     /// True when the Profiles pane shows its "· {name} ACTIVE" status-bar indicator, i.e. some
-    /// profile is active. The indicator's Visibility binds to the active-profile name (collapsed,
-    /// and so absent from the UIA tree, when none is active), making its presence a reliable
-    /// signal. "ACTIVE" appears only here on the Profiles pane (the ACTIVATE/DEACTIVATE button
-    /// label contains "ACTIVATE"/"DEACTIVATE", neither of which contains the substring "ACTIVE").
+    /// profile is active. The indicator carries a dedicated AutomationId and its Visibility binds
+    /// to the active-profile name (collapsed, and so absent from the UIA tree, when none is
+    /// active), so an id lookup is a deterministic signal — unaffected by profile names (a profile
+    /// named "...ACTIVE" would defeat a substring scan of the pane's text).
     /// </summary>
-    private bool IsAnyProfileActiveIndicatorPresent()
-    {
-        foreach (var text in MainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Text)))
-        {
-            if ((text.Name ?? string.Empty).Contains(PROFILE_ACTIVE_INDICATOR_TEXT, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    private bool IsAnyProfileActiveIndicatorPresent() =>
+        MainWindow.FindFirstDescendant(cf => cf.ByAutomationId(ACTIVE_PROFILE_INDICATOR_ID)) != null;
 
     /// <summary>
     /// Waits (polling) until the per-device sampling frequency flyout reads

--- a/Daqifi.Desktop.UITest/ProfilesTests.cs
+++ b/Daqifi.Desktop.UITest/ProfilesTests.cs
@@ -1,0 +1,135 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Daqifi.Desktop.UITest;
+
+/// <summary>
+/// Scenario 6 — Profiles: save, activate, delete. Drives the real GUI out-of-process against an
+/// attached device through the full lifecycle of a saved configuration preset:
+///
+/// 1. Configure a known state (a sampling frequency + a set of active analog channels).
+/// 2. <b>Save</b> it as a profile — once by capturing the live device settings
+///    (<c>SaveCurrentSettingsCommand</c>) and once via the new-profile form
+///    (<c>SaveNewProfileCommand</c>) — and assert the profile appears in the list.
+/// 3. Change the device configuration to something clearly different.
+/// 4. <b>Activate</b> the saved profile (<c>ActivateProfileCommand</c>) and assert the captured
+///    channel + frequency intent is re-applied to the device, verified through the Channels pane
+///    "n / N ACTIVE" indicator and the per-device frequency flyout (ground-truth UI, not internals).
+/// 5. <b>Delete</b> the profile (<c>DeleteProfileCommand</c>) and assert it leaves the list.
+///
+/// All assertions read from visible UI via UI Automation. Each test is self-contained: it launches
+/// a fresh app (base fixture), records the profile count up-front, and removes any profile it
+/// creates, asserting the list returns to its original membership. Requires a DAQiFi device.
+/// </summary>
+[TestClass]
+public class ProfilesTests : DaqifiAppFixture
+{
+    #region Constants
+    // The captured-then-reapplied frequency and the deliberately different "changed" frequency.
+    // Both values are exercised by the other scenarios (100 Hz / 1000 Hz), so both are known to be
+    // settable on the device; they are far apart so re-application is unambiguous.
+    private const double CapturedFrequencyHz = 100d;
+    private const double ChangedFrequencyHz = 1000d;
+
+    private static readonly TimeSpan UiSettleTimeout = TimeSpan.FromSeconds(15);
+    #endregion
+
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void SaveActivateDelete_ProfileRoundTrips()
+    {
+        // Arrange — connect to the physically attached device.
+        var transport = ResolveTransport();
+        ConnectFirstDevice(transport);
+
+        // Configure a known state: a captured frequency + a set of active analog channels.
+        var capturedFrequency = SetSamplingFrequency(CapturedFrequencyHz);
+        var capturedChannels = EnableAllAnalogChannels();
+        Assert.IsTrue(
+            capturedChannels > 0,
+            "Pre-condition failed: no analog channels became active, so there is nothing to capture.");
+
+        // Baseline membership before we add ours (the test DB persists profiles across runs).
+        var profilesBefore = GetProfileCount();
+
+        // Act (SAVE) — snapshot the live device settings into a new profile via "CAPTURE FROM
+        // CURRENT SETTINGS" in the new-profile drawer.
+        OpenNewProfileDrawer();
+        SetNewProfileName($"UITest Profile {DateTime.Now:HHmmss}");
+        SaveCurrentSettingsAsProfile();
+
+        // Assert — the new profile appears in the list.
+        WaitForProfileCount(profilesBefore + 1, UiSettleTimeout);
+
+        // Change the device configuration to something clearly different from the saved profile:
+        // clear all channels (N -> 0) and set a different frequency.
+        ClearAllChannels();
+        var changedFrequency = SetSamplingFrequency(ChangedFrequencyHz);
+        Assert.AreNotEqual(
+            capturedFrequency,
+            changedFrequency,
+            0.5,
+            "Pre-condition failed: the 'changed' frequency must differ from the captured one for " +
+            "re-application to be observable.");
+        Assert.AreEqual(
+            0,
+            GetActiveAnalogChannelCount(),
+            "Pre-condition failed: channels were not cleared before activation.");
+
+        // Act (ACTIVATE) — open the saved profile and activate it.
+        OpenLastProfileEditDrawer();
+        ActivateSelectedProfile();
+
+        // Assert (re-application, ground-truth UI) — the device's frequency and active analog
+        // channels match the saved profile again.
+        var reappliedFrequency = WaitForSamplingFrequency(capturedFrequency, UiSettleTimeout);
+        Assert.AreEqual(
+            capturedFrequency,
+            reappliedFrequency,
+            0.5,
+            $"Activation did not re-apply the captured frequency ({capturedFrequency} Hz); the " +
+            $"device flyout read {reappliedFrequency} Hz.");
+        WaitForActiveAnalogChannelCount(capturedChannels, UiSettleTimeout);
+
+        // Act (DELETE) — deactivate (delete is blocked while active) then delete the profile.
+        OpenLastProfileEditDrawer();
+        DeactivateSelectedProfile();
+        DeleteSelectedProfile();
+
+        // Assert — the profile is gone; the list is back to its original membership.
+        WaitForProfileCount(profilesBefore, UiSettleTimeout);
+
+        // Per-test independence: the base fixture's [TestCleanup] closes the app (disconnecting
+        // the device). A fresh app instance is launched per test.
+    }
+
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void CreateProfileViaForm_AppearsAndDeletes()
+    {
+        // Arrange — connect to the physically attached device.
+        var transport = ResolveTransport();
+        ConnectFirstDevice(transport);
+
+        var profilesBefore = GetProfileCount();
+
+        // Act (SAVE via form) — open the new-profile drawer, name it, select the connected
+        // device, and save via "SAVE PROFILE" (SaveNewProfileCommand).
+        OpenNewProfileDrawer();
+        SetNewProfileName($"UITest Form {DateTime.Now:HHmmss}");
+        SelectFirstNewProfileDevice();
+        SaveNewProfileFromForm();
+
+        // Assert — the new profile appears in the list.
+        WaitForProfileCount(profilesBefore + 1, UiSettleTimeout);
+
+        // Act (DELETE) — the profile was never activated, so it deletes directly.
+        OpenLastProfileEditDrawer();
+        DeleteSelectedProfile();
+
+        // Assert — the list is back to its original membership.
+        WaitForProfileCount(profilesBefore, UiSettleTimeout);
+    }
+}

--- a/Daqifi.Desktop.UITest/ProfilesTests.cs
+++ b/Daqifi.Desktop.UITest/ProfilesTests.cs
@@ -28,9 +28,10 @@ public class ProfilesTests : DaqifiAppFixture
     // The captured-then-reapplied frequency and the deliberately different "changed" frequency.
     // Both values are exercised by the other scenarios (100 Hz / 1000 Hz), so both are known to be
     // settable on the device; they are far apart so re-application is unambiguous.
-    private const double CapturedFrequencyHz = 100d;
-    private const double ChangedFrequencyHz = 1000d;
+    private const double CAPTURED_FREQUENCY_HZ = 100d;
+    private const double CHANGED_FREQUENCY_HZ = 1000d;
 
+    // static readonly (not const), so PascalCase per the existing RunPollTimeout precedent.
     private static readonly TimeSpan UiSettleTimeout = TimeSpan.FromSeconds(15);
     #endregion
 
@@ -44,7 +45,7 @@ public class ProfilesTests : DaqifiAppFixture
         ConnectFirstDevice(transport);
 
         // Configure a known state: a captured frequency + a set of active analog channels.
-        var capturedFrequency = SetSamplingFrequency(CapturedFrequencyHz);
+        var capturedFrequency = SetSamplingFrequency(CAPTURED_FREQUENCY_HZ);
         var capturedChannels = EnableAllAnalogChannels();
         Assert.IsTrue(
             capturedChannels > 0,
@@ -65,7 +66,7 @@ public class ProfilesTests : DaqifiAppFixture
         // Change the device configuration to something clearly different from the saved profile:
         // clear all channels (N -> 0) and set a different frequency.
         ClearAllChannels();
-        var changedFrequency = SetSamplingFrequency(ChangedFrequencyHz);
+        var changedFrequency = SetSamplingFrequency(CHANGED_FREQUENCY_HZ);
         Assert.AreNotEqual(
             capturedFrequency,
             changedFrequency,

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -192,6 +192,7 @@ suffix), also hosted by `MainWindow.xaml`.
 | New-profile drawer: CAPTURE FROM CURRENT SETTINGS / SAVE PROFILE | `SaveCurrentSettingsButton` / `SaveNewProfileButton` | `View/ProfilesPane.xaml` |
 | New-profile drawer: per-device select checkbox | `NewProfileDeviceCheckbox` | `View/ProfilesPane.xaml` |
 | Edit drawer: ACTIVATE/DEACTIVATE / DELETE PROFILE | `ActivateProfileButton` / `DeleteProfileButton` | `View/ProfilesPane.xaml` |
+| Profiles status-bar active indicator (present only while a profile is active) | `ActiveProfileIndicator` | `View/ProfilesPane.xaml` |
 
 ---
 
@@ -322,10 +323,12 @@ why.
     does not land from a background host (#6/#12), so activation/deletion is driven through the
     **edit drawer's** `ActivateProfileButton` / `DeleteProfileButton` — plain `Button`s whose
     `InvokePattern` raises a real click and runs the bound command. Open the drawer via the tile
-    gear first. **(c)** Deactivation is confirmed by the **status-bar `· {name} ACTIVE`
-    indicator** leaving the tree (a Visibility binding on the active-profile name), **not** by the
-    activate button's swapped label — that label is a DataTrigger content swap and may not surface
-    as a UIA name change (#8). Two more load-bearing facts: `IsProfileActive` is **not persisted**
+    gear first. **(c)** Deactivation is confirmed by the **status-bar active indicator**
+    (`ActiveProfileIndicator`) leaving the tree — its Visibility binds to the active-profile name,
+    so it is collapsed (and absent from UIA) when none is active. Look it up **by AutomationId**,
+    not by scanning the pane's text for "ACTIVE" (a profile *named* "…ACTIVE" would defeat a
+    substring scan), and **not** via the activate button's swapped label — that label is a
+    DataTrigger content swap and may not surface as a UIA name change (#8). Two more load-bearing facts: `IsProfileActive` is **not persisted**
     to the profiles XML, so a fresh launch has **no active profile** and single-profile activation
     takes the no-confirm path (`ActivateProfile` only prompts when switching *between* two active
     profiles); and **delete is blocked while any profile is active**, so the cleanup path must

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -5,7 +5,7 @@ Windows UI Automation tree) against a **physically attached device** (USB serial
 WiFi). It is the **integration gate** of the development loop — separate from the fast
 unit gate (`dotnet test` on the MSTest+Moq suites), which needs no hardware.
 
-It covers five end-to-end workflows plus a launch smoke test:
+It covers six end-to-end workflows plus a launch smoke test:
 
 | Test | What it verifies |
 |---|---|
@@ -15,6 +15,7 @@ It covers five end-to-end workflows plus a launch smoke test:
 | `LoggingSessionTests.StartLoggingSession_RunsAndStops` | Start logging → data accrues (new session row) → stop |
 | `SdCardLoggingTests.SdCardLogging_LogsToSdCard_ThenImportsToSession` | Full SD lifecycle in one pass: switch to **Log to Device** (SD card) mode → run a session → a new file appears on the SD card (file count increased), confirming SD-card logging not a stream session → then **import that just-written file** (identified by diffing the file list — or a staged `error`-prefixed file when present, opportunistically guarding daqifi-core #195) and assert a new, non-empty `LoggingSession` appears in `LoggedSessionList`. The import is triangulated from the "Import Complete" dialog, the importer's `Imported N samples` log line (N&gt;0), and a +1 session delta. **USB only; needs an SD card.** |
 | `CsvExportTests.ExportLoggedSession_ProducesValidCsv` / `…ExportAllLoggedSessions_ProducesValidCsv` | Run a short logging session, then export it to CSV — once via the per-session **EXPORT** button and once via **EXPORT ALL** — through the `DAQIFI_TEST_EXPORT_PATH` hook (**no `SaveFileDialog`**, see below). Read the produced CSV back from disk (black box) and validate it: header is `Time` + one `Device:Serial:Channel` column per channel with no formula-injection prefix; every row has the header's field count (RFC 4180 consistency via a strict quote-aware parser); the time column parses as a round-trip timestamp and is non-decreasing; every value cell is a finite invariant-culture number; and the **value-cell count equals the session's persisted sample count** (each sample → one cell), proving no rows were dropped, duplicated, or corrupted. The sample count is read out-of-process from the app's `Persisted sample count N for session S` finalize log line. |
+| `ProfilesTests.SaveActivateDelete_ProfileRoundTrips` / `…CreateProfileViaForm_AppearsAndDeletes` | Full **Profiles** lifecycle. Configure a known state (set a frequency + enable analog channels), **save** it as a profile — once by capturing the live device settings (`SaveCurrentSettingsCommand`) and once via the new-profile form (`SaveNewProfileCommand`) — and assert it appears in the list. Then change the device config to something different (clear channels, set a different frequency), **activate** the saved profile (`ActivateProfileCommand`), and assert the captured **channel + frequency intent is re-applied to the device** — verified through the Channels pane `n / N ACTIVE` ground-truth indicator and the per-device frequency flyout (0 → N active; changed-Hz → captured-Hz). Finally **delete** the profile (`DeleteProfileCommand`) and assert the list returns to its original membership. Each test records the profile count up-front and removes any profile it creates (asserts membership before/after via deltas). A fresh launch never has an active profile (`IsProfileActive` is not persisted to XML), so single-profile activation takes the no-confirm path. **USB or WiFi.** |
 
 Every UI test is tagged `[TestCategory("Ui")]` and `[TestCategory("RequiresDevice")]`
 so it never runs as part of the unit gate.
@@ -157,9 +158,11 @@ exactly `N` value cells.
   e.g. the frequency slider’s `Delay=500`.)
 
 ### AutomationIds — where they live
-IDs are added only on the controls the scenarios touch. The panes are the
+IDs are added only on the controls the scenarios touch. Most panes are the
 `View/Prototype/*.xaml` files (they are the **live** views despite the “Prototype” suffix —
-`MainWindow.xaml` hosts them; confirm against the runtime tree, not a prototype twin).
+`MainWindow.xaml` hosts them; confirm against the runtime tree, not a prototype twin). The
+**Profiles** pane is the exception: its live view is `View/ProfilesPane.xaml` (no `Prototype`
+suffix), also hosted by `MainWindow.xaml`.
 
 | Logical control | AutomationId | File |
 |---|---|---|
@@ -171,6 +174,7 @@ IDs are added only on the controls the scenarios touch. The panes are the
 | Discovered / serial device lists | `DiscoveredDeviceList` / `SerialPortList` | `View/ConnectionDialog.xaml` |
 | Connect buttons | `ConnectButton_Wifi` / `ConnectButton_Manual` / `ConnectButton_Serial` | `View/ConnectionDialog.xaml` |
 | Channel list + “SELECT ALL” (analog) | `ChannelList` / `SelectAllAnalogChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
+| Channels “CLEAR ALL” (status bar; clears every section) | `ClearAllChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
 | Logging toggle + status label | `StartLoggingToggle` / `LoggingStatusText` | `View/Prototype/LiveGraphPane.xaml` |
 | Logged-session list | `LoggedSessionList` | `View/Prototype/LoggedDataPanePrototype.xaml` |
 | Per-row session **EXPORT** button (one per row) | `ExportSessionButton` | `View/Prototype/LoggedDataPanePrototype.xaml` |
@@ -181,6 +185,13 @@ IDs are added only on the controls the scenarios touch. The panes are the
 | SD refresh button / status line / file list | `RefreshSdCardFilesButton` / `SdCardStatusText` / `SdCardFileList` | `View/DeviceLogsView.xaml` |
 | Per-row SD file IMPORT button | `ImportSdCardFileButton` | `View/DeviceLogsView.xaml` |
 | Per-row SD file NAME cell (for deterministic file-name reads) | `SdCardFileNameText` | `View/DeviceLogsView.xaml` |
+| Profiles: saved-profile list | `ProfileList` | `View/ProfilesPane.xaml` |
+| Profiles: per-tile settings (gear) → opens the edit drawer | `ProfileSettingsButton` | `View/ProfilesPane.xaml` |
+| Profiles: “+ ADD PROFILE” (status bar / empty-state CTA) | `AddProfileButton` / `AddProfileButtonEmpty` | `View/ProfilesPane.xaml` |
+| New-profile drawer: NAME field | `NewProfileNameInput` | `View/ProfilesPane.xaml` |
+| New-profile drawer: CAPTURE FROM CURRENT SETTINGS / SAVE PROFILE | `SaveCurrentSettingsButton` / `SaveNewProfileButton` | `View/ProfilesPane.xaml` |
+| New-profile drawer: per-device select checkbox | `NewProfileDeviceCheckbox` | `View/ProfilesPane.xaml` |
+| Edit drawer: ACTIVATE/DEACTIVATE / DELETE PROFILE | `ActivateProfileButton` / `DeleteProfileButton` | `View/ProfilesPane.xaml` |
 
 ---
 
@@ -300,6 +311,26 @@ why.
     unreachable by the harness. Production keeps virtualization **on** (the list grows unbounded
     over a device's lifetime); screen readers realize rows on navigation, so the per-row
     `AutomationProperties.Name` (bound to `LoggingSession.AccessibilitySummary`) still works there.
+
+16. **Profiles are targeted by position, driven through the drawer, and confirmed by independent
+    signals.** Three things make the Profiles round-trip automatable: **(a)** like the
+    logged-session rows (#15), a profile tile exposes only its **gear button**
+    (`ProfileSettingsButton`) to UIA — its name/date TextBlocks do not surface — so a profile is
+    targeted by **position**: the newest is the **last** tile (`SubscribedProfiles` appends; the
+    list renders in insertion order, and the plain `ItemsControl` does not virtualize, so every
+    tile is realized). **(b)** A profile tile **activates via a `MouseBinding` LeftClick**, which
+    does not land from a background host (#6/#12), so activation/deletion is driven through the
+    **edit drawer's** `ActivateProfileButton` / `DeleteProfileButton` — plain `Button`s whose
+    `InvokePattern` raises a real click and runs the bound command. Open the drawer via the tile
+    gear first. **(c)** Deactivation is confirmed by the **status-bar `· {name} ACTIVE`
+    indicator** leaving the tree (a Visibility binding on the active-profile name), **not** by the
+    activate button's swapped label — that label is a DataTrigger content swap and may not surface
+    as a UIA name change (#8). Two more load-bearing facts: `IsProfileActive` is **not persisted**
+    to the profiles XML, so a fresh launch has **no active profile** and single-profile activation
+    takes the no-confirm path (`ActivateProfile` only prompts when switching *between* two active
+    profiles); and **delete is blocked while any profile is active**, so the cleanup path must
+    deactivate before deleting. Frequency lives in the per-device flyout, not the profile drawer
+    (#5) — the profile only *captures and re-applies* it.
 
 ---
 

--- a/Daqifi.Desktop/View/ProfilesPane.xaml
+++ b/Daqifi.Desktop/View/ProfilesPane.xaml
@@ -386,6 +386,7 @@
                         <TextBlock FontSize="10" FontWeight="SemiBold"
                                    Foreground="{StaticResource StatusGreen}"
                                    VerticalAlignment="Center"
+                                   AutomationProperties.AutomationId="ActiveProfileIndicator"
                                    Margin="12,0,0,0">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">

--- a/Daqifi.Desktop/View/ProfilesPane.xaml
+++ b/Daqifi.Desktop/View/ProfilesPane.xaml
@@ -229,7 +229,8 @@
                           VerticalScrollBarVisibility="Auto"
                           HorizontalScrollBarVisibility="Disabled"
                           Padding="28,0,28,0">
-                <ItemsControl ItemsSource="{Binding Profiles}">
+                <ItemsControl ItemsSource="{Binding Profiles}"
+                              AutomationProperties.AutomationId="ProfileList">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border Margin="0,0,0,8"
@@ -335,6 +336,7 @@
                                                 BorderThickness="0"
                                                 Cursor="Hand"
                                                 ToolTip="Profile settings"
+                                                AutomationProperties.AutomationId="ProfileSettingsButton"
                                                 VerticalAlignment="Center"
                                                 Command="{Binding DataContext.OpenEditDrawerCommand, ElementName=Root}"
                                                 CommandParameter="{Binding}">
@@ -414,6 +416,7 @@
                     <Button Grid.Column="1"
                             Style="{StaticResource PillButton}"
                             Content="+ ADD PROFILE"
+                            AutomationProperties.AutomationId="AddProfileButton"
                             IsEnabled="{Binding IsLoggingActive, Converter={StaticResource BooleanToInverse}}"
                             Command="{Binding OpenNewDrawerCommand}"/>
                 </Grid>
@@ -459,6 +462,7 @@
                 <Button Content="+ ADD PROFILE"
                         Style="{StaticResource AccentPillButton}"
                         HorizontalAlignment="Center"
+                        AutomationProperties.AutomationId="AddProfileButtonEmpty"
                         IsEnabled="{Binding IsLoggingActive, Converter={StaticResource BooleanToInverse}}"
                         Command="{Binding OpenNewDrawerCommand}"/>
             </StackPanel>
@@ -494,6 +498,7 @@
                     <Button Grid.Column="1"
                             Style="{StaticResource PillButton}"
                             Content="+ ADD PROFILE"
+                            AutomationProperties.AutomationId="AddProfileButton"
                             IsEnabled="{Binding IsLoggingActive, Converter={StaticResource BooleanToInverse}}"
                             Command="{Binding OpenNewDrawerCommand}"/>
                 </Grid>
@@ -736,6 +741,7 @@
                                            Margin="0,8,0,16"/>
 
                                 <Button Margin="0,0,0,8"
+                                        AutomationProperties.AutomationId="ActivateProfileButton"
                                         Command="{Binding ActivateProfileCommand}"
                                         CommandParameter="{Binding SelectedProfile}">
                                     <Button.Style>
@@ -752,6 +758,7 @@
 
                                 <Button Content="DELETE PROFILE"
                                         Style="{StaticResource DangerPillButton}"
+                                        AutomationProperties.AutomationId="DeleteProfileButton"
                                         Command="{Binding DeleteProfileCommand}"
                                         CommandParameter="{Binding SelectedProfile}"/>
 
@@ -767,6 +774,7 @@
                                            Style="{StaticResource SectionLabel}"
                                            Margin="0,8,0,8"/>
                                 <TextBox Style="{StaticResource DrawerTextBox}"
+                                         AutomationProperties.AutomationId="NewProfileNameInput"
                                          Text="{Binding NewProfileName, UpdateSourceTrigger=PropertyChanged}"/>
 
                                 <!-- CAPTURE shortcut -->
@@ -775,6 +783,7 @@
                                         HorizontalAlignment="Left"
                                         Margin="0,14,0,0"
                                         ToolTip="Snapshot currently active channels and device settings"
+                                        AutomationProperties.AutomationId="SaveCurrentSettingsButton"
                                         Command="{Binding SaveCurrentSettingsCommand}"/>
 
                                 <!-- DEVICES -->
@@ -820,6 +829,7 @@
 
                                                     <!-- Device checkbox -->
                                                     <CheckBox Style="{StaticResource DarkCheckBox}"
+                                                              AutomationProperties.AutomationId="NewProfileDeviceCheckbox"
                                                               IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}">
                                                         <StackPanel Orientation="Horizontal">
                                                             <TextBlock Text="{Binding Name}"
@@ -899,6 +909,7 @@
                                            Margin="0,20,0,16"/>
                                 <Button Content="SAVE PROFILE"
                                         Style="{StaticResource AccentPillButton}"
+                                        AutomationProperties.AutomationId="SaveNewProfileButton"
                                         Command="{Binding SaveNewProfileCommand}"/>
 
                             </StackPanel>

--- a/Daqifi.Desktop/View/Prototype/ChannelsPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/ChannelsPanePrototype.xaml
@@ -458,6 +458,7 @@
                     <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
                         <Button Style="{StaticResource PillButton}"
                                 Content="CLEAR ALL"
+                                AutomationProperties.AutomationId="ClearAllChannels"
                                 Command="{Binding ClearAllCommand}"/>
                     </StackPanel>
                 </Grid>


### PR DESCRIPTION
Closes #558.

Adds a FlaUI UI-automation scenario class `ProfilesTests` that drives the full **Profiles** lifecycle out-of-process against a physically attached device — the pane the harness did not touch before. A green `dotnet test Daqifi.Desktop.UITest` now exercises save → activate → delete.

## Scenarios

**`SaveActivateDelete_ProfileRoundTrips`** (the core acceptance flow)
1. Connect; configure a known state — set a sampling frequency (100 Hz) and enable the analog channels.
2. **Save** the live settings as a profile via *CAPTURE FROM CURRENT SETTINGS* (`SaveCurrentSettingsCommand`); assert it appears in the list (count +1).
3. **Change** the device config to something different — clear all channels (N → 0) and set a different frequency (1000 Hz).
4. **Activate** the saved profile (`ActivateProfileCommand`); assert the captured **channel + frequency intent is re-applied to the device**, verified through the Channels pane `n / N ACTIVE` ground-truth indicator (0 → N) and the per-device frequency flyout (1000 Hz → 100 Hz).
5. **Delete** the profile (`DeleteProfileCommand`); assert the list returns to its original membership.

**`CreateProfileViaForm_AppearsAndDeletes`**
Creates a profile through the new-profile **form** (`SaveNewProfileCommand` — select the device, save), asserts it appears, then deletes it. Exercises the second save path named in the issue.

Each test records the profile count up-front and removes any profile it creates, asserting membership via deltas — self-contained and order-independent (the test DB persists profiles across runs).

## Harness work
- **AutomationIds** (literal, PascalCase) on `View/ProfilesPane.xaml`: `ProfileList`, `ProfileSettingsButton`, `AddProfileButton`/`AddProfileButtonEmpty`, `NewProfileNameInput`, `SaveCurrentSettingsButton`, `SaveNewProfileButton`, `NewProfileDeviceCheckbox`, `ActivateProfileButton`, `DeleteProfileButton`; plus `ClearAllChannels` on the Channels pane (to establish the "different" pre-activation state). All are purely additive attributes — no behavior change.
- **`DaqifiAppFixture` helpers**: count/wait profiles, open the new-profile drawer, set the name, capture/save, select a device, open the last profile's edit drawer, activate/deactivate/delete, clear channels, and wait for the re-applied frequency. Uses `InvokePattern`/`ValuePattern`/`TogglePattern` + `Retry`/`WaitUntil*` — no fixed sleeps.
- **README**: new test-table row, AutomationId map entries (noting `ProfilesPane.xaml` lives in `View/`, not `View/Prototype/`), and a gotcha (#16) documenting the load-bearing facts: profiles are targeted by **position** (newest = last tile, since only the gear button surfaces to UIA), activation/deletion is driven through the **edit drawer** (the tile's `MouseBinding` click won't land from a background host), deactivation is confirmed by the **independent status-bar `ACTIVE` indicator** (not the button's DataTrigger label swap), `IsProfileActive` isn't persisted so a fresh launch has no active profile (single-profile activation takes the no-confirm path), and delete is blocked while active.

## Testing
- `dotnet build "DAQiFi Desktop.sln" -c Debug` — 0 errors.
- Fast unit gate (`TestCategory!=Ui`) — **274 passed, 0 failed**.
- UI gate against the attached USB device — **`ProfilesTests` 2/2 passed** (run individually and as a class, ~1m30s together).

## Acceptance criteria
- [x] Test saves a profile, activates it (verifying channel + frequency intent applied to the device), and deletes it.
- [x] Asserts list membership before/after, and re-applied config via the Channels `n / N ACTIVE` indicator + frequency flyout.
- [x] Green against a real device; self-contained; cleans up any profile it creates.
- [x] New AutomationIds documented in the README map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)