### PR TITLE
chore(firmware): delegate WiFi version check to Core CheckWifiFirmwareStatusAsync

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -90,6 +90,9 @@ public class DaqifiViewModelFirmwareUpdateTests
             firmwareFilePath,
             It.IsAny<IProgress<FirmwareUpdateProgress>>(),
             It.IsAny<CancellationToken>()), Times.Once);
+        firmwareUpdateService.Verify(service => service.CheckWifiFirmwareStatusAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            It.IsAny<CancellationToken>()), Times.Never);
         firmwareDownloadService.Verify(service => service.DownloadLatestFirmwareAsync(
             It.IsAny<string>(),
             It.IsAny<bool>(),
@@ -105,12 +108,7 @@ public class DaqifiViewModelFirmwareUpdateTests
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
 
-        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core", new LanChipInfo
-        {
-            ChipId = 0x1503,
-            FwVersion = "19.3.0",
-            BuildDate = "2026-03-01"
-        });
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
         coreDevice.Connect();
 
         var serialDevice = CreateSerialDeviceWithCoreDevice("COM9", coreDevice);
@@ -151,14 +149,11 @@ public class DaqifiViewModelFirmwareUpdateTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(pic32FirmwarePath);
 
-        firmwareDownloadService
-            .Setup(service => service.GetLatestWifiReleaseAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FirmwareReleaseInfo
-            {
-                Version = new FirmwareVersion(19, 7, 0, null, 0),
-                TagName = "v19.7.0",
-                IsPreRelease = false
-            });
+        pic32FirmwareUpdateService
+            .Setup(service => service.CheckWifiFirmwareStatusAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateWifiStatus(WifiFirmwareStatusReason.UpdateAvailable, "19.3.0", "v19.7.0"));
 
         firmwareDownloadService
             .Setup(service => service.DownloadWifiFirmwareAsync(
@@ -203,6 +198,169 @@ public class DaqifiViewModelFirmwareUpdateTests
             pic32FirmwarePath,
             It.IsAny<IProgress<FirmwareUpdateProgress>>(),
             It.IsAny<CancellationToken>()), Times.Once);
+        pic32FirmwareUpdateService.Verify(service => service.CheckWifiFirmwareStatusAsync(
+            coreDevice,
+            It.IsAny<CancellationToken>()), Times.Once);
+        wifiFirmwareUpdateService.Verify(service => service.UpdateWifiModuleAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            wifiPackageDirectory,
+            It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>(),
+            true), Times.Once);
+        firmwareDownloadService.Verify(service => service.GetLatestWifiReleaseAsync(
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UploadFirmware_WifiFirmwareUpToDate_SkipsWifiFlash()
+    {
+        var dialogService = new Mock<IDialogService>();
+        var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM9", coreDevice);
+        var pic32FirmwarePath = CreateTempFile(".hex");
+        var wifiFactoryCalls = 0;
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.UpdateFirmwareAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                pic32FirmwarePath,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.CheckWifiFirmwareStatusAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateWifiStatus(WifiFirmwareStatusReason.UpToDate, "19.7.0", "v19.7.0"));
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadLatestFirmwareAsync(
+                It.IsAny<string>(),
+                true,
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pic32FirmwarePath);
+
+        var viewModel = new DaqifiViewModel(
+            dialogService.Object,
+            pic32FirmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            NullLogger<FirmwareUpdateService>.Instance,
+            (_, _) =>
+            {
+                wifiFactoryCalls++;
+                return Mock.Of<IFirmwareUpdateService>();
+            })
+        {
+            SelectedDevice = serialDevice
+        };
+
+        await InvokeUploadFirmwareAsync(viewModel);
+
+        Assert.AreEqual(0, wifiFactoryCalls);
+        Assert.IsTrue(viewModel.IsUploadComplete);
+        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.AreEqual(100, viewModel.UploadWiFiProgress);
+        Assert.AreEqual("WiFi firmware already up to date (19.7.0).", viewModel.FirmwareUpdateStatusText);
+
+        firmwareDownloadService.Verify(service => service.DownloadWifiFirmwareAsync(
+            It.IsAny<string>(),
+            It.IsAny<IProgress<int>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    [DataRow(WifiFirmwareStatusReason.ChipInfoUnavailable, true)]
+    [DataRow(WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery, true)]
+    [DataRow(WifiFirmwareStatusReason.LatestReleaseUnavailable, false)]
+    [DataRow(WifiFirmwareStatusReason.VersionUnparseable, true)]
+    public async Task UploadFirmware_WifiFirmwareStatusUnknown_StillFlashesWifi(
+        WifiFirmwareStatusReason reason,
+        bool expectsUnavailableStatusText)
+    {
+        var dialogService = new Mock<IDialogService>();
+        var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM9", coreDevice);
+        var pic32FirmwarePath = CreateTempFile(".hex");
+        var wifiPackageDirectory = CreateTempDirectory();
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.UpdateFirmwareAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                pic32FirmwarePath,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.CheckWifiFirmwareStatusAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateUnknownWifiStatus(reason));
+
+        wifiFirmwareUpdateService
+            .Setup(service => service.UpdateWifiModuleAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                wifiPackageDirectory,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadLatestFirmwareAsync(
+                It.IsAny<string>(),
+                true,
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pic32FirmwarePath);
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadWifiFirmwareAsync(
+                It.IsAny<string>(),
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
+
+        var viewModel = new DaqifiViewModel(
+            dialogService.Object,
+            pic32FirmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            NullLogger<FirmwareUpdateService>.Instance,
+            (_, _) => wifiFirmwareUpdateService.Object)
+        {
+            SelectedDevice = serialDevice
+        };
+
+        var statusTextHistory = new List<string>();
+        viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(DaqifiViewModel.FirmwareUpdateStatusText))
+            {
+                statusTextHistory.Add(viewModel.FirmwareUpdateStatusText);
+            }
+        };
+
+        await InvokeUploadFirmwareAsync(viewModel);
+
+        Assert.IsTrue(viewModel.IsUploadComplete);
+        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.AreEqual(
+            expectsUnavailableStatusText,
+            statusTextHistory.Contains("WiFi firmware version unavailable; continuing with update."));
+
         wifiFirmwareUpdateService.Verify(service => service.UpdateWifiModuleAsync(
             It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
             wifiPackageDirectory,
@@ -214,6 +372,70 @@ public class DaqifiViewModelFirmwareUpdateTests
     private static SerialStreamingDevice CreateSerialDeviceWithCoreDevice(string portName, TestCoreStreamingDevice coreDevice)
     {
         return new SerialStreamingDevice(portName, coreDevice);
+    }
+
+    private static WifiFirmwareStatus CreateWifiStatus(
+        WifiFirmwareStatusReason reason,
+        string deviceVersion,
+        string latestTag)
+    {
+        return new WifiFirmwareStatus
+        {
+            CurrentChipInfo = CreateLanChipInfo(deviceVersion),
+            LatestRelease = new FirmwareReleaseInfo
+            {
+                Version = new FirmwareVersion(19, 7, 0, null, 0),
+                TagName = latestTag,
+                IsPreRelease = false
+            },
+            IsUpToDate = reason == WifiFirmwareStatusReason.UpToDate,
+            Reason = reason
+        };
+    }
+
+    /// <summary>
+    /// Builds an inconclusive <see cref="WifiFirmwareStatus"/> mirroring Core's contract:
+    /// IsUpToDate is false and CurrentChipInfo/LatestRelease are populated only as far
+    /// as the check got before failing.
+    /// </summary>
+    private static WifiFirmwareStatus CreateUnknownWifiStatus(WifiFirmwareStatusReason reason)
+    {
+        return reason switch
+        {
+            WifiFirmwareStatusReason.LatestReleaseUnavailable => new WifiFirmwareStatus
+            {
+                CurrentChipInfo = CreateLanChipInfo("19.3.0"),
+                IsUpToDate = false,
+                Reason = reason
+            },
+            WifiFirmwareStatusReason.VersionUnparseable => new WifiFirmwareStatus
+            {
+                CurrentChipInfo = CreateLanChipInfo("WINC-19.3"),
+                LatestRelease = new FirmwareReleaseInfo
+                {
+                    Version = new FirmwareVersion(19, 7, 0, null, 0),
+                    TagName = "v19.7.0",
+                    IsPreRelease = false
+                },
+                IsUpToDate = false,
+                Reason = reason
+            },
+            _ => new WifiFirmwareStatus
+            {
+                IsUpToDate = false,
+                Reason = reason
+            }
+        };
+    }
+
+    private static LanChipInfo CreateLanChipInfo(string firmwareVersion)
+    {
+        return new LanChipInfo
+        {
+            ChipId = 0x1503,
+            FwVersion = firmwareVersion,
+            BuildDate = "2026-03-01"
+        };
     }
 
     private static async Task InvokeUploadFirmwareAsync(DaqifiViewModel viewModel)
@@ -251,12 +473,9 @@ public class DaqifiViewModelFirmwareUpdateTests
 
     private sealed class TestCoreStreamingDevice : DaqifiStreamingDevice, ILanChipInfoProvider
     {
-        private readonly LanChipInfo? _lanChipInfo;
-
-        public TestCoreStreamingDevice(string name, LanChipInfo? lanChipInfo = null)
+        public TestCoreStreamingDevice(string name)
             : base(name, new MockStreamTransport())
         {
-            _lanChipInfo = lanChipInfo;
         }
 
         public List<string> SentCommands { get; } = [];
@@ -266,9 +485,12 @@ public class DaqifiViewModelFirmwareUpdateTests
             SentCommands.Add(message.Data?.ToString() ?? string.Empty);
         }
 
+        // Shadows the base implementation so no test path ever runs a real SCPI
+        // exchange against the mock transport. The WiFi status check itself is
+        // mocked at the IFirmwareUpdateService level.
         Task<LanChipInfo?> ILanChipInfoProvider.GetLanChipInfoAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(_lanChipInfo);
+            return Task.FromResult<LanChipInfo?>(null);
         }
     }
 

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -284,6 +284,36 @@ public class DaqifiViewModelFirmwareUpdateTests
         WifiFirmwareStatusReason reason,
         bool expectsUnavailableStatusText)
     {
+        await AssertWifiFlashProceedsAsync(
+            pic32Service => pic32Service
+                .Setup(service => service.CheckWifiFirmwareStatusAsync(
+                    It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(CreateUnknownWifiStatus(reason)),
+            expectsUnavailableStatusText);
+    }
+
+    [TestMethod]
+    public async Task UploadFirmware_WifiStatusCheckThrows_StillFlashesWifi()
+    {
+        await AssertWifiFlashProceedsAsync(
+            pic32Service => pic32Service
+                .Setup(service => service.CheckWifiFirmwareStatusAsync(
+                    It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("WiFi status check failed")),
+            expectsUnavailableStatusText: true);
+    }
+
+    /// <summary>
+    /// Drives a full non-manual firmware upload where the WiFi status check yields no usable
+    /// verdict (inconclusive reason or thrown exception) and asserts the WiFi flash still runs
+    /// with skipVersionCheck: true.
+    /// </summary>
+    private async Task AssertWifiFlashProceedsAsync(
+        Action<Mock<IFirmwareUpdateService>> configureStatusCheck,
+        bool expectsUnavailableStatusText)
+    {
         var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
@@ -304,11 +334,7 @@ public class DaqifiViewModelFirmwareUpdateTests
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        pic32FirmwareUpdateService
-            .Setup(service => service.CheckWifiFirmwareStatusAsync(
-                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateUnknownWifiStatus(reason));
+        configureStatusCheck(pic32FirmwareUpdateService);
 
         wifiFirmwareUpdateService
             .Setup(service => service.UpdateWifiModuleAsync(

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -40,9 +40,6 @@ namespace Daqifi.Desktop.ViewModels;
 
 public partial class DaqifiViewModel : ObservableObject
 {
-    private const int WifiChipInfoMaxAttempts = 3;
-    private static readonly TimeSpan WifiChipInfoRetryDelay = TimeSpan.FromSeconds(2);
-
     private readonly AppLogger _appLogger = AppLogger.Instance;
 
     #region Private Variables
@@ -815,49 +812,67 @@ public partial class DaqifiViewModel : ObservableObject
         SerialStreamingDevice serialStreamingDevice,
         CancellationToken cancellationToken)
     {
-        // Probe the WiFi version here so the desktop can skip unnecessary downloads and surface the
-        // current/update version in the UI. Because the desktop owns this check, the Core call below
-        // passes skipVersionCheck: true so the device isn't queried a second time.
-        if (serialStreamingDevice is ILanChipInfoProvider lanChipProvider)
+        // Let Core probe the WiFi version and look up the latest release in one call so the desktop
+        // can skip unnecessary downloads and surface the current/update versions in the UI. Core owns
+        // the startup retry policy for the chip-info probe (the chip may still be booting right after
+        // a PIC32 update; see FirmwareUpdateServiceOptions.LanChipInfoMaxAttempts/LanChipInfoRetryDelay).
+        // Because the desktop owns this check, the Core flash call below passes skipVersionCheck: true
+        // so the device isn't queried a second time.
+        const string versionUnavailableStatus = "WiFi firmware version unavailable; continuing with update.";
+
+        FirmwareUpdateStatusText = "Checking WiFi firmware version...";
+        _appLogger.Information("Checking WiFi firmware version before deciding whether to flash the WiFi module.");
+
+        var wifiStatus = await _firmwareUpdateService.CheckWifiFirmwareStatusAsync(coreDevice, cancellationToken);
+
+        if (wifiStatus.CurrentChipInfo != null)
         {
-            FirmwareUpdateStatusText = "Checking WiFi firmware version...";
-            _appLogger.Information("Checking WiFi firmware version before deciding whether to flash the WiFi module.");
+            _appLogger.Information(
+                $"WiFi chip info query succeeded. Device WiFi firmware version: {wifiStatus.CurrentChipInfo.FwVersion}.");
+        }
 
-            var chipInfo = await TryGetLanChipInfoAsync(lanChipProvider, cancellationToken);
-
-            if (chipInfo == null)
+        switch (wifiStatus.Reason)
+        {
+            case WifiFirmwareStatusReason.UpToDate:
             {
-                _appLogger.Warning("WiFi chip info unavailable after startup retries; continuing with WiFi update.");
-                FirmwareUpdateStatusText = "WiFi firmware version unavailable; continuing with update.";
-            }
-            else
-            {
+                var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
+                FirmwareUpdateStatusText = $"WiFi firmware already up to date ({wifiStatus.CurrentChipInfo!.FwVersion}).";
                 _appLogger.Information(
-                    $"WiFi chip info query succeeded. Device WiFi firmware version: {chipInfo.FwVersion}.");
-
-                var latestRelease = await _firmwareDownloadService.GetLatestWifiReleaseAsync(cancellationToken);
-
-                if (latestRelease != null)
-                {
-                    var latestVersion = NormalizeWifiFirmwareVersion(latestRelease.TagName);
-                    if (IsWifiVersionCurrent(chipInfo.FwVersion, latestVersion))
-                    {
-                        FirmwareUpdateStatusText = $"WiFi firmware already up to date ({chipInfo.FwVersion}).";
-                        _appLogger.Information(
-                            $"WiFi firmware is already up to date (device: {chipInfo.FwVersion}, latest: {latestVersion}); skipping WiFi flash.");
-                        UploadWiFiProgress = 100;
-                        return;
-                    }
-
-                    FirmwareUpdateStatusText = $"WiFi update available ({chipInfo.FwVersion} → {latestVersion}). Downloading...";
-                    _appLogger.Information(
-                        $"WiFi firmware update required (device: {chipInfo.FwVersion}, latest: {latestVersion}); proceeding with WiFi flash.");
-                }
-                else
-                {
-                    _appLogger.Warning("Latest WiFi firmware release metadata was unavailable; continuing with WiFi update.");
-                }
+                    $"WiFi firmware is already up to date (device: {wifiStatus.CurrentChipInfo.FwVersion}, latest: {latestVersion}); skipping WiFi flash.");
+                UploadWiFiProgress = 100;
+                return;
             }
+
+            case WifiFirmwareStatusReason.UpdateAvailable:
+            {
+                var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
+                FirmwareUpdateStatusText = $"WiFi update available ({wifiStatus.CurrentChipInfo!.FwVersion} → {latestVersion}). Downloading...";
+                _appLogger.Information(
+                    $"WiFi firmware update required (device: {wifiStatus.CurrentChipInfo.FwVersion}, latest: {latestVersion}); proceeding with WiFi flash.");
+                break;
+            }
+
+            case WifiFirmwareStatusReason.ChipInfoUnavailable:
+                _appLogger.Warning("WiFi chip info unavailable after startup retries; continuing with WiFi update.");
+                FirmwareUpdateStatusText = versionUnavailableStatus;
+                break;
+
+            case WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery:
+                _appLogger.Warning("Device does not support WiFi chip info queries; continuing with WiFi update.");
+                FirmwareUpdateStatusText = versionUnavailableStatus;
+                break;
+
+            case WifiFirmwareStatusReason.LatestReleaseUnavailable:
+                _appLogger.Warning("Latest WiFi firmware release metadata was unavailable; continuing with WiFi update.");
+                break;
+
+            default:
+                // VersionUnparseable or future reasons — the comparison was inconclusive,
+                // so conservatively continue with the flash.
+                _appLogger.Warning(
+                    $"WiFi firmware version check was inconclusive ({wifiStatus.Reason}); continuing with WiFi update.");
+                FirmwareUpdateStatusText = versionUnavailableStatus;
+                break;
         }
 
         FirmwareUpdateStatusText = "Downloading WiFi firmware package...";
@@ -917,46 +932,6 @@ public partial class DaqifiViewModel : ObservableObject
                 serialStreamingDevice.ResetLanAfterUpdate();
             }
         }
-    }
-
-    private async Task<LanChipInfo?> TryGetLanChipInfoAsync(
-        ILanChipInfoProvider lanChipProvider,
-        CancellationToken cancellationToken)
-    {
-        for (var attempt = 1; attempt <= WifiChipInfoMaxAttempts; attempt++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            try
-            {
-                var chipInfo = await lanChipProvider.GetLanChipInfoAsync(cancellationToken);
-                if (chipInfo != null)
-                {
-                    return chipInfo;
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _appLogger.Warning(
-                    $"WiFi chip info query attempt {attempt}/{WifiChipInfoMaxAttempts} failed: {ex.Message}");
-            }
-
-            if (attempt >= WifiChipInfoMaxAttempts)
-            {
-                break;
-            }
-
-            _appLogger.Information(
-                $"WiFi chip info unavailable on attempt {attempt}/{WifiChipInfoMaxAttempts}; retrying after startup delay.");
-            FirmwareUpdateStatusText = "Waiting for device to finish starting up before checking WiFi firmware version...";
-            await Task.Delay(WifiChipInfoRetryDelay, cancellationToken);
-        }
-
-        return null;
     }
 
     private FirmwareUpdateService CreateWifiFirmwareUpdateService(string wifiVersion, string portName)
@@ -1045,13 +1020,6 @@ public partial class DaqifiViewModel : ObservableObject
         }
 
         return normalized;
-    }
-
-    private static bool IsWifiVersionCurrent(string deviceVersion, string latestVersion)
-    {
-        if (!FirmwareVersion.TryParse(deviceVersion, out var device)) return false;
-        if (!FirmwareVersion.TryParse(latestVersion, out var latest)) return false;
-        return device >= latest;
     }
 
     private void HandleFirmwareUpdateException(FirmwareUpdateException exception)

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -823,56 +823,85 @@ public partial class DaqifiViewModel : ObservableObject
         FirmwareUpdateStatusText = "Checking WiFi firmware version...";
         _appLogger.Information("Checking WiFi firmware version before deciding whether to flash the WiFi module.");
 
-        var wifiStatus = await _firmwareUpdateService.CheckWifiFirmwareStatusAsync(coreDevice, cancellationToken);
-
-        if (wifiStatus.CurrentChipInfo != null)
+        WifiFirmwareStatus? wifiStatus = null;
+        try
         {
-            _appLogger.Information(
-                $"WiFi chip info query succeeded. Device WiFi firmware version: {wifiStatus.CurrentChipInfo.FwVersion}.");
+            wifiStatus = await _firmwareUpdateService.CheckWifiFirmwareStatusAsync(coreDevice, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The status check is a UX optimization and expected failures already surface as Reason
+            // values, so this guards only unexpected faults (e.g. a broken service instance). Never
+            // let those abort the flash below, which runs on its own freshly created service.
+            _appLogger.Warning($"WiFi firmware status check failed ({ex.Message}); continuing with WiFi update.");
+            FirmwareUpdateStatusText = versionUnavailableStatus;
         }
 
-        switch (wifiStatus.Reason)
+        if (wifiStatus != null)
         {
-            case WifiFirmwareStatusReason.UpToDate:
+            if (wifiStatus.CurrentChipInfo != null)
             {
-                var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
-                FirmwareUpdateStatusText = $"WiFi firmware already up to date ({wifiStatus.CurrentChipInfo!.FwVersion}).";
                 _appLogger.Information(
-                    $"WiFi firmware is already up to date (device: {wifiStatus.CurrentChipInfo.FwVersion}, latest: {latestVersion}); skipping WiFi flash.");
-                UploadWiFiProgress = 100;
-                return;
+                    "WiFi chip info query succeeded. " +
+                    $"Device WiFi firmware version: {wifiStatus.CurrentChipInfo.FwVersion}.");
             }
 
-            case WifiFirmwareStatusReason.UpdateAvailable:
+            switch (wifiStatus.Reason)
             {
-                var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
-                FirmwareUpdateStatusText = $"WiFi update available ({wifiStatus.CurrentChipInfo!.FwVersion} → {latestVersion}). Downloading...";
-                _appLogger.Information(
-                    $"WiFi firmware update required (device: {wifiStatus.CurrentChipInfo.FwVersion}, latest: {latestVersion}); proceeding with WiFi flash.");
-                break;
+                case WifiFirmwareStatusReason.UpToDate:
+                {
+                    var deviceVersion = wifiStatus.CurrentChipInfo!.FwVersion;
+                    var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
+                    FirmwareUpdateStatusText = $"WiFi firmware already up to date ({deviceVersion}).";
+                    _appLogger.Information(
+                        $"WiFi firmware is already up to date (device: {deviceVersion}, latest: {latestVersion}); " +
+                        "skipping WiFi flash.");
+                    UploadWiFiProgress = 100;
+                    return;
+                }
+
+                case WifiFirmwareStatusReason.UpdateAvailable:
+                {
+                    var deviceVersion = wifiStatus.CurrentChipInfo!.FwVersion;
+                    var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
+                    FirmwareUpdateStatusText =
+                        $"WiFi update available ({deviceVersion} → {latestVersion}). Downloading...";
+                    _appLogger.Information(
+                        $"WiFi firmware update required (device: {deviceVersion}, latest: {latestVersion}); " +
+                        "proceeding with WiFi flash.");
+                    break;
+                }
+
+                case WifiFirmwareStatusReason.ChipInfoUnavailable:
+                    _appLogger.Warning(
+                        "WiFi chip info unavailable after startup retries; continuing with WiFi update.");
+                    FirmwareUpdateStatusText = versionUnavailableStatus;
+                    break;
+
+                case WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery:
+                    _appLogger.Warning(
+                        "Device does not support WiFi chip info queries; continuing with WiFi update.");
+                    FirmwareUpdateStatusText = versionUnavailableStatus;
+                    break;
+
+                case WifiFirmwareStatusReason.LatestReleaseUnavailable:
+                    _appLogger.Warning(
+                        "Latest WiFi firmware release metadata was unavailable; continuing with WiFi update.");
+                    break;
+
+                default:
+                    // VersionUnparseable or future reasons — the comparison was inconclusive,
+                    // so conservatively continue with the flash.
+                    _appLogger.Warning(
+                        $"WiFi firmware version check was inconclusive ({wifiStatus.Reason}); " +
+                        "continuing with WiFi update.");
+                    FirmwareUpdateStatusText = versionUnavailableStatus;
+                    break;
             }
-
-            case WifiFirmwareStatusReason.ChipInfoUnavailable:
-                _appLogger.Warning("WiFi chip info unavailable after startup retries; continuing with WiFi update.");
-                FirmwareUpdateStatusText = versionUnavailableStatus;
-                break;
-
-            case WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery:
-                _appLogger.Warning("Device does not support WiFi chip info queries; continuing with WiFi update.");
-                FirmwareUpdateStatusText = versionUnavailableStatus;
-                break;
-
-            case WifiFirmwareStatusReason.LatestReleaseUnavailable:
-                _appLogger.Warning("Latest WiFi firmware release metadata was unavailable; continuing with WiFi update.");
-                break;
-
-            default:
-                // VersionUnparseable or future reasons — the comparison was inconclusive,
-                // so conservatively continue with the flash.
-                _appLogger.Warning(
-                    $"WiFi firmware version check was inconclusive ({wifiStatus.Reason}); continuing with WiFi update.");
-                FirmwareUpdateStatusText = versionUnavailableStatus;
-                break;
         }
 
         FirmwareUpdateStatusText = "Downloading WiFi firmware package...";


### PR DESCRIPTION
## Summary

Replaces the hand-rolled WiFi firmware version check in `DaqifiViewModel.UpdateWifiModuleAsync` with Daqifi.Core 0.22.0's purpose-built `IFirmwareUpdateService.CheckWifiFirmwareStatusAsync`, which does the chip-info probe, GitHub release lookup, and version comparison in one call. The desktop now just switches on `WifiFirmwareStatus.Reason` to drive UX. Builds on #552.

### Behavior (user-perspective: unchanged)

- **Up to date** → same "WiFi firmware already up to date (version)" status, `UploadWiFiProgress = 100`, no download, no flash
- **Update available** → same "WiFi update available (current → target). Downloading..." status; target version still formatted via `NormalizeWifiFirmwareVersion(TagName)` so display is identical
- **Inconclusive** → still conservatively continues with the flash, but logs now say *why* (chip probe failed vs release lookup failed vs device doesn't support the query vs unparseable version)
- `skipVersionCheck: true` retained on the Core flash call — the device is never probed twice

### Retry policy

The deleted desktop retry loop (`WifiChipInfoMaxAttempts = 3` / `WifiChipInfoRetryDelay = 2s`) is not wrapped around the new call: Core 0.22.0's check embeds the same policy internally (`LanChipInfoMaxAttempts = 3`, `LanChipInfoRetryDelay = 2s` defaults, plus an 8s wall-clock cap — added upstream to close daqifi-core#144 for exactly this caller). Wrapping a second loop would have multiplied probes (up to 9 attempts / ~30s worst case). Only UX delta: the interim "Waiting for device to finish starting up..." status line between retries is gone; the UI shows "Checking WiFi firmware version..." for the whole ≤8s window.

### Cleanup

- Deleted `TryGetLanChipInfoAsync`, `IsWifiVersionCurrent`, and the two retry constants
- Kept `NormalizeWifiFirmwareVersion` — still formats the downloaded package version for the flash-tool `/v` argument and status text

### Tests

- Existing update-needed test now mocks the check at the service seam and verifies the no-double-probe contract (`CheckWifiFirmwareStatusAsync` called once with the connected core device; desktop never calls `GetLatestWifiReleaseAsync` itself)
- Manual-upload test verifies the check is never made
- New: up-to-date path (no download/flash, progress 100, exact status text)
- New: data-driven coverage of all four inconclusive reasons — including the previously uncovered probe-failure path — asserting the flash still runs with `skipVersionCheck: true`

## Test plan

- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 355 passed, 0 failed
- [x] Multi-angle self-review of the diff (correctness/removed-behavior/cross-file): no regressions found

🤖 Generated with [Claude Code](https://claude.com/claude-code)