### PR TITLE
chore: integration coverage for live plot believability while streaming (#560)

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/PlotStatsSummaryTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/PlotStatsSummaryTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using Daqifi.Desktop.Logger;
+using OxyPlot;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Unit coverage for <see cref="PlotLogger.BuildPlotStatsSummary"/>, the pure formatter behind the
+/// live-plot stats hook the UI-automation harness reads to assert the plot renders believable data
+/// (issue #560). Verifies the subtle parts deterministically, without a live PlotModel or hardware:
+/// gap markers are excluded from the point count, a non-finite sample VALUE is counted (not hidden),
+/// <c>last</c> tracks the greatest-X sample, and numbers are always invariant-culture.
+/// </summary>
+[TestClass]
+public class PlotStatsSummaryTests
+{
+    private static List<List<DataPoint>> Series(params List<DataPoint>[] series) => [.. series];
+
+    [TestMethod]
+    public void Build_NoSeries_ReportsEmptySummary()
+    {
+        var summary = PlotLogger.BuildPlotStatsSummary(0, Series());
+
+        Assert.AreEqual(
+            "series=0;points=0;nonfinite=0;last=NaN;min=NaN;max=NaN",
+            summary,
+            "An empty plot should report zero series/points and NaN value stats.");
+    }
+
+    [TestMethod]
+    public void Build_FinitePoints_ReportsCountsAndExtents()
+    {
+        var summary = PlotLogger.BuildPlotStatsSummary(
+            1,
+            Series([new DataPoint(0, 1.5), new DataPoint(1, -0.5), new DataPoint(2, 2.25)]));
+
+        // last = value at greatest X (X=2 -> 2.25); min/max span the values.
+        Assert.AreEqual("series=1;points=3;nonfinite=0;last=2.25;min=-0.5;max=2.25", summary);
+    }
+
+    [TestMethod]
+    public void Build_GapMarkers_AreExcludedFromPointsAndNotCountedNonFinite()
+    {
+        // DataPoint.Undefined is the gap marker (NaN X, NaN Y) the logger inserts between
+        // discontiguous samples. It is not data and must not inflate points or nonfinite.
+        var summary = PlotLogger.BuildPlotStatsSummary(
+            1,
+            Series([new DataPoint(0, 1.5), DataPoint.Undefined, new DataPoint(1, 2.5)]));
+
+        Assert.AreEqual("series=1;points=2;nonfinite=0;last=2.5;min=1.5;max=2.5", summary);
+    }
+
+    [TestMethod]
+    public void Build_NonFiniteSampleValues_AreCountedButExcludedFromExtents()
+    {
+        // Real samples (finite X) whose VALUE is NaN/Inf are genuine bad data — counted in both
+        // points and nonfinite, but excluded from min/max/last so they cannot corrupt the extents.
+        var summary = PlotLogger.BuildPlotStatsSummary(
+            1,
+            Series(
+            [
+                new DataPoint(0, 1.5),
+                new DataPoint(1, double.NaN),
+                new DataPoint(2, double.PositiveInfinity),
+                new DataPoint(3, 2.5)
+            ]));
+
+        Assert.AreEqual("series=1;points=4;nonfinite=2;last=2.5;min=1.5;max=2.5", summary);
+    }
+
+    [TestMethod]
+    public void Build_MultipleSeries_AggregatesPointsAndTracksGreatestXForLast()
+    {
+        // last must reflect the greatest X across ALL series, regardless of enumeration order.
+        var summary = PlotLogger.BuildPlotStatsSummary(
+            2,
+            Series(
+                [new DataPoint(0, 10.5), new DataPoint(5, 50.5)],
+                [new DataPoint(2, 20.5), new DataPoint(10, 99.5)]));
+
+        Assert.AreEqual("series=2;points=4;nonfinite=0;last=99.5;min=10.5;max=99.5", summary);
+    }
+
+    [TestMethod]
+    public void Build_FormatsNumbersInvariant_RegardlessOfCurrentCulture()
+    {
+        var original = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            // A culture whose decimal separator is ',' would corrupt the ';'-delimited summary if
+            // the formatter were culture-sensitive; the harness parses it as invariant.
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+            var summary = PlotLogger.BuildPlotStatsSummary(
+                1, Series([new DataPoint(0, -1.5), new DataPoint(1, 2.5)]));
+
+            Assert.AreEqual("series=1;points=2;nonfinite=0;last=2.5;min=-1.5;max=2.5", summary);
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = original;
+        }
+    }
+}

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -56,6 +56,13 @@ public abstract class DaqifiAppFixture
     private const string LOGGING_STATUS_TEXT_ID = "LoggingStatusText";
     private const string LOGGED_SESSION_LIST_ID = "LoggedSessionList";
 
+    // The (invisible) live-plot stats indicator on the Live Graph pane. OxyPlot draws every
+    // point to one canvas and exposes no per-point UI Automation elements, so the harness
+    // cannot walk the tree for points. Instead it reads this element's Name — a machine-readable
+    // "series=..;points=..;nonfinite=..;last=..;min=..;max=.." summary of what the live plot is
+    // rendering — to assert the plot shows believable data while streaming (issue #560).
+    private const string PLOT_STATS_TEXT_ID = "PlotStatsText";
+
     // Per-row DELETE button (one per session row, like ExportSessionButton — it is in the item
     // template, so a row-scoped search targets that one row) and the affirmative button of the
     // app's in-pane confirm overlay. That overlay is the dark, in-window card the app shows for
@@ -1028,6 +1035,192 @@ public abstract class DaqifiAppFixture
             timeoutMessage:
                 "The in-pane confirm overlay did not close after invoking its affirmative button; " +
                 "its blocking scrim is still present, so the confirm command may not have run.");
+    }
+    #endregion
+
+    #region Live-Plot (Plot-Stats) Helpers
+    /// <summary>
+    /// A parsed snapshot of what the live plot is rendering, read out-of-process from the
+    /// Live Graph pane's invisible <c>PlotStatsText</c> indicator (issue #560). OxyPlot draws
+    /// points to a single canvas with no per-point UI Automation elements, so this summary is
+    /// the harness's black-box window onto the plot's ground truth.
+    /// </summary>
+    /// <param name="SeriesCount">Number of rendered series (one per streaming channel).</param>
+    /// <param name="PointCount">Real sample points across all series (gap markers excluded).</param>
+    /// <param name="NonFiniteCount">Real samples whose VALUE is NaN/Inf (expected 0).</param>
+    /// <param name="Last">Latest-in-time finite sample value (<see cref="double.NaN"/> if none).</param>
+    /// <param name="Min">Minimum finite sample value (<see cref="double.NaN"/> if none).</param>
+    /// <param name="Max">Maximum finite sample value (<see cref="double.NaN"/> if none).</param>
+    protected readonly record struct PlotStats(
+        int SeriesCount, long PointCount, long NonFiniteCount, double Last, double Min, double Max);
+
+    /// <summary>
+    /// Reads and parses the live-plot stats indicator (<c>PlotStatsText</c>) from the Live Graph
+    /// pane. Navigates there first (the indicator is only realized in the UIA tree while that tab
+    /// is selected). Re-resolves and re-reads under a short retry because, while a device streams,
+    /// a single UIA Name read can transiently fail (gotcha #10) and the summary itself only
+    /// refreshes about once a second.
+    /// </summary>
+    protected PlotStats ReadPlotStats()
+    {
+        NavigateToTab(LIVE_GRAPH_TAB_TEXT);
+
+        var summary = string.Empty;
+        Retry.WhileFalse(
+            () =>
+            {
+                var name = MainWindow
+                    .FindFirstDescendant(cf => cf.ByAutomationId(PLOT_STATS_TEXT_ID))?.Name;
+                if (string.IsNullOrEmpty(name))
+                {
+                    return false;
+                }
+
+                summary = name;
+                return true;
+            },
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                "The live-plot stats indicator (PlotStatsText) was not readable on the Live Graph " +
+                "pane. Ensure the plot-stats UIA hook in LiveGraphPane.xaml is present.");
+
+        return ParsePlotStats(summary);
+    }
+
+    /// <summary>
+    /// Parses the <c>"series=N;points=M;nonfinite=K;last=V;min=A;max=B"</c> summary string
+    /// (invariant culture; <c>last/min/max</c> may be <c>"NaN"</c>) into a <see cref="PlotStats"/>.
+    /// </summary>
+    private static PlotStats ParsePlotStats(string summary)
+    {
+        var series = 0;
+        long points = 0;
+        long nonFinite = 0;
+        var last = double.NaN;
+        var min = double.NaN;
+        var max = double.NaN;
+
+        foreach (var field in summary.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var pair = field.Split('=', 2);
+            if (pair.Length != 2)
+            {
+                continue;
+            }
+
+            var key = pair[0].Trim();
+            var value = pair[1].Trim();
+            switch (key)
+            {
+                case "series": series = int.Parse(value, System.Globalization.CultureInfo.InvariantCulture); break;
+                case "points": points = long.Parse(value, System.Globalization.CultureInfo.InvariantCulture); break;
+                case "nonfinite": nonFinite = long.Parse(value, System.Globalization.CultureInfo.InvariantCulture); break;
+                case "last": last = ParseStatDouble(value); break;
+                case "min": min = ParseStatDouble(value); break;
+                case "max": max = ParseStatDouble(value); break;
+            }
+        }
+
+        return new PlotStats(series, points, nonFinite, last, min, max);
+    }
+
+    /// <summary>Parses an invariant-culture double, tolerating the "NaN" sentinel.</summary>
+    private static double ParseStatDouble(string value) =>
+        double.Parse(
+            value,
+            System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Waits (polling) until the live plot reports exactly <paramref name="expected"/> series.
+    /// Series materialize one per channel as each channel produces its first sample, so the
+    /// count ramps up over the first moments of streaming; this rides out that ramp. Reads the
+    /// plot-stats indicator, so it navigates to the Live Graph pane.
+    /// </summary>
+    protected void WaitForPlotSeriesCount(int expected, TimeSpan timeout)
+    {
+        Retry.WhileFalse(
+            () => ReadPlotStats().SeriesCount == expected,
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(500),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage:
+                $"The live plot did not render exactly {expected} series (one per active channel) " +
+                $"within {timeout.TotalSeconds:N0}s. A mismatch means the plot is not rendering the " +
+                "active channels' data.");
+    }
+
+    /// <summary>
+    /// Proves the live plot's rendered point count strictly increases over a streaming window
+    /// (data is flowing, not frozen). Takes a baseline reading, then polls until the point count
+    /// exceeds it or <paramref name="timeout"/> elapses, and fails if it never grew. Returns the
+    /// baseline and the first reading that showed growth.
+    /// </summary>
+    protected (PlotStats Before, PlotStats After) WaitForPlotPointGrowth(TimeSpan timeout)
+    {
+        var before = ReadPlotStats();
+        var after = before;
+
+        var grew = Retry.WhileFalse(
+            () =>
+            {
+                after = ReadPlotStats();
+                return after.PointCount > before.PointCount;
+            },
+            timeout: timeout,
+            interval: TimeSpan.FromMilliseconds(400),
+            throwOnTimeout: false,
+            ignoreException: true).Result;
+
+        Assert.IsTrue(
+            grew,
+            $"The live plot's rendered point count did not increase within {timeout.TotalSeconds:N0}s " +
+            $"(stayed at {before.PointCount}). The plot is frozen — data is not reaching it while streaming.");
+
+        return (before, after);
+    }
+
+    /// <summary>
+    /// Asserts the live plot stops accruing points after logging has stopped — by proving its
+    /// rendered point count <b>converges to a stable value</b>. Once the session goes inactive no
+    /// samples reach the plot (<c>HandleChannelUpdate</c> early-returns on <c>!Active</c>), so the
+    /// count stops rising; but the stats indicator recomputes only about once a second, so it takes
+    /// a tick or two to catch up to the final pre-stop points (and a brief post-stop pipeline drain
+    /// may add a few). This polls for two consecutive equal readings spaced safely longer than the
+    /// indicator's ~1 s refresh — so a genuinely frozen plot settles within a tick, while a plot
+    /// that kept streaming at any real rate would never produce two equal readings and so would
+    /// (correctly) fail. Convergence is the proof it stopped accruing. Call only after
+    /// <see cref="StopLogging"/> has confirmed "LOGGING OFF".
+    /// </summary>
+    protected void AssertPlotStoppedAccruing(TimeSpan settleTimeout)
+    {
+        // Read interval comfortably exceeds the indicator's ~1 s recompute, guaranteeing at least
+        // one refresh between consecutive reads: equal across that gap ⇒ the buffer is frozen;
+        // unequal ⇒ still accruing. (Two reads inside one refresh period could alias to the same
+        // stale value, so the gap must clear a full period.)
+        var previous = -1L;
+        var settled = Retry.WhileFalse(
+            () =>
+            {
+                var current = ReadPlotStats().PointCount;
+                var isStable = current >= 0 && current == previous;
+                previous = current;
+                return isStable;
+            },
+            timeout: settleTimeout,
+            interval: TimeSpan.FromMilliseconds(1500),
+            throwOnTimeout: false,
+            ignoreException: true).Result;
+
+        Assert.IsTrue(
+            settled,
+            $"The live plot's rendered point count never settled within {settleTimeout.TotalSeconds:N0}s " +
+            "of stopping logging — it kept accruing. Stopping logging should freeze the plot (no samples " +
+            "reach it once the session is inactive).");
     }
     #endregion
 

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -1065,8 +1065,14 @@ public abstract class DaqifiAppFixture
     {
         NavigateToTab(LIVE_GRAPH_TAB_TEXT);
 
-        var summary = string.Empty;
-        Retry.WhileFalse(
+        var stats = default(PlotStats);
+        var lastRaw = string.Empty;
+
+        // Read AND parse inside the retry: while a device streams, a single UIA Name read can
+        // transiently fail or (rarely) return a partial value, so retrying the parse — not just
+        // the read — keeps every caller's first read robust (e.g. the baseline in
+        // WaitForPlotPointGrowth, which is otherwise unguarded). TryParse keeps it non-throwing.
+        var read = Retry.WhileFalse(
             () =>
             {
                 var name = MainWindow
@@ -1076,63 +1082,96 @@ public abstract class DaqifiAppFixture
                     return false;
                 }
 
-                summary = name;
-                return true;
+                lastRaw = name;
+                return TryParsePlotStats(name, out stats);
             },
             timeout: TimeSpan.FromSeconds(15),
             interval: TimeSpan.FromMilliseconds(300),
-            throwOnTimeout: true,
-            ignoreException: true,
-            timeoutMessage:
-                "The live-plot stats indicator (PlotStatsText) was not readable on the Live Graph " +
-                "pane. Ensure the plot-stats UIA hook in LiveGraphPane.xaml is present.");
+            throwOnTimeout: false,
+            ignoreException: true).Result;
 
-        return ParsePlotStats(summary);
+        // Assert (not throwOnTimeout) so the failure message can include the last raw value read,
+        // which the eagerly-built timeoutMessage could not capture.
+        Assert.IsTrue(
+            read,
+            "The live-plot stats indicator (PlotStatsText) was not readable/parseable on the Live " +
+            $"Graph pane (last raw value: '{lastRaw}'). Ensure the plot-stats UIA hook in " +
+            "LiveGraphPane.xaml is present and emits the expected 'series=..;points=..;..' format.");
+
+        return stats;
     }
 
     /// <summary>
-    /// Parses the <c>"series=N;points=M;nonfinite=K;last=V;min=A;max=B"</c> summary string
+    /// Tries to parse the <c>"series=N;points=M;nonfinite=K;last=V;min=A;max=B"</c> summary string
     /// (invariant culture; <c>last/min/max</c> may be <c>"NaN"</c>) into a <see cref="PlotStats"/>.
+    /// Returns false (so the caller retries) on any malformed or partially-read value, and requires
+    /// every field to be present so a truncated read is not silently accepted.
     /// </summary>
-    private static PlotStats ParsePlotStats(string summary)
+    private static bool TryParsePlotStats(string summary, out PlotStats stats)
     {
-        var series = 0;
-        long points = 0;
-        long nonFinite = 0;
-        var last = double.NaN;
-        var min = double.NaN;
-        var max = double.NaN;
+        stats = default;
 
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var field in summary.Split(';', StringSplitOptions.RemoveEmptyEntries))
         {
             var pair = field.Split('=', 2);
             if (pair.Length != 2)
             {
-                continue;
+                return false;
             }
 
-            var key = pair[0].Trim();
-            var value = pair[1].Trim();
-            switch (key)
-            {
-                case "series": series = int.Parse(value, System.Globalization.CultureInfo.InvariantCulture); break;
-                case "points": points = long.Parse(value, System.Globalization.CultureInfo.InvariantCulture); break;
-                case "nonfinite": nonFinite = long.Parse(value, System.Globalization.CultureInfo.InvariantCulture); break;
-                case "last": last = ParseStatDouble(value); break;
-                case "min": min = ParseStatDouble(value); break;
-                case "max": max = ParseStatDouble(value); break;
-            }
+            fields[pair[0].Trim()] = pair[1].Trim();
         }
 
-        return new PlotStats(series, points, nonFinite, last, min, max);
+        if (!TryParseLong(fields, "points", out var points)
+            || !TryParseLong(fields, "nonfinite", out var nonFinite)
+            || !TryParseStat(fields, "last", out var last)
+            || !TryParseStat(fields, "min", out var min)
+            || !TryParseStat(fields, "max", out var max))
+        {
+            return false;
+        }
+
+        if (!fields.TryGetValue("series", out var seriesText)
+            || !int.TryParse(
+                seriesText,
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var series))
+        {
+            return false;
+        }
+
+        stats = new PlotStats(series, points, nonFinite, last, min, max);
+        return true;
     }
 
-    /// <summary>Parses an invariant-culture double, tolerating the "NaN" sentinel.</summary>
-    private static double ParseStatDouble(string value) =>
-        double.Parse(
-            value,
-            System.Globalization.NumberStyles.Float,
-            System.Globalization.CultureInfo.InvariantCulture);
+    /// <summary>Parses a required invariant-culture integer field; false if missing or malformed.</summary>
+    private static bool TryParseLong(IReadOnlyDictionary<string, string> fields, string key, out long value)
+    {
+        value = 0;
+        return fields.TryGetValue(key, out var text)
+            && long.TryParse(
+                text,
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out value);
+    }
+
+    /// <summary>
+    /// Parses a required invariant-culture double field, tolerating the "NaN" sentinel; false if the
+    /// field is missing (a truncated read should retry, not be read as NaN) or malformed.
+    /// </summary>
+    private static bool TryParseStat(IReadOnlyDictionary<string, string> fields, string key, out double value)
+    {
+        value = double.NaN;
+        return fields.TryGetValue(key, out var text)
+            && double.TryParse(
+                text,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out value);
+    }
 
     /// <summary>
     /// Waits (polling) until the live plot reports exactly <paramref name="expected"/> series.

--- a/Daqifi.Desktop.UITest/LoggingSessionTests.cs
+++ b/Daqifi.Desktop.UITest/LoggingSessionTests.cs
@@ -8,16 +8,21 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Daqifi.Desktop.UITest;
 
 /// <summary>
-/// Scenario 3 — Start / run / stop a logging session, then delete it (issue #557).
+/// Scenario 3 — Start / run / stop a logging session, asserting the <b>live plot renders
+/// believable data while streaming</b> (issue #560), then delete the session (issue #557).
 /// Drives the real GUI out-of-process: connects to the physically attached device,
 /// configures logging (frequency + channels), starts a logging session via the toolbar
-/// toggle, polls for evidence that data is accruing, then stops the session. It then
-/// deletes the just-created session via its per-row DELETE action (accepting the app's
-/// in-pane confirm overlay) and asserts the row is gone and the session count returns to
-/// its pre-run baseline — which also leaves the persistent test-mode DB self-cleaned
-/// rather than leaking one session per run. All assertions read from the visible UI
-/// (logging status text, the Logged Data session list) plus the app's NLog log file.
-/// Requires a DAQiFi device.
+/// toggle, and — while it streams — reads the Live Graph pane's plot-stats hook to assert the
+/// plot is genuinely rendering data: one series per active channel, a rendered point count that
+/// strictly increases over a window (flowing, not frozen), and sample values that are finite,
+/// in a plausible range, and not a dead flatline at zero. It also polls for the DB-level accrual
+/// signal (a new logged-session row), stops the session, and asserts the plot then stops
+/// accruing. Finally it deletes the just-created session via its per-row DELETE action (accepting
+/// the app's in-pane confirm overlay) and asserts the row is gone and the session count returns
+/// to its pre-run baseline — which also leaves the persistent test-mode DB self-cleaned rather
+/// than leaking one session per run. All assertions read from the visible/accessible UI (the
+/// plot-stats hook, logging status text, the Logged Data session list) plus the app's NLog log
+/// file — never app internals. Requires a DAQiFi device.
 /// </summary>
 [TestClass]
 public class LoggingSessionTests : DaqifiAppFixture
@@ -32,12 +37,27 @@ public class LoggingSessionTests : DaqifiAppFixture
     // an upper bound for a POLLING wait (Retry), not a fixed sleep — it returns as
     // soon as the signal is observed.
     private static readonly TimeSpan RunPollTimeout = TimeSpan.FromSeconds(20);
+
+    // Generous magnitude sanity bound for analog sample VALUES (volts). DAQiFi analog inputs
+    // are a few volts full-scale; this loose ceiling is not a tight spec but catches obviously
+    // broken/garbage scaling while staying hardware-agnostic (the issue's "within the channel's
+    // expected range"). Non-finite values are caught separately (NonFiniteCount / IsFinite).
+    private const double PLAUSIBLE_ANALOG_CEILING_VOLTS = 1000d;
+
+    // Upper bounds for the live-plot believability polls (return as soon as satisfied).
+    private static readonly TimeSpan PlotSeriesTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan PlotGrowthTimeout = TimeSpan.FromSeconds(20);
+
+    // How long to allow the live plot's point count to settle to a stable value after logging
+    // stops (proving it froze). Generous enough to ride out the ~1 Hz stats refresh catching up
+    // to the final pre-stop points plus any brief post-stop pipeline drain.
+    private static readonly TimeSpan PlotSettleTimeout = TimeSpan.FromSeconds(15);
     #endregion
 
     [TestMethod]
     [TestCategory("Ui")]
     [TestCategory("RequiresDevice")]
-    public void StartLoggingSession_RunsStopsAndDeletesSession()
+    public void StartLoggingSession_RendersLivePlot_RunsStopsAndDeletesSession()
     {
         // Arrange — connect to the attached device.
         var transport = ResolveTransport();
@@ -67,6 +87,39 @@ public class LoggingSessionTests : DaqifiAppFixture
         // (no toggle-state fallback), so it fails if the label goes stale.
         WaitForLoggingStatusLabel("LOGGING ON", TimeSpan.FromSeconds(15));
 
+        // ── Live plot renders believable data while streaming (issue #560) ──
+        // OxyPlot draws points to a single canvas with no per-point UIA elements, so this reads
+        // the Live Graph pane's plot-stats hook (PlotStatsText) — visible/accessible UI state,
+        // not app internals — to prove the plot is genuinely rendering the streaming data.
+
+        // (a) One series per active channel. Series materialize as each channel first reports,
+        //     so this rides out that ramp-up.
+        WaitForPlotSeriesCount(activeChannels, PlotSeriesTimeout);
+
+        // (b) The rendered point count strictly increases over a window — data is flowing into
+        //     the plot, not frozen.
+        var (_, streaming) = WaitForPlotPointGrowth(PlotGrowthTimeout);
+
+        // (c) The rendered sample values are believable: finite (no NaN/Inf), within a plausible
+        //     range, and not a dead flatline pinned at exactly zero.
+        Assert.AreEqual(
+            0L, streaming.NonFiniteCount,
+            $"The live plot rendered {streaming.NonFiniteCount} non-finite (NaN/Inf) sample value(s); " +
+            "streaming values should all be finite.");
+        Assert.IsTrue(
+            double.IsFinite(streaming.Last) && double.IsFinite(streaming.Min) && double.IsFinite(streaming.Max),
+            $"The live plot's summary stats were not finite (last={streaming.Last}, min={streaming.Min}, " +
+            $"max={streaming.Max}) despite {streaming.PointCount} points — the plot is not rendering real values.");
+        Assert.IsFalse(
+            streaming.Min == 0d && streaming.Max == 0d,
+            "The live plot is a dead flatline at exactly zero (min == max == 0) across every channel — " +
+            "the value path is broken (real input is essentially never identically zero on all channels).");
+        Assert.IsTrue(
+            Math.Abs(streaming.Min) <= PLAUSIBLE_ANALOG_CEILING_VOLTS
+                && Math.Abs(streaming.Max) <= PLAUSIBLE_ANALOG_CEILING_VOLTS,
+            $"The live plot's sample values are outside the plausible range (min={streaming.Min}, " +
+            $"max={streaming.Max}, ceiling=±{PLAUSIBLE_ANALOG_CEILING_VOLTS}) — likely broken scaling.");
+
         // Run — poll (not sleep) for an accrual signal. The session-finalize path only
         // keeps the session if samples were recorded, so a new logged-session row
         // appearing is positive proof of accrual. As a best-effort secondary channel,
@@ -83,6 +136,11 @@ public class LoggingSessionTests : DaqifiAppFixture
 
         // Assert — the user-visible label (not just the toggle) reads "LOGGING OFF".
         WaitForLoggingStatusLabel("LOGGING OFF", TimeSpan.FromSeconds(15));
+
+        // Assert (issue #560) — with the session inactive, no samples reach the plot, so the
+        // rendered point count must stop growing. Proven by the count converging to a stable
+        // value (a still-streaming plot would never settle); reads the plot-stats hook.
+        AssertPlotStoppedAccruing(PlotSettleTimeout);
 
         // Assert (out-of-process) — a new logged session exists, proving the session
         // ran and accrued data. If the row had not yet rendered during the run window,
@@ -131,7 +189,7 @@ public class LoggingSessionTests : DaqifiAppFixture
             "The app logged 'Failed in DeleteLoggingSession' — the SQLite delete transaction threw.");
 
         // Capture a screenshot of the final state as a test artifact.
-        CaptureScreenshot("StartLoggingSession_RunsStopsAndDeletesSession_final");
+        CaptureScreenshot("StartLoggingSession_RendersLivePlot_RunsStopsAndDeletesSession_final");
 
         // Per-test independence: the base fixture's [TestCleanup] closes the app,
         // which disconnects the device. A fresh app instance is launched per test.

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -12,7 +12,7 @@ It covers six end-to-end workflows plus a launch smoke test:
 | `LaunchSmokeTests.Launch_MainWindowAppears_AndIsResponsive` | App launches with no prompts; main window appears and is responsive |
 | `AddDeviceTests.AddDevice_ConnectsToAttachedDevice` | Open connection dialog → discover → connect; device shows in connected list |
 | `ConfigureLoggingTests.ConfigureLogging_SetsFrequencyAndChannels` | Set sample frequency (device flyout) + enable analog channels; read both back |
-| `LoggingSessionTests.StartLoggingSession_RunsStopsAndDeletesSession` | Start logging → data accrues (new session row) → stop → **delete that session** (issue #557) via its per-row trash action, accepting the dark **in-pane confirm overlay**. Asserts the row is gone and the session count returns to its pre-run baseline (the view), with **DB-level deletion proven separately from the app's log lines** — `DeleteLoggingSession completed` present and `Failed in DeleteLoggingSession` absent (the SQL `DELETE`s commit in a transaction; the view removal alone isn't DB-proof, since that delete swallows its exceptions). Leaves the test-mode DB self-cleaned (no per-run session leak). |
+| `LoggingSessionTests.StartLoggingSession_RendersLivePlot_RunsStopsAndDeletesSession` | Start logging → **assert the live plot renders believable data while streaming** (issue #560) → data accrues (new session row) → stop → **assert the plot stops accruing** → **delete that session** (issue #557) via its per-row trash action, accepting the dark **in-pane confirm overlay**. The believability check reads the Live Graph pane's **plot-stats hook** (`PlotStatsText`, see gotcha #18) — accessible UI state, not app internals — and asserts **series count == active channels**, **rendered point count strictly increases** over a window (flowing, not frozen), and **values are finite, in a plausible range, and not a dead flatline at zero**; after stop it asserts the point count freezes (no samples reach the plot once the session is inactive). Then asserts the row is gone and the session count returns to its pre-run baseline (the view), with **DB-level deletion proven separately from the app's log lines** — `DeleteLoggingSession completed` present and `Failed in DeleteLoggingSession` absent (the SQL `DELETE`s commit in a transaction; the view removal alone isn't DB-proof, since that delete swallows its exceptions). Leaves the test-mode DB self-cleaned (no per-run session leak). |
 | `SdCardLoggingTests.SdCardLogging_LogsToSdCard_ThenImportsToSession` | Full SD lifecycle in one pass: switch to **Log to Device** (SD card) mode → run a session → a new file appears on the SD card (file count increased), confirming SD-card logging not a stream session → then **import that just-written file** (identified by diffing the file list — or a staged `error`-prefixed file when present, opportunistically guarding daqifi-core #195) and assert a new, non-empty `LoggingSession` appears in `LoggedSessionList`. The import is triangulated from the "Import Complete" dialog, the importer's `Imported N samples` log line (N&gt;0), and a +1 session delta. **USB only; needs an SD card.** |
 | `CsvExportTests.ExportLoggedSession_ProducesValidCsv` / `…ExportAllLoggedSessions_ProducesValidCsv` | Run a short logging session, then export it to CSV — once via the per-session **EXPORT** button and once via **EXPORT ALL** — through the `DAQIFI_TEST_EXPORT_PATH` hook (**no `SaveFileDialog`**, see below). Read the produced CSV back from disk (black box) and validate it: header is `Time` + one `Device:Serial:Channel` column per channel with no formula-injection prefix; every row has the header's field count (RFC 4180 consistency via a strict quote-aware parser); the time column parses as a round-trip timestamp and is non-decreasing; every value cell is a finite invariant-culture number; and the **value-cell count equals the session's persisted sample count** (each sample → one cell), proving no rows were dropped, duplicated, or corrupted. The sample count is read out-of-process from the app's `Persisted sample count N for session S` finalize log line. |
 | `ProfilesTests.SaveActivateDelete_ProfileRoundTrips` / `…CreateProfileViaForm_AppearsAndDeletes` | Full **Profiles** lifecycle. Configure a known state (set a frequency + enable analog channels), **save** it as a profile — once by capturing the live device settings (`SaveCurrentSettingsCommand`) and once via the new-profile form (`SaveNewProfileCommand`) — and assert it appears in the list. Then change the device config to something different (clear channels, set a different frequency), **activate** the saved profile (`ActivateProfileCommand`), and assert the captured **channel + frequency intent is re-applied to the device** — verified through the Channels pane `n / N ACTIVE` ground-truth indicator and the per-device frequency flyout (0 → N active; changed-Hz → captured-Hz). Finally **delete** the profile (`DeleteProfileCommand`) and assert the list returns to its original membership. Each test records the profile count up-front and removes any profile it creates (asserts membership before/after via deltas). A fresh launch never has an active profile (`IsProfileActive` is not persisted to XML), so single-profile activation takes the no-confirm path. **USB or WiFi.** |
@@ -176,6 +176,7 @@ suffix), also hosted by `MainWindow.xaml`.
 | Channel list + “SELECT ALL” (analog) | `ChannelList` / `SelectAllAnalogChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
 | Channels “CLEAR ALL” (status bar; clears every section) | `ClearAllChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
 | Logging toggle + status label | `StartLoggingToggle` / `LoggingStatusText` | `View/Prototype/LiveGraphPane.xaml` |
+| Live-plot stats hook (invisible; surfaces the rendered plot's ground truth — see gotcha #18) | `PlotStatsText` | `View/Prototype/LiveGraphPane.xaml` |
 | Logged-session list | `LoggedSessionList` | `View/Prototype/LoggedDataPanePrototype.xaml` |
 | Per-row session **EXPORT** button (one per row) | `ExportSessionButton` | `View/Prototype/LoggedDataPanePrototype.xaml` |
 | Per-row session **DELETE** button (one per row) | `DeleteSessionButton` | `View/Prototype/LoggedDataPanePrototype.xaml` |
@@ -352,6 +353,31 @@ why.
     `DbLogger.DeleteLoggingSession` swallows its own exceptions, so the view-model removes the row
     even on a failed delete. DB-level deletion is asserted separately from the app's NLog lines
     (`DeleteLoggingSession completed` present, `Failed in DeleteLoggingSession` absent).
+
+18. **The live plot is an OxyPlot canvas with no per-point UIA elements — assert on a stats hook,
+    not the plot.** The Live Graph plot (`oxy:PlotView x:Name="DataLog"`, `Model="{Binding
+    Plotter.PlotModel}"`) draws every series and point to a **single drawing surface**; individual
+    points/series are **not** exposed as UI Automation elements, so the harness cannot walk the tree
+    to verify what is rendered. To assert the plot shows believable data while streaming (issue
+    #560) without touching app internals, `LiveGraphPane.xaml` carries an **invisible UIA-visible
+    indicator** `PlotStatsText` whose `AutomationProperties.Name` is bound to
+    `PlotLogger.PlotStatsSummary` — a machine-readable, invariant-culture string
+    `"series=N;points=M;nonfinite=K;last=V;min=A;max=B"` recomputed on the plot's own once-a-second
+    render tick. The harness reads and parses it (`ReadPlotStats` → `PlotStats`) to assert series
+    count == active channels, strictly-increasing point count (data flowing), and finite/plausible/
+    non-flatline values; mirrors the `LoggingStatusText` hook (#8). Two load-bearing details:
+    **(a)** the element is kept out of the `IsLogging`-collapsed status-chip `StackPanel` and made
+    invisible with **`Opacity="0"` + `IsHitTestVisible="False"`, NOT `Visibility="Collapsed"`** — a
+    `Collapsed` element is pruned from the UIA tree (so unreadable), whereas an `Opacity=0` element
+    stays in the tree and readable, and being outside the chips means it is readable **after** stop
+    too (for the freezes-after-stop assertion). **(b)** `PlotStatsSummary` distinguishes a **gap
+    marker** (`DataPoint.Undefined`, NaN *X*) from a real sample (finite *X*), so intentional gap
+    NaNs are not counted as data nor mistaken for a non-finite sample *value* — `nonfinite` counts
+    only real samples whose *value* is NaN/Inf. Samples reach the plot **only** while a stream-mode
+    session is active (`LoggingManager.HandleChannelUpdate` early-returns unless
+    `Active && CurrentMode == Stream && hasActiveApplicationSession`), which is exactly why the plot
+    accrues between start and stop and freezes after — and why an SD-card (`Log to Device`) run does
+    not populate the live plot.
 
 ---
 

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -25,7 +25,7 @@ public partial class PlotLogger : ObservableObject, ILogger
     private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _loggedPoints = [];
     private Dictionary<(string deviceSerial, string channelName), LineSeries> _loggedChannels = [];
     private readonly TimestampGapDetector _gapDetector = new();
-    private string _plotStatsSummary = EmptyPlotStatsSummary;
+    private string _plotStatsSummary = EMPTY_PLOT_STATS_SUMMARY;
     #endregion
 
     #region Plot-stats UIA hook
@@ -39,7 +39,7 @@ public partial class PlotLogger : ObservableObject, ILogger
     // where series = PlotModel.Series.Count, points = real sample points across all series
     // (gap markers excluded), nonfinite = real samples whose VALUE is NaN/Inf (expected 0),
     // and last/min/max are the latest-in-time / extent sample values ("NaN" when no data).
-    private const string EmptyPlotStatsSummary =
+    private const string EMPTY_PLOT_STATS_SUMMARY =
         "series=0;points=0;nonfinite=0;last=NaN;min=NaN;max=NaN";
 
     /// <summary>
@@ -50,12 +50,7 @@ public partial class PlotLogger : ObservableObject, ILogger
     public string PlotStatsSummary
     {
         get => _plotStatsSummary;
-        private set
-        {
-            if (_plotStatsSummary == value) { return; }
-            _plotStatsSummary = value;
-            OnPropertyChanged();
-        }
+        private set => SetProperty(ref _plotStatsSummary, value);
     }
     #endregion
 
@@ -272,7 +267,6 @@ public partial class PlotLogger : ObservableObject, ILogger
     {
         var key = (DeviceSerialNo, channelName);
         var newDataPoints = new List<DataPoint>();
-        LoggedPoints.Add(key, newDataPoints);
 
         var serialSuffix = DeviceSerialNo?.Length > 4
             ? $"...{DeviceSerialNo[^4..]}"
@@ -307,8 +301,16 @@ public partial class PlotLogger : ObservableObject, ILogger
             _ => newLineSeries.YAxisKey
         };
 
-        LoggedChannels.Add(key, newLineSeries);
-        PlotModel.Series.Add(newLineSeries);
+        // Mutate the shared collections under PlotModel.SyncRoot — the same lock held by Log()'s
+        // point-append and by the render tick (InvalidatePlot + plot-stats recompute). Without it
+        // these structural Adds raced the render-tick enumeration, so a concurrent OxyPlot render
+        // or stats recompute could observe a half-updated dictionary/series list.
+        lock (PlotModel.SyncRoot)
+        {
+            LoggedPoints.Add(key, newDataPoints);
+            LoggedChannels.Add(key, newLineSeries);
+            PlotModel.Series.Add(newLineSeries);
+        }
 
         OnPropertyChanged(nameof(PlotModel));
     }
@@ -342,27 +344,18 @@ public partial class PlotLogger : ObservableObject, ILogger
     }
 
     /// <summary>
-    /// Recomputes <see cref="PlotStatsSummary"/> from the currently buffered points. Called
-    /// on the once-a-second render tick while holding <c>PlotModel.SyncRoot</c> (so the
-    /// per-channel point lists are not mutated mid-read by <see cref="Log(DataSample)"/>).
-    /// Gap markers are inserted as <c>DataPoint.Undefined</c> (NaN X); a real sample always
-    /// has a finite X (elapsed ms), so an NaN X distinguishes a gap from data and lets a
-    /// genuinely non-finite sample VALUE still be counted (nonfinite) rather than hidden.
-    /// Best-effort: a transient enumeration race with off-thread series creation
-    /// (<see cref="AddChannelSeries"/> adds a dictionary key outside the lock) is swallowed so
-    /// the render callback never throws; the summary simply keeps its previous value.
+    /// Recomputes <see cref="PlotStatsSummary"/> from the currently buffered points. Called on the
+    /// once-a-second render tick while holding <c>PlotModel.SyncRoot</c>. Every mutation of the
+    /// per-channel collections — <see cref="Log(DataSample)"/>'s point-append and
+    /// <see cref="AddChannelSeries"/>'s series creation — takes that same lock, so enumerating the
+    /// point lists here is consistent (no torn reads, no structural-modification race).
+    /// Gap markers are inserted as <c>DataPoint.Undefined</c> (NaN X); a real sample always has a
+    /// finite X (elapsed ms), so an NaN X distinguishes a gap from data and lets a genuinely
+    /// non-finite sample VALUE still be counted (nonfinite) rather than hidden.
     /// </summary>
     private void UpdatePlotStatsSummary()
     {
-        try
-        {
-            PlotStatsSummary = BuildPlotStatsSummary(PlotModel.Series.Count, LoggedPoints.Values);
-        }
-        catch (InvalidOperationException)
-        {
-            // LoggedPoints was modified (a new channel series was added off-thread) while we
-            // enumerated it. Skip this tick; the next one recomputes from a settled dictionary.
-        }
+        PlotStatsSummary = BuildPlotStatsSummary(PlotModel.Series.Count, LoggedPoints.Values);
     }
 
     /// <summary>
@@ -387,7 +380,11 @@ public partial class PlotLogger : ObservableObject, ILogger
             for (var i = 0; i < pointList.Count; i++)
             {
                 var point = pointList[i];
-                if (double.IsNaN(point.X)) { continue; } // gap marker, not data
+                if (double.IsNaN(point.X))
+                {
+                    // Gap marker (DataPoint.Undefined), not data.
+                    continue;
+                }
 
                 points++;
 
@@ -398,14 +395,29 @@ public partial class PlotLogger : ObservableObject, ILogger
                     continue;
                 }
 
-                if (!any) { min = max = y; any = true; }
+                if (!any)
+                {
+                    min = max = y;
+                    any = true;
+                }
                 else
                 {
-                    if (y < min) { min = y; }
-                    if (y > max) { max = y; }
+                    if (y < min)
+                    {
+                        min = y;
+                    }
+
+                    if (y > max)
+                    {
+                        max = y;
+                    }
                 }
 
-                if (point.X >= lastX) { lastX = point.X; last = y; }
+                if (point.X >= lastX)
+                {
+                    lastX = point.X;
+                    last = y;
+                }
             }
         }
 
@@ -423,7 +435,7 @@ public partial class PlotLogger : ObservableObject, ILogger
         PlotModel.Series.Clear();
         PlotModel.InvalidatePlot(true);
         FirstTime = null;
-        PlotStatsSummary = EmptyPlotStatsSummary;
+        PlotStatsSummary = EMPTY_PLOT_STATS_SUMMARY;
         OnPropertyChanged(nameof(LoggedChannels));
         OnPropertyChanged(nameof(LoggedPoints));
         OnPropertyChanged(nameof(PlotModel));

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -6,6 +6,7 @@ using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.Series;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -24,6 +25,38 @@ public partial class PlotLogger : ObservableObject, ILogger
     private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _loggedPoints = [];
     private Dictionary<(string deviceSerial, string channelName), LineSeries> _loggedChannels = [];
     private readonly TimestampGapDetector _gapDetector = new();
+    private string _plotStatsSummary = EmptyPlotStatsSummary;
+    #endregion
+
+    #region Plot-stats UIA hook
+    // Ground-truth summary of what the live plot is rendering, surfaced as a single
+    // machine-readable string so an out-of-process UI test can assert the plot is showing
+    // believable data while streaming (issue #560). OxyPlot draws every point to one canvas
+    // and exposes no per-point UI Automation elements, so the harness cannot walk the tree
+    // for points; this property is bound to an (invisible) UIA element's Name in
+    // LiveGraphPane.xaml, mirroring the LoggingStatusText hook. Format (invariant culture):
+    //   "series={count};points={n};nonfinite={n};last={y};min={y};max={y}"
+    // where series = PlotModel.Series.Count, points = real sample points across all series
+    // (gap markers excluded), nonfinite = real samples whose VALUE is NaN/Inf (expected 0),
+    // and last/min/max are the latest-in-time / extent sample values ("NaN" when no data).
+    private const string EmptyPlotStatsSummary =
+        "series=0;points=0;nonfinite=0;last=NaN;min=NaN;max=NaN";
+
+    /// <summary>
+    /// Machine-readable summary of the live plot's rendered content, updated about once a
+    /// second while streaming. Exposed for out-of-process UI automation (issue #560); not
+    /// shown to users. See the format note above.
+    /// </summary>
+    public string PlotStatsSummary
+    {
+        get => _plotStatsSummary;
+        private set
+        {
+            if (_plotStatsSummary == value) { return; }
+            _plotStatsSummary = value;
+            OnPropertyChanged();
+        }
+    }
     #endregion
 
     #region Properties
@@ -302,9 +335,84 @@ public partial class PlotLogger : ObservableObject, ILogger
                     }
                 }
                 PlotModel.InvalidatePlot(true); // This will redraw the plot with updated series visibility
+                UpdatePlotStatsSummary();
                 _lastUpdateMilliSeconds = _stopwatch.ElapsedMilliseconds;
             }
         }
+    }
+
+    /// <summary>
+    /// Recomputes <see cref="PlotStatsSummary"/> from the currently buffered points. Called
+    /// on the once-a-second render tick while holding <c>PlotModel.SyncRoot</c> (so the
+    /// per-channel point lists are not mutated mid-read by <see cref="Log(DataSample)"/>).
+    /// Gap markers are inserted as <c>DataPoint.Undefined</c> (NaN X); a real sample always
+    /// has a finite X (elapsed ms), so an NaN X distinguishes a gap from data and lets a
+    /// genuinely non-finite sample VALUE still be counted (nonfinite) rather than hidden.
+    /// Best-effort: a transient enumeration race with off-thread series creation
+    /// (<see cref="AddChannelSeries"/> adds a dictionary key outside the lock) is swallowed so
+    /// the render callback never throws; the summary simply keeps its previous value.
+    /// </summary>
+    private void UpdatePlotStatsSummary()
+    {
+        try
+        {
+            PlotStatsSummary = BuildPlotStatsSummary(PlotModel.Series.Count, LoggedPoints.Values);
+        }
+        catch (InvalidOperationException)
+        {
+            // LoggedPoints was modified (a new channel series was added off-thread) while we
+            // enumerated it. Skip this tick; the next one recomputes from a settled dictionary.
+        }
+    }
+
+    /// <summary>
+    /// Builds the <see cref="PlotStatsSummary"/> string from a series count and the per-series
+    /// point lists. Pure and side-effect-free so it can be unit-tested without a live PlotModel.
+    /// Gap markers (<c>DataPoint.Undefined</c>, i.e. NaN X) are excluded from the point count and
+    /// never mistaken for a non-finite sample value; <c>nonfinite</c> counts only real samples
+    /// (finite X) whose VALUE (Y) is NaN/Inf; <c>last</c> is the value at the greatest X seen.
+    /// </summary>
+    internal static string BuildPlotStatsSummary(int seriesCount, IEnumerable<List<DataPoint>> pointLists)
+    {
+        long points = 0;
+        long nonFinite = 0;
+        var min = double.NaN;
+        var max = double.NaN;
+        var last = double.NaN;
+        var lastX = double.NegativeInfinity;
+        var any = false;
+
+        foreach (var pointList in pointLists)
+        {
+            for (var i = 0; i < pointList.Count; i++)
+            {
+                var point = pointList[i];
+                if (double.IsNaN(point.X)) { continue; } // gap marker, not data
+
+                points++;
+
+                var y = point.Y;
+                if (double.IsNaN(y) || double.IsInfinity(y))
+                {
+                    nonFinite++;
+                    continue;
+                }
+
+                if (!any) { min = max = y; any = true; }
+                else
+                {
+                    if (y < min) { min = y; }
+                    if (y > max) { max = y; }
+                }
+
+                if (point.X >= lastX) { lastX = point.X; last = y; }
+            }
+        }
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "series={0};points={1};nonfinite={2};last={3:R};min={4:R};max={5:R}",
+            seriesCount, points, nonFinite, last, min, max);
     }
 
     public void ClearPlot()
@@ -315,6 +423,7 @@ public partial class PlotLogger : ObservableObject, ILogger
         PlotModel.Series.Clear();
         PlotModel.InvalidatePlot(true);
         FirstTime = null;
+        PlotStatsSummary = EmptyPlotStatsSummary;
         OnPropertyChanged(nameof(LoggedChannels));
         OnPropertyChanged(nameof(LoggedPoints));
         OnPropertyChanged(nameof(PlotModel));

--- a/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
+++ b/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
@@ -394,6 +394,25 @@
                                    Margin="0,4,0,0"/>
                     </StackPanel>
                 </Border>
+
+                <!--
+                    Invisible plot-stats hook for out-of-process UI automation (issue #560).
+                    OxyPlot renders points to a single canvas with no per-point UI Automation
+                    elements, so the harness reads this element's Name to assert the live plot
+                    is rendering believable data while streaming (series count, point growth,
+                    finite/plausible values). Opacity=0 + IsHitTestVisible=False keeps it fully
+                    invisible and non-interactive while remaining present and readable in the UIA
+                    tree (a Collapsed element would be pruned from it). Both Text and
+                    AutomationProperties.Name are bound so the Name tracks the value, mirroring
+                    the LoggingStatusText hook.
+                -->
+                <TextBlock AutomationProperties.AutomationId="PlotStatsText"
+                           Text="{Binding Plotter.PlotStatsSummary}"
+                           AutomationProperties.Name="{Binding Plotter.PlotStatsSummary}"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Top"
+                           Opacity="0"
+                           IsHitTestVisible="False"/>
             </Grid>
 
             <!-- ── Channel legend sidebar ── -->


### PR DESCRIPTION
## What & why

Closes #560. The UI integration gate asserted that a logging *session* accrues, but never that the **live plot actually renders believable data** while streaming — a large, fragile surface (viewport downsampling, minimap, zoom/pan) that can silently break (blank plot, frozen series, all-zero/NaN) while every other assertion stays green.

### The OxyPlot challenge
The live plot is an OxyPlot `PlotView` that draws every series/point to a **single canvas** with **no per-point UI Automation elements**, so the harness cannot walk the tree to verify what is rendered. Following the issue's recommended approach (and mirroring the existing `LoggingStatusText` hook), this adds a small **invisible, UIA-readable plot-stats indicator** (`PlotStatsText`) on the Live Graph pane whose `AutomationProperties.Name` surfaces ground truth from the live `PlotModel`:

```
series=N;points=M;nonfinite=K;last=V;min=A;max=B
```

recomputed on the plot's own once-a-second render tick. It keeps the test black-box (reads visible/accessible state, never app internals). `Opacity=0` + `IsHitTestVisible=False` keeps it fully invisible yet present in the UIA tree (a `Collapsed` element would be pruned).

## Expand vs. new scenario

The issue suggested a new `LivePlotTests` class; I was asked to push back if expanding an existing test made more sense. **It does** — so I expanded `LoggingSessionTests`. The decider is `LoggingManager.HandleChannelUpdate`: samples reach the live plot **only** while a stream-mode session is `Active`. `LoggingSessionTests` owns the only existing stream-mode start→accrue→stop window; `ConfigureLoggingTests` never starts logging, and `SdCardLoggingTests` runs in Log-to-Device mode (its data never reaches the live plot). A standalone class would re-run the full connect/configure/start/stop scaffolding against the device purely to duplicate the most expensive part of an integration test. The tradeoff (the scenario now also covers #557 delete) is owned in its renamed method + docs.

## What the test now asserts (while streaming, from the plot-stats hook)
- **series count == active channels**
- **rendered point count strictly increases** over a window (flowing, not frozen)
- **values are finite** (no NaN/Inf), **within a plausible range**, and **not a dead flatline at zero**
- after stop, **the plot stops accruing** — proven by the point count **converging to a stable value** (a still-streaming plot never settles)

## Also
- Extracted the formatter as a pure `internal static BuildPlotStatsSummary` and added focused **unit tests** (gap-marker exclusion via NaN-X, non-finite value counting, greatest-X `last`, invariant-culture formatting) — no hardware needed.
- README updated: scenario table, AutomationId map (`PlotStatsText`), and new **gotcha #18** (OxyPlot canvas → stats hook; `Opacity=0` not `Collapsed`; gap-marker semantics).

## Validation
- ✅ **Green against a real device** (`dotnet test Daqifi.Desktop.UITest --filter ...RendersLivePlot`, ~1m16s). The believability assertions surfaced a real subtlety — the ~1 Hz indicator lags the final pre-stop points — which is why the freeze check asserts *convergence* rather than comparing two raw endpoints.
- ✅ Fast unit gate clean: **280 passing, 0 failures** (incl. 6 new formatter tests); solution builds with 0 errors.
- ✅ Self-contained: the scenario deletes the session it creates, leaving the test-mode DB at its pre-run baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)