### PR TITLE
fix(device): classify WiFi connect timeout as warning, surface inline dialog error

### DIFF
--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-	  <PackageReference Include="Daqifi.Core" Version="0.22.0" />
+	  <PackageReference Include="Daqifi.Core" Version="0.23.0" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.8" />
-		<PackageReference Include="Daqifi.Core" Version="0.22.0" />
+		<PackageReference Include="Daqifi.Core" Version="0.23.0" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
@@ -113,10 +113,12 @@ public class ConnectionDialogViewModelCloseTests
         await viewModel.ConnectManualWifiCommand.ExecuteAsync(null);
 
         Assert.IsFalse(closeRaised(), "CloseRequested should not fire when the manual IP is blank.");
+        Assert.IsNull(viewModel.ManualWifiError,
+            "Blank input should not surface a validation error message.");
     }
 
     [TestMethod]
-    public async Task ConnectManualWifiCommand_WithInvalidAddress_DoesNotRaiseCloseRequested()
+    public async Task ConnectManualWifiCommand_WithInvalidAddress_SetsManualWifiError()
     {
         var viewModel = CreateViewModel();
         viewModel.ManualIpAddress = "not a valid hostname or ip !@#";
@@ -125,6 +127,20 @@ public class ConnectionDialogViewModelCloseTests
         await viewModel.ConnectManualWifiCommand.ExecuteAsync(null);
 
         Assert.IsFalse(closeRaised(), "CloseRequested should not fire when the manual endpoint fails to resolve.");
+        Assert.IsNotNull(viewModel.ManualWifiError,
+            "ManualWifiError should be set when the entered endpoint fails to resolve.");
+    }
+
+    [TestMethod]
+    public void ManualWifiError_ClearsWhenManualIpAddressChanges()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.ManualWifiError = "stale validation message";
+
+        viewModel.ManualIpAddress = "192.168.1.50";
+
+        Assert.IsNull(viewModel.ManualWifiError,
+            "Editing the manual IP address should clear any prior validation error.");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
@@ -103,6 +103,9 @@ public class ConnectionDialogViewModelCloseTests
             "Editing the manual port name should clear any prior validation error.");
     }
 
+    /// <summary>
+    /// Blank manual-WiFi input is a no-op: no close, and no validation error surfaced.
+    /// </summary>
     [TestMethod]
     public async Task ConnectManualWifiCommand_WithBlankAddress_DoesNotRaiseCloseRequested()
     {
@@ -117,6 +120,10 @@ public class ConnectionDialogViewModelCloseTests
             "Blank input should not surface a validation error message.");
     }
 
+    /// <summary>
+    /// An endpoint that fails to resolve must keep the dialog open and surface the
+    /// inline <c>ManualWifiError</c> message (issue #517).
+    /// </summary>
     [TestMethod]
     public async Task ConnectManualWifiCommand_WithInvalidAddress_SetsManualWifiError()
     {
@@ -131,6 +138,10 @@ public class ConnectionDialogViewModelCloseTests
             "ManualWifiError should be set when the entered endpoint fails to resolve.");
     }
 
+    /// <summary>
+    /// Editing the manual IP address clears a stale validation error
+    /// (the <c>OnManualIpAddressChanged</c> clear-on-edit behavior).
+    /// </summary>
     [TestMethod]
     public void ManualWifiError_ClearsWhenManualIpAddressChanges()
     {

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -669,6 +669,88 @@ public abstract class DaqifiAppFixture
     }
     #endregion
 
+    #region Manual-WiFi Connect Helpers (issue #517)
+    // The connection dialog's Manual WiFi tab: type an IP address by hand and connect. Mirrors the
+    // Manual-Serial helpers above for the WiFi twin of that fix — an unreachable device (TCP connect
+    // timeout) must surface an inline error and keep the dialog open instead of silently closing
+    // and capturing a Sentry error.
+    private const string CONN_TAB_MANUAL_WIFI_ID = "ConnTab_Manual";
+    private const string MANUAL_IP_INPUT_ID = "ManualIpInput";
+    private const string MANUAL_WIFI_ERROR_ID = "ManualWifiError";
+    private const string CONNECT_BUTTON_MANUAL_WIFI_ID = "ConnectButton_Manual";
+
+    /// <summary>
+    /// Navigates to Devices, opens the connection dialog, and selects the Manual WiFi tab. Returns
+    /// the modal dialog window so callers can scope their element lookups to it.
+    /// </summary>
+    protected Window OpenManualWifiTab()
+    {
+        NavigateToTab(DEVICES_TAB_TEXT);
+        OpenConnectionDialog();
+        var dialog = WaitForConnectionDialog();
+
+        var tab = Retry.WhileNull(
+            () => dialog.FindFirstDescendant(cf => cf.ByAutomationId(CONN_TAB_MANUAL_WIFI_ID)),
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "Manual WiFi tab not found in the connection dialog.").Result!;
+        tab.AsTabItem().Select();
+
+        // The IP ADDRESS field is realized only once the tab's content is selected/visible.
+        Retry.WhileNull(
+            () => dialog.FindFirstDescendant(cf => cf.ByAutomationId(MANUAL_IP_INPUT_ID)),
+            timeout: TimeSpan.FromSeconds(15),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "IP ADDRESS input did not appear after selecting the Manual WiFi tab.");
+
+        return dialog;
+    }
+
+    /// <summary>Types <paramref name="ipAddress"/> into the Manual WiFi tab's IP ADDRESS field via the ValuePattern.</summary>
+    protected void SetManualIpAddress(Window dialog, string ipAddress)
+    {
+        var input = Retry.WhileNull(
+            () => dialog.FindFirstDescendant(cf => cf.ByAutomationId(MANUAL_IP_INPUT_ID)),
+            timeout: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMilliseconds(200),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "IP ADDRESS input not found on the Manual WiFi tab.").Result!;
+        input.Patterns.Value.Pattern.SetValue(ipAddress);
+    }
+
+    /// <summary>Invokes the Manual WiFi tab's Connect button (runs <c>ConnectManualWifiCommand</c>).</summary>
+    protected void InvokeManualWifiConnect(Window dialog)
+    {
+        var button = Retry.WhileNull(
+            () => dialog.FindFirstDescendant(cf => cf.ByAutomationId(CONNECT_BUTTON_MANUAL_WIFI_ID)),
+            timeout: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMilliseconds(200),
+            throwOnTimeout: true,
+            ignoreException: true,
+            timeoutMessage: "Connect button not found on the Manual WiFi tab.").Result!;
+        var b = button.AsButton();
+        b.WaitUntilEnabled(TimeSpan.FromSeconds(10));
+        b.Invoke();
+    }
+
+    /// <summary>
+    /// Reads the Manual WiFi tab's inline validation message (<c>ManualWifiError</c>), or null when
+    /// none is shown. The TextBlock's Visibility binds through NotNullToVis, so a null/empty error
+    /// collapses it out of the UIA tree (absent == no error); when shown, a TextBlock surfaces its
+    /// text as its UIA Name.
+    /// </summary>
+    protected string? ReadManualWifiError(Window dialog)
+    {
+        var error = dialog.FindFirstDescendant(cf => cf.ByAutomationId(MANUAL_WIFI_ERROR_ID));
+        return string.IsNullOrEmpty(error?.Name) ? null : error!.Name;
+    }
+    #endregion
+
     #region Disconnect / Reconnect Lifecycle Helpers
     /// <summary>
     /// Disconnects the currently connected device through the real UI: opens its settings drawer

--- a/Daqifi.Desktop.UITest/ManualWifiConnectTests.cs
+++ b/Daqifi.Desktop.UITest/ManualWifiConnectTests.cs
@@ -1,0 +1,102 @@
+using System;
+using FlaUI.Core.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Daqifi.Desktop.UITest;
+
+/// <summary>
+/// Manual-WiFi connect scenario for issue #517 — graceful handling of an unreachable device.
+/// Drives the real GUI out-of-process: opens the connection dialog's Manual WiFi tab, types an
+/// unroutable IP address by hand, connects, and asserts the user-visible outcome (inline error,
+/// dialog stays open) plus the NLog log.
+///
+/// Before the fix, the TCP connect timeout surfaced from Core as a <c>TaskCanceledException</c>
+/// that was logged at error level (the sole Sentry-capture path) and the dialog closed silently.
+/// The fix classifies the timeout as a warning and keeps the dialog open with an inline message.
+/// </summary>
+[TestClass]
+public class ManualWifiConnectTests : DaqifiAppFixture
+{
+    // RFC 5737 TEST-NET-1: guaranteed unroutable, so the TCP connect always exhausts Core's
+    // connection timeout (~5s) — the exact failure mode Sentry reported in issue #517.
+    private const string UNREACHABLE_IP = "192.0.2.1";
+
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void ManualWifi_UnreachableAddress_ShowsInlineError_KeepsDialogOpen_NoErrorLog()
+    {
+        Assert.AreEqual(0, GetConnectedDeviceCount(), "Expected no device connected at test start.");
+
+        var dialog = OpenManualWifiTab();
+        SetManualIpAddress(dialog, UNREACHABLE_IP);
+        InvokeManualWifiConnect(dialog);
+
+        // The inline error appears once the connect attempt times out (Core's ~5s connection
+        // timeout plus UI marshalling), naming the offending address.
+        var error = Retry.WhileNull(
+            () => ReadManualWifiError(dialog),
+            timeout: TimeSpan.FromSeconds(30),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: false,
+            ignoreException: true).Result;
+
+        // Evidence: capture the dialog showing the red inline error (PASS-path screenshot — the base
+        // fixture only screenshots on failure). Best-effort; never let capture mask the assertion.
+        try
+        {
+            var shot = CaptureElementPng(dialog, "manual_wifi_unreachable_error.png");
+            TestContext.WriteLine($"Screenshot: {shot}");
+        }
+        catch (Exception ex)
+        {
+            TestContext.WriteLine($"Screenshot capture skipped: {ex.Message}");
+        }
+
+        Assert.IsNotNull(error, "Expected an inline ManualWifiError after connecting to an unreachable address.");
+        StringAssert.Contains(error, UNREACHABLE_IP, "Inline error should name the offending address.");
+
+        // The dialog must stay open (no silent close) and no device should connect.
+        Assert.IsTrue(dialog.IsAvailable, "The connection dialog should stay open after a failed manual connect.");
+        Assert.AreEqual(0, GetConnectedDeviceCount(), "No device should connect for an unreachable address.");
+
+        // The fix: the connect timeout is classified as a WARNING (no Sentry). The warning names
+        // the endpoint; the old error line (the Sentry capture path) must be absent.
+        Assert.IsTrue(
+            WaitForLogContains($"{UNREACHABLE_IP}:9760", TimeSpan.FromSeconds(5)),
+            "Expected a warning-level log line naming the unreachable endpoint.");
+        var log = ReadNewLogText();
+        Assert.IsFalse(
+            log.Contains("Problem with connecting to DAQiFi Device", StringComparison.Ordinal),
+            "The unreachable-device path must NOT log DaqifiStreamingDevice's error (the Sentry capture path).");
+    }
+
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void ManualWifi_InlineError_ClearsWhenAddressEdited()
+    {
+        var dialog = OpenManualWifiTab();
+        SetManualIpAddress(dialog, UNREACHABLE_IP);
+        InvokeManualWifiConnect(dialog);
+
+        var error = Retry.WhileNull(
+            () => ReadManualWifiError(dialog),
+            timeout: TimeSpan.FromSeconds(30),
+            interval: TimeSpan.FromMilliseconds(300),
+            throwOnTimeout: false,
+            ignoreException: true).Result;
+        Assert.IsNotNull(error, "Expected the inline error to appear before editing the address.");
+
+        // Editing the address should clear the stale validation error (OnManualIpAddressChanged).
+        SetManualIpAddress(dialog, "192.0.2.2");
+        var cleared = Retry.WhileFalse(
+            () => ReadManualWifiError(dialog) == null,
+            timeout: TimeSpan.FromSeconds(10),
+            interval: TimeSpan.FromMilliseconds(200),
+            throwOnTimeout: false,
+            ignoreException: true).Result;
+
+        Assert.IsTrue(cleared, "Editing the IP address should clear the inline validation error.");
+    }
+}

--- a/Daqifi.Desktop.UITest/ManualWifiConnectTests.cs
+++ b/Daqifi.Desktop.UITest/ManualWifiConnectTests.cs
@@ -13,6 +13,10 @@ namespace Daqifi.Desktop.UITest;
 /// Before the fix, the TCP connect timeout surfaced from Core as a <c>TaskCanceledException</c>
 /// that was logged at error level (the sole Sentry-capture path) and the dialog closed silently.
 /// The fix classifies the timeout as a warning and keeps the dialog open with an inline message.
+///
+/// No physical device is required: the scenario types an unroutable address by hand, so these
+/// tests carry only <c>[TestCategory("Ui")]</c> (excluded from the unit gate, runnable on a
+/// hardware-free bench).
 /// </summary>
 [TestClass]
 public class ManualWifiConnectTests : DaqifiAppFixture
@@ -21,9 +25,13 @@ public class ManualWifiConnectTests : DaqifiAppFixture
     // connection timeout (~5s) — the exact failure mode Sentry reported in issue #517.
     private const string UNREACHABLE_IP = "192.0.2.1";
 
+    /// <summary>
+    /// Connecting to an unreachable address must show the inline error naming the address,
+    /// keep the dialog open, and log the timeout at warning level — never the error-level
+    /// (Sentry-capturing) connect-failure line.
+    /// </summary>
     [TestMethod]
     [TestCategory("Ui")]
-    [TestCategory("RequiresDevice")]
     public void ManualWifi_UnreachableAddress_ShowsInlineError_KeepsDialogOpen_NoErrorLog()
     {
         Assert.AreEqual(0, GetConnectedDeviceCount(), "Expected no device connected at test start.");
@@ -71,9 +79,12 @@ public class ManualWifiConnectTests : DaqifiAppFixture
             "The unreachable-device path must NOT log DaqifiStreamingDevice's error (the Sentry capture path).");
     }
 
+    /// <summary>
+    /// Editing the IP address after a failed connect must clear the stale inline error
+    /// (the <c>OnManualIpAddressChanged</c> clear-on-edit behavior).
+    /// </summary>
     [TestMethod]
     [TestCategory("Ui")]
-    [TestCategory("RequiresDevice")]
     public void ManualWifi_InlineError_ClearsWhenAddressEdited()
     {
         var dialog = OpenManualWifiTab();

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -184,6 +184,7 @@ suffix), also hosted by `MainWindow.xaml`.
 | Discovered / serial device lists | `DiscoveredDeviceList` / `SerialPortList` | `View/ConnectionDialog.xaml` |
 | Connect buttons | `ConnectButton_Wifi` / `ConnectButton_Manual` / `ConnectButton_Serial` | `View/ConnectionDialog.xaml` |
 | **Manual USB** tab + its COM-port field, inline error, and Connect button (issue #524) | `ConnTab_ManualSerial` / `ManualPortInput` / `ManualPortError` / `ConnectButton_ManualSerial` | `View/ConnectionDialog.xaml` |
+| **Manual WiFi** tab's IP field + inline error (issue #517) | `ManualIpInput` / `ManualWifiError` | `View/ConnectionDialog.xaml` |
 | Channel list + “SELECT ALL” (analog) | `ChannelList` / `SelectAllAnalogChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
 | Channels “CLEAR ALL” (status bar; clears every section) | `ClearAllChannels` | `View/Prototype/ChannelsPanePrototype.xaml` |
 | Logging toggle + status label | `StartLoggingToggle` / `LoggingStatusText` | `View/Prototype/LiveGraphPane.xaml` |

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -20,8 +20,10 @@ It covers seven end-to-end workflows plus a launch smoke test:
 | `ConnectionLifecycleTests.DisconnectThenReconnect_TearsDownCleanly_AndDeviceIsUsableAgain` | Device **disconnect + reconnect lifecycle** (issue #559) in one self-contained pass. Two cycles, each: connect → enable channels → run a brief logging session (start, assert the live plot streams real data, stop, assert a new session row persisted) → **disconnect** via the device drawer's `DisconnectSelectedButton`. After each disconnect it asserts a **clean teardown** through the visible UI alone — the device leaves `ConnectedDeviceList`, its channels disappear from the Channels pane (the pane returns to its empty state, so `ChannelList` leaves the UIA tree — subscriptions torn down), and the logging toggle falls back to **disabled** (`CanToggleLogging` goes false once `ActiveChannels` empties) — plus a black-box negative log check that the app logged no `Failed in Disconnect`. The **second cycle is the payload**: it proves the same device, after a full disconnect, **reconnects and is fully usable again** (channels re-enable; a second session starts, streams, and stops exactly like the first), with no leaked state (un-disposed transport, dangling subscriptions, stale connection status) degrading it. Self-cleans the sessions it created back to baseline. **USB or WiFi.** |
 | `ProfilesTests.SaveActivateDelete_ProfileRoundTrips` / `…CreateProfileViaForm_AppearsAndDeletes` | Full **Profiles** lifecycle. Configure a known state (set a frequency + enable analog channels), **save** it as a profile — once by capturing the live device settings (`SaveCurrentSettingsCommand`) and once via the new-profile form (`SaveNewProfileCommand`) — and assert it appears in the list. Then change the device config to something different (clear channels, set a different frequency), **activate** the saved profile (`ActivateProfileCommand`), and assert the captured **channel + frequency intent is re-applied to the device** — verified through the Channels pane `n / N ACTIVE` ground-truth indicator and the per-device frequency flyout (0 → N active; changed-Hz → captured-Hz). Finally **delete** the profile (`DeleteProfileCommand`) and assert the list returns to its original membership. Each test records the profile count up-front and removes any profile it creates (asserts membership before/after via deltas). A fresh launch never has an active profile (`IsProfileActive` is not persisted to XML), so single-profile activation takes the no-confirm path. **USB or WiFi.** |
 
-Every UI test is tagged `[TestCategory("Ui")]` and `[TestCategory("RequiresDevice")]`
-so it never runs as part of the unit gate.
+Every UI test is tagged `[TestCategory("Ui")]` so it never runs as part of the unit gate.
+Tests that need attached hardware are additionally tagged `[TestCategory("RequiresDevice")]`;
+scenarios that drive the GUI without a device (e.g. `ManualWifiConnectTests`, which connects
+to an unroutable address) carry only `Ui` so device-filtered runs classify them correctly.
 
 ---
 
@@ -442,8 +444,8 @@ why.
 3. **Add a reusable helper** to `DaqifiAppFixture` (e.g. a new `protected` method) and a
    constant for the id, following the existing regions.
 4. **Write the test** in a new `*Tests.cs` class inheriting `DaqifiAppFixture`, tagged
-   `[TestCategory("Ui")]` and `[TestCategory("RequiresDevice")]`. Assert only through visible
-   UI + the NLog log.
+   `[TestCategory("Ui")]` — plus `[TestCategory("RequiresDevice")]` when the scenario needs
+   attached hardware. Assert only through visible UI + the NLog log.
 5. **Use patterns, not clicks** (gotcha #9) and `Retry`/`WaitUntil*`, never fixed sleeps.
 6. **Run with a device attached** and verify green before committing. Conventional commits
    (`test(ui): …`, and `fix(...)` for any app fix the harness surfaces).

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-		<PackageReference Include="Daqifi.Core" Version="0.22.0" />
+		<PackageReference Include="Daqifi.Core" Version="0.23.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -93,12 +93,14 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
         switch (ex)
         {
             case OperationCanceledException:
+            case TimeoutException:
                 // Core's TcpStreamTransport enforces its connection timeout with a
                 // CancellationTokenSource, so an unreachable device (powered off, stale
-                // discovery entry, wrong subnet) surfaces as a TaskCanceledException.
-                // Treat as a user/environmental condition, not an app bug — log a warning
-                // (keeping the exception detail in the local log) instead of capturing to
-                // Sentry (issue #517).
+                // discovery entry, wrong subnet) surfaces as a TaskCanceledException —
+                // or a TimeoutException once daqifi-core#237 translates it. Treat as a
+                // user/environmental condition, not an app bug — log a warning (keeping
+                // the exception detail in the local log) instead of capturing to Sentry
+                // (issue #517).
                 AppLogger.Warning(ex, $"Device at {IpAddress}:{Port} did not respond within the connection timeout");
                 break;
             case SocketException socketEx:

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -1,4 +1,5 @@
-﻿using Daqifi.Core.Communication.Messages;
+﻿using System.Net.Sockets;
+using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using CoreDeviceInfo = Daqifi.Core.Device.Discovery.IDeviceInfo;
@@ -89,7 +90,25 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
 
     protected override void LogConnectFailure(Exception ex)
     {
-        AppLogger.Error(ex, $"Problem with connecting to DAQiFi Device at {IpAddress}:{Port}");
+        switch (ex)
+        {
+            case OperationCanceledException:
+                // Core's TcpStreamTransport enforces its connection timeout with a
+                // CancellationTokenSource, so an unreachable device (powered off, stale
+                // discovery entry, wrong subnet) surfaces as a TaskCanceledException.
+                // Treat as a user/environmental condition, not an app bug — log a warning
+                // (keeping the exception detail in the local log) instead of capturing to
+                // Sentry (issue #517).
+                AppLogger.Warning(ex, $"Device at {IpAddress}:{Port} did not respond within the connection timeout");
+                break;
+            case SocketException socketEx:
+                // Connection refused / host unreachable. Same classification as above.
+                AppLogger.Warning(ex, $"Cannot reach device at {IpAddress}:{Port}: {socketEx.SocketErrorCode}");
+                break;
+            default:
+                AppLogger.Error(ex, $"Problem with connecting to DAQiFi Device at {IpAddress}:{Port}");
+                break;
+        }
     }
 
     /// <summary>

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -92,15 +92,12 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     {
         switch (ex)
         {
-            case OperationCanceledException:
             case TimeoutException:
-                // Core's TcpStreamTransport enforces its connection timeout with a
-                // CancellationTokenSource, so an unreachable device (powered off, stale
-                // discovery entry, wrong subnet) surfaces as a TaskCanceledException —
-                // or a TimeoutException once daqifi-core#237 translates it. Treat as a
-                // user/environmental condition, not an app bug — log a warning (keeping
-                // the exception detail in the local log) instead of capturing to Sentry
-                // (issue #517).
+                // Core's TcpStreamTransport surfaces an exhausted connection timeout as a
+                // TimeoutException (daqifi-core#237). An unreachable device (powered off,
+                // stale discovery entry, wrong subnet) is a user/environmental condition,
+                // not an app bug — log a warning (keeping the exception detail in the
+                // local log) instead of capturing to Sentry (issue #517).
                 AppLogger.Warning(ex, $"Device at {IpAddress}:{Port} did not respond within the connection timeout");
                 break;
             case SocketException socketEx:

--- a/Daqifi.Desktop/View/ConnectionDialog.xaml
+++ b/Daqifi.Desktop/View/ConnectionDialog.xaml
@@ -302,11 +302,17 @@
                         <TextBlock Text="IP ADDRESS" Style="{StaticResource FieldLabel}"/>
                         <Border Style="{StaticResource DarkTextField}">
                             <TextBox Text="{Binding ManualIpAddress, UpdateSourceTrigger=PropertyChanged}"
+                                     AutomationProperties.AutomationId="ManualIpInput"
                                      Style="{StaticResource DarkTextBox}"/>
                         </Border>
                         <TextBlock Text="Enter the IP address or hostname of the DAQiFi device."
                                    FontSize="10" Foreground="{StaticResource TextTertiary}"
                                    Margin="0,6,0,0" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding ManualWifiError}"
+                                   AutomationProperties.AutomationId="ManualWifiError"
+                                   FontSize="11" Foreground="{StaticResource StatusRed}"
+                                   Margin="0,8,0,0" TextWrapping="Wrap"
+                                   Visibility="{Binding ManualWifiError, Converter={StaticResource NotNullToVis}}"/>
                     </StackPanel>
 
                     <Border Grid.Row="1"

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -324,16 +324,16 @@ public partial class ConnectionDialogViewModel : ObservableObject
         catch (ArgumentException ex)
         {
             ManualWifiError = $"'{endpointInput}' is not a valid IP address or host name.";
-            Common.Loggers.AppLogger.Instance.Warning(
+            Common.Loggers.AppLogger.Instance.Warning(ex,
                 $"Manual WiFi connection requires a valid IP address or host name. " +
-                $"Received '{ManualIpAddress}': {ex.Message}");
+                $"Received '{ManualIpAddress}'");
             return;
         }
         catch (SocketException ex)
         {
             ManualWifiError = $"Could not resolve '{endpointInput}'. Check the address and try again.";
-            Common.Loggers.AppLogger.Instance.Warning(
-                $"Failed to resolve manual WiFi endpoint '{ManualIpAddress}': {ex.Message}");
+            Common.Loggers.AppLogger.Instance.Warning(ex,
+                $"Failed to resolve manual WiFi endpoint '{ManualIpAddress}'");
             return;
         }
         catch (Exception ex)

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -69,7 +69,16 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     public SerialStreamingDevice ManualSerialDevice { get; set; }
 
-    public string ManualIpAddress { get; set; }
+    [ObservableProperty]
+    private string? _manualIpAddress;
+
+    /// <summary>
+    /// User-facing validation message for the Manual WiFi tab. Non-null when the entered
+    /// endpoint failed to resolve or the device did not respond (issue #517).
+    /// Cleared automatically when the user edits <see cref="ManualIpAddress"/>.
+    /// </summary>
+    [ObservableProperty]
+    private string? _manualWifiError;
     #endregion
 
     partial void OnManualPortNameChanged(string? value)
@@ -78,6 +87,15 @@ public partial class ConnectionDialogViewModel : ObservableObject
         if (!string.IsNullOrEmpty(ManualPortError))
         {
             ManualPortError = null;
+        }
+    }
+
+    partial void OnManualIpAddressChanged(string? value)
+    {
+        // Clear stale validation error as soon as the user starts editing the address.
+        if (!string.IsNullOrEmpty(ManualWifiError))
+        {
+            ManualWifiError = null;
         }
     }
 
@@ -293,6 +311,8 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     private async Task ConnectManualWifiAsync()
     {
+        ManualWifiError = null;
+
         if (string.IsNullOrWhiteSpace(ManualIpAddress)) { return; }
 
         var endpointInput = ManualIpAddress.Trim();
@@ -303,6 +323,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
         }
         catch (ArgumentException ex)
         {
+            ManualWifiError = $"'{endpointInput}' is not a valid IP address or host name.";
             Common.Loggers.AppLogger.Instance.Warning(
                 $"Manual WiFi connection requires a valid IP address or host name. " +
                 $"Received '{ManualIpAddress}': {ex.Message}");
@@ -310,6 +331,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
         }
         catch (SocketException ex)
         {
+            ManualWifiError = $"Could not resolve '{endpointInput}'. Check the address and try again.";
             Common.Loggers.AppLogger.Instance.Warning(
                 $"Failed to resolve manual WiFi endpoint '{ManualIpAddress}': {ex.Message}");
             return;
@@ -324,6 +346,7 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         if (ipAddress == null)
         {
+            ManualWifiError = $"Could not resolve '{endpointInput}'. Check the address and try again.";
             Common.Loggers.AppLogger.Instance.Warning(
                 $"Manual WiFi endpoint '{ManualIpAddress}' did not resolve to an IP address.");
             return;
@@ -340,6 +363,17 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         var device = new DaqifiStreamingDevice(deviceInfo);
         await ConnectionManager.Instance.Connect(device);
+
+        // Post-connect status check mirrors the manual-serial path: an unreachable device
+        // (connect timeout — issue #517) must keep the dialog open with an inline message
+        // instead of closing silently.
+        if (ConnectionManager.Instance.ConnectionStatus == DAQiFiConnectionStatus.Error)
+        {
+            ManualWifiError =
+                $"Could not connect to '{endpointInput}'. " +
+                "Verify the device is powered on and reachable on this network.";
+            return;
+        }
 
         RaiseCloseRequested();
     }


### PR DESCRIPTION
## Summary

Fixes #517 (Sentry: `TaskCanceledException: A task was canceled.`).

An unreachable WiFi device (powered off, stale discovery entry, wrong subnet, mistyped manual IP) made Core's TCP connect time out. `DaqifiStreamingDevice` logged every connect failure at error level — the sole Sentry capture path — so each timeout raised a Sentry event for what is a user/environmental condition. The manual WiFi connect dialog also closed silently on failure, giving the user no feedback.

This mirrors the manual-serial fix from #524:

- **`DaqifiStreamingDevice.LogConnectFailure`** now classifies `TimeoutException` (connect timeout) and `SocketException` (refused/unreachable) as warnings — stack trace stays in the local log, no Sentry capture. Unexpected exceptions still log at error level.
- **Connection dialog (Manual WiFi tab)**: failed connects keep the dialog open with an inline `ManualWifiError` message (post-connect `ConnectionStatus == Error` check, same seam the manual-serial path uses). Resolution failures surface inline too, and editing the address clears the stale error. `ManualIpAddress` became an `[ObservableProperty]` to support the clear-on-edit behavior.
- **`Daqifi.Core` bumped 0.22.0 → 0.23.0**, which includes daqifi-core#237: the transport now surfaces connect timeouts as `TimeoutException` (with endpoint/timeout context and the original cancellation as `InnerException`) instead of the misleading `TaskCanceledException` from the original Sentry report. The classifier here keys off the new exception type directly.

## Tests

- **Unit** (`ConnectionDialogViewModelCloseTests`): invalid endpoint sets `ManualWifiError`; blank input does not; editing the address clears it. Full fast gate green against Core 0.23.0: 363 passed.
- **UI regression** (`ManualWifiConnectTests`, FlaUI): connects to RFC 5737 TEST-NET `192.0.2.1` so the TCP connect exhausts Core's timeout — the exact #517 failure mode — and asserts the inline error appears, the dialog stays open, the log carries the endpoint at warning level, and the old `Problem with connecting to DAQiFi Device` error line (the Sentry path) is absent. Both tests pass on the hardware bench against Core 0.23.0, so the live `TimeoutException` path is verified end-to-end. New AutomationIds (`ManualIpInput`, `ManualWifiError`) are documented in the UITest README map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)