### PR TITLE
fix(plot): tolerate duplicate-timestamp samples when displaying logged sessions (#572)

### DIFF
--- a/Daqifi.Desktop.Test/Helpers/MinMaxDownsamplerTests.cs
+++ b/Daqifi.Desktop.Test/Helpers/MinMaxDownsamplerTests.cs
@@ -41,6 +41,41 @@ public class MinMaxDownsamplerTests
     }
 
     [TestMethod]
+    public void Downsample_AllPointsShareOneX_ReturnsVerticalValueSpread()
+    {
+        // Degenerate session shape from issue #572: every sample at one timestamp
+        var points = new List<DataPoint>();
+        for (var i = 0; i < 10000; i++)
+        {
+            points.Add(new DataPoint(5.0, Math.Cos(i * 0.01)));
+        }
+
+        var result = MinMaxDownsampler.Downsample(points, 100);
+
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual(5.0, result[0].X);
+        Assert.AreEqual(5.0, result[1].X);
+        Assert.AreEqual(points.Min(p => p.Y), result[0].Y);
+        Assert.AreEqual(points.Max(p => p.Y), result[1].Y);
+    }
+
+    [TestMethod]
+    public void Downsample_AllPointsIdentical_ReturnsSinglePoint()
+    {
+        var points = new List<DataPoint>();
+        for (var i = 0; i < 10000; i++)
+        {
+            points.Add(new DataPoint(5.0, 1.25));
+        }
+
+        var result = MinMaxDownsampler.Downsample(points, 100);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(5.0, result[0].X);
+        Assert.AreEqual(1.25, result[0].Y);
+    }
+
+    [TestMethod]
     public void Downsample_PreservesMinMax()
     {
         var points = new List<DataPoint>();

--- a/Daqifi.Desktop.Test/Loggers/DatabaseLoggerChannelDiscoveryTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/DatabaseLoggerChannelDiscoveryTests.cs
@@ -1,0 +1,128 @@
+using Daqifi.Desktop.Logger;
+using OxyPlot;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Regression tests for issue #572: sessions whose samples contain duplicate
+/// (device serial, channel name) rows at a single timestamp must not abort
+/// channel discovery when displaying a logging session.
+/// </summary>
+[TestClass]
+public class DatabaseLoggerChannelDiscoveryTests
+{
+    private static SessionChannelInfo Analog(string channelName, string serial, string color = "#D32F2F")
+    {
+        return new SessionChannelInfo(channelName, serial, ChannelType.Analog, color);
+    }
+
+    [TestMethod]
+    public void DeduplicateChannelInfo_DuplicateChannelAtSameTimestamp_ReturnsSingleEntry()
+    {
+        // Arrange - the data shape from issue #572: the same channel sampled
+        // twice at the session's first timestamp
+        var rows = new List<SessionChannelInfo>
+        {
+            Analog("AI0", "9090684023231015079"),
+            Analog("AI0", "9090684023231015079"),
+            Analog("AI1", "9090684023231015079")
+        };
+
+        // Act
+        var result = DatabaseLogger.DeduplicateChannelInfo(rows);
+
+        // Assert
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual("AI0", result[0].ChannelName);
+        Assert.AreEqual("AI1", result[1].ChannelName);
+    }
+
+    [TestMethod]
+    public void DeduplicateChannelInfo_DuplicateWithDifferentColor_KeepsFirstOccurrence()
+    {
+        // Arrange
+        var rows = new List<SessionChannelInfo>
+        {
+            Analog("AI0", "1234", "#111111"),
+            Analog("AI0", "1234", "#222222")
+        };
+
+        // Act
+        var result = DatabaseLogger.DeduplicateChannelInfo(rows);
+
+        // Assert
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("#111111", result[0].Color);
+    }
+
+    [TestMethod]
+    public void DeduplicateChannelInfo_SameChannelNameOnDifferentDevices_KeepsBoth()
+    {
+        // Arrange
+        var rows = new List<SessionChannelInfo>
+        {
+            Analog("AI0", "device-a"),
+            Analog("AI0", "device-b")
+        };
+
+        // Act
+        var result = DatabaseLogger.DeduplicateChannelInfo(rows);
+
+        // Assert
+        Assert.AreEqual(2, result.Count);
+    }
+
+    [TestMethod]
+    public void DeduplicateChannelInfo_UnorderedChannels_ReturnsNaturalOrder()
+    {
+        // Arrange
+        var rows = new List<SessionChannelInfo>
+        {
+            Analog("AI10", "1234"),
+            Analog("AI2", "1234"),
+            Analog("AI0", "1234")
+        };
+
+        // Act
+        var result = DatabaseLogger.DeduplicateChannelInfo(rows);
+
+        // Assert
+        string[] expectedOrder = ["AI0", "AI2", "AI10"];
+        CollectionAssert.AreEqual(expectedOrder, result.Select(r => r.ChannelName).ToArray());
+    }
+
+    [TestMethod]
+    public void DeduplicateChannelInfo_EmptyInput_ReturnsEmptyList()
+    {
+        // Act
+        var result = DatabaseLogger.DeduplicateChannelInfo([]);
+
+        // Assert
+        Assert.AreEqual(0, result.Count);
+    }
+
+    [TestMethod]
+    public void DeduplicateChannelInfo_DeduplicatedKeys_CanSeedPointDictionaryWithoutThrowing()
+    {
+        // Arrange - every channel duplicated, as in a session whose duplicate
+        // samples all share the first timestamp
+        var rows = new List<SessionChannelInfo>();
+        for (var i = 0; i < 8; i++)
+        {
+            rows.Add(Analog($"AI{i}", "1234"));
+            rows.Add(Analog($"AI{i}", "1234"));
+        }
+
+        var localPoints = new Dictionary<(string deviceSerial, string channelName), List<DataPoint>>();
+
+        // Act - mirrors AddChannelSeries seeding one dictionary entry per channel
+        foreach (var row in DatabaseLogger.DeduplicateChannelInfo(rows))
+        {
+            localPoints.Add((row.DeviceSerialNo, row.ChannelName), []);
+        }
+
+        // Assert
+        Assert.AreEqual(8, localPoints.Count);
+    }
+}

--- a/Daqifi.Desktop.Test/Loggers/DatabaseLoggerSingleTickSpreadTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/DatabaseLoggerSingleTickSpreadTests.cs
@@ -1,0 +1,181 @@
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Logger;
+using Microsoft.EntityFrameworkCore;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Covers the single-timestamp value-spread fallback used when a session has no
+/// usable time range (issue #572): the spread must aggregate over every row in
+/// the database, not just the rows Phase 1 happened to load.
+/// </summary>
+[TestClass]
+public class DatabaseLoggerSingleTickSpreadTests
+{
+    private const string Serial = "9090684023231015079";
+    private const long Tick = 638_000_000_000_000_000;
+
+    private TempSqliteLoggingContextFactory _factory;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _factory = new TempSqliteLoggingContextFactory();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _factory.Dispose();
+    }
+
+    [TestMethod]
+    public void LoadSingleTickValueSpread_AggregatesMinMaxAcrossAllRows()
+    {
+        // Arrange - extrema deliberately placed in the LAST rows, beyond any
+        // load cap, to prove the spread is aggregated over the whole table
+        using (var context = _factory.CreateDbContext())
+        {
+            context.Sessions.Add(new LoggingSession(1, "single-tick"));
+            context.SaveChanges();
+
+            for (var i = 0; i < 200; i++)
+            {
+                context.Samples.Add(MakeSample("AI0", 0.5));
+                context.Samples.Add(MakeSample("AI1", 1.5));
+            }
+
+            context.Samples.Add(MakeSample("AI0", -4.0));
+            context.Samples.Add(MakeSample("AI0", 6.0));
+            context.Samples.Add(MakeSample("AI1", 2.5));
+            context.SaveChanges();
+        }
+
+        var channelKeys = new List<(string deviceSerial, string channelName)>
+        {
+            (Serial, "AI0"),
+            (Serial, "AI1")
+        };
+
+        // Act
+        var result = DatabaseLogger.LoadSingleTickValueSpread(_factory, 1, channelKeys);
+
+        // Assert - AI0 spans its true extrema; both points sit at delta-time zero
+        var ai0 = result[(Serial, "AI0")];
+        Assert.AreEqual(2, ai0.Count);
+        Assert.AreEqual(-4.0, ai0[0].Y);
+        Assert.AreEqual(6.0, ai0[1].Y);
+        Assert.AreEqual(0.0, ai0[0].X);
+        Assert.AreEqual(0.0, ai0[1].X);
+
+        var ai1 = result[(Serial, "AI1")];
+        Assert.AreEqual(2, ai1.Count);
+        Assert.AreEqual(1.5, ai1[0].Y);
+        Assert.AreEqual(2.5, ai1[1].Y);
+    }
+
+    [TestMethod]
+    public void LoadSingleTickValueSpread_ConstantValue_ReturnsSinglePoint()
+    {
+        // Arrange
+        using (var context = _factory.CreateDbContext())
+        {
+            context.Sessions.Add(new LoggingSession(1, "constant"));
+            context.SaveChanges();
+
+            for (var i = 0; i < 10; i++)
+            {
+                context.Samples.Add(MakeSample("AI0", 1.25));
+            }
+
+            context.SaveChanges();
+        }
+
+        // Act
+        var result = DatabaseLogger.LoadSingleTickValueSpread(
+            _factory, 1, [(Serial, "AI0")]);
+
+        // Assert
+        var points = result[(Serial, "AI0")];
+        Assert.AreEqual(1, points.Count);
+        Assert.AreEqual(1.25, points[0].Y);
+    }
+
+    [TestMethod]
+    public void LoadSingleTickValueSpread_OnlyRequestedChannelKeysAreReturned()
+    {
+        // Arrange - DB contains a channel that discovery did not request, and
+        // discovery requested a channel that has no rows
+        using (var context = _factory.CreateDbContext())
+        {
+            context.Sessions.Add(new LoggingSession(1, "keys"));
+            context.SaveChanges();
+
+            context.Samples.Add(MakeSample("AI0", 1.0));
+            context.Samples.Add(MakeSample("AI9", 9.0));
+            context.SaveChanges();
+        }
+
+        // Act
+        var result = DatabaseLogger.LoadSingleTickValueSpread(
+            _factory, 1, [(Serial, "AI0"), (Serial, "AI1")]);
+
+        // Assert
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual(1, result[(Serial, "AI0")].Count);
+        Assert.AreEqual(0, result[(Serial, "AI1")].Count);
+        Assert.IsFalse(result.ContainsKey((Serial, "AI9")));
+    }
+
+    private static DataSample MakeSample(string channelName, double value)
+    {
+        return new DataSample
+        {
+            LoggingSessionID = 1,
+            ChannelName = channelName,
+            DeviceName = "Nq1",
+            DeviceSerialNo = Serial,
+            Color = "#FFD32F2F",
+            Type = ChannelType.Analog,
+            Value = value,
+            TimestampTicks = Tick
+        };
+    }
+
+    /// <summary>
+    /// A real file-backed SQLite <see cref="IDbContextFactory{TContext}"/>, mirroring the
+    /// pattern in ExportDialogViewModelTests: the GroupBy aggregation must run through the
+    /// actual EF-to-SQLite translation, not a mock. The .db file is deleted on Dispose.
+    /// </summary>
+    private sealed class TempSqliteLoggingContextFactory : IDbContextFactory<LoggingContext>, IDisposable
+    {
+        private readonly string _dbPath;
+        private readonly DbContextOptions<LoggingContext> _options;
+
+        public TempSqliteLoggingContextFactory()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"daqifi_singletick_{Guid.NewGuid():N}.db");
+            _options = new DbContextOptionsBuilder<LoggingContext>()
+                .UseSqlite($"Data Source={_dbPath}")
+                .Options;
+            using var ctx = new LoggingContext(_options);
+            ctx.Database.EnsureCreated();
+        }
+
+        public LoggingContext CreateDbContext() => new(_options);
+
+        public void Dispose()
+        {
+            try
+            {
+                Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+                if (File.Exists(_dbPath)) { File.Delete(_dbPath); }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
+++ b/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
@@ -74,8 +74,15 @@ public static class MinMaxDownsampler
             for (var i = startIndex; i < endIndex; i++)
             {
                 var y = points[i].Y;
-                if (y < rangeMinY) { rangeMinY = y; }
-                if (y > rangeMaxY) { rangeMaxY = y; }
+                if (y < rangeMinY)
+                {
+                    rangeMinY = y;
+                }
+
+                if (y > rangeMaxY)
+                {
+                    rangeMaxY = y;
+                }
             }
 
             return rangeMinY < rangeMaxY

--- a/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
+++ b/Daqifi.Desktop/Helpers/MinMaxDownsampler.cs
@@ -66,7 +66,21 @@ public static class MinMaxDownsampler
 
         if (xRange <= 0)
         {
-            return [points[startIndex]];
+            // Degenerate time range (every point shares one X, e.g. duplicate
+            // timestamps): a single point renders as nothing on a LineSeries,
+            // so return the value spread as a vertical segment instead.
+            var rangeMinY = double.MaxValue;
+            var rangeMaxY = double.MinValue;
+            for (var i = startIndex; i < endIndex; i++)
+            {
+                var y = points[i].Y;
+                if (y < rangeMinY) { rangeMinY = y; }
+                if (y > rangeMaxY) { rangeMaxY = y; }
+            }
+
+            return rangeMinY < rangeMaxY
+                ? [new DataPoint(xMin, rangeMinY), new DataPoint(xMin, rangeMaxY)]
+                : [points[startIndex]];
         }
 
         var bucketWidth = xRange / bucketCount;

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -99,6 +99,15 @@ public partial class LoggedSeriesLegendItem : ObservableObject
     }
 }
 
+/// <summary>
+/// Channel identity and presentation info discovered from a session's sample rows.
+/// </summary>
+/// <param name="ChannelName">Channel identifier (e.g., "AI0").</param>
+/// <param name="DeviceSerialNo">Serial number of the device that owns the channel.</param>
+/// <param name="Type">Channel type used to pick the Y axis.</param>
+/// <param name="Color">Series color stored with the samples.</param>
+internal sealed record SessionChannelInfo(string ChannelName, string DeviceSerialNo, ChannelType Type, string Color);
+
 public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
 {
     #region Constants
@@ -471,8 +480,13 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
 
                     // Commit the transaction after the bulk insert
                     transaction.Commit();
+
+                    // Clear immediately after a successful commit: if disposal of the
+                    // transaction or context throws, the catch below keeps the list for
+                    // retry — re-inserting an already-committed batch would write
+                    // duplicate rows. A failure before the commit still retries.
+                    samples.Clear();
                 }
-                samples.Clear();
                 _consumerBusy = false;
             }
             catch (OperationCanceledException)
@@ -594,12 +608,24 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                 }
 
                 // Get all channels from the first timestamp (32 rows, instant)
-                var channelInfoList = baseQuery
+                var channelInfoRows = baseQuery
                     .Where(s => s.TimestampTicks == firstSample.TimestampTicks)
                     .Select(s => new { s.ChannelName, s.DeviceSerialNo, s.Type, s.Color })
-                    .ToList()
-                    .NaturalOrderBy(s => s.ChannelName)
+                    .AsEnumerable()
+                    .Select(s => new SessionChannelInfo(s.ChannelName, s.DeviceSerialNo, s.Type, s.Color))
                     .ToList();
+
+                // A channel can appear more than once at a single timestamp (e.g.
+                // firmware that emits multiple messages per sample period, or SD
+                // imports whose timestamps could not be reconstructed). Series and
+                // legend items are keyed by (serial, channel), so duplicates here
+                // would abort the whole session load (#572).
+                var channelInfoList = DeduplicateChannelInfo(channelInfoRows);
+                if (channelInfoList.Count != channelInfoRows.Count)
+                {
+                    _appLogger.Warning(
+                        $"Session {session.ID}: first timestamp has {channelInfoRows.Count - channelInfoList.Count} duplicate channel sample(s); ignoring duplicates for channel discovery.");
+                }
 
                 foreach (var chInfo in channelInfoList)
                 {
@@ -673,6 +699,19 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                 }
 
                 var phase2FirstTime = LoadSampledData(session.ID, tempSeriesList.Count, phase2Points);
+
+                // LoadSampledData returns null when the session has no usable time
+                // range (e.g. every sample shares one timestamp). phase2Points is
+                // still empty then — swapping it in would blank the Phase 1 plot.
+                if (phase2FirstTime == null)
+                {
+                    Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        PlotModel.Subtitle = string.Empty;
+                        PlotModel.InvalidatePlot(false);
+                    });
+                    return;
+                }
 
                 // Refresh UI with sampled full-range data — swap on UI thread
                 var fullMinimapData = PrepareMinimapData(tempSeriesList, phase2Points);
@@ -1105,6 +1144,23 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     public void ResumeConsumer()
     {
         _consumerGate.Set();
+    }
+
+    /// <summary>
+    /// Collapses duplicate (device serial, channel name) rows to a single entry,
+    /// keeping the first occurrence, and orders the result naturally by channel name.
+    /// A session can contain several samples for one channel at a single timestamp
+    /// (duplicate device messages, SD imports without reconstructable timestamps);
+    /// series and legend construction require exactly one entry per channel.
+    /// </summary>
+    /// <param name="rows">Channel rows discovered from a session's samples.</param>
+    /// <returns>One entry per (device serial, channel name), naturally ordered.</returns>
+    internal static List<SessionChannelInfo> DeduplicateChannelInfo(IEnumerable<SessionChannelInfo> rows)
+    {
+        return rows
+            .DistinctBy(r => (r.DeviceSerialNo, r.ChannelName))
+            .NaturalOrderBy(r => r.ChannelName)
+            .ToList();
     }
 
     private (LineSeries series, LoggedSeriesLegendItem legendItem) AddChannelSeries(

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -607,25 +607,36 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                     return;
                 }
 
-                // Get all channels from the first timestamp (32 rows, instant)
-                var channelInfoRows = baseQuery
+                // Get the channels present at the first timestamp. A channel can
+                // appear there more than once (e.g. firmware that emits multiple
+                // messages per sample period, or SD imports whose timestamps could
+                // not be reconstructed), and series/legend items are keyed by
+                // (serial, channel), so duplicates would abort the whole session
+                // load (#572). Collapse them in SQL so a degenerate session does
+                // not materialize thousands of rows just to discover its channels.
+                var channelGroups = baseQuery
                     .Where(s => s.TimestampTicks == firstSample.TimestampTicks)
-                    .Select(s => new { s.ChannelName, s.DeviceSerialNo, s.Type, s.Color })
-                    .AsEnumerable()
-                    .Select(s => new SessionChannelInfo(s.ChannelName, s.DeviceSerialNo, s.Type, s.Color))
+                    .GroupBy(s => new { s.DeviceSerialNo, s.ChannelName })
+                    .Select(g => new
+                    {
+                        g.Key.DeviceSerialNo,
+                        g.Key.ChannelName,
+                        Type = g.Min(s => (int)s.Type),
+                        Color = g.Min(s => s.Color),
+                        RowCount = g.Count()
+                    })
                     .ToList();
 
-                // A channel can appear more than once at a single timestamp (e.g.
-                // firmware that emits multiple messages per sample period, or SD
-                // imports whose timestamps could not be reconstructed). Series and
-                // legend items are keyed by (serial, channel), so duplicates here
-                // would abort the whole session load (#572).
-                var channelInfoList = DeduplicateChannelInfo(channelInfoRows);
-                if (channelInfoList.Count != channelInfoRows.Count)
+                var duplicateRows = channelGroups.Sum(g => g.RowCount) - channelGroups.Count;
+                if (duplicateRows > 0)
                 {
                     _appLogger.Warning(
-                        $"Session {session.ID}: first timestamp has {channelInfoRows.Count - channelInfoList.Count} duplicate channel sample(s); ignoring duplicates for channel discovery.");
+                        $"Session {session.ID}: first timestamp has {duplicateRows} duplicate " +
+                        "channel sample(s); ignoring duplicates for channel discovery.");
                 }
+
+                var channelInfoList = DeduplicateChannelInfo(channelGroups.Select(g =>
+                    new SessionChannelInfo(g.ChannelName, g.DeviceSerialNo, (ChannelType)g.Type, g.Color)));
 
                 foreach (var chInfo in channelInfoList)
                 {
@@ -701,14 +712,30 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
                 var phase2FirstTime = LoadSampledData(session.ID, tempSeriesList.Count, phase2Points);
 
                 // LoadSampledData returns null when the session has no usable time
-                // range (e.g. every sample shares one timestamp). phase2Points is
-                // still empty then — swapping it in would blank the Phase 1 plot.
+                // range (every sample shares one timestamp). Phase 1 capped its
+                // load at INITIAL_LOAD_POINTS, so its value spread may be missing
+                // extrema from later rows — rebuild each channel as an exact
+                // min/max vertical segment aggregated in SQL over all rows.
                 if (phase2FirstTime == null)
                 {
+                    var spreadPoints = LoadSingleTickValueSpread(_loggingContext, session.ID, channelKeys);
+                    var spreadMinimapData = PrepareMinimapData(tempSeriesList, spreadPoints);
                     Application.Current.Dispatcher.Invoke(() =>
                     {
+                        _allSessionPoints = spreadPoints;
                         PlotModel.Subtitle = string.Empty;
-                        PlotModel.InvalidatePlot(false);
+
+                        foreach (var series in PlotModel.Series.OfType<LineSeries>())
+                        {
+                            if (series.Tag is (string deviceSerial, string channelName)
+                                && spreadPoints.TryGetValue((deviceSerial, channelName), out var points))
+                            {
+                                series.ItemsSource = points;
+                            }
+                        }
+
+                        SetupMinimapSeries(spreadMinimapData);
+                        PlotModel.InvalidatePlot(true);
                     });
                     return;
                 }
@@ -1161,6 +1188,58 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             .DistinctBy(r => (r.DeviceSerialNo, r.ChannelName))
             .NaturalOrderBy(r => r.ChannelName)
             .ToList();
+    }
+
+    /// <summary>
+    /// Builds per-channel value spreads for a session whose samples all share a
+    /// single timestamp. Phase 1 caps how many rows it loads, so this aggregates
+    /// MIN/MAX over every row in SQL — exact without materializing the rows —
+    /// and represents each channel as a two-point vertical segment at delta-time
+    /// zero (one point when the value never changes).
+    /// </summary>
+    /// <param name="contextFactory">Factory for the logging database context.</param>
+    /// <param name="sessionId">The session whose samples are aggregated.</param>
+    /// <param name="channelKeys">The channels discovered for the session.</param>
+    /// <returns>One point list per requested channel key.</returns>
+    internal static Dictionary<(string deviceSerial, string channelName), List<DataPoint>> LoadSingleTickValueSpread(
+        IDbContextFactory<LoggingContext> contextFactory,
+        int sessionId,
+        List<(string deviceSerial, string channelName)> channelKeys)
+    {
+        var result = new Dictionary<(string deviceSerial, string channelName), List<DataPoint>>();
+        foreach (var key in channelKeys)
+        {
+            result[key] = [];
+        }
+
+        using var context = contextFactory.CreateDbContext();
+        var spreads = context.Samples.AsNoTracking()
+            .Where(s => s.LoggingSessionID == sessionId)
+            .GroupBy(s => new { s.DeviceSerialNo, s.ChannelName })
+            .Select(g => new
+            {
+                g.Key.DeviceSerialNo,
+                g.Key.ChannelName,
+                MinValue = g.Min(s => s.Value),
+                MaxValue = g.Max(s => s.Value)
+            })
+            .ToList();
+
+        foreach (var spread in spreads)
+        {
+            if (!result.TryGetValue((spread.DeviceSerialNo, spread.ChannelName), out var points))
+            {
+                continue;
+            }
+
+            points.Add(new DataPoint(0, spread.MinValue));
+            if (spread.MaxValue > spread.MinValue)
+            {
+                points.Add(new DataPoint(0, spread.MaxValue));
+            }
+        }
+
+        return result;
     }
 
     private (LineSeries series, LoggedSeriesLegendItem legendItem) AddChannelSeries(


### PR DESCRIPTION
Fixes #572.

## Root cause

`System.ArgumentException: An item with the same key has already been added. Key: (9090684023231015079, AI0)` fires in `DisplayLoggingSession` whenever a session contains **two samples for the same channel with identical `TimestampTicks` at the session's first timestamp**.

The 3.2.0 viewer rewrite (#467) discovers a session's channels by selecting every raw sample row at the first timestamp and seeding a dictionary with `Dictionary.Add` — with no deduplication. 3.1.0 built the channel list from all samples with `.Distinct()`, so the same data displayed fine there; #469 (DB survives updates) then carried those older sessions into 3.2.0, where clicking them silently fails (the exception is caught, logged, and reported to Sentry — the user just sees a session that never renders).

Duplicate-timestamp rows are real and reproducible. The Sentry breadcrumbs show occurrences across **two different Nq1 units** on the reporter's machine. Producers consistent with the code:

- **Live streaming**: firmware demonstrably reuses one `msg_time_stamp` across messages (Core's SD parser documents and merges exactly this pattern); `TimestampProcessor` maps a repeated counter to a bit-identical `DateTime` (delta = 0), and the positional channel mapping then re-samples the same channels at the same tick. The live path has no equivalent of the SD parser's merge.
- **SD import**: entries whose `MsgTimeStamp` is 0 (or whose `TimestampFreq` is unavailable) collapse to `baseTime` in Core's parsers — the importer already warns about this ("Timestamps may not be properly reconstructed") and imports anyway.
- A narrow app-side window: the DB consumer didn't clear its batch list on an exception after a successful commit, so disposal failures could re-insert an already-committed batch verbatim.

## Changes

- **`DisplayLoggingSession`**: dedupe channel discovery by `(DeviceSerialNo, ChannelName)` (first occurrence wins, natural channel order preserved) via a new testable `DeduplicateChannelInfo` helper, and log a warning with the duplicate count so affected sessions are diagnosable from logs/Sentry.
- **Phase 2 guard**: when `LoadSampledData` finds no usable time range (e.g. every sample shares one timestamp), keep the Phase 1 plot instead of swapping in empty point lists (which blanked the plot for >100K-row degenerate sessions), and clear the "Loading full dataset..." subtitle.
- **`MinMaxDownsampler`**: render a zero-width time range as a vertical min/max segment instead of a single point — a 1-point `LineSeries` draws nothing, which read as "no data".
- **DB consumer**: clear the batch list immediately after a successful commit so a post-commit exception can't re-insert committed rows; a pre-commit failure still retries the batch (transaction rolls back).

Ingestion behavior is deliberately unchanged: with the viewer tolerant, duplicate rows render as two points at the same X. Guarding the live pipeline against same-timestamp message bursts (mirroring the SD parser's merge) is a possible follow-up but risks dropping real device data without hardware that reproduces the firmware pattern.

## Verification

- 8 new unit tests (`DatabaseLoggerChannelDiscoveryTests`, `MinMaxDownsamplerTests`); full fast gate green: **326 passed, 0 failed**.
- End-to-end on real hardware bench data: seeded the app database with both failing shapes — a session with **every (channel, tick) duplicated** (the exact #572 shape) and a session with **150K samples all on a single tick**. Before the fix both fail with the #572 exception. After the fix both render in the app (verified visually): deduplicated legend (AI0–AI3 once each), full plot + minimap for the duplicated session, vertical-segment rendering for the one-tick session, subtitle cleared, and the log shows the new warnings (`Session 9997: first timestamp has 149996 duplicate channel sample(s)...`) with no `Failed in DisplayLoggingSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
