### PR TITLE
fix(sd-import): warn when imported SD files lack usable per-sample timestamps

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
@@ -1,4 +1,4 @@
-using Daqifi.Desktop.Loggers;
+﻿using Daqifi.Desktop.Loggers;
 
 namespace Daqifi.Desktop.Test.Loggers;
 
@@ -9,8 +9,8 @@ namespace Daqifi.Desktop.Test.Loggers;
 [TestClass]
 public class ImportTimestampQualityTests
 {
-    private const long BaseTicks = 638_000_000_000_000_000;
-    private const long TickStep = 1_000_000; // 100 ms
+    private const long BASE_TICKS = 638_000_000_000_000_000;
+    private const long TICK_STEP = 1_000_000; // 100 ms
 
     [TestMethod]
     public void Observe_AdvancingTimestamps_IsHealthy()
@@ -21,7 +21,7 @@ public class ImportTimestampQualityTests
         // Act
         for (var i = 0; i < 100; i++)
         {
-            quality.Observe(BaseTicks + i * TickStep);
+            quality.Observe(BASE_TICKS + i * TICK_STEP);
         }
 
         // Assert
@@ -41,7 +41,7 @@ public class ImportTimestampQualityTests
         // Act
         for (var i = 0; i < 50; i++)
         {
-            quality.Observe(BaseTicks);
+            quality.Observe(BASE_TICKS);
         }
 
         // Assert
@@ -61,14 +61,14 @@ public class ImportTimestampQualityTests
         // timestamp, interleaved with 69 advancing entries (mixed file where
         // only some messages carry msg_time_stamp)
         var quality = new ImportTimestampQuality();
-        quality.Observe(BaseTicks);
+        quality.Observe(BASE_TICKS);
         for (var i = 1; i < 70; i++)
         {
-            quality.Observe(BaseTicks + i * TickStep);
+            quality.Observe(BASE_TICKS + i * TICK_STEP);
         }
         for (var i = 0; i < 30; i++)
         {
-            quality.Observe(BaseTicks);
+            quality.Observe(BASE_TICKS);
         }
 
         // Assert - 30 of 99 follow-on entries collapsed (~30%)
@@ -87,14 +87,14 @@ public class ImportTimestampQualityTests
     {
         // Arrange - 10 of 99 follow-on entries collapsed (~10%, below the 20% threshold)
         var quality = new ImportTimestampQuality();
-        quality.Observe(BaseTicks);
+        quality.Observe(BASE_TICKS);
         for (var i = 1; i < 90; i++)
         {
-            quality.Observe(BaseTicks + i * TickStep);
+            quality.Observe(BASE_TICKS + i * TICK_STEP);
         }
         for (var i = 0; i < 10; i++)
         {
-            quality.Observe(BaseTicks);
+            quality.Observe(BASE_TICKS);
         }
 
         // Assert
@@ -108,14 +108,14 @@ public class ImportTimestampQualityTests
     {
         // Arrange - 101 entries, 20 of 100 follow-on entries collapsed (exactly 20%)
         var quality = new ImportTimestampQuality();
-        quality.Observe(BaseTicks);
+        quality.Observe(BASE_TICKS);
         for (var i = 1; i <= 80; i++)
         {
-            quality.Observe(BaseTicks + i * TickStep);
+            quality.Observe(BASE_TICKS + i * TICK_STEP);
         }
         for (var i = 0; i < 20; i++)
         {
-            quality.Observe(BaseTicks);
+            quality.Observe(BASE_TICKS);
         }
 
         // Assert
@@ -131,7 +131,7 @@ public class ImportTimestampQualityTests
         var quality = new ImportTimestampQuality();
 
         // Act
-        quality.Observe(BaseTicks);
+        quality.Observe(BASE_TICKS);
 
         // Assert - one sample has no meaningful time axis either way; no warning
         Assert.IsFalse(quality.HasFlatTimeAxis);

--- a/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
@@ -1,0 +1,154 @@
+using Daqifi.Desktop.Loggers;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Covers the timestamp-quality classification used to warn when an SD card
+/// file's time axis could not be reconstructed (issue #572 follow-up).
+/// </summary>
+[TestClass]
+public class ImportTimestampQualityTests
+{
+    private const long BaseTicks = 638_000_000_000_000_000;
+    private const long TickStep = 1_000_000; // 100 ms
+
+    [TestMethod]
+    public void Observe_AdvancingTimestamps_IsHealthy()
+    {
+        // Arrange
+        var quality = new ImportTimestampQuality();
+
+        // Act
+        for (var i = 0; i < 100; i++)
+        {
+            quality.Observe(BaseTicks + i * TickStep);
+        }
+
+        // Assert
+        Assert.AreEqual(100, quality.TotalEntries);
+        Assert.AreEqual(1, quality.EntriesAtFirstTimestamp);
+        Assert.IsFalse(quality.HasFlatTimeAxis);
+        Assert.IsFalse(quality.HasDegenerateTimeAxis);
+        Assert.IsNull(quality.BuildUserWarning());
+    }
+
+    [TestMethod]
+    public void Observe_AllIdenticalTimestamps_IsFlatAndDegenerate()
+    {
+        // Arrange - the issue #572 collapse shape: every entry at base time
+        var quality = new ImportTimestampQuality();
+
+        // Act
+        for (var i = 0; i < 50; i++)
+        {
+            quality.Observe(BaseTicks);
+        }
+
+        // Assert
+        Assert.IsTrue(quality.HasFlatTimeAxis);
+        Assert.IsTrue(quality.HasDegenerateTimeAxis);
+        Assert.AreEqual(1.0, quality.CollapsedFraction);
+
+        var warning = quality.BuildUserWarning();
+        Assert.IsNotNull(warning);
+        StringAssert.Contains(warning, "flat");
+    }
+
+    [TestMethod]
+    public void Observe_PartialCollapseAboveThreshold_IsDegenerateButNotFlat()
+    {
+        // Arrange - 100 entries: the first plus 30 more collapsed onto its
+        // timestamp, interleaved with 69 advancing entries (mixed file where
+        // only some messages carry msg_time_stamp)
+        var quality = new ImportTimestampQuality();
+        quality.Observe(BaseTicks);
+        for (var i = 1; i < 70; i++)
+        {
+            quality.Observe(BaseTicks + i * TickStep);
+        }
+        for (var i = 0; i < 30; i++)
+        {
+            quality.Observe(BaseTicks);
+        }
+
+        // Assert - 30 of 99 follow-on entries collapsed (~30%)
+        Assert.AreEqual(100, quality.TotalEntries);
+        Assert.AreEqual(31, quality.EntriesAtFirstTimestamp);
+        Assert.IsFalse(quality.HasFlatTimeAxis);
+        Assert.IsTrue(quality.HasDegenerateTimeAxis);
+
+        var warning = quality.BuildUserWarning();
+        Assert.IsNotNull(warning);
+        StringAssert.Contains(warning, "%");
+    }
+
+    [TestMethod]
+    public void Observe_PartialCollapseBelowThreshold_IsHealthy()
+    {
+        // Arrange - 10 of 99 follow-on entries collapsed (~10%, below the 20% threshold)
+        var quality = new ImportTimestampQuality();
+        quality.Observe(BaseTicks);
+        for (var i = 1; i < 90; i++)
+        {
+            quality.Observe(BaseTicks + i * TickStep);
+        }
+        for (var i = 0; i < 10; i++)
+        {
+            quality.Observe(BaseTicks);
+        }
+
+        // Assert
+        Assert.AreEqual(100, quality.TotalEntries);
+        Assert.IsFalse(quality.HasDegenerateTimeAxis);
+        Assert.IsNull(quality.BuildUserWarning());
+    }
+
+    [TestMethod]
+    public void Observe_CollapseExactlyAtThreshold_IsDegenerate()
+    {
+        // Arrange - 101 entries, 20 of 100 follow-on entries collapsed (exactly 20%)
+        var quality = new ImportTimestampQuality();
+        quality.Observe(BaseTicks);
+        for (var i = 1; i <= 80; i++)
+        {
+            quality.Observe(BaseTicks + i * TickStep);
+        }
+        for (var i = 0; i < 20; i++)
+        {
+            quality.Observe(BaseTicks);
+        }
+
+        // Assert
+        Assert.AreEqual(101, quality.TotalEntries);
+        Assert.AreEqual(0.2, quality.CollapsedFraction, 1e-12);
+        Assert.IsTrue(quality.HasDegenerateTimeAxis);
+    }
+
+    [TestMethod]
+    public void Observe_SingleEntry_IsHealthy()
+    {
+        // Arrange
+        var quality = new ImportTimestampQuality();
+
+        // Act
+        quality.Observe(BaseTicks);
+
+        // Assert - one sample has no meaningful time axis either way; no warning
+        Assert.IsFalse(quality.HasFlatTimeAxis);
+        Assert.IsFalse(quality.HasDegenerateTimeAxis);
+        Assert.IsNull(quality.BuildUserWarning());
+    }
+
+    [TestMethod]
+    public void NoEntries_IsHealthy()
+    {
+        // Arrange
+        var quality = new ImportTimestampQuality();
+
+        // Assert
+        Assert.AreEqual(0, quality.TotalEntries);
+        Assert.AreEqual(0.0, quality.CollapsedFraction);
+        Assert.IsFalse(quality.HasDegenerateTimeAxis);
+        Assert.IsNull(quality.BuildUserWarning());
+    }
+}

--- a/Daqifi.Desktop.Test/Loggers/SdCardSessionImporterTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardSessionImporterTests.cs
@@ -1,0 +1,161 @@
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Loggers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Exercises the SD card import pipeline against a real (tiny) SQLite database
+/// with synthetic parsed sessions, covering the timestamp-quality diagnostics
+/// added for the issue #572 follow-up: collapsed-timestamp files still import,
+/// but the result flags the degenerate time axis so callers can warn the user.
+/// </summary>
+[TestClass]
+public class SdCardSessionImporterTests
+{
+    private static readonly DateTime BaseTime = new(2026, 6, 9, 12, 0, 0, DateTimeKind.Utc);
+
+    private TempSqliteLoggingContextFactory _factory;
+    private SdCardSessionImporter _importer;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _factory = new TempSqliteLoggingContextFactory();
+        _importer = new SdCardSessionImporter(_factory);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _factory.Dispose();
+    }
+
+    [TestMethod]
+    public async Task ImportSessionAsync_AdvancingTimestamps_ImportsWithoutWarning()
+    {
+        // Arrange - 10 entries x 2 analog channels at 10 Hz
+        var entries = new List<SdCardLogEntry>();
+        for (var i = 0; i < 10; i++)
+        {
+            entries.Add(new SdCardLogEntry(
+                BaseTime.AddMilliseconds(i * 100), [1.0 + i, 2.0 + i], 0u, null));
+        }
+
+        var logSession = new SdCardLogSession("log_20260609_120000.bin", BaseTime, null, AsAsync(entries));
+
+        // Act
+        var result = await _importer.ImportSessionAsync(logSession, null, null, CancellationToken.None);
+
+        // Assert
+        Assert.IsFalse(result.TimestampQuality.HasDegenerateTimeAxis);
+        Assert.IsNull(result.TimestampQuality.BuildUserWarning());
+
+        using var context = _factory.CreateDbContext();
+        var samples = context.Samples.AsNoTracking()
+            .Where(s => s.LoggingSessionID == result.Session.ID)
+            .ToList();
+        Assert.AreEqual(20, samples.Count);
+        Assert.AreEqual(10, samples.Select(s => s.TimestampTicks).Distinct().Count());
+
+        var persisted = context.Sessions.AsNoTracking().Single(s => s.ID == result.Session.ID);
+        Assert.AreEqual(20, persisted.SampleCount);
+    }
+
+    [TestMethod]
+    public async Task ImportSessionAsync_CollapsedTimestamps_ImportsAndFlagsDegenerateTimeAxis()
+    {
+        // Arrange - the issue #572 shape: every entry shares one timestamp
+        // (messages without msg_time_stamp collapse onto the parser's base time)
+        var entries = new List<SdCardLogEntry>();
+        for (var i = 0; i < 50; i++)
+        {
+            entries.Add(new SdCardLogEntry(BaseTime, [1.0 + i, 2.0 + i], 0u, null));
+        }
+
+        var logSession = new SdCardLogSession("log_20260609_120000.bin", BaseTime, null, AsAsync(entries));
+
+        // Act
+        var result = await _importer.ImportSessionAsync(logSession, null, null, CancellationToken.None);
+
+        // Assert - data is kept (the viewer tolerates it) but the result warns
+        Assert.IsTrue(result.TimestampQuality.HasFlatTimeAxis);
+        Assert.IsTrue(result.TimestampQuality.HasDegenerateTimeAxis);
+        Assert.IsNotNull(result.TimestampQuality.BuildUserWarning());
+
+        using var context = _factory.CreateDbContext();
+        var samples = context.Samples.AsNoTracking()
+            .Where(s => s.LoggingSessionID == result.Session.ID)
+            .ToList();
+        Assert.AreEqual(100, samples.Count);
+        Assert.AreEqual(1, samples.Select(s => s.TimestampTicks).Distinct().Count());
+    }
+
+    [TestMethod]
+    public async Task ImportSessionAsync_SessionNameOverride_IsApplied()
+    {
+        // Arrange
+        var entries = new List<SdCardLogEntry>
+        {
+            new(BaseTime, [1.0], 0u, null),
+            new(BaseTime.AddMilliseconds(100), [2.0], 0u, null)
+        };
+        var logSession = new SdCardLogSession("log.bin", BaseTime, null, AsAsync(entries));
+        var options = new ImportOptions { SessionNameOverride = "My Import" };
+
+        // Act
+        var result = await _importer.ImportSessionAsync(logSession, options, null, CancellationToken.None);
+
+        // Assert
+        Assert.AreEqual("My Import", result.Session.Name);
+        Assert.IsFalse(result.TimestampQuality.HasDegenerateTimeAxis);
+    }
+
+    private static async IAsyncEnumerable<SdCardLogEntry> AsAsync(IEnumerable<SdCardLogEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            yield return entry;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A real file-backed SQLite <see cref="IDbContextFactory{TContext}"/>, mirroring the
+    /// pattern used by ExportDialogViewModelTests/ExportPerformanceTests: the importer's
+    /// bulk-insert pipeline runs against a real (tiny) database rather than a mock.
+    /// The .db file is deleted on Dispose.
+    /// </summary>
+    private sealed class TempSqliteLoggingContextFactory : IDbContextFactory<LoggingContext>, IDisposable
+    {
+        private readonly string _dbPath;
+        private readonly DbContextOptions<LoggingContext> _options;
+
+        public TempSqliteLoggingContextFactory()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"daqifi_sdimport_{Guid.NewGuid():N}.db");
+            _options = new DbContextOptionsBuilder<LoggingContext>()
+                .UseSqlite($"Data Source={_dbPath}")
+                .Options;
+            using var ctx = new LoggingContext(_options);
+            ctx.Database.EnsureCreated();
+        }
+
+        public LoggingContext CreateDbContext() => new(_options);
+
+        public void Dispose()
+        {
+            try
+            {
+                Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+                if (File.Exists(_dbPath)) { File.Delete(_dbPath); }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/Daqifi.Desktop.Test/Loggers/SdCardSessionImporterTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardSessionImporterTests.cs
@@ -10,8 +10,12 @@ namespace Daqifi.Desktop.Test.Loggers;
 /// with synthetic parsed sessions, covering the timestamp-quality diagnostics
 /// added for the issue #572 follow-up: collapsed-timestamp files still import,
 /// but the result flags the degenerate time axis so callers can warn the user.
+/// The bulk-insert pipeline is the subject under test, so the database is real
+/// (file-backed temp SQLite, hermetic per test) rather than mocked; the class
+/// is categorized accordingly. It still runs in the fast unit gate.
 /// </summary>
 [TestClass]
+[TestCategory("Integration")]
 public class SdCardSessionImporterTests
 {
     private static readonly DateTime BaseTime = new(2026, 6, 9, 12, 0, 0, DateTimeKind.Utc);
@@ -150,11 +154,15 @@ public class SdCardSessionImporterTests
             try
             {
                 Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
-                if (File.Exists(_dbPath)) { File.Delete(_dbPath); }
+                if (File.Exists(_dbPath))
+                {
+                    File.Delete(_dbPath);
+                }
             }
-            catch
+            catch (Exception ex)
             {
-                // Best-effort cleanup.
+                // Best-effort cleanup of a temp file; never fail the test run.
+                Console.WriteLine($"Cleanup of test database '{_dbPath}' failed: {ex.Message}");
             }
         }
     }

--- a/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
+++ b/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
@@ -84,8 +84,16 @@ public sealed class ImportTimestampQuality
             EntriesAtFirstTimestamp++;
         }
 
-        if (timestampTicks < _minTicks) { _minTicks = timestampTicks; }
-        if (timestampTicks > _maxTicks) { _maxTicks = timestampTicks; }
+        if (timestampTicks < _minTicks)
+        {
+            _minTicks = timestampTicks;
+        }
+
+        if (timestampTicks > _maxTicks)
+        {
+            _maxTicks = timestampTicks;
+        }
+
         TotalEntries++;
     }
 

--- a/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
+++ b/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+
+namespace Daqifi.Desktop.Loggers;
+
+/// <summary>
+/// Accumulates timestamp statistics for the entries of an SD card import and
+/// classifies whether the file's time axis could be reconstructed.
+/// </summary>
+/// <remarks>
+/// Core's SD card parsers assign the session base time to any entry whose
+/// message carries no usable timestamp (e.g. <c>msg_time_stamp == 0</c>, or a
+/// CSV row without a timestamp column), so such entries collapse onto one
+/// identical tick. A healthy parse produces strictly advancing timestamps with
+/// only the anchor entry at the base time, which is what makes the collapse
+/// detectable here with O(1) memory: count entries that share the first
+/// entry's tick. See issue #572 for the full background.
+/// </remarks>
+public sealed class ImportTimestampQuality
+{
+    #region Constants
+    /// <summary>
+    /// Fraction of entries (beyond the first) collapsed onto the first
+    /// timestamp above which the time axis is reported as degenerate. A
+    /// healthy file sits at ~0; a file whose messages all lack timestamps
+    /// sits at 1.0. The margin tolerates occasional firmware stragglers
+    /// without missing mostly-collapsed files.
+    /// </summary>
+    private const double DEGENERATE_COLLAPSED_FRACTION = 0.2;
+    #endregion
+
+    #region Private Fields
+    private long _firstTicks;
+    private long _minTicks = long.MaxValue;
+    private long _maxTicks = long.MinValue;
+    #endregion
+
+    #region Public Properties
+    /// <summary>
+    /// Total number of entries observed.
+    /// </summary>
+    public long TotalEntries { get; private set; }
+
+    /// <summary>
+    /// Number of entries (including the first) whose timestamp equals the
+    /// first entry's timestamp.
+    /// </summary>
+    public long EntriesAtFirstTimestamp { get; private set; }
+
+    /// <summary>
+    /// Fraction of entries beyond the first that collapsed onto the first
+    /// entry's timestamp. Zero for an empty or single-entry import.
+    /// </summary>
+    public double CollapsedFraction => TotalEntries > 1
+        ? (EntriesAtFirstTimestamp - 1) / (double)(TotalEntries - 1)
+        : 0.0;
+
+    /// <summary>
+    /// True when every observed entry shares one identical timestamp.
+    /// </summary>
+    public bool HasFlatTimeAxis => TotalEntries > 1 && _minTicks == _maxTicks;
+
+    /// <summary>
+    /// True when the time axis is unusable for analysis: either fully flat,
+    /// or a meaningful fraction of entries collapsed onto the first timestamp.
+    /// </summary>
+    public bool HasDegenerateTimeAxis =>
+        HasFlatTimeAxis || (TotalEntries > 1 && CollapsedFraction >= DEGENERATE_COLLAPSED_FRACTION);
+    #endregion
+
+    #region Public Methods
+    /// <summary>
+    /// Records one parsed entry's timestamp.
+    /// </summary>
+    /// <param name="timestampTicks">The entry's reconstructed timestamp, in ticks.</param>
+    public void Observe(long timestampTicks)
+    {
+        if (TotalEntries == 0)
+        {
+            _firstTicks = timestampTicks;
+        }
+
+        if (timestampTicks == _firstTicks)
+        {
+            EntriesAtFirstTimestamp++;
+        }
+
+        if (timestampTicks < _minTicks) { _minTicks = timestampTicks; }
+        if (timestampTicks > _maxTicks) { _maxTicks = timestampTicks; }
+        TotalEntries++;
+    }
+
+    /// <summary>
+    /// Builds a user-facing warning describing the timestamp problem, or
+    /// returns null when the time axis is usable.
+    /// </summary>
+    /// <returns>A warning suitable for the import-complete dialog, or null.</returns>
+    public string? BuildUserWarning()
+    {
+        if (!HasDegenerateTimeAxis)
+        {
+            return null;
+        }
+
+        if (HasFlatTimeAxis)
+        {
+            return "This file does not contain usable per-sample timestamps, so every imported " +
+                   "sample shares one timestamp and the session's time axis will be flat. " +
+                   "Older device firmware may not record timestamps in SD card logs.";
+        }
+
+        var percent = (CollapsedFraction * 100).ToString("0", CultureInfo.InvariantCulture);
+        return $"About {percent}% of the samples in this file have no usable timestamp and were " +
+               "collapsed onto the session start time, so time spacing for those samples is not " +
+               "meaningful. Older device firmware may not record timestamps in SD card logs.";
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -25,7 +25,7 @@ public class SdCardSessionImporter
     /// <summary>
     /// Imports an SD card log file from a local file path.
     /// </summary>
-    public async Task<LoggingSession> ImportFromFileAsync(
+    public async Task<SdCardImportResult> ImportFromFileAsync(
         string filePath,
         ImportOptions? options = null,
         IProgress<ImportProgress>? progress = null,
@@ -39,7 +39,7 @@ public class SdCardSessionImporter
     /// <summary>
     /// Imports an SD card log file from a stream.
     /// </summary>
-    public async Task<LoggingSession> ImportFromStreamAsync(
+    public async Task<SdCardImportResult> ImportFromStreamAsync(
         Stream stream,
         string fileName,
         ImportOptions? options = null,
@@ -54,7 +54,7 @@ public class SdCardSessionImporter
     /// <summary>
     /// Downloads an SD card log file from a connected USB device and imports it.
     /// </summary>
-    public async Task<LoggingSession> ImportFromDeviceAsync(
+    public async Task<SdCardImportResult> ImportFromDeviceAsync(
         IStreamingDevice device,
         string fileName,
         ImportOptions? options = null,
@@ -121,7 +121,7 @@ public class SdCardSessionImporter
                 FileShare.Read, 65536, useAsync: true);
             var logSession = await SdCardFileParserFactory.ParseAsync(
                 fileStream, downloadResult.FileName, parseOptions, ct);
-            var session = await ImportSessionAsync(logSession, options, progress, ct);
+            var result = await ImportSessionAsync(logSession, options, progress, ct);
 
             // Optionally delete from device after successful import
             if (options.DeleteFromDeviceAfterImport)
@@ -131,7 +131,7 @@ public class SdCardSessionImporter
             }
 
             _logger.Information($"Successfully imported '{fileName}' from device {device.DeviceSerialNo}");
-            return session;
+            return result;
         }
         finally
         {
@@ -152,14 +152,17 @@ public class SdCardSessionImporter
 
     /// <summary>
     /// Core import logic: maps parsed SD card data to desktop entities and bulk-inserts into SQLite.
+    /// Internal so tests can drive it with a synthetic <see cref="SdCardLogSession"/>;
+    /// production code enters through the file/stream/device methods above.
     /// </summary>
-    private async Task<LoggingSession> ImportSessionAsync(
+    internal async Task<SdCardImportResult> ImportSessionAsync(
         SdCardLogSession logSession,
         ImportOptions? options,
         IProgress<ImportProgress>? progress,
         CancellationToken ct)
     {
         options ??= new ImportOptions();
+        var timestampQuality = new ImportTimestampQuality();
 
         var config = logSession.DeviceConfig;
         var deviceSerialNo = config?.DeviceSerialNumber ?? "Unknown";
@@ -205,6 +208,7 @@ public class SdCardSessionImporter
             }
 
             sampleIndex++;
+            timestampQuality.Observe(entry.Timestamp.Ticks);
 
             // If we didn't have config, discover channel count from first entry
             if (analogPortCount == 0 && entry.AnalogValues.Count > 0)
@@ -277,6 +281,14 @@ public class SdCardSessionImporter
 
         _logger.Information($"Imported {samplesProcessed} samples for session '{session.Name}' (ID={session.ID})");
 
+        if (timestampQuality.HasDegenerateTimeAxis)
+        {
+            _logger.Warning(
+                $"Imported session '{session.Name}' (ID={session.ID}) has a degenerate time axis: " +
+                $"{timestampQuality.EntriesAtFirstTimestamp:N0} of {timestampQuality.TotalEntries:N0} " +
+                "entries share the first timestamp. The source file likely lacks per-sample timestamps.");
+        }
+
         // Record the sample count on the session so the list view can show it
         // without falling back to the lazy backfill on the next reload. We
         // already have the exact count locally, so no extra query is needed.
@@ -308,7 +320,11 @@ public class SdCardSessionImporter
             _logger.Error(ex, $"Failed to persist SampleCount for imported session {session.ID}");
         }
 
-        return session;
+        return new SdCardImportResult
+        {
+            Session = session,
+            TimestampQuality = timestampQuality
+        };
     }
 
     private LoggingSession CreateSession(SdCardLogSession logSession, ImportOptions options)
@@ -413,6 +429,24 @@ public class SdCardSessionImporter
             }
         }
     }
+}
+
+/// <summary>
+/// Outcome of an SD card import: the created logging session plus the
+/// timestamp-quality diagnostics gathered while importing, so callers can
+/// warn the user when the file's time axis could not be reconstructed.
+/// </summary>
+public sealed class SdCardImportResult
+{
+    /// <summary>
+    /// The logging session the import created.
+    /// </summary>
+    public required LoggingSession Session { get; init; }
+
+    /// <summary>
+    /// Timestamp statistics observed across the imported entries.
+    /// </summary>
+    public required ImportTimestampQuality TimestampQuality { get; init; }
 }
 
 public class ImportOptions

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1431,17 +1431,22 @@ public partial class DaqifiViewModel : ObservableObject
                 LoggedDataBusyReason = $"Importing... {p.SamplesProcessed:N0} samples";
             });
 
-            var session = await Task.Run(() =>
+            var result = await Task.Run(() =>
                 importer.ImportFromFileAsync(dialog.FileName, null, progress, CancellationToken.None));
 
             Application.Current.Dispatcher.Invoke(() =>
             {
-                LoggingManager.Instance.LoggingSessions.Add(session);
+                LoggingManager.Instance.LoggingSessions.Add(result.Session);
             });
 
-            await ShowMessage("Import Complete",
-                $"Successfully imported {System.IO.Path.GetFileName(dialog.FileName)}",
-                MessageDialogStyle.Affirmative);
+            var message = $"Successfully imported {System.IO.Path.GetFileName(dialog.FileName)}";
+            var timestampWarning = result.TimestampQuality.BuildUserWarning();
+            if (timestampWarning != null)
+            {
+                message += $"\n\nWarning: {timestampWarning}";
+            }
+
+            await ShowMessage("Import Complete", message, MessageDialogStyle.Affirmative);
         }
         catch (OperationCanceledException)
         {

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -310,17 +310,22 @@ public partial class DeviceLogsViewModel : ObservableObject
                 BusyMessage = $"Importing {file.FileName}... {p.SamplesProcessed:N0} samples";
             });
 
-            var session = await Task.Run(() =>
+            var result = await Task.Run(() =>
                 importer.ImportFromDeviceAsync(SelectedDevice, file.FileName, null, progress, CancellationToken.None));
 
             Application.Current.Dispatcher.Invoke(() =>
             {
-                LoggingManager.Instance.LoggingSessions.Add(session);
+                LoggingManager.Instance.LoggingSessions.Add(result.Session);
             });
 
-            await ShowMessage("Import Complete",
-                $"Successfully imported {file.FileName}",
-                MessageDialogStyle.Affirmative);
+            var message = $"Successfully imported {file.FileName}";
+            var timestampWarning = result.TimestampQuality.BuildUserWarning();
+            if (timestampWarning != null)
+            {
+                message += $"\n\nWarning: {timestampWarning}";
+            }
+
+            await ShowMessage("Import Complete", message, MessageDialogStyle.Affirmative);
         }
         catch (OperationCanceledException)
         {
@@ -348,6 +353,7 @@ public partial class DeviceLogsViewModel : ObservableObject
         var filesToImport = DeviceFiles.ToList();
         var successCount = 0;
         var failCount = 0;
+        var timestampWarningCount = 0;
 
         try
         {
@@ -368,13 +374,18 @@ public partial class DeviceLogsViewModel : ObservableObject
                         BusyMessage = $"Importing {file.FileName} ({i + 1}/{filesToImport.Count})... {p.SamplesProcessed:N0} samples";
                     });
 
-                    var session = await Task.Run(() =>
+                    var result = await Task.Run(() =>
                         importer.ImportFromDeviceAsync(SelectedDevice, file.FileName, null, progress, CancellationToken.None));
 
                     Application.Current.Dispatcher.Invoke(() =>
                     {
-                        LoggingManager.Instance.LoggingSessions.Add(session);
+                        LoggingManager.Instance.LoggingSessions.Add(result.Session);
                     });
+
+                    if (result.TimestampQuality.HasDegenerateTimeAxis)
+                    {
+                        timestampWarningCount++;
+                    }
 
                     successCount++;
                 }
@@ -389,6 +400,12 @@ public partial class DeviceLogsViewModel : ObservableObject
             if (failCount > 0)
             {
                 message += $"\n{failCount} file(s) failed to import.";
+            }
+
+            if (timestampWarningCount > 0)
+            {
+                message += $"\nWarning: {timestampWarningCount} file(s) lack usable per-sample timestamps; " +
+                           "their sessions' time axes will be flat.";
             }
 
             await ShowMessage("Import Complete", message, MessageDialogStyle.Affirmative);

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -404,8 +404,8 @@ public partial class DeviceLogsViewModel : ObservableObject
 
             if (timestampWarningCount > 0)
             {
-                message += $"\nWarning: {timestampWarningCount} file(s) lack usable per-sample timestamps; " +
-                           "their sessions' time axes will be flat.";
+                message += $"\nWarning: {timestampWarningCount} file(s) have missing or unusable per-sample " +
+                           "timestamps; their sessions' time axes may be flat or partially collapsed.";
             }
 
             await ShowMessage("Import Complete", message, MessageDialogStyle.Affirmative);


### PR DESCRIPTION
Follow-up to #572 (analysis) and #582 (viewer fix).

## Problem

Core's SD card parsers assign the session base time to any entry whose message carries no usable timestamp (`msg_time_stamp == 0` in protobuf logs, or a CSV row without a timestamp), so those entries collapse onto one identical tick. [SdCardSessionImporter.cs](../blob/main/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs) already logged a parse-time warning ("Timestamps may not be properly reconstructed") but then imported the collapsed data **silently** — the user got a "Import Complete ✓" dialog and a session whose time axis is flat. #582 made the viewer tolerate such sessions (they render as a vertical segment instead of failing), but they remain useless for analysis, and nothing told the user why.

## Approach

Detect the collapse during the existing single pass over parsed entries and **tell the user**, in the import-complete dialog, exactly what they imported:

- **`ImportTimestampQuality`** accumulates per-entry timestamp stats with O(1) memory: total entries, entries collapsed onto the first timestamp, min/max ticks. A healthy parse has strictly advancing timestamps with only the anchor entry at the base time, so the time axis is classified degenerate when it is **fully flat** or when **≥ 20% of follow-on entries** collapsed onto the first timestamp (tolerates occasional firmware stragglers; a fully collapsed file sits at 100%).
- The import methods now return **`SdCardImportResult`** (session + quality). All three import flows — file import on the Logged Data pane, per-file device import, and Import All — append a plain-language warning to their "Import Complete" dialog when degenerate, e.g.:
  > *Warning: This file does not contain usable per-sample timestamps, so every imported sample shares one timestamp and the session's time axis will be flat. Older device firmware may not record timestamps in SD card logs.*
  
  Import All reports a count of affected files. A warning with the counts is also written to the NLog log so affected imports are diagnosable from logs/Sentry.

**Timestamps are deliberately not synthesized** (the task's option (a)): SD files don't carry a trustworthy nominal sample rate — the embedded `TimestampFreq` is the 50 MHz tick clock, not the sampling rate, and a connected device's *current* configuration isn't necessarily what the file was recorded with. Fabricating time spacing would misrepresent the data; the import keeps the data unchanged and the user is told clearly what they have.

The existing dialogs, log lines (`Imported N samples...`), and the UI-test harness oracles are unchanged for healthy files.

## Tests

10 new tests, all green (full fast gate: 328 passed / 0 failed):

- `ImportTimestampQualityTests` — classification: advancing (healthy), all-identical (flat), partial collapse above / below / exactly at the 20% threshold, single-entry and empty inputs, warning text selection.
- `SdCardSessionImporterTests` — the import pipeline against a **real temp SQLite database** (mirroring the `TempSqliteLoggingContextFactory` pattern from the exporter tests) with synthetic `SdCardLogSession`s: collapsed files still import all samples *and* flag the degenerate axis; healthy files import without warning and persist the right `SampleCount`; `SessionNameOverride` honored. `ImportSessionAsync` was made `internal` as the test seam (the file/stream/device entry points require real files or hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
