### PR TITLE
feat(ui): dark-mode the legacy dialogs and redesign the export flow

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
@@ -1,0 +1,221 @@
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Covers the export dialog's three-state machine (Configure / Exporting / Done) and the
+/// Export command gating. Uses the internal factory-injecting constructor so the dialog can
+/// be exercised without the App/DI container.
+/// </summary>
+[TestClass]
+public class ExportDialogViewModelTests
+{
+    private static readonly string TestDirectoryPath =
+        Path.Combine(Path.GetTempPath(), "DAQiFi", "ExportDialogViewModelTests");
+
+    [TestInitialize]
+    public void Setup() => Directory.CreateDirectory(TestDirectoryPath);
+
+    private static ExportDialogViewModel CreateViewModel(IDbContextFactory<LoggingContext> factory = null)
+        => new(factory ?? new Mock<IDbContextFactory<LoggingContext>>().Object, sessionId: 1);
+
+    #region IsConfiguring (which of the three states is shown)
+
+    [TestMethod]
+    public void IsConfiguring_IsTrue_OnNewViewModel()
+    {
+        var vm = CreateViewModel();
+
+        Assert.IsTrue(vm.IsConfiguring);
+        Assert.IsFalse(vm.IsExporting);
+        Assert.IsFalse(vm.IsExportComplete);
+    }
+
+    [TestMethod]
+    public void IsConfiguring_IsFalse_WhileExporting()
+    {
+        var vm = CreateViewModel();
+
+        vm.IsExporting = true;
+
+        Assert.IsFalse(vm.IsConfiguring);
+    }
+
+    [TestMethod]
+    public void IsConfiguring_IsFalse_WhenComplete()
+    {
+        var vm = CreateViewModel();
+
+        vm.IsExportComplete = true;
+
+        Assert.IsFalse(vm.IsConfiguring);
+    }
+
+    [TestMethod]
+    public void IsConfiguring_RaisesPropertyChanged_WhenExportingChanges()
+    {
+        var vm = CreateViewModel();
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.IsExporting = true;
+
+        CollectionAssert.Contains(raised, nameof(ExportDialogViewModel.IsConfiguring));
+    }
+
+    [TestMethod]
+    public void IsConfiguring_RaisesPropertyChanged_WhenCompleteChanges()
+    {
+        var vm = CreateViewModel();
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.IsExportComplete = true;
+
+        CollectionAssert.Contains(raised, nameof(ExportDialogViewModel.IsConfiguring));
+    }
+
+    #endregion
+
+    #region Export command gating (CanExport)
+
+    [TestMethod]
+    public void ExportCommand_CannotExecute_WithoutDestination()
+    {
+        var vm = CreateViewModel();
+
+        Assert.IsFalse(vm.ExportLoggingSessionsCommand.CanExecute(null));
+    }
+
+    [TestMethod]
+    public void ExportCommand_CanExecute_OnceDestinationIsSet()
+    {
+        var vm = CreateViewModel();
+
+        vm.ExportFilePath = Path.Combine(TestDirectoryPath, "out.csv");
+
+        Assert.IsTrue(vm.ExportLoggingSessionsCommand.CanExecute(null));
+    }
+
+    [TestMethod]
+    public void SettingDestination_RaisesCanExecuteChanged_ForExportCommand()
+    {
+        var vm = CreateViewModel();
+        var raised = false;
+        vm.ExportLoggingSessionsCommand.CanExecuteChanged += (_, _) => raised = true;
+
+        vm.ExportFilePath = Path.Combine(TestDirectoryPath, "out.csv");
+
+        Assert.IsTrue(raised);
+    }
+
+    #endregion
+
+    #region Terminal state transitions
+
+    [TestMethod]
+    public async Task Export_OnFailure_ShowsFailedResult()
+    {
+        // A factory that throws when the export reads the session forces the catch-all path
+        // deterministically — no file-system or timing dependence.
+        var factory = new Mock<IDbContextFactory<LoggingContext>>();
+        factory.Setup(f => f.CreateDbContext()).Throws(new InvalidOperationException("boom"));
+        var vm = new ExportDialogViewModel(factory.Object, sessionId: 1)
+        {
+            ExportFilePath = Path.Combine(TestDirectoryPath, "fail.csv")
+        };
+
+        await vm.ExportLoggingSessionsCommand.ExecuteAsync(null);
+
+        Assert.IsTrue(vm.IsExportComplete, "Failure should still land on the result state.");
+        Assert.IsFalse(vm.ExportSucceeded);
+        Assert.IsFalse(vm.IsExporting);
+        Assert.IsFalse(vm.IsConfiguring);
+        Assert.AreEqual("Export failed. Please try again.", vm.ExportResultMessage);
+    }
+
+    [TestMethod]
+    public async Task Export_OnSuccess_ShowsCompleteResultAndWritesFile()
+    {
+        using var factory = new TempSqliteLoggingContextFactory();
+        SeedSession(factory, sessionId: 1);
+        var exportPath = Path.Combine(TestDirectoryPath, $"success_{Guid.NewGuid():N}.csv");
+        var vm = new ExportDialogViewModel(factory, sessionId: 1) { ExportFilePath = exportPath };
+
+        await vm.ExportLoggingSessionsCommand.ExecuteAsync(null);
+
+        Assert.IsTrue(vm.IsExportComplete);
+        Assert.IsTrue(vm.ExportSucceeded);
+        Assert.IsFalse(vm.IsExporting);
+        Assert.IsFalse(vm.IsConfiguring);
+        Assert.AreEqual("Export complete", vm.ExportResultMessage);
+        Assert.IsTrue(File.Exists(exportPath), "A successful export should have written the file.");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static void SeedSession(IDbContextFactory<LoggingContext> factory, int sessionId)
+    {
+        using var context = factory.CreateDbContext();
+        context.Sessions.Add(new LoggingSession
+        {
+            ID = sessionId,
+            Name = "Test",
+            SessionStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+        var baseTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var t = 0; t < 3; t++)
+        {
+            context.Samples.Add(new DataSample
+            {
+                LoggingSessionID = sessionId,
+                DeviceName = "TestDevice",
+                DeviceSerialNo = "TEST001",
+                ChannelName = "Channel 1",
+                TimestampTicks = baseTime.AddMilliseconds(t * 10).Ticks,
+                Value = t,
+                Color = ""
+            });
+        }
+        context.SaveChanges();
+    }
+
+    private sealed class TempSqliteLoggingContextFactory : IDbContextFactory<LoggingContext>, IDisposable
+    {
+        private readonly string _dbPath;
+        private readonly DbContextOptions<LoggingContext> _options;
+
+        public TempSqliteLoggingContextFactory()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"daqifi_exportvm_{Guid.NewGuid():N}.db");
+            _options = new DbContextOptionsBuilder<LoggingContext>()
+                .UseSqlite($"Data Source={_dbPath}")
+                .Options;
+            using var ctx = new LoggingContext(_options);
+            ctx.Database.EnsureCreated();
+        }
+
+        public LoggingContext CreateDbContext() => new(_options);
+
+        public void Dispose()
+        {
+            try
+            {
+                Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+                if (File.Exists(_dbPath)) { File.Delete(_dbPath); }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    #endregion
+}

--- a/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
@@ -20,6 +20,20 @@ public class ExportDialogViewModelTests
     [TestInitialize]
     public void Setup() => Directory.CreateDirectory(TestDirectoryPath);
 
+    [TestCleanup]
+    public void Cleanup()
+    {
+        // Remove exported CSVs / temp DBs so repeated runs don't accumulate files under %TEMP%.
+        try
+        {
+            if (Directory.Exists(TestDirectoryPath)) { Directory.Delete(TestDirectoryPath, recursive: true); }
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
+    }
+
     private static ExportDialogViewModel CreateViewModel(IDbContextFactory<LoggingContext> factory = null)
         => new(factory ?? new Mock<IDbContextFactory<LoggingContext>>().Object, sessionId: 1);
 
@@ -28,8 +42,10 @@ public class ExportDialogViewModelTests
     [TestMethod]
     public void IsConfiguring_IsTrue_OnNewViewModel()
     {
+        // Arrange & Act
         var vm = CreateViewModel();
 
+        // Assert
         Assert.IsTrue(vm.IsConfiguring);
         Assert.IsFalse(vm.IsExporting);
         Assert.IsFalse(vm.IsExportComplete);
@@ -38,44 +54,56 @@ public class ExportDialogViewModelTests
     [TestMethod]
     public void IsConfiguring_IsFalse_WhileExporting()
     {
+        // Arrange
         var vm = CreateViewModel();
 
+        // Act
         vm.IsExporting = true;
 
+        // Assert
         Assert.IsFalse(vm.IsConfiguring);
     }
 
     [TestMethod]
     public void IsConfiguring_IsFalse_WhenComplete()
     {
+        // Arrange
         var vm = CreateViewModel();
 
+        // Act
         vm.IsExportComplete = true;
 
+        // Assert
         Assert.IsFalse(vm.IsConfiguring);
     }
 
     [TestMethod]
     public void IsConfiguring_RaisesPropertyChanged_WhenExportingChanges()
     {
+        // Arrange
         var vm = CreateViewModel();
         var raised = new List<string>();
         vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
 
+        // Act
         vm.IsExporting = true;
 
+        // Assert
         CollectionAssert.Contains(raised, nameof(ExportDialogViewModel.IsConfiguring));
     }
 
     [TestMethod]
     public void IsConfiguring_RaisesPropertyChanged_WhenCompleteChanges()
     {
+        // Arrange
         var vm = CreateViewModel();
         var raised = new List<string>();
         vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
 
+        // Act
         vm.IsExportComplete = true;
 
+        // Assert
         CollectionAssert.Contains(raised, nameof(ExportDialogViewModel.IsConfiguring));
     }
 
@@ -86,30 +114,41 @@ public class ExportDialogViewModelTests
     [TestMethod]
     public void ExportCommand_CannotExecute_WithoutDestination()
     {
+        // Arrange
         var vm = CreateViewModel();
 
-        Assert.IsFalse(vm.ExportLoggingSessionsCommand.CanExecute(null));
+        // Act
+        var canExecute = vm.ExportLoggingSessionsCommand.CanExecute(null);
+
+        // Assert
+        Assert.IsFalse(canExecute);
     }
 
     [TestMethod]
     public void ExportCommand_CanExecute_OnceDestinationIsSet()
     {
+        // Arrange
         var vm = CreateViewModel();
 
+        // Act
         vm.ExportFilePath = Path.Combine(TestDirectoryPath, "out.csv");
 
+        // Assert
         Assert.IsTrue(vm.ExportLoggingSessionsCommand.CanExecute(null));
     }
 
     [TestMethod]
     public void SettingDestination_RaisesCanExecuteChanged_ForExportCommand()
     {
+        // Arrange
         var vm = CreateViewModel();
         var raised = false;
         vm.ExportLoggingSessionsCommand.CanExecuteChanged += (_, _) => raised = true;
 
+        // Act
         vm.ExportFilePath = Path.Combine(TestDirectoryPath, "out.csv");
 
+        // Assert
         Assert.IsTrue(raised);
     }
 
@@ -120,8 +159,8 @@ public class ExportDialogViewModelTests
     [TestMethod]
     public async Task Export_OnFailure_ShowsFailedResult()
     {
-        // A factory that throws when the export reads the session forces the catch-all path
-        // deterministically — no file-system or timing dependence.
+        // Arrange — a factory that throws when the export reads the session forces the
+        // catch-all path deterministically (no file-system or timing dependence).
         var factory = new Mock<IDbContextFactory<LoggingContext>>();
         factory.Setup(f => f.CreateDbContext()).Throws(new InvalidOperationException("boom"));
         var vm = new ExportDialogViewModel(factory.Object, sessionId: 1)
@@ -129,8 +168,10 @@ public class ExportDialogViewModelTests
             ExportFilePath = Path.Combine(TestDirectoryPath, "fail.csv")
         };
 
+        // Act
         await vm.ExportLoggingSessionsCommand.ExecuteAsync(null);
 
+        // Assert
         Assert.IsTrue(vm.IsExportComplete, "Failure should still land on the result state.");
         Assert.IsFalse(vm.ExportSucceeded);
         Assert.IsFalse(vm.IsExporting);
@@ -141,13 +182,16 @@ public class ExportDialogViewModelTests
     [TestMethod]
     public async Task Export_OnSuccess_ShowsCompleteResultAndWritesFile()
     {
+        // Arrange
         using var factory = new TempSqliteLoggingContextFactory();
         SeedSession(factory, sessionId: 1);
         var exportPath = Path.Combine(TestDirectoryPath, $"success_{Guid.NewGuid():N}.csv");
         var vm = new ExportDialogViewModel(factory, sessionId: 1) { ExportFilePath = exportPath };
 
+        // Act
         await vm.ExportLoggingSessionsCommand.ExecuteAsync(null);
 
+        // Assert
         Assert.IsTrue(vm.IsExportComplete);
         Assert.IsTrue(vm.ExportSucceeded);
         Assert.IsFalse(vm.IsExporting);
@@ -186,6 +230,12 @@ public class ExportDialogViewModelTests
         context.SaveChanges();
     }
 
+    /// <summary>
+    /// A real file-backed SQLite <see cref="IDbContextFactory{T}"/>. The export success path runs
+    /// the full EF + streaming-exporter pipeline, so it is exercised against a real (tiny) database
+    /// rather than a mock — mirroring the existing pattern in ExportPerformanceTests. The state-machine
+    /// and command-gating tests above use a Moq factory instead. The .db file is deleted on Dispose.
+    /// </summary>
     private sealed class TempSqliteLoggingContextFactory : IDbContextFactory<LoggingContext>, IDisposable
     {
         private readonly string _dbPath;

--- a/Daqifi.Desktop/Resources/DarkDialog.xaml
+++ b/Daqifi.Desktop/Resources/DarkDialog.xaml
@@ -1,0 +1,180 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Dark-mode control skins for the app's legacy MahApps dialogs (Export, Firmware,
+        DuplicateDevice). The application runs on the MahApps "Light.Blue" theme, so a plain
+        MetroWindow and its standard controls render light; these styles re-skin GroupBox,
+        TextBox, Label and a secondary Button onto the dark design tokens so older dialogs
+        match the rest of the app (see /Resources/DesignTokens.xaml and
+        docs/design-philosophy.md §2 dark by default, §9 one visual system).
+
+        Usage: merge this dictionary into a dialog's Window.Resources and set the root
+        container Background to {StaticResource Surface}. The GroupBox/TextBox/Label styles
+        are implicit (no x:Key) so they apply automatically within that window only.
+
+        Tokens are referenced via DynamicResource so they resolve against the
+        application-scope DesignTokens dictionary at runtime — this file is merged into a
+        window, not into App.xaml, so the tokens are not in its own static scope. The
+        templates intentionally reference only DesignTokens keys (never MahApps-internal
+        brush/style keys) so there are no load-time resolution surprises.
+    -->
+
+    <!-- ── Content labels ──────────────────────────────────────────────── -->
+    <Style TargetType="Label">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+    </Style>
+
+    <!-- ── Radio option ─────────────────────────────────────────────────────
+         Self-contained dark template. The MahApps light-theme radio brings a white
+         content background that swallows light text, so we own the whole visual:
+         a ring + accent dot on a transparent background. -->
+    <Style TargetType="RadioButton">
+        <Setter Property="Foreground"               Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="Background"               Value="Transparent"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RadioButton">
+                    <Grid Background="Transparent">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid Grid.Column="0" Width="16" Height="16" VerticalAlignment="Center">
+                            <Ellipse x:Name="Ring"
+                                     Stroke="{DynamicResource BorderBright}"
+                                     StrokeThickness="1"
+                                     Fill="{DynamicResource Surface}"/>
+                            <Ellipse x:Name="Dot"
+                                     Margin="4"
+                                     Fill="{DynamicResource Accent}"
+                                     Visibility="Collapsed"/>
+                        </Grid>
+                        <ContentPresenter Grid.Column="1"
+                                          Margin="8,0,0,0"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Dot"  Property="Visibility" Value="Visible"/>
+                            <Setter TargetName="Ring" Property="Stroke"     Value="{DynamicResource Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Ring" Property="Stroke" Value="{DynamicResource Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── Dark input field ────────────────────────────────────────────── -->
+    <Style TargetType="TextBox">
+        <Setter Property="Foreground"               Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="CaretBrush"               Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="Background"               Value="{DynamicResource Surface}"/>
+        <Setter Property="BorderBrush"              Value="{DynamicResource BorderDim}"/>
+        <Setter Property="BorderThickness"          Value="1"/>
+        <Setter Property="Padding"                  Value="8,4"/>
+        <Setter Property="MinHeight"                Value="28"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="3">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── Grouping container: small header label over a raised panel ──── -->
+    <Style TargetType="GroupBox">
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderDim}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Margin"          Value="0,0,0,12"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="GroupBox">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <ContentPresenter Grid.Row="0"
+                                          ContentSource="Header"
+                                          TextElement.Foreground="{DynamicResource TextSecondary}"
+                                          TextElement.FontSize="11"
+                                          TextElement.FontWeight="SemiBold"
+                                          Margin="2,0,2,6"/>
+                        <Border Grid.Row="1"
+                                Background="{DynamicResource SurfaceRaised}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="4"
+                                Padding="10">
+                            <ContentPresenter/>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ── Secondary (non-accent) button ───────────────────────────────────
+         SurfaceActive (the lightest surface token) so the button reads as a control
+         on both the root Surface and the raised SurfaceRaised GroupBox panels. -->
+    <Style x:Key="DarkSecondaryButton" TargetType="Button">
+        <Setter Property="Background"      Value="{DynamicResource SurfaceActive}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBright}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="Padding"         Value="16,6"/>
+        <Setter Property="FontSize"        Value="12"/>
+        <Setter Property="Cursor"          Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bg"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="3">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bg" Property="Background"  Value="#283143"/>
+                            <Setter TargetName="Bg" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/Daqifi.Desktop/View/DuplicateDeviceDialog.xaml
+++ b/Daqifi.Desktop/View/DuplicateDeviceDialog.xaml
@@ -3,8 +3,17 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-        Title="Device Already Connected" ResizeMode="NoResize" Width="480" Height="350" GlowBrush="{DynamicResource AccentColorBrush}">
-    <Grid Margin="20">
+        Title="Device Already Connected" ResizeMode="NoResize" Width="480" Height="280" BorderThickness="0" Background="{StaticResource Surface}" GlowBrush="{DynamicResource AccentColorBrush}">
+
+    <controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Resources/DarkDialog.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </controls:MetroWindow.Resources>
+
+    <Grid Margin="20" Background="{StaticResource Surface}" TextElement.Foreground="{StaticResource TextPrimary}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -17,22 +26,22 @@
         </Grid.ColumnDefinitions>
 
         <!-- Icon -->
-        <iconPacks:PackIconMaterial Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" 
-                                   Margin="5" Kind="AlertCircleOutline" 
+        <iconPacks:PackIconMaterial Grid.Row="0" Grid.Column="0"
+                                   Margin="5,5,10,0" Kind="AlertCircleOutline"
                                    HorizontalAlignment="Center" VerticalAlignment="Top"
-                                   Height="50" Width="50" Foreground="Orange"/>
+                                   Height="40" Width="40" Foreground="{StaticResource StatusAmber}"/>
 
         <!-- Message -->
-        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Message}" 
-                  VerticalAlignment="Top" Margin="10,5,0,10" 
-                  TextWrapping="Wrap" FontSize="14"/>
+        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Message}"
+                  VerticalAlignment="Top" Margin="10,5,0,10"
+                  TextWrapping="Wrap" FontSize="14" Foreground="{StaticResource TextPrimary}"/>
 
-        <!-- Options -->
-        <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,20,10,10">
-            <RadioButton x:Name="KeepExistingRadio" Content="{Binding KeepExistingText}" 
-                        IsChecked="True" Margin="5,8" FontSize="12"/>
-            <RadioButton x:Name="SwitchToNewRadio" Content="{Binding SwitchToNewText}" 
-                        Margin="5,8" FontSize="12"/>
+        <!-- Options (sit directly under the prompt, aligned with the message) -->
+        <StackPanel Grid.Row="1" Grid.Column="1" Margin="10,14,0,0">
+            <RadioButton x:Name="KeepExistingRadio" Content="{Binding KeepExistingText}"
+                        IsChecked="True" Margin="0,6" FontSize="13" Foreground="{StaticResource TextPrimary}"/>
+            <RadioButton x:Name="SwitchToNewRadio" Content="{Binding SwitchToNewText}"
+                        Margin="0,6" FontSize="13" Foreground="{StaticResource TextPrimary}"/>
         </StackPanel>
 
         <!-- Buttons -->
@@ -42,7 +51,7 @@
                    Style="{StaticResource MahApps.Styles.Button.Square.Accent}" 
                    controls:ControlsHelper.ContentCharacterCasing="Normal"/>
             <Button Content="Cancel" Click="BtnCancel_Click" Width="80" Height="30"
-                   Style="{StaticResource MahApps.Styles.Button.Square}" 
+                   Style="{StaticResource DarkSecondaryButton}"
                    controls:ControlsHelper.ContentCharacterCasing="Normal"/>
         </StackPanel>
     </Grid>

--- a/Daqifi.Desktop/View/ErrorDialog.xaml
+++ b/Daqifi.Desktop/View/ErrorDialog.xaml
@@ -3,16 +3,16 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-        Title="Error" ResizeMode="NoResize" Width="300" Height="200" GlowBrush="{DynamicResource AccentColorBrush}">
-    <Grid>
+        Title="Error" ResizeMode="NoResize" Width="300" Height="200" BorderThickness="0" Background="{StaticResource Surface}" GlowBrush="{DynamicResource AccentColorBrush}">
+    <Grid Background="{StaticResource Surface}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <iconPacks:PackIconMaterial Grid.Column="0" Margin="5" Kind="AlertCircleOutline" HorizontalAlignment="Center" Height="50" Width="50"/>
+        <iconPacks:PackIconMaterial Grid.Column="0" Margin="5" Kind="AlertCircleOutline" HorizontalAlignment="Center" Height="50" Width="50" Foreground="{StaticResource StatusRed}"/>
 
-        <TextBox Grid.Column="1" Text="{Binding ErrorMessage}" VerticalAlignment="Center" IsReadOnly="True" TextWrapping="Wrap" BorderThickness="0" Foreground="Black"/>
+        <TextBox Grid.Column="1" Text="{Binding ErrorMessage}" VerticalAlignment="Center" IsReadOnly="True" TextWrapping="Wrap" BorderThickness="0" Background="Transparent" Foreground="{StaticResource TextPrimary}"/>
 
         <Button Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Click="btnOk_Click" Content="Ok" Width="100" Height="30"  Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
     </Grid>

--- a/Daqifi.Desktop/View/ExportDialog.xaml
+++ b/Daqifi.Desktop/View/ExportDialog.xaml
@@ -1,88 +1,109 @@
-﻿<controls:MetroWindow x:Class="Daqifi.Desktop.View.ExportDialog"
+<controls:MetroWindow x:Class="Daqifi.Desktop.View.ExportDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+        xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
         xmlns:viewModels="clr-namespace:Daqifi.Desktop.ViewModels"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=viewModels:ExportDialogViewModel}"
-        Title="Export Logging Session" ResizeMode="NoResize" Height="350" Width="600" GlowBrush="{DynamicResource AccentColorBrush}">
+        Title="Export Logging Session" ResizeMode="NoResize" Height="390" Width="560" BorderThickness="0" Background="{StaticResource Surface}" GlowBrush="{DynamicResource AccentColorBrush}">
 
-    <Grid Margin="5">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
+    <controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Resources/DarkDialog.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </controls:MetroWindow.Resources>
 
-        <!-- Export Location -->
-        <GroupBox Grid.Row="0" Grid.ColumnSpan="2" Header="Export Location">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <TextBox Grid.Column="0" HorizontalAlignment="Stretch" Text="{Binding ExportFilePath, Mode=OneWay}" IsEnabled="False"/>
-                <Button Grid.Column="1" Content="Browse" Command="{Binding BrowseExportPathCommand}"/>
-            </Grid>
-        </GroupBox>
+    <Grid Margin="16" Background="{StaticResource Surface}" TextElement.Foreground="{StaticResource TextPrimary}">
 
-        <!-- Export Type -->
-        <GroupBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Header="Export Type">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <RadioButton Grid.Column="0" Grid.Row="0" Content="All Samples" IsChecked="{Binding ExportAllSelected}"/>
-                <RadioButton Grid.Column="0" Grid.Row="1" Padding="5" Content="Average Every &quot;N&quot; Samples" IsChecked="{Binding ExportAverageSelected}"/>
-                <TextBox Grid.Column="1" Grid.Row="1" Width="50" Text="{Binding AverageQuantity, Mode=TwoWay}"/>
-            </Grid>
-        </GroupBox>
+        <!-- ══════════════════════════════ Configure ══════════════════════════════ -->
+        <Grid Visibility="{Binding IsConfiguring, Converter={StaticResource BoolToVis}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
 
-        <GroupBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Header="Timestamp Format" Margin="0,10,0,0">
-            <StackPanel Orientation="Horizontal">
-                <RadioButton Content="Absolute Time" IsChecked="True" Padding="5" />
-                <RadioButton Content="Relative Time" IsChecked="{Binding ExportRelativeTime}" Margin="0,0,10,0"/>
+            <!-- Export Location -->
+            <GroupBox Grid.Row="0" Header="Export Location">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBox Grid.Column="0" HorizontalAlignment="Stretch" Text="{Binding ExportFilePath, Mode=OneWay}" IsEnabled="False"/>
+                    <Button Grid.Column="1" Content="Browse" Command="{Binding BrowseCommand}" Margin="8,0,0,0" Style="{StaticResource DarkSecondaryButton}"/>
+                </Grid>
+            </GroupBox>
+
+            <!-- Export Type -->
+            <GroupBox Grid.Row="1" Header="Export Type">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <RadioButton Grid.Column="0" Grid.Row="0" Content="All Samples" IsChecked="{Binding ExportAllSelected}" Margin="0,0,0,8"/>
+                    <RadioButton Grid.Column="0" Grid.Row="1" Content="Average Every &quot;N&quot; Samples" IsChecked="{Binding ExportAverageSelected}" VerticalAlignment="Center"/>
+                    <TextBox Grid.Column="1" Grid.Row="1" Width="60" Margin="12,0,0,0" Text="{Binding AverageQuantity, Mode=TwoWay}"/>
+                </Grid>
+            </GroupBox>
+
+            <!-- Timestamp Format -->
+            <GroupBox Grid.Row="2" Header="Timestamp Format">
+                <StackPanel Orientation="Horizontal">
+                    <RadioButton Content="Absolute Time" IsChecked="True"/>
+                    <RadioButton Content="Relative Time" IsChecked="{Binding ExportRelativeTime}" Margin="24,0,0,0"/>
+                </StackPanel>
+            </GroupBox>
+
+            <!-- Actions -->
+            <DockPanel Grid.Row="4" HorizontalAlignment="Right" Margin="0,8,0,0">
+                <Button Click="btnCancel_Click" Content="Cancel" Width="100" Height="32" Margin="0,0,10,0" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                <Button Content="Export" Command="{Binding ExportLoggingSessionsCommand}" Width="100" Height="32" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+            </DockPanel>
+        </Grid>
+
+        <!-- ══════════════════════════════ Exporting ══════════════════════════════ -->
+        <StackPanel Visibility="{Binding IsExporting, Converter={StaticResource BoolToVis}}"
+                    VerticalAlignment="Center" HorizontalAlignment="Center" Width="400">
+            <TextBlock Text="Exporting…" FontSize="16" HorizontalAlignment="Center" Foreground="{StaticResource TextPrimary}"/>
+            <controls:MetroProgressBar Minimum="0" Maximum="100" Value="{Binding ExportProgress}" Height="6" Margin="0,18,0,0"/>
+            <TextBlock Text="{Binding ExportProgress, StringFormat={}{0}%}" HorizontalAlignment="Center" Foreground="{StaticResource TextSecondary}" Margin="0,12,0,22"/>
+            <Button Content="Cancel" Command="{Binding CancelExportCommand}" Width="120" Height="32" HorizontalAlignment="Center" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+        </StackPanel>
+
+        <!-- ════════════════════════════════ Result ═══════════════════════════════ -->
+        <StackPanel Visibility="{Binding IsExportComplete, Converter={StaticResource BoolToVis}}"
+                    VerticalAlignment="Center" HorizontalAlignment="Center" Width="440">
+            <iconPacks:PackIconMaterial Kind="CheckCircleOutline" Width="46" Height="46" HorizontalAlignment="Center"
+                                        Foreground="{StaticResource StatusGreen}"
+                                        Visibility="{Binding ExportSucceeded, Converter={StaticResource BoolToVis}}"/>
+            <iconPacks:PackIconMaterial Kind="AlertCircleOutline" Width="46" Height="46" HorizontalAlignment="Center"
+                                        Foreground="{StaticResource StatusRed}"
+                                        Visibility="{Binding ExportSucceeded, Converter={StaticResource InvertedBoolToVis}}"/>
+            <TextBlock Text="{Binding ExportResultMessage}" FontSize="16" HorizontalAlignment="Center" Margin="0,14,0,4" Foreground="{StaticResource TextPrimary}"/>
+            <TextBlock Text="{Binding ExportFilePath}" FontSize="11" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap"
+                       Foreground="{StaticResource TextSecondary}" Margin="0,0,0,22"
+                       Visibility="{Binding ExportSucceeded, Converter={StaticResource BoolToVis}}"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <Button Content="Open Folder" Command="{Binding OpenExportLocationCommand}" Width="120" Height="32" Margin="0,0,10,0"
+                        Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"
+                        Visibility="{Binding ExportSucceeded, Converter={StaticResource BoolToVis}}"/>
+                <Button Content="Done" Click="btnDone_Click" Width="120" Height="32"
+                        Style="{StaticResource MahApps.Styles.Button.Square.Accent}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
             </StackPanel>
-        </GroupBox>
+        </StackPanel>
 
-        <GroupBox Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Header="Exporting file" >
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <!-- Progress Bar -->
-                <controls:MetroProgressBar Grid.Column="0" Grid.Row="0" Height="25" Minimum="0" Maximum="100" 
-                                   Value="{Binding ExportProgress}" 
-                                   Visibility="{Binding IsExporting, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="5"/>
-
-                <!-- Cancel Button -->
-                <Button Grid.Column="1" Grid.Row="0" Content="Cancel" Command="{Binding CancelExportCommand}" 
-                Visibility="{Binding IsExporting, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="5"/>
-                <Label Grid.Row="1" Grid.Column="0" Content="{Binding ExportProgressText}"  HorizontalAlignment="Center"/>
-            </Grid>
-        </GroupBox>
-
-        <DockPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Grid.RowSpan="3"  HorizontalAlignment="Right" VerticalAlignment="Bottom">
-            <Button Click="btnCancel_Click" Content="Cancel" Width="100" Height="30"  Style="{StaticResource  MahApps.Styles.Button.Square}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
-            <Button Content="Export"  Command="{Binding ExportLoggingSessionsCommand}" IsEnabled="{Binding IsExporting, Converter={StaticResource BooleanToInverse}}"    Width="100" Height="30" Style="{StaticResource MahApps.Styles.Button.Square.Accent }"  controls:ControlsHelper.ContentCharacterCasing="Normal"/>
-        </DockPanel>
     </Grid>
 </controls:MetroWindow>

--- a/Daqifi.Desktop/View/ExportDialog.xaml.cs
+++ b/Daqifi.Desktop/View/ExportDialog.xaml.cs
@@ -16,4 +16,9 @@ public partial class ExportDialog
     {
         Close();
     }
+
+    private void btnDone_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
 }

--- a/Daqifi.Desktop/View/FirmwareDialog.xaml
+++ b/Daqifi.Desktop/View/FirmwareDialog.xaml
@@ -9,8 +9,17 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=viewModels:FirmwareDialogViewModel}"
         dialogService:DialogService.IsRegisteredView="True"
-        Title="Firmware Settings" Height="300" Width="500" GlowBrush="{DynamicResource AccentColorBrush}">
-    <Grid>
+        Title="Firmware Settings" Height="300" Width="500" BorderThickness="0" Background="{StaticResource Surface}" GlowBrush="{DynamicResource AccentColorBrush}">
+
+    <controls:MetroWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Resources/DarkDialog.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </controls:MetroWindow.Resources>
+
+    <Grid Background="{StaticResource Surface}" TextElement.Foreground="{StaticResource TextPrimary}">
         
         <!-- Before Upload -->
         <Grid Visibility="{Binding IsUploadComplete, Converter={StaticResource InvertedBoolToVis}}">
@@ -32,14 +41,14 @@
                         <ColumnDefinition Width="85"/>
                     </Grid.ColumnDefinitions>
                     <TextBox Grid.Column="0" Height="30" VerticalAlignment="Top" Margin="5" Text="{Binding FirmwareFilePath, Mode=OneWay}"/>
-                    <Button Grid.Column="1" Content="Browse" Width="75" Height="30" Margin="5" VerticalAlignment="Top" Style="{StaticResource  MahApps.Styles.Button.Square}" controls:ControlsHelper.ContentCharacterCasing="Normal" Command="{Binding BrowseFirmwarePathCommand}"/>
+                    <Button Grid.Column="1" Content="Browse" Width="75" Height="30" Margin="5" VerticalAlignment="Top" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal" Command="{Binding BrowseFirmwarePathCommand}"/>
                 </Grid>
             </GroupBox>
 
-            <Label Visibility="{Binding HasErrorOccured, Converter={StaticResource BoolToVis}}" Grid.Row="2" Content="Sorry, something went wrong uploading the firmware.  :(" HorizontalContentAlignment="Center" Foreground="Red"/>
+            <Label Visibility="{Binding HasErrorOccured, Converter={StaticResource BoolToVis}}" Grid.Row="2" Content="Sorry, something went wrong uploading the firmware.  :(" HorizontalContentAlignment="Center" Foreground="{StaticResource StatusRed}"/>
 
             <DockPanel Grid.Row="3" HorizontalAlignment="Right" VerticalAlignment="Bottom" LastChildFill="True" Margin="5">
-                <Button Click="btnCancel_Click" Content="Cancel" Width="100" Height="30"  Style="{StaticResource  MahApps.Styles.Button.Square}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                <Button Click="btnCancel_Click" Content="Cancel" Width="100" Height="30" Margin="0,0,10,0" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
                 <Button DockPanel.Dock="Bottom" Content="Upload" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal" Command="{Binding UploadFirmwareCommand}"/>
             </DockPanel>
 

--- a/Daqifi.Desktop/View/SuccessDialog.xaml
+++ b/Daqifi.Desktop/View/SuccessDialog.xaml
@@ -3,16 +3,16 @@
               xmlns:controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-            Title="Success" ResizeMode="NoResize" Width="300" Height="200" GlowBrush="{DynamicResource AccentColorBrush}">
-    <Grid>
+            Title="Success" ResizeMode="NoResize" Width="300" Height="200" BorderThickness="0" Background="{StaticResource Surface}" GlowBrush="{DynamicResource AccentColorBrush}">
+    <Grid Background="{StaticResource Surface}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <iconPacks:PackIconMaterial Grid.Column="0" Margin="5" Kind="AlertCircleCheckOutline" HorizontalAlignment="Center" Height="50" Width="50"/>
+        <iconPacks:PackIconMaterial Grid.Column="0" Margin="5" Kind="AlertCircleCheckOutline" HorizontalAlignment="Center" Height="50" Width="50" Foreground="{StaticResource StatusGreen}"/>
 
-        <TextBox Grid.Column="1" Text="{Binding SuccessMessage}" VerticalAlignment="Center" IsReadOnly="True" TextWrapping="Wrap" BorderThickness="0" Foreground="Black"/>
+        <TextBox Grid.Column="1" Text="{Binding SuccessMessage}" VerticalAlignment="Center" IsReadOnly="True" TextWrapping="Wrap" BorderThickness="0" Background="Transparent" Foreground="{StaticResource TextPrimary}"/>
 
         <Button Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Click="btnOk_Click" Content="Ok" Width="100" Height="30"  Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
     </Grid>

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -3,6 +3,7 @@ using Daqifi.Desktop.Exporter;
 using Daqifi.Desktop.Logger;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics;
 using System.IO;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -29,7 +30,15 @@ public partial class ExportDialogViewModel : ObservableObject
     [ObservableProperty]
     private bool _exportAverageSelected;
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsConfiguring))]
     private bool _isExporting;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsConfiguring))]
+    private bool _isExportComplete;
+    [ObservableProperty]
+    private bool _exportSucceeded;
+    [ObservableProperty]
+    private string _exportResultMessage;
     [ObservableProperty]
     private int _averageQuantity = 2;
     [ObservableProperty]
@@ -47,6 +56,7 @@ public partial class ExportDialogViewModel : ObservableObject
         {
             _exportFilePath = value;
             OnPropertyChanged();
+            ExportLoggingSessionsCommand.NotifyCanExecuteChanged();
             CommandManager.InvalidateRequerySuggested();
         }
     }
@@ -61,6 +71,12 @@ public partial class ExportDialogViewModel : ObservableObject
             ExportProgressText = $"Exporting progress: {ExportProgress}% completed";
         }
     }
+
+    /// <summary>
+    /// True while the dialog is showing its configuration form — i.e. not mid-export and not
+    /// showing the completion result. Selects which of the dialog's three states is visible.
+    /// </summary>
+    public bool IsConfiguring => !IsExporting && !IsExportComplete;
     #endregion
 
     #region Commands
@@ -82,6 +98,17 @@ public partial class ExportDialogViewModel : ObservableObject
         _loggingContext = App.ServiceProvider.GetRequiredService<IDbContextFactory<LoggingContext>>();
         _sessionsIds = sessions.Select(s => s.ID).ToList();
         BrowseCommand = BrowseExportDirectoryCommand;
+    }
+
+    /// <summary>
+    /// Test seam: supplies the logging-context factory directly so unit tests can exercise the
+    /// dialog's state machine and export flow without booting the App/DI container.
+    /// </summary>
+    internal ExportDialogViewModel(IDbContextFactory<LoggingContext> loggingContext, int sessionId)
+    {
+        _loggingContext = loggingContext;
+        _sessionsIds = [sessionId];
+        BrowseCommand = BrowseExportPathCommand;
     }
     #endregion
 
@@ -121,17 +148,20 @@ public partial class ExportDialogViewModel : ObservableObject
         _cts?.Cancel();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanExport))]
     private async Task ExportLoggingSessions()
     {
         if (string.IsNullOrWhiteSpace(ExportFilePath)) { return; }
 
         IsExporting = true;
+        IsExportComplete = false;
         _cts = new CancellationTokenSource();
         var cancellationToken = _cts.Token;
         var progress = new Progress<int>(progressValue => ExportProgress = progressValue);
         AppLogger.Instance.AddBreadcrumb("export", $"Data export started ({_sessionsIds.Count} session(s))");
 
+        var cancelled = false;
+        var failed = false;
         try
         {
             await Task.Run(async () =>
@@ -152,14 +182,21 @@ public partial class ExportDialogViewModel : ObservableObject
                         continue;
                     }
 
-                    // Resolve the display name for per-session file naming; fall back to the default
-                    // "Session_{id}" form when the session is no longer in the in-memory list. Avoids
-                    // a NullReferenceException (FirstOrDefault can be null) that would fail the export.
-                    var sessionName = LoggingManager.Instance.LoggingSessions
-                        .FirstOrDefault(s => s.ID == sessionId)?.Name ?? $"Session_{sessionId}";
-                    var filepath = _forceDirectoryLayout || totalSessions > 1
-                        ? Path.Combine(ExportFilePath, $"{MakeSafeFileName(sessionName)}.csv")
-                        : ExportFilePath;
+                    // Per-session file naming only applies when writing into a directory (multi-session
+                    // export, or the directory-layout test hook). Resolve the display name lazily so a
+                    // plain single-file export doesn't depend on LoggingManager — falling back to the
+                    // default "Session_{id}" form when the session is no longer in the in-memory list.
+                    string filepath;
+                    if (_forceDirectoryLayout || totalSessions > 1)
+                    {
+                        var sessionName = LoggingManager.Instance.LoggingSessions
+                            .FirstOrDefault(s => s.ID == sessionId)?.Name ?? $"Session_{sessionId}";
+                        filepath = Path.Combine(ExportFilePath, $"{MakeSafeFileName(sessionName)}.csv");
+                    }
+                    else
+                    {
+                        filepath = ExportFilePath;
+                    }
 
                     if (ExportAllSelected)
                     {
@@ -172,35 +209,88 @@ public partial class ExportDialogViewModel : ObservableObject
                 }
             }, cancellationToken);
 
-            AppLogger.Instance.AddBreadcrumb("export", "Data export completed");
+            cancelled = cancellationToken.IsCancellationRequested;
+            if (!cancelled)
+            {
+                AppLogger.Instance.AddBreadcrumb("export", "Data export completed");
+            }
         }
         catch (OperationCanceledException)
         {
+            cancelled = true;
             AppLogger.Instance.Information("Export operation was cancelled by user.");
             AppLogger.Instance.AddBreadcrumb("export", "Data export cancelled", Common.Loggers.BreadcrumbLevel.Warning);
         }
         catch (Exception ex)
         {
+            failed = true;
             AppLogger.Instance.Error(ex, "Problem Exporting Data");
             AppLogger.Instance.AddBreadcrumb("export", "Data export failed", Common.Loggers.BreadcrumbLevel.Error);
         }
         finally
         {
-            IsExporting = false;
             _cts.Dispose();
             _cts = null;
+
+            // A cancel returns to the configuration form; a success or failure shows the
+            // result state (set complete before clearing IsExporting so IsConfiguring never
+            // flips true in between).
+            if (!cancelled)
+            {
+                ExportSucceeded = !failed;
+                ExportResultMessage = failed ? "Export failed. Please try again." : "Export complete";
+                IsExportComplete = true;
+            }
+
+            IsExporting = false;
+        }
+    }
+
+    private bool CanExport => !string.IsNullOrWhiteSpace(ExportFilePath);
+
+    /// <summary>
+    /// Opens the export destination in File Explorer: the folder itself for a directory export,
+    /// or the containing folder with the file selected for a single-file export.
+    /// </summary>
+    [RelayCommand]
+    private void OpenExportLocation()
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(ExportFilePath)) { return; }
+
+            if (Directory.Exists(ExportFilePath))
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"\"{ExportFilePath}\"") { UseShellExecute = true });
+            }
+            else if (File.Exists(ExportFilePath))
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{ExportFilePath}\"") { UseShellExecute = true });
+            }
+            else
+            {
+                var directory = Path.GetDirectoryName(ExportFilePath);
+                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+                {
+                    Process.Start(new ProcessStartInfo("explorer.exe", $"\"{directory}\"") { UseShellExecute = true });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Instance.Warning($"Could not open export location: {ex.Message}");
         }
     }
 
     private void ExportAllSamples(LoggingSession session, string filepath, IProgress<int> progress, CancellationToken cancellationToken, int sessionIndex, int totalSessions)
     {
-        var loggingSessionExporter = new OptimizedLoggingSessionExporter();
+        var loggingSessionExporter = new OptimizedLoggingSessionExporter(_loggingContext);
         loggingSessionExporter.ExportLoggingSession(session, filepath, ExportRelativeTime, progress, cancellationToken, sessionIndex, totalSessions);
     }
 
     private void ExportAverageSamples(LoggingSession session, string filepath, IProgress<int> progress, CancellationToken cancellationToken, int sessionIndex, int totalSessions)
     {
-        var loggingSessionExporter = new OptimizedLoggingSessionExporter();
+        var loggingSessionExporter = new OptimizedLoggingSessionExporter(_loggingContext);
         loggingSessionExporter.ExportAverageSamples(session, filepath, AverageQuantity, ExportRelativeTime, progress, cancellationToken, sessionIndex, totalSessions);
     }
 

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -169,10 +169,7 @@ public partial class ExportDialogViewModel : ObservableObject
                 var totalSessions = _sessionsIds.Count;
                 for (var i = 0; i < totalSessions; i++)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        return;
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
                     var sessionId = _sessionsIds[i];
                     var loggingSession = await GetLoggingSessionFromId(sessionId);
                     if (loggingSession == null)
@@ -209,11 +206,11 @@ public partial class ExportDialogViewModel : ObservableObject
                 }
             }, cancellationToken);
 
-            cancelled = cancellationToken.IsCancellationRequested;
-            if (!cancelled)
-            {
-                AppLogger.Instance.AddBreadcrumb("export", "Data export completed");
-            }
+            // Reaching here means the loop ran to completion without a cancellation being
+            // observed at a checkpoint — a Cancel click that lands after the work is done no
+            // longer suppresses the result state. Cancellation is signalled only by the
+            // OperationCanceledException path below.
+            AppLogger.Instance.AddBreadcrumb("export", "Data export completed");
         }
         catch (OperationCanceledException)
         {
@@ -278,7 +275,7 @@ public partial class ExportDialogViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            AppLogger.Instance.Warning($"Could not open export location: {ex.Message}");
+            AppLogger.Instance.Warning(ex, $"Could not open export location '{ExportFilePath}'.");
         }
     }
 


### PR DESCRIPTION
## Summary

The app runs on the MahApps **Light.Blue** theme; dark mode is applied per-window via the `DesignTokens` brushes. Several dialogs never got that treatment and rendered with a white body and dark text. This PR brings them into the dark visual system and reworks the **Export** dialog into a clear, state-driven flow.

## Dialogs

- **New `Resources/DarkDialog.xaml`** — shared dark control skins (`GroupBox`, `TextBox`, `Label`, `RadioButton`, and a secondary button) that reference only the `DesignTokens`. Merged per-dialog into `Window.Resources`, so there's **no app-wide style impact** and no dependency on MahApps-internal brush keys.
- **SuccessDialog, ErrorDialog, ExportDialog, FirmwareDialog, DuplicateDeviceDialog** — dark `Surface` background, design-token text colors, status-colored icons (green check / red alert / amber warning), dark radios, and `BorderThickness="0"`. (The lingering white frame was the light *window* background showing through the root grid's margin — fixed by darkening the window background.)

## Export dialog redesign

- **Three states** — Configure → Exporting → Done — replacing the single form with its persistent, mostly-empty "Exporting file" panel.
- **A real completion state** (Open Folder + Done) so finishing no longer forces the title-bar **X**; failures show a red result with a Done button.
- **Export is disabled until a destination is chosen.**

## Bugs fixed along the way

- **Crash on open:** ExportDialog bound `Converter={StaticResource BooleanToVisibilityConverter}` — a key defined nowhere — which throws `XamlParseException` at window load (the dialog service has no try/catch, so opening Export crashed, likely surfacing only as a silent Sentry report). Now uses the defined `BoolToVis`.
- **Wrong Browse picker:** Browse always opened the file picker; it now uses the dialog's intended picker (file for a single session, folder for many).
- Per-session export file name is now resolved lazily, so a single-file export no longer depends on `LoggingManager`.

## Tests

- New `ExportDialogViewModelTests` (10 tests): the `IsConfiguring` state machine, `CanExport` command gating, and the success/failure terminal transitions. Adds an internal test constructor and routes the exporter through the view model's own context factory (an explicit dependency, same factory as production) to make the flow testable without booting the DI container.
- Full fast gate green: **317 passed, 0 failed**.

## Verification

Built and run on a Windows dev machine with an attached DAQiFi device. Visually confirmed the dark theming, the white-frame fix, the radio rendering, and the redesigned Export flow (configure → export → done) and the tightened Duplicate-Device dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)