### PR TITLE
chore(device): collapse shared Core connect/wiring logic into AbstractStreamingDevice

### DIFF
--- a/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
+++ b/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
@@ -1,0 +1,277 @@
+﻿using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Device;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
+
+namespace Daqifi.Desktop.Test.Device;
+
+/// <summary>
+/// Tests for the shared Core connect/wire/cleanup template in
+/// <see cref="AbstractStreamingDevice"/> (issue #591).
+/// </summary>
+[TestClass]
+public class CoreConnectionTemplateTests
+{
+    [TestMethod]
+    public void Connect_RunsTemplateStepsInOrder()
+    {
+        // Arrange
+        var device = new TemplateTestDevice();
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsTrue(connected, "Connect should succeed when the Core device is created.");
+        Assert.IsNotNull(device.ExposedCoreDevice, "The created Core device should be retained.");
+        Assert.AreSame(device.CreatedCoreDevice, device.ExposedCoreDevice);
+        CollectionAssert.AreEqual(
+            new[] { "CleanupConnection", "CreateCoreDevice", "InitializeAsync", "OnCoreDeviceInitialized" },
+            device.HookCalls,
+            "The template must clean up, create, initialize, then run the post-initialize hook.");
+        Assert.AreEqual(0, device.LoggedConnectFailures.Count, "No failure should be logged on success.");
+    }
+
+    [TestMethod]
+    public void Connect_WiresChannelsPopulatedEventToCoreSync()
+    {
+        // Arrange
+        var device = new TemplateTestDevice();
+        device.Connect();
+
+        // Act — raise the real Core event by populating channels from a status message
+        var statusMessage = BuildStatusMessage();
+        device.CreatedCoreDevice!.Metadata.UpdateFromProtobuf(statusMessage);
+        device.CreatedCoreDevice.PopulateChannelsFromStatus(statusMessage);
+
+        // Assert
+        Assert.AreEqual(2, device.DataChannels.Count, "Channel sync should run via the wired event.");
+        Assert.AreEqual(1, device.DataChannels.OfType<AnalogChannel>().Count());
+        Assert.AreEqual(1, device.DataChannels.OfType<DigitalChannel>().Count());
+        Assert.AreEqual("1.2.3", device.DeviceVersion, "Metadata should hydrate via the wired event.");
+    }
+
+    [TestMethod]
+    public void Connect_WhenCreateCoreDeviceReturnsNull_ReturnsFalseWithoutFailureLogging()
+    {
+        // Arrange — a factory returning null means the failure was already logged
+        var device = new TemplateTestDevice(returnNullCoreDevice: true);
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsFalse(connected);
+        Assert.IsNull(device.ExposedCoreDevice);
+        Assert.AreEqual(0, device.LoggedConnectFailures.Count,
+            "A null factory result must not be double-logged as a connect failure.");
+        CollectionAssert.AreEqual(
+            new[] { "CleanupConnection", "CreateCoreDevice" },
+            device.HookCalls,
+            "Initialization must not run when no Core device was created.");
+    }
+
+    [TestMethod]
+    public void Connect_WhenCreateCoreDeviceThrows_LogsFailureAndCleansUp()
+    {
+        // Arrange
+        var failure = new InvalidOperationException("Transport exploded.");
+        var device = new TemplateTestDevice(createException: failure);
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsFalse(connected);
+        Assert.AreEqual(1, device.LoggedConnectFailures.Count);
+        Assert.AreSame(failure, device.LoggedConnectFailures[0],
+            "The original exception must reach the classification hook.");
+        Assert.AreEqual("CleanupConnection", device.HookCalls.Last(),
+            "Failure must clean up the connection.");
+        Assert.IsNull(device.ExposedCoreDevice);
+    }
+
+    [TestMethod]
+    public void Connect_WhenPostInitializeThrows_CleansUpCoreDeviceAndUnsubscribesEvents()
+    {
+        // Arrange — serial's initial-status wait throwing is the real-world case
+        var failure = new TimeoutException("Device did not report status.");
+        var device = new TemplateTestDevice(postInitializeException: failure);
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsFalse(connected);
+        Assert.AreSame(failure, device.LoggedConnectFailures.Single());
+        Assert.AreEqual("CleanupConnection", device.HookCalls.Last(),
+            "Failure must clean up the connection.");
+        Assert.IsNull(device.ExposedCoreDevice, "Cleanup must drop the Core device on failure.");
+
+        // The Core device outlives the failed attempt; its events must be unsubscribed.
+        var statusMessage = BuildStatusMessage();
+        device.CreatedCoreDevice!.Metadata.UpdateFromProtobuf(statusMessage);
+        device.CreatedCoreDevice.PopulateChannelsFromStatus(statusMessage);
+        Assert.AreEqual(0, device.ChannelsPopulatedHandlerCalls,
+            "ChannelsPopulated must be unsubscribed after a failed connect.");
+        Assert.AreEqual(0, device.DataChannels.Count);
+    }
+
+    [TestMethod]
+    public void Disconnect_UnsubscribesClearsChannelsAndDropsCoreDevice()
+    {
+        // Arrange — connected device with synced channels
+        var device = new TemplateTestDevice();
+        device.Connect();
+        var coreDevice = device.CreatedCoreDevice!;
+        var statusMessage = BuildStatusMessage();
+        coreDevice.Metadata.UpdateFromProtobuf(statusMessage);
+        coreDevice.PopulateChannelsFromStatus(statusMessage);
+        Assert.AreEqual(2, device.DataChannels.Count, "Precondition: channels synced.");
+
+        // Act
+        var disconnected = device.Disconnect();
+
+        // Assert
+        Assert.IsTrue(disconnected);
+        Assert.AreEqual(0, device.DataChannels.Count, "Channels must clear to prevent ghosts (issue #29).");
+        Assert.IsNull(device.ExposedCoreDevice);
+        Assert.AreEqual("CleanupConnection", device.HookCalls.Last(),
+            "Disconnect must run the shared cleanup.");
+
+        // A late Core event after disconnect must not repopulate the channel list.
+        var handlerCallsBefore = device.ChannelsPopulatedHandlerCalls;
+        coreDevice.PopulateChannelsFromStatus(statusMessage);
+        Assert.AreEqual(handlerCallsBefore, device.ChannelsPopulatedHandlerCalls,
+            "ChannelsPopulated must be unsubscribed on disconnect.");
+        Assert.AreEqual(0, device.DataChannels.Count);
+    }
+
+    [TestMethod]
+    public void Connect_WhenNotOverridden_ReturnsFalse()
+    {
+        // Arrange — a device that does not provide a Core device factory
+        var device = new HookFreeTestDevice();
+
+        // Act & Assert
+        Assert.IsFalse(device.Connect(),
+            "The default template must fail safely when CreateCoreDevice is not overridden.");
+    }
+
+    private static DaqifiOutMessage BuildStatusMessage()
+    {
+        return new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 12345,
+            DeviceFwRev = "1.2.3",
+            AnalogInPortNum = 1,
+            AnalogInRes = 4095,
+            DigitalPortNum = 1,
+            AnalogInCalM = { 1.0f },
+            AnalogInCalB = { 0.0f },
+            AnalogInIntScaleM = { 1.0f },
+            AnalogInPortRange = { 5.0f }
+        };
+    }
+
+    /// <summary>
+    /// Streaming device exercising the shared connect template with recording hooks.
+    /// </summary>
+    private sealed class TemplateTestDevice(
+        bool returnNullCoreDevice = false,
+        Exception? createException = null,
+        Exception? postInitializeException = null) : AbstractStreamingDevice
+    {
+        public List<string> HookCalls { get; } = [];
+        public List<Exception> LoggedConnectFailures { get; } = [];
+        public TemplateCoreDevice? CreatedCoreDevice { get; private set; }
+        public CoreStreamingDevice? ExposedCoreDevice => CoreDevice;
+        public int ChannelsPopulatedHandlerCalls { get; private set; }
+
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+
+        protected override CoreStreamingDevice? CreateCoreDevice()
+        {
+            HookCalls.Add("CreateCoreDevice");
+
+            if (createException != null)
+            {
+                throw createException;
+            }
+
+            if (returnNullCoreDevice)
+            {
+                return null;
+            }
+
+            CreatedCoreDevice = new TemplateCoreDevice(() => HookCalls.Add("InitializeAsync"));
+            CreatedCoreDevice.Connect();
+            return CreatedCoreDevice;
+        }
+
+        protected override void OnCoreDeviceInitialized()
+        {
+            HookCalls.Add("OnCoreDeviceInitialized");
+
+            if (postInitializeException != null)
+            {
+                throw postInitializeException;
+            }
+        }
+
+        protected override void LogConnectFailure(Exception ex)
+        {
+            LoggedConnectFailures.Add(ex);
+        }
+
+        protected override void CleanupConnection()
+        {
+            HookCalls.Add("CleanupConnection");
+            base.CleanupConnection();
+        }
+
+        protected override void OnCoreChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e)
+        {
+            ChannelsPopulatedHandlerCalls++;
+            base.OnCoreChannelsPopulated(sender, e);
+        }
+    }
+
+    /// <summary>
+    /// Device relying entirely on the base template defaults (no CreateCoreDevice override).
+    /// </summary>
+    private sealed class HookFreeTestDevice : AbstractStreamingDevice
+    {
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Transportless Core device with a stubbed initialization sequence.
+    /// </summary>
+    private sealed class TemplateCoreDevice(Action onInitialize) : CoreStreamingDevice("TemplateCore")
+    {
+        public override Task InitializeAsync()
+        {
+            onInitialize();
+            return Task.CompletedTask;
+        }
+
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+    }
+}

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -310,7 +310,15 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         try
         {
             StopStreaming();
+        }
+        catch (Exception ex)
+        {
+            // A dead transport (e.g., USB unplugged mid-stream) must not abort teardown.
+            AppLogger.Warning(ex, $"Error stopping streaming while disconnecting DAQiFi device {DisplayIdentifier}");
+        }
 
+        try
+        {
             // Unsubscribe before clearing channels so a late ChannelsPopulated event
             // cannot repopulate the list after the clear.
             if (CoreDevice != null)
@@ -376,15 +384,24 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return;
         }
 
+        UnsubscribeCoreDeviceEvents(coreDevice);
+
         try
         {
-            UnsubscribeCoreDeviceEvents(coreDevice);
             coreDevice.Disconnect();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Warning(ex, "Error disconnecting Core device during cleanup");
+        }
+
+        try
+        {
             coreDevice.Dispose();
         }
         catch (Exception ex)
         {
-            AppLogger.Warning($"Error disconnecting Core device during cleanup: {ex.Message}");
+            AppLogger.Warning(ex, "Error disposing Core device during cleanup");
         }
 
         CoreDevice = null;

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -72,6 +72,10 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     private const uint DEFAULT_TIMESTAMP_FREQUENCY = 50_000_000;
 
+    private const string SD_UNAVAILABLE_MESSAGE = "Core SD card operations are not available for this device.";
+    private const string STREAMING_UNAVAILABLE_MESSAGE = "Core live streaming operations are not available for this device.";
+    private const string NOT_CONNECTED_MESSAGE = "Device is not connected.";
+
     private readonly ITimestampProcessor _timestampProcessor = new TimestampProcessor();
     private List<SdCardFile> _sdCardFiles = [];
 
@@ -94,6 +98,12 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     private IProtocolHandler? _protocolHandler;
 
     /// <summary>
+    /// The Core streaming device created by the shared <see cref="Connect"/> template,
+    /// or null while disconnected.
+    /// </summary>
+    protected CoreStreamingDevice? CoreDevice { get; set; }
+
+    /// <summary>
     /// Core streaming device used for SD card operations (USB devices only).
     /// </summary>
     protected virtual CoreStreamingDevice? CoreDeviceForSd => null;
@@ -101,12 +111,12 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// <summary>
     /// Core streaming device used for live stream start/stop operations.
     /// </summary>
-    protected virtual CoreStreamingDevice? CoreDeviceForStreaming => null;
+    protected virtual CoreStreamingDevice? CoreDeviceForStreaming => CoreDevice;
 
     /// <summary>
     /// Core streaming device used for network configuration orchestration.
     /// </summary>
-    protected virtual CoreStreamingDevice? CoreDeviceForNetworkConfiguration => null;
+    protected virtual CoreStreamingDevice? CoreDeviceForNetworkConfiguration => CoreDevice;
 
     #region Properties
 
@@ -209,10 +219,9 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     public List<IChannel> DataChannels { get; set; } = [];
 
     /// <summary>
-    /// Gets whether the device is currently connected.
-    /// Override in derived classes to provide accurate connection state.
+    /// Gets whether the device is currently connected via its Core device.
     /// </summary>
-    public virtual bool IsConnected => DeviceState == DeviceState.Connected || DeviceState == DeviceState.Ready;
+    public virtual bool IsConnected => CoreDevice?.IsConnected == true;
 
     public bool IsStreaming { get; set; }
     public bool IsFirmwareOutdated { get; set; }
@@ -231,10 +240,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     #endregion
 
     #region Abstract Methods
-    public abstract bool Connect();
-
-    public abstract bool Disconnect();
-
     public abstract bool Write(string command);
 
     /// <summary>
@@ -243,6 +248,164 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     /// <param name="message">The SCPI message to send.</param>
     protected abstract void SendMessage(IOutboundMessage<string> message);
+    #endregion
+
+    #region Core Connection Template
+    /// <summary>
+    /// Connects to the device using the shared Core connect/wire/initialize skeleton:
+    /// tear down any previous connection, create the transport-specific Core device
+    /// (<see cref="CreateCoreDevice"/>), subscribe Core events, initialize desktop state, run
+    /// Core's async initialization, then run the optional transport-specific post-initialize
+    /// step (<see cref="OnCoreDeviceInitialized"/>). On any failure the attempt is logged
+    /// (<see cref="LogConnectFailure"/>) and fully cleaned up (<see cref="CleanupConnection"/>).
+    /// </summary>
+    /// <remarks>
+    /// Synchronous by contract: <see cref="ConnectionManager"/> invokes <c>Connect()</c> from
+    /// <c>Task.Run</c>, which is what makes blocking on <c>InitializeAsync()</c> safe here.
+    /// Do not call this from the UI thread.
+    /// </remarks>
+    /// <returns><c>true</c> when the device connected and initialized; otherwise <c>false</c>.</returns>
+    public virtual bool Connect()
+    {
+        // Ensure any previous connection state is cleaned up first
+        CleanupConnection();
+
+        try
+        {
+            var coreDevice = CreateCoreDevice();
+            if (coreDevice == null)
+            {
+                return false;
+            }
+
+            CoreDevice = coreDevice;
+
+            coreDevice.ChannelsPopulated += OnCoreChannelsPopulated;
+            coreDevice.MessageReceived += OnCoreMessageReceived;
+
+            InitializeDeviceState();
+
+            // Blocking on Core's async initialization is safe because Connect() is invoked
+            // from Task.Run by ConnectionManager (see remarks).
+            coreDevice.InitializeAsync().GetAwaiter().GetResult();
+
+            OnCoreDeviceInitialized();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LogConnectFailure(ex);
+            CleanupConnection();
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Disconnects from the device: stops streaming, unsubscribes Core events, clears
+    /// channels, and tears down the connection via <see cref="CleanupConnection"/>.
+    /// </summary>
+    /// <returns><c>true</c> when the disconnect completed; otherwise <c>false</c>.</returns>
+    public virtual bool Disconnect()
+    {
+        try
+        {
+            StopStreaming();
+
+            // Unsubscribe before clearing channels so a late ChannelsPopulated event
+            // cannot repopulate the list after the clear.
+            if (CoreDevice != null)
+            {
+                UnsubscribeCoreDeviceEvents(CoreDevice);
+            }
+
+            // Clear channels to prevent ghost channels on reconnect (Issue #29)
+            AppLogger.Information($"Cleared {DataChannels.Count} channels for device {DeviceSerialNo}");
+            DataChannels.Clear();
+
+            CleanupConnection();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error(ex, $"Error disconnecting from DAQiFi device {DisplayIdentifier}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Creates and connects the transport-specific Core streaming device for the shared
+    /// <see cref="Connect"/> template. Return <c>null</c> (after logging) to fail without an
+    /// exception, or throw to route the failure through <see cref="LogConnectFailure"/>.
+    /// Intermediate state assigned before a throw (e.g., a transport, or
+    /// <see cref="CoreDevice"/> itself) is torn down by <see cref="CleanupConnection"/>.
+    /// The default returns <c>null</c>; devices using the shared template must override.
+    /// </summary>
+    protected virtual CoreStreamingDevice? CreateCoreDevice() => null;
+
+    /// <summary>
+    /// Called by <see cref="Connect"/> after Core's <c>InitializeAsync()</c> completes.
+    /// Default does nothing; serial overrides to block until the device reports its
+    /// initial status message.
+    /// </summary>
+    protected virtual void OnCoreDeviceInitialized()
+    {
+    }
+
+    /// <summary>
+    /// Logs a failure of the shared <see cref="Connect"/> template. Default logs an error;
+    /// transports override to add context or downgrade user/environmental conditions
+    /// (e.g., a COM port that disappeared) to warnings.
+    /// </summary>
+    /// <param name="ex">The exception that failed the connection attempt.</param>
+    protected virtual void LogConnectFailure(Exception ex)
+    {
+        AppLogger.Error(ex, $"Problem connecting to DAQiFi device {DisplayIdentifier}");
+    }
+
+    /// <summary>
+    /// Tears down the Core device created by <see cref="Connect"/>: unsubscribes Core
+    /// events, disconnects, and disposes. Safe to call when no Core device is set.
+    /// Transports override to also tear down transport-specific state and must call the
+    /// base implementation.
+    /// </summary>
+    protected virtual void CleanupConnection()
+    {
+        var coreDevice = CoreDevice;
+        if (coreDevice == null)
+        {
+            return;
+        }
+
+        try
+        {
+            UnsubscribeCoreDeviceEvents(coreDevice);
+            coreDevice.Disconnect();
+            coreDevice.Dispose();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Warning($"Error disconnecting Core device during cleanup: {ex.Message}");
+        }
+
+        CoreDevice = null;
+    }
+
+    private void UnsubscribeCoreDeviceEvents(CoreStreamingDevice coreDevice)
+    {
+        coreDevice.ChannelsPopulated -= OnCoreChannelsPopulated;
+        coreDevice.MessageReceived -= OnCoreMessageReceived;
+    }
+
+    /// <summary>
+    /// Handles non-status messages received from Core's DaqifiDevice and routes them
+    /// to the protocol handler for streaming data processing.
+    /// Status messages are handled via <see cref="OnCoreChannelsPopulated"/>.
+    /// </summary>
+    private void OnCoreMessageReceived(object? sender, MessageReceivedEventArgs e)
+    {
+        var args = new MessageEventArgs<object>(e.Message);
+        HandleInboundMessage(args);
+    }
     #endregion
 
     #region Message Handlers
@@ -639,7 +802,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
                 ? ScpiMessageProducer.EnableDioPorts()
                 : ScpiMessageProducer.DisableDioPorts());
 
-            var coreDevice = GetCoreDeviceForSd();
+            var coreDevice = GetCoreDevice(CoreDeviceForSd, SD_UNAVAILABLE_MESSAGE);
             coreDevice.StreamingFrequency = StreamingFrequency;
 
             // The Core package resumes StartSdCardLoggingAsync continuations on the caller's
@@ -669,7 +832,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         try
         {
-            var coreDevice = GetCoreDeviceForSd();
+            var coreDevice = GetCoreDevice(CoreDeviceForSd, SD_UNAVAILABLE_MESSAGE);
             coreDevice.StopSdCardLoggingAsync().GetAwaiter().GetResult();
 
             IsLoggingToSdCard = false;
@@ -698,7 +861,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         EnsureSdOperationsQuiesced();
 
-        var coreDevice = GetCoreDeviceForSd();
+        var coreDevice = GetCoreDevice(CoreDeviceForSd, SD_UNAVAILABLE_MESSAGE);
         var files = Task.Run(() => coreDevice.GetSdCardFilesAsync()).GetAwaiter().GetResult();
         UpdateSdCardFiles(MapSdCardFiles(files));
     }
@@ -712,15 +875,13 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         OnPropertyChanged(nameof(SdCardFiles));
     }
 
-    private CoreStreamingDevice GetCoreDeviceForSd()
+    /// <summary>
+    /// Returns the given Core device, or throws <see cref="InvalidOperationException"/> with
+    /// <paramref name="unavailableMessage"/> when the operation is not available.
+    /// </summary>
+    private static CoreStreamingDevice GetCoreDevice(CoreStreamingDevice? coreDevice, string unavailableMessage)
     {
-        var coreDevice = CoreDeviceForSd;
-        if (coreDevice == null)
-        {
-            throw new InvalidOperationException("Core SD card operations are not available for this device.");
-        }
-
-        return coreDevice;
+        return coreDevice ?? throw new InvalidOperationException(unavailableMessage);
     }
 
     /// <summary>
@@ -737,7 +898,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     {
         EnsureSdOperationsQuiesced();
 
-        var coreDevice = GetCoreDeviceForSd();
+        var coreDevice = GetCoreDevice(CoreDeviceForSd, SD_UNAVAILABLE_MESSAGE);
         return await coreDevice.DownloadSdCardFileAsync(fileName, progress, ct);
     }
 
@@ -751,19 +912,8 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     {
         EnsureSdOperationsQuiesced();
 
-        var coreDevice = GetCoreDeviceForSd();
+        var coreDevice = GetCoreDevice(CoreDeviceForSd, SD_UNAVAILABLE_MESSAGE);
         await coreDevice.DeleteSdCardFileAsync(fileName, ct);
-    }
-
-    private CoreStreamingDevice GetCoreDeviceForNetworkConfiguration()
-    {
-        var coreDevice = CoreDeviceForNetworkConfiguration;
-        if (coreDevice == null)
-        {
-            throw new InvalidOperationException("Device is not connected.");
-        }
-
-        return coreDevice;
     }
 
     private static List<SdCardFile> MapSdCardFiles(IEnumerable<CoreSdCardFileInfo> files)
@@ -825,7 +975,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             throw new InvalidOperationException("Cannot initialize streaming while in LogToDevice mode");
         }
 
-        var coreStreamingDevice = GetCoreDeviceForStreaming();
+        var coreStreamingDevice = GetCoreDevice(CoreDeviceForStreaming, STREAMING_UNAVAILABLE_MESSAGE);
         coreStreamingDevice.StreamingFrequency = StreamingFrequency;
 
         // A session must never anchor its time axis on prior-session data (issue #573).
@@ -861,7 +1011,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             AppLogger.Information("Allowing computer sleep after streaming.");
         }
 
-        var coreStreamingDevice = GetCoreDeviceForStreaming();
+        var coreStreamingDevice = GetCoreDevice(CoreDeviceForStreaming, STREAMING_UNAVAILABLE_MESSAGE);
         coreStreamingDevice.StopStreaming();
         IsStreaming = coreStreamingDevice.IsStreaming;
         AppLogger.AddBreadcrumb("streaming", "Streaming stopped");
@@ -877,18 +1027,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             }
         }
     }
-
-    private CoreStreamingDevice GetCoreDeviceForStreaming()
-    {
-        var coreDevice = CoreDeviceForStreaming;
-        if (coreDevice == null)
-        {
-            throw new InvalidOperationException("Core live streaming operations are not available for this device.");
-        }
-
-        return coreDevice;
-    }
-
 
     #endregion
 
@@ -1050,8 +1188,10 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// <summary>
     /// Handles the <see cref="DaqifiDevice.ChannelsPopulated"/> event from Core.
     /// Syncs metadata and channel wrappers from the already-populated Core device.
+    /// Virtual so transports can layer additional signaling (serial signals its
+    /// initial-status wait) before the shared sync runs.
     /// </summary>
-    protected void OnCoreChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e)
+    protected virtual void OnCoreChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e)
     {
         if (sender is not DaqifiDevice coreDevice)
         {
@@ -1221,7 +1361,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
     public async Task UpdateNetworkConfiguration()
     {
-        var coreDevice = GetCoreDeviceForNetworkConfiguration();
+        var coreDevice = GetCoreDevice(CoreDeviceForNetworkConfiguration, NOT_CONNECTED_MESSAGE);
 
         var restoreSdInterface = ConnectionType == ConnectionType.Usb && Mode == DeviceMode.LogToDevice;
 

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -164,7 +164,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
             }
             catch (Exception ex)
             {
-                AppLogger.Warning($"Failed to re-request device info on {PortName}: {ex.Message}");
+                AppLogger.Warning(ex, $"Failed to re-request device info on {PortName}");
             }
 
             nextDeviceInfoRequestAt = DateTime.UtcNow + InitialStatusRequestInterval;
@@ -234,7 +234,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
             }
             catch (Exception ex)
             {
-                AppLogger.Warning($"Error disconnecting transport during cleanup: {ex.Message}");
+                AppLogger.Warning(ex, "Error disconnecting transport during cleanup");
             }
             _transport = null;
         }

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -4,7 +4,6 @@ using Daqifi.Core.Device;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Firmware;
-using Daqifi.Desktop.IO.Messages;
 using ScpiMessageProducer = Daqifi.Core.Communication.Producers.ScpiMessageProducer;
 using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
 
@@ -18,7 +17,6 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
 
     #region Properties
     private SerialPort? _port;
-    private CoreStreamingDevice? _coreDevice;
     private SerialStreamTransport? _transport;
     private TaskCompletionSource<bool>? _initialStatusReceivedSource;
 
@@ -44,14 +42,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
 
     public override ConnectionType ConnectionType => ConnectionType.Usb;
 
-    /// <summary>
-    /// Gets whether the device is currently connected via Core's transport.
-    /// </summary>
-    public override bool IsConnected => _coreDevice?.IsConnected == true;
-
-    protected override CoreStreamingDevice? CoreDeviceForSd => _coreDevice;
-    protected override CoreStreamingDevice? CoreDeviceForStreaming => _coreDevice;
-    protected override CoreStreamingDevice? CoreDeviceForNetworkConfiguration => _coreDevice;
+    protected override CoreStreamingDevice? CoreDeviceForSd => CoreDevice;
     #endregion
 
     #region Constructor
@@ -64,7 +55,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     internal SerialStreamingDevice(string portName, CoreStreamingDevice coreDevice)
         : this(portName)
     {
-        _coreDevice = coreDevice ?? throw new ArgumentNullException(nameof(coreDevice));
+        CoreDevice = coreDevice ?? throw new ArgumentNullException(nameof(coreDevice));
     }
 
     /// <summary>
@@ -81,88 +72,70 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
 
     #endregion
     #region Override Methods
-    public override bool Connect()
+    /// <summary>
+    /// Connects a Core streaming device over the serial transport for the shared
+    /// <see cref="AbstractStreamingDevice.Connect"/> template. <see cref="CoreDevice"/> is
+    /// assigned before its transport connect so every failure path is cleaned up by
+    /// <see cref="CleanupConnection"/>.
+    /// </summary>
+    protected override CoreStreamingDevice CreateCoreDevice()
     {
-        // Ensure any previous connection state is cleaned up first
-        CleanupConnection();
+        _initialStatusReceivedSource = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
-        try
+        // Use Core's transport for unified message handling (both send and receive).
+        // The transport manages the actual SerialPort connection internally; DTR must stay
+        // enabled or the device will not stream over USB.
+        _transport = new SerialStreamTransport(Port.PortName, enableDtr: true);
+        _transport.Connect();
+
+        CoreDevice = new CoreStreamingDevice(
+            string.IsNullOrWhiteSpace(Name) ? "DAQiFi Serial Device" : Name,
+            _transport);
+        CoreDevice.Connect();
+        return CoreDevice;
+    }
+
+    protected override void LogConnectFailure(Exception ex)
+    {
+        switch (ex)
         {
-            _initialStatusReceivedSource = new TaskCompletionSource<bool>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-
-            // Use Core's transport for unified message handling (both send and receive)
-            // Note: Transport manages the actual SerialPort connection internally
-            _transport = new SerialStreamTransport(Port.PortName, enableDtr: true);
-            _transport.Connect();
-
-            // Create Core device with transport - this enables both sending AND receiving
-            _coreDevice = new CoreStreamingDevice(
-                string.IsNullOrWhiteSpace(Name) ? "DAQiFi Serial Device" : Name,
-                _transport);
-            _coreDevice.Connect();
-
-            // Subscribe to Core device events
-            _coreDevice.ChannelsPopulated += OnCoreChannelsPopulatedSerial;
-            _coreDevice.MessageReceived += OnCoreMessageReceived;
-
-            InitializeDeviceState();
-
-            // Use Core's async initialization (safe because Connect() is called from Task.Run)
-            _coreDevice.InitializeAsync().GetAwaiter().GetResult();
-            WaitForInitialStatusMessage();
-            return true;
-        }
-        catch (FileNotFoundException ex)
-        {
-            // .NET's SerialPort.Open throws FileNotFoundException when the COM port no
-            // longer exists (device unplugged, never present, or renamed). Treat as a
-            // user/environmental condition, not an app bug — log a warning (keeping the
-            // exception detail in the local log) instead of capturing to Sentry.
-            AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is not available");
-            CleanupConnection();
-            return false;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            // SerialPort.Open throws UnauthorizedAccessException when another process
-            // already holds the port open. Same classification as above.
-            AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is in use by another process");
-            CleanupConnection();
-            return false;
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error(ex, $"Failed to connect on {PortName}");
-            CleanupConnection();
-            return false;
+            case FileNotFoundException:
+                // .NET's SerialPort.Open throws FileNotFoundException when the COM port no
+                // longer exists (device unplugged, never present, or renamed). Treat as a
+                // user/environmental condition, not an app bug — log a warning (keeping the
+                // exception detail in the local log) instead of capturing to Sentry.
+                AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is not available");
+                break;
+            case UnauthorizedAccessException:
+                // SerialPort.Open throws UnauthorizedAccessException when another process
+                // already holds the port open. Same classification as above.
+                AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is in use by another process");
+                break;
+            default:
+                AppLogger.Error(ex, $"Failed to connect on {PortName}");
+                break;
         }
     }
 
     /// <summary>
-    /// Handles the <see cref="DaqifiDevice.ChannelsPopulated"/> event from Core and
-    /// signals the initial-status wait so <see cref="WaitForInitialStatusMessage"/> can return.
+    /// Signals the initial-status wait so <see cref="OnCoreDeviceInitialized"/> can return,
+    /// then runs the shared Core-to-desktop sync.
     /// </summary>
-    private void OnCoreChannelsPopulatedSerial(object? sender, ChannelsPopulatedEventArgs e)
+    protected override void OnCoreChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e)
     {
         _initialStatusReceivedSource?.TrySetResult(true);
-        OnCoreChannelsPopulated(sender, e);
+        base.OnCoreChannelsPopulated(sender, e);
     }
 
     /// <summary>
-    /// Handles non-status messages received from Core's DaqifiDevice and routes them
-    /// to the protocol handler for streaming data processing.
-    /// Status messages are handled via <see cref="OnCoreChannelsPopulatedSerial"/>.
+    /// Blocks until the device reports its initial status message, which gates
+    /// <see cref="AbstractStreamingDevice.Connect"/> returning for serial devices.
     /// </summary>
-    private void OnCoreMessageReceived(object? sender, MessageReceivedEventArgs e)
+    protected override void OnCoreDeviceInitialized()
     {
-        var args = new MessageEventArgs<object>(e.Message);
-        HandleInboundMessage(args);
-    }
-
-    private void WaitForInitialStatusMessage()
-    {
-        if (_coreDevice == null)
+        var coreDevice = CoreDevice;
+        if (coreDevice == null)
         {
             throw new InvalidOperationException("Core device was not initialized.");
         }
@@ -187,7 +160,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
 
             try
             {
-                _coreDevice.Send(ScpiMessageProducer.GetDeviceInfo);
+                coreDevice.Send(ScpiMessageProducer.GetDeviceInfo);
             }
             catch (Exception ex)
             {
@@ -206,12 +179,12 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     /// </summary>
     protected override void SendMessage(IOutboundMessage<string> message)
     {
-        if (_coreDevice == null || !_coreDevice.IsConnected)
+        if (CoreDevice == null || !CoreDevice.IsConnected)
         {
             AppLogger.Warning($"Cannot send to {PortName}: Core device not connected");
             return;
         }
-        _coreDevice.Send(message);
+        CoreDevice.Send(message);
     }
 
     public override bool Write(string command)
@@ -244,53 +217,12 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
         }
     }
 
-    public override bool Disconnect()
-    {
-        try
-        {
-            StopStreaming();
-
-            // Unsubscribe from Core device events
-            if (_coreDevice != null)
-            {
-                _coreDevice.ChannelsPopulated -= OnCoreChannelsPopulatedSerial;
-                _coreDevice.MessageReceived -= OnCoreMessageReceived;
-            }
-
-            // Clear channels to prevent ghost channels on reconnect (Issue #29)
-            AppLogger.Information($"Cleared {DataChannels.Count} channels for device {DeviceSerialNo}");
-            DataChannels.Clear();
-
-            CleanupConnection();
-            return true;
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error(ex, "Error during disconnect");
-            return false;
-        }
-    }
-
-    private void CleanupConnection()
+    protected override void CleanupConnection()
     {
         _initialStatusReceivedSource = null;
 
-        // Unsubscribe from Core device events first
-        if (_coreDevice != null)
-        {
-            try
-            {
-                _coreDevice.ChannelsPopulated -= OnCoreChannelsPopulatedSerial;
-                _coreDevice.MessageReceived -= OnCoreMessageReceived;
-                _coreDevice.Disconnect();
-                _coreDevice.Dispose();
-            }
-            catch (Exception ex)
-            {
-                AppLogger.Warning($"Error disconnecting Core device during cleanup: {ex.Message}");
-            }
-            _coreDevice = null;
-        }
+        // Unsubscribe Core device events and dispose the Core device first
+        base.CleanupConnection();
 
         // Clean up transport (this handles the actual serial port)
         if (_transport != null)
@@ -322,13 +254,13 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     /// <summary>
     /// Gets the connected Core serial streaming device used for firmware update workflows.
     /// </summary>
-    internal CoreStreamingDevice ConnectedCoreStreamingDevice => _coreDevice ?? throw new InvalidOperationException(
+    internal CoreStreamingDevice ConnectedCoreStreamingDevice => CoreDevice ?? throw new InvalidOperationException(
         $"Core streaming device for {PortName} is not connected.");
 
     public bool EnableLanUpdateMode()
     {
         AppLogger.Information($"Preparing {PortName} for WiFi firmware mode.");
-        if (_coreDevice == null || !_coreDevice.IsConnected)
+        if (CoreDevice == null || !CoreDevice.IsConnected)
         {
             AppLogger.Warning($"Cannot prepare {PortName} for WiFi firmware mode: core device is not connected.");
             return false;
@@ -345,19 +277,19 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
         // the bridge before the tool issues its first serial query.
         Thread.Sleep(2000);
         AppLogger.Information("Sending LAN FW update prep command: SYSTem:POWer:STATe 1");
-        _coreDevice.Send(ScpiMessageProducer.TurnDeviceOn);
+        CoreDevice.Send(ScpiMessageProducer.TurnDeviceOn);
         Thread.Sleep(1000);
         AppLogger.Information("Sending LAN FW update prep command: SYSTem:COMMUnicate:LAN:FWUpdate");
-        _coreDevice.Send(ScpiMessageProducer.SetLanFirmwareUpdateMode);
+        CoreDevice.Send(ScpiMessageProducer.SetLanFirmwareUpdateMode);
         return true;
     }
 
     public void ResetLanAfterUpdate()
     {
-        _coreDevice?.Send(ScpiMessageProducer.SetUsbTransparencyMode(0));
-        _coreDevice?.Send(ScpiMessageProducer.EnableNetworkLan);
-        _coreDevice?.Send(ScpiMessageProducer.ApplyNetworkLan);
-        _coreDevice?.Send(ScpiMessageProducer.SaveNetworkLan);
+        CoreDevice?.Send(ScpiMessageProducer.SetUsbTransparencyMode(0));
+        CoreDevice?.Send(ScpiMessageProducer.EnableNetworkLan);
+        CoreDevice?.Send(ScpiMessageProducer.ApplyNetworkLan);
+        CoreDevice?.Send(ScpiMessageProducer.SaveNetworkLan);
     }
 
     /// <summary>
@@ -365,7 +297,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     /// </summary>
     public Task<LanChipInfo?> GetLanChipInfoAsync(CancellationToken cancellationToken = default)
     {
-        if (_coreDevice is not ILanChipInfoProvider provider)
+        if (CoreDevice is not ILanChipInfoProvider provider)
             return Task.FromResult<LanChipInfo?>(null);
         return provider.GetLanChipInfoAsync(cancellationToken);
     }

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -1,7 +1,6 @@
 ﻿using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
-using Daqifi.Desktop.IO.Messages;
 using CoreDeviceInfo = Daqifi.Core.Device.Discovery.IDeviceInfo;
 using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
 
@@ -14,18 +13,11 @@ namespace Daqifi.Desktop.Device.WiFiDevice;
 /// </summary>
 public class DaqifiStreamingDevice : AbstractStreamingDevice
 {
-    #region Private Fields
-    private CoreStreamingDevice? _coreDevice;
-    #endregion
-
     #region Properties
 
     public int Port { get; set; }
     public bool IsPowerOn { get; set; }
     public override ConnectionType ConnectionType => ConnectionType.Wifi;
-    public override bool IsConnected => _coreDevice?.IsConnected == true;
-    protected override CoreStreamingDevice? CoreDeviceForStreaming => _coreDevice;
-    protected override CoreStreamingDevice? CoreDeviceForNetworkConfiguration => _coreDevice;
 
     #endregion
 
@@ -65,64 +57,39 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     #endregion
 
     #region Override Methods
-    public override bool Connect()
+    /// <summary>
+    /// Connects a Core streaming device over TCP for the shared
+    /// <see cref="AbstractStreamingDevice.Connect"/> template.
+    /// </summary>
+    protected override CoreStreamingDevice? CreateCoreDevice()
     {
-        try
+        var options = new DeviceConnectionOptions
         {
-            var options = new DeviceConnectionOptions
-            {
-                DeviceName = string.IsNullOrWhiteSpace(Name) ? "DAQiFi Device" : Name,
-                ConnectionRetry = ConnectionRetryOptions.NoRetry,
-                InitializeDevice = false
-            };
+            DeviceName = string.IsNullOrWhiteSpace(Name) ? "DAQiFi Device" : Name,
+            ConnectionRetry = ConnectionRetryOptions.NoRetry,
+            InitializeDevice = false
+        };
 
-            var connectedDevice = DaqifiDeviceFactory.ConnectTcp(IpAddress, Port, options);
-            _coreDevice = connectedDevice as CoreStreamingDevice;
-            if (_coreDevice == null)
-            {
-                connectedDevice.Dispose();
-                throw new InvalidOperationException("Connected Core device does not support streaming operations.");
-            }
-
-            if (!_coreDevice.IsConnected)
-            {
-                AppLogger.Error($"Failed to connect to DAQiFi device at {IpAddress}:{Port}");
-                return false;
-            }
-
-            // Subscribe to Core device events
-            _coreDevice.ChannelsPopulated += OnCoreChannelsPopulated;
-            _coreDevice.MessageReceived += OnCoreMessageReceived;
-
-            InitializeDeviceState();
-
-            // Use async initialization (safe because Connect() is called from Task.Run)
-            _coreDevice.InitializeAsync().GetAwaiter().GetResult();
-            return true;
-        }
-        catch (Exception ex)
+        var connectedDevice = DaqifiDeviceFactory.ConnectTcp(IpAddress, Port, options);
+        if (connectedDevice is not CoreStreamingDevice coreDevice)
         {
-            AppLogger.Error(ex, $"Problem with connecting to DAQiFi Device at {IpAddress}:{Port}");
-
-            // Clean up partially initialized device
-            if (_coreDevice != null)
-            {
-                try
-                {
-                    _coreDevice.ChannelsPopulated -= OnCoreChannelsPopulated;
-                    _coreDevice.MessageReceived -= OnCoreMessageReceived;
-                    _coreDevice.Disconnect();
-                    _coreDevice.Dispose();
-                }
-                catch (Exception cleanupEx)
-                {
-                    AppLogger.Warning($"Error during connection cleanup: {cleanupEx.Message}");
-                }
-                _coreDevice = null;
-            }
-
-            return false;
+            connectedDevice.Dispose();
+            throw new InvalidOperationException("Connected Core device does not support streaming operations.");
         }
+
+        if (!coreDevice.IsConnected)
+        {
+            AppLogger.Error($"Failed to connect to DAQiFi device at {IpAddress}:{Port}");
+            coreDevice.Dispose();
+            return null;
+        }
+
+        return coreDevice;
+    }
+
+    protected override void LogConnectFailure(Exception ex)
+    {
+        AppLogger.Error(ex, $"Problem with connecting to DAQiFi Device at {IpAddress}:{Port}");
     }
 
     /// <summary>
@@ -135,41 +102,12 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
             "Raw text writes are not supported on WiFi devices.");
     }
 
-    public override bool Disconnect()
-    {
-        try
-        {
-            StopStreaming();
-
-            // Unsubscribe from Core device events
-            if (_coreDevice != null)
-            {
-                _coreDevice.ChannelsPopulated -= OnCoreChannelsPopulated;
-                _coreDevice.MessageReceived -= OnCoreMessageReceived;
-            }
-
-            // Clear channels to prevent ghost channels on reconnect (Issue #29)
-            AppLogger.Information($"Cleared {DataChannels.Count} channels for device {DeviceSerialNo}");
-            DataChannels.Clear();
-
-            _coreDevice?.Disconnect();
-            _coreDevice?.Dispose();
-            _coreDevice = null;
-            return true;
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error(ex, "Problem with Disconnecting from DAQiFi Device.");
-            return false;
-        }
-    }
-
     /// <summary>
     /// Sends messages directly through Core's DaqifiDevice instead of using adapters.
     /// </summary>
     protected override void SendMessage(IOutboundMessage<string> message)
     {
-        if (_coreDevice == null || !_coreDevice.IsConnected)
+        if (CoreDevice == null || !CoreDevice.IsConnected)
         {
             AppLogger.Warning($"Cannot send message to {IpAddress}:{Port}: Core device is not connected (MessageType={message?.GetType().Name})");
             return;
@@ -177,25 +115,12 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
 
         try
         {
-            _coreDevice.Send(message);
+            CoreDevice.Send(message);
         }
         catch (Exception ex)
         {
             AppLogger.Error(ex, $"Failed to send message to {IpAddress}:{Port} (MessageType={message?.GetType().Name})");
         }
-    }
-    #endregion
-
-    #region Event Handlers
-    /// <summary>
-    /// Handles non-status messages received from Core's DaqifiDevice and routes them
-    /// to the protocol handler for streaming data processing.
-    /// Status messages are handled via <see cref="AbstractStreamingDevice.OnCoreChannelsPopulated"/>.
-    /// </summary>
-    private void OnCoreMessageReceived(object? sender, MessageReceivedEventArgs e)
-    {
-        var args = new MessageEventArgs<object>(e.Message);
-        HandleInboundMessage(args);
     }
     #endregion
 

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -109,7 +109,9 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     {
         if (CoreDevice == null || !CoreDevice.IsConnected)
         {
-            AppLogger.Warning($"Cannot send message to {IpAddress}:{Port}: Core device is not connected (MessageType={message?.GetType().Name})");
+            AppLogger.Warning(
+                $"Cannot send message to {IpAddress}:{Port}: Core device is not connected " +
+                $"(MessageType={message?.GetType().Name})");
             return;
         }
 
@@ -119,7 +121,8 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
         }
         catch (Exception ex)
         {
-            AppLogger.Error(ex, $"Failed to send message to {IpAddress}:{Port} (MessageType={message?.GetType().Name})");
+            AppLogger.Error(
+                ex, $"Failed to send message to {IpAddress}:{Port} (MessageType={message?.GetType().Name})");
         }
     }
     #endregion


### PR DESCRIPTION
Closes #591

## What

Collapses the duplicated Core connect/wiring glue between `SerialStreamingDevice` and the WiFi `DaqifiStreamingDevice` into a shared template in `AbstractStreamingDevice`, per the issue's proposed design:

- **Shared `Connect()` template** (`AbstractStreamingDevice.Connect`): tear down previous connection → `CreateCoreDevice()` (transport-specific factory) → subscribe `ChannelsPopulated`/`MessageReceived` → `InitializeDeviceState()` → blocking `InitializeAsync()` → optional post-initialize hook (`OnCoreDeviceInitialized`). Failures route through `LogConnectFailure(ex)` (exception-classification hook) and `CleanupConnection()`. The "synchronous by contract, invoked from `Task.Run` by `ConnectionManager`" invariant is documented on the template.
- **Shared `Disconnect()` template**: stop streaming → unsubscribe (before clearing, so a late `ChannelsPopulated` can't repopulate) → clear channels (issue #29) → `CleanupConnection()`.
- **Shared `CleanupConnection()`** (virtual): unsubscribe + disconnect + dispose the Core device; serial layers its transport/TCS teardown on top via override.
- **Shared `OnCoreMessageReceived`** in the base (was duplicated verbatim in both subclasses).
- **Base-owned `CoreDevice` property** replaces the two private `_coreDevice` fields; `CoreDeviceForStreaming`/`CoreDeviceForNetworkConfiguration` now default to it (subclass overrides deleted), `CoreDeviceForSd` stays USB-only.
- **Single `GetCoreDevice(coreDevice, message)` helper** replaces the three near-identical `GetCoreDeviceForX()` null-check copies; all three original exception messages preserved.

Subclasses now contain only transport-specific code:
- **Serial**: `CreateCoreDevice` (DTR-enabled `SerialStreamTransport` + Core device; assigns `CoreDevice` before its transport connect so every failure path is cleaned up), `OnCoreDeviceInitialized` (the initial-status wait that gates `Connect()`), `LogConnectFailure` (`FileNotFoundException`/`UnauthorizedAccessException` → `Warning`, not Sentry-captured), `OnCoreChannelsPopulated` override (signals the initial-status wait), `CleanupConnection` override (transport teardown).
- **WiFi**: `CreateCoreDevice` (`DaqifiDeviceFactory.ConnectTcp`, NoRetry, cast guard), `LogConnectFailure` (keeps the `{IpAddress}:{Port}` context). `Write(string)` still throws `NotSupportedException`; `IsPowerOn` from discovery untouched.

`Daqifi.Core` delegation status: connect/initialize/cleanup remain on Core APIs (`DaqifiDeviceFactory.ConnectTcp`, `SerialStreamTransport`, `InitializeAsync`, `Disconnect`/`Dispose`). `DaqifiDeviceFactory.ConnectSerial` exists in Core but does not expose the transport, which the serial device needs for raw firmware-update writes (`_transport.Stream` in `Write`), so serial keeps constructing its own transport (with `enableDtr: true`, matching Core's default).

## Gotchas preserved (issue checklist)

- Serial DTR stays enabled; the initial-status wait still gates `Connect()` returning; cleanup still runs both before connect and on every failure path (now owned by the template).
- Serial exception classification unchanged: missing/in-use COM port logs a `Warning`, everything else an `Error` — same messages.
- WiFi failure cleanup still unsubscribes events **before** `Disconnect()`/`Dispose()`.
- `Connect()` remains synchronous (`bool Connect()`), and the `Task.Run` invariant is documented on the template.

## Intentional edge-path unifications (called out for review)

These are the "two slightly-different cleanups → one correct one" consolidations; all are failure-edge or log-text only:

1. WiFi `Disconnect()`: Core `Disconnect/Dispose` exceptions are now swallowed with a `Warning` (serial's existing semantics) instead of failing the whole `Disconnect()` with an `Error`; the disconnect log message is unified.
2. WiFi `Connect()` now tears down a stale Core device at entry (previously it was overwritten without dispose; serial already cleaned up first).
3. WiFi's defensive `!IsConnected` path after `ConnectTcp` now disposes the just-created device before returning false (previously left assigned and undisposed).
4. Base `IsConnected` default is now `CoreDevice?.IsConnected == true` — exactly what both production subclasses' (deleted) overrides did; nothing in app or tests relied on the old `DeviceState`-derived fallback.

## Tests

- New `CoreConnectionTemplateTests` (7 tests): hook ordering, null-factory fail-fast, factory-throw → classification hook + cleanup, post-initialize-throw → cleanup + event unsubscription, disconnect teardown (channels cleared, late Core events ignored), default-template fail-safe.
- Fast gate green: `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 362 passed.
- Hardware integration gate on the final build (`dotnet test Daqifi.Desktop.UITest`, physically attached USB device): **13/14 scenarios passed**, including every scenario that exercises the refactored skeleton — `AddDevice` (connect), `ConnectionLifecycle` (two full connect → stream → disconnect → reconnect cycles, clean-teardown assertions), `ManualSerialConnect` (asserts the missing-COM-port path logs only a `WARN`, i.e. the preserved serial exception classification), `LoggingSession`, `StreamRestart`, `CsvExport` ×2, `ConfigureLogging`, `Profiles` ×2, launch smoke.
- The one failure, `SdCardLogging_LogsToSdCard_ThenImportsToSession`, is environmental: the bench device's SD subsystem stopped writing files mid-session (first a 0-byte file, then no new files at all), and the scenario **fails identically on unmodified `main`** (control run on the same bench). Sentry auto-filed #593 from the 0-byte import. The device needs a power-cycle; nothing in this PR touches the SD write path beyond the identical-semantics null-check helper.

## Line count

Net −3 lines in `Daqifi.Desktop/Device/` (serial −68, WiFi −75, base +140 — the base growth is predominantly XML documentation on the new template members, which the project's documentation standard requires; all listed duplication from the issue is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
