### PR TITLE
docs: add build-from-source section, clarify badge and Sentry notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > The official Windows desktop application for DAQiFi hardware — real-time visualization, session logging, and firmware updates, all in one place.
 
-[![Latest release](https://img.shields.io/github/v/release/daqifi/daqifi-desktop?style=flat-square&label=release&color=brightgreen)](https://github.com/daqifi/daqifi-desktop/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/daqifi/daqifi-desktop?style=flat-square&label=release&color=brightgreen&cacheSeconds=3600)](https://github.com/daqifi/daqifi-desktop/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows-blue?style=flat-square)](https://github.com/daqifi/daqifi-desktop/releases)
 [![.NET](https://img.shields.io/badge/.NET-10.0-purple?style=flat-square)](https://dotnet.microsoft.com/)
@@ -101,6 +101,25 @@ Both devices are SCPI-compliant and compatible with LabVIEW.
 - **Bug reports and feature requests**: [GitHub Issues](https://github.com/daqifi/daqifi-desktop/issues)
 - **Commercial inquiries and custom hardware**: [daqifi.com](https://daqifi.com)
 
+## Build from source
+
+Building and running the app requires **Windows** (the UI targets WPF / `net10.0-windows`) and the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) — the exact SDK version is pinned in [`global.json`](global.json).
+
+```bash
+git clone https://github.com/daqifi/daqifi-desktop.git
+cd daqifi-desktop
+dotnet build                          # restore + build the solution
+dotnet run --project Daqifi.Desktop   # launch the app
+```
+
+Run the unit tests (no hardware required):
+
+```bash
+dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"
+```
+
+The `DAQifiDesktop_Setup.msi` installer is produced from the `Daqifi.Desktop.Setup` project (WiX Toolset) and is normally built by CI on release; to build it locally, run `dotnet build -c Release` inside `Daqifi.Desktop.Setup`. The UI-automation test gate drives the real GUI against an attached device — see [Daqifi.Desktop.UITest/README.md](Daqifi.Desktop.UITest/README.md).
+
 ## Contributing
 
 Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull request. See [docs/architecture.md](docs/architecture.md) for the streaming data pipeline and system overview, and [docs/design-philosophy.md](docs/design-philosophy.md) for UI/UX principles. All PRs require a conventional commit title (`feat:`, `fix:`, `docs:`, `deps:`, `chore:`) and at least one approving review from a DAQiFi core member.
@@ -109,7 +128,7 @@ Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull
 
 Releases are created by publishing a GitHub Release (via the GitHub web UI or API — the `release.yaml` workflow triggers on the `release: created` event, not on a tag push alone). Once a release is published, the workflow builds the MSI via WiX Toolset and attaches `DAQifiDesktop_Setup.msi` automatically. The app version is set in `Daqifi.Desktop/Daqifi.Desktop.csproj` (`<Version>`). Follow [semantic versioning](https://semver.org/); breaking changes should use the `feat!:` prefix in the PR title.
 
-Unhandled exceptions are captured via Sentry. The DSN is in `Daqifi.Desktop/App.config`.
+Unhandled exceptions are reported to Sentry. The DSN lives in [`Daqifi.Desktop/App.config`](Daqifi.Desktop/App.config); like any Sentry client DSN it is write-only — it can submit crash events but cannot read them back — so it is safe to commit and ship in the app, and is not a leaked secret.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Both devices are SCPI-compliant and compatible with LabVIEW.
 
 ## Build from source
 
-Building and running the app requires **Windows** (the UI targets WPF / `net10.0-windows`) and the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) — the exact SDK version is pinned in [`global.json`](global.json).
+Building and running the app requires **Windows** (the UI targets WPF / `net10.0-windows`) and the
+[.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) — the exact SDK version is pinned in
+[`global.json`](global.json).
 
 ```bash
 git clone https://github.com/daqifi/daqifi-desktop.git
@@ -118,7 +120,17 @@ Run the unit tests (no hardware required):
 dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"
 ```
 
-The `DAQifiDesktop_Setup.msi` installer is produced from the `Daqifi.Desktop.Setup` project (WiX Toolset) and is normally built by CI on release; to build it locally, run `dotnet build -c Release` inside `Daqifi.Desktop.Setup`. The UI-automation test gate drives the real GUI against an attached device — see [Daqifi.Desktop.UITest/README.md](Daqifi.Desktop.UITest/README.md).
+The `DAQifiDesktop_Setup.msi` installer is built from the `Daqifi.Desktop.Setup` project (WiX Toolset)
+and is normally produced by CI on release. The WiX project harvests the app's **published** output, so
+build it locally by publishing first, then building the setup project (mirroring CI):
+
+```bash
+dotnet publish Daqifi.Desktop/Daqifi.Desktop.csproj -c Release
+dotnet build -c Release Daqifi.Desktop.Setup
+```
+
+The UI-automation test gate drives the real GUI against an attached device — see
+[Daqifi.Desktop.UITest/README.md](Daqifi.Desktop.UITest/README.md).
 
 ## Contributing
 
@@ -128,7 +140,10 @@ Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening a pull
 
 Releases are created by publishing a GitHub Release (via the GitHub web UI or API — the `release.yaml` workflow triggers on the `release: created` event, not on a tag push alone). Once a release is published, the workflow builds the MSI via WiX Toolset and attaches `DAQifiDesktop_Setup.msi` automatically. The app version is set in `Daqifi.Desktop/Daqifi.Desktop.csproj` (`<Version>`). Follow [semantic versioning](https://semver.org/); breaking changes should use the `feat!:` prefix in the PR title.
 
-Unhandled exceptions are reported to Sentry. The DSN lives in [`Daqifi.Desktop/App.config`](Daqifi.Desktop/App.config); like any Sentry client DSN it is write-only — it can submit crash events but cannot read them back — so it is safe to commit and ship in the app, and is not a leaked secret.
+Unhandled exceptions are reported to Sentry. The DSN lives in
+[`Daqifi.Desktop/App.config`](Daqifi.Desktop/App.config); like any Sentry client DSN it is write-only
+— it can submit crash events but cannot read them back — so it is safe to commit and ship in the app,
+and is not a leaked secret.
 
 ---
 


### PR DESCRIPTION
## What

Three small README improvements, all confined to `README.md`:

1. **Add a "Build from source" section.** The README was end-user focused with no path for developers who want to build it. New section documents the Windows + .NET 10 SDK prerequisites (pinned in `global.json`), `git clone` → `dotnet build` → `dotnet run`, the no-hardware unit-test command (matching the project's fast gate), and pointers to the WiX MSI build and the device-dependent UI-automation gate.

2. **Clarify the Sentry note.** "For maintainers" pointed at the committed DSN in `App.config` without context. Reworded to make clear a Sentry client DSN is write-only (can submit crash events, can't read them back) — so it's safe to commit/ship and is not a leaked secret.

3. **Harden the release badge.** Added `cacheSeconds=3600` to the shields.io release badge. The badge had been intermittently rendering `Unable to select next GitHub token from pool` — a transient shields.io-side error when their shared GitHub-API token pool is rate-limited. The longer cache reduces how often shields.io re-queries GitHub, shrinking that window. (Root cause is on shields.io's infrastructure, not this repo — the repo has releases and the endpoint resolves correctly.)

## Why

Closes a content gap for contributors (build instructions) and removes two sources of reader confusion (a scary-looking but harmless DSN, and a flaky-looking badge).

## Notes

- Docs-only; no code or behavior changes.
- A screenshot for the README hero was discussed but intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)