### PR TITLE
fix(firmware): widen PIC32 bootloader HID timeouts to 30s (#575)

### DIFF
--- a/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
@@ -1,3 +1,4 @@
+using Daqifi.Core.Firmware;
 using Daqifi.Desktop.Device.Firmware;
 
 namespace Daqifi.Desktop.Test.Device.Firmware;
@@ -44,11 +45,15 @@ public class FirmwareUpdateServiceConfigTests
     [TestMethod]
     public void CreateOptions_LeavesProgrammingTimeoutAtCoreDefault()
     {
-        // Act - the overall programming-phase budget should remain the Core default (10 min);
-        // only the per-operation HID window is widened.
+        // Arrange - compare against a fresh Core default rather than a hard-coded value so this
+        // stays green if Core changes its default; the intent is "desktop config does not override
+        // ProgrammingTimeout", not "ProgrammingTimeout is exactly 10 min".
+        var coreDefault = new FirmwareUpdateServiceOptions().ProgrammingTimeout;
+
+        // Act - only the per-operation HID window is widened, not the overall programming budget.
         var options = FirmwareUpdateServiceConfig.CreateOptions();
 
         // Assert
-        Assert.AreEqual(TimeSpan.FromMinutes(10), options.ProgrammingTimeout);
+        Assert.AreEqual(coreDefault, options.ProgrammingTimeout);
     }
 }

--- a/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
@@ -1,0 +1,54 @@
+using Daqifi.Desktop.Device.Firmware;
+
+namespace Daqifi.Desktop.Test.Device.Firmware;
+
+/// <summary>
+/// Verifies the PIC32 bootloader HID timeouts are widened past Core's 10 s defaults so a long
+/// late flash op doesn't trip the firmware update (issue #575).
+/// </summary>
+[TestClass]
+public class FirmwareUpdateServiceConfigTests
+{
+    [TestMethod]
+    public void BootloaderHidTimeout_IsThirtySeconds()
+    {
+        // Arrange / Act
+        var timeout = FirmwareUpdateServiceConfig.BootloaderHidTimeout;
+
+        // Assert
+        Assert.AreEqual(TimeSpan.FromSeconds(30), timeout);
+    }
+
+    [TestMethod]
+    public void CreateBootloaderHidTransport_AppliesTimeoutToReadAndWrite()
+    {
+        // Act
+        var transport = FirmwareUpdateServiceConfig.CreateBootloaderHidTransport();
+
+        // Assert - WriteAsync uses the transport's WriteTimeout (the "HID write failed" path);
+        // a stray null-timeout read would use ReadTimeout, so both must be widened.
+        Assert.AreEqual(FirmwareUpdateServiceConfig.BootloaderHidTimeout, transport.WriteTimeout);
+        Assert.AreEqual(FirmwareUpdateServiceConfig.BootloaderHidTimeout, transport.ReadTimeout);
+    }
+
+    [TestMethod]
+    public void CreateOptions_SetsBootloaderResponseTimeout()
+    {
+        // Act - the service passes BootloaderResponseTimeout to every bootloader read.
+        var options = FirmwareUpdateServiceConfig.CreateOptions();
+
+        // Assert
+        Assert.AreEqual(FirmwareUpdateServiceConfig.BootloaderHidTimeout, options.BootloaderResponseTimeout);
+    }
+
+    [TestMethod]
+    public void CreateOptions_LeavesProgrammingTimeoutAtCoreDefault()
+    {
+        // Act - the overall programming-phase budget should remain the Core default (10 min);
+        // only the per-operation HID window is widened.
+        var options = FirmwareUpdateServiceConfig.CreateOptions();
+
+        // Assert
+        Assert.AreEqual(TimeSpan.FromMinutes(10), options.ProgrammingTimeout);
+    }
+}

--- a/Daqifi.Desktop/App.xaml.cs
+++ b/Daqifi.Desktop/App.xaml.cs
@@ -3,6 +3,7 @@ using Daqifi.Core.Firmware;
 using Daqifi.Desktop.Common;
 using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Configuration;
+using Daqifi.Desktop.Device.Firmware;
 using Daqifi.Desktop.DialogService;
 using Daqifi.Desktop.Services;
 using Daqifi.Desktop.Logger;
@@ -11,6 +12,7 @@ using Daqifi.Desktop.WindowViewModelMapping;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System.IO;
 using System.Net.Http;
 using System.Windows;
@@ -90,9 +92,16 @@ public partial class App
             var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
             return new GitHubFirmwareDownloadService(httpClientFactory.CreateClient());
         });
-        serviceCollection.AddSingleton<IHidTransport, HidLibraryTransport>();
+        // Widen the bootloader HID timeouts past Core's 10 s defaults so a long late flash op
+        // doesn't trip the PIC32 update; see FirmwareUpdateServiceConfig / issue #575.
+        serviceCollection.AddSingleton<IHidTransport>(_ => FirmwareUpdateServiceConfig.CreateBootloaderHidTransport());
         serviceCollection.AddSingleton<IExternalProcessRunner, ProcessExternalProcessRunner>();
-        serviceCollection.AddSingleton<IFirmwareUpdateService, FirmwareUpdateService>();
+        serviceCollection.AddSingleton<IFirmwareUpdateService>(provider => new FirmwareUpdateService(
+            provider.GetRequiredService<IHidTransport>(),
+            provider.GetRequiredService<IFirmwareDownloadService>(),
+            provider.GetRequiredService<IExternalProcessRunner>(),
+            provider.GetRequiredService<ILogger<FirmwareUpdateService>>(),
+            options: FirmwareUpdateServiceConfig.CreateOptions()));
 
         serviceCollection.AddSingleton<LoggingManager>();
         ServiceLocator.RegisterSingleton<IDialogService, DialogService.DialogService>();

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
@@ -1,0 +1,60 @@
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Centralizes the HID timing configuration for PIC32 bootloader firmware updates so every
+/// construction site (DI registration and fallback factories) shares one value.
+/// </summary>
+/// <remarks>
+/// The PIC32 bootloader performs a long flash operation (region erase / bank finalize) on a late
+/// record that can keep its HID endpoint busy for longer than Core's 10 s defaults. That trips the
+/// update with an <c>IOException: HID write failed</c> (transport <see cref="IHidTransport.WriteTimeout"/>)
+/// or a read <see cref="System.TimeoutException"/>
+/// (<see cref="FirmwareUpdateServiceOptions.BootloaderResponseTimeout"/>) — issue #575. The
+/// pre-Core desktop flasher used unbounded blocking HID I/O and waited it out; we restore
+/// equivalent headroom by widening both knobs to 30 s. That value is hardware-tested on a bench
+/// NQ1. The overall <see cref="FirmwareUpdateServiceOptions.ProgrammingTimeout"/> (10 min) is left
+/// at the Core default and still caps the whole programming phase.
+/// </remarks>
+public static class FirmwareUpdateServiceConfig
+{
+    #region Constants
+    /// <summary>
+    /// Per-operation HID timeout for the PIC32 bootloader handshake. Applied to both the transport
+    /// (<see cref="IHidTransport.WriteTimeout"/> / <see cref="IHidTransport.ReadTimeout"/>) and
+    /// <see cref="FirmwareUpdateServiceOptions.BootloaderResponseTimeout"/> so the write and read
+    /// paths share the same window. <c>WriteAsync</c> takes no timeout argument and always uses the
+    /// transport's <see cref="IHidTransport.WriteTimeout"/>, while the service passes
+    /// <see cref="FirmwareUpdateServiceOptions.BootloaderResponseTimeout"/> to every read — so both
+    /// must be set to cover the failure.
+    /// </summary>
+    public static readonly TimeSpan BootloaderHidTimeout = TimeSpan.FromSeconds(30);
+    #endregion
+
+    #region Public Methods
+    /// <summary>
+    /// Creates a HID transport configured with <see cref="BootloaderHidTimeout"/> for both reads and writes.
+    /// </summary>
+    public static HidLibraryTransport CreateBootloaderHidTransport()
+    {
+        return new HidLibraryTransport
+        {
+            ReadTimeout = BootloaderHidTimeout,
+            WriteTimeout = BootloaderHidTimeout
+        };
+    }
+
+    /// <summary>
+    /// Creates the firmware update options for PIC32 updates with the widened bootloader response timeout.
+    /// </summary>
+    public static FirmwareUpdateServiceOptions CreateOptions()
+    {
+        return new FirmwareUpdateServiceOptions
+        {
+            BootloaderResponseTimeout = BootloaderHidTimeout
+        };
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
@@ -37,6 +37,7 @@ public static class FirmwareUpdateServiceConfig
     /// <summary>
     /// Creates a HID transport configured with <see cref="BootloaderHidTimeout"/> for both reads and writes.
     /// </summary>
+    /// <returns>A <see cref="HidLibraryTransport"/> whose read and write timeouts are set to <see cref="BootloaderHidTimeout"/>.</returns>
     public static HidLibraryTransport CreateBootloaderHidTransport()
     {
         return new HidLibraryTransport
@@ -49,6 +50,10 @@ public static class FirmwareUpdateServiceConfig
     /// <summary>
     /// Creates the firmware update options for PIC32 updates with the widened bootloader response timeout.
     /// </summary>
+    /// <returns>
+    /// A <see cref="FirmwareUpdateServiceOptions"/> with <see cref="FirmwareUpdateServiceOptions.BootloaderResponseTimeout"/>
+    /// set to <see cref="BootloaderHidTimeout"/>; all other options retain their Core defaults.
+    /// </returns>
     public static FirmwareUpdateServiceOptions CreateOptions()
     {
         return new FirmwareUpdateServiceOptions

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1006,7 +1006,9 @@ public partial class DaqifiViewModel : ObservableObject
         };
 
         return new FirmwareUpdateService(
-            new HidLibraryTransport(),
+            // Keep firmware HID transports uniformly configured even though the WiFi flow flashes
+            // via the external WINC tool rather than the HID loop (issue #575).
+            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
             _firmwareDownloadService,
             new WifiPromptDelayProcessRunner(
                 new ProcessExternalProcessRunner(),
@@ -1120,10 +1122,11 @@ public partial class DaqifiViewModel : ObservableObject
         ILogger<FirmwareUpdateService> logger)
     {
         return new FirmwareUpdateService(
-            new HidLibraryTransport(),
+            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
             firmwareDownloadService,
             new ProcessExternalProcessRunner(),
-            logger);
+            logger,
+            options: FirmwareUpdateServiceConfig.CreateOptions());
     }
 
     #endregion

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1005,9 +1005,24 @@ public partial class DaqifiViewModel : ObservableObject
             }
         };
 
+        // Start from the shared firmware config so the bootloader HID timeouts stay aligned with
+        // the transport (keeps read and write windows symmetric), then layer on WiFi-specific
+        // settings. The WiFi flow flashes via the external WINC tool rather than the HID loop, so
+        // the bootloader timeout is inert here, but starting from CreateOptions() keeps every
+        // construction site uniform (issue #575).
+        var wifiOptions = FirmwareUpdateServiceConfig.CreateOptions();
+        // winc_flash_tool.cmd requires an explicit release version folder.
+        // Keep legacy argument profile used by shipped WINC tool bundle.
+        wifiOptions.WifiFlashToolArgumentsTemplate = $"/p {{port}} /d WINC1500 /v {wifiVersion} /k /e /i aio /w";
+        wifiOptions.WifiPortOverride = portName;
+        // After sending FWUpdate (flag-only, no APPLY), disconnect quickly so the
+        // COM port is free for the bridge activation raw write at the "Power cycle
+        // WINC" prompt.  The FWUpdate flag persists in firmware RAM until APPLY fires.
+        wifiOptions.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(100);
+        // Give Windows a little more time to re-enumerate the UART before reconnect attempts.
+        wifiOptions.PostWifiReconnectDelay = TimeSpan.FromSeconds(3);
+
         return new FirmwareUpdateService(
-            // Keep firmware HID transports uniformly configured even though the WiFi flow flashes
-            // via the external WINC tool rather than the HID loop (issue #575).
             FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
             _firmwareDownloadService,
             new WifiPromptDelayProcessRunner(
@@ -1015,19 +1030,7 @@ public partial class DaqifiViewModel : ObservableObject
                 promptResponseDelay: TimeSpan.FromSeconds(2),
                 bridgeActivationAction: bridgeActivationAction),
             firmwareLogger,
-            options: new FirmwareUpdateServiceOptions
-            {
-                // winc_flash_tool.cmd requires an explicit release version folder.
-                // Keep legacy argument profile used by shipped WINC tool bundle.
-                WifiFlashToolArgumentsTemplate = $"/p {{port}} /d WINC1500 /v {wifiVersion} /k /e /i aio /w",
-                WifiPortOverride = portName,
-                // After sending FWUpdate (flag-only, no APPLY), disconnect quickly so the
-                // COM port is free for the bridge activation raw write at the "Power cycle
-                // WINC" prompt.  The FWUpdate flag persists in firmware RAM until APPLY fires.
-                PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(100),
-                // Give Windows a little more time to re-enumerate the UART before reconnect attempts.
-                PostWifiReconnectDelay = TimeSpan.FromSeconds(3)
-            });
+            options: wifiOptions);
     }
 
     private static string NormalizeWifiFirmwareVersion(string rawVersion)

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -1,4 +1,3 @@
-using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Firmware;
 using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device.Firmware;
@@ -148,9 +147,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
     {
         var downloadService = new GitHubFirmwareDownloadService(new HttpClient());
         return new FirmwareUpdateService(
-            new HidLibraryTransport(),
+            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
             downloadService,
             new ProcessExternalProcessRunner(),
-            NullLogger<FirmwareUpdateService>.Instance);
+            NullLogger<FirmwareUpdateService>.Instance,
+            options: FirmwareUpdateServiceConfig.CreateOptions());
     }
 }


### PR DESCRIPTION
## Summary

Fixes the firmware update failing mid-`Programming` with `IOException: HID write failed` / `TimeoutException: Timed out waiting for HID data after 10000 ms` (#575).

**Root cause** (confirmed via USBPcap + a working desktop v3.0.0 flash of the same hex/bootloader/device, per the investigation in #575): the new Core HID flasher caps each bootloader HID op at **10 s**. A long late flash op (region erase / bank finalize) keeps the device's HID endpoint busy past that cap, so the write is NAK'd / the read times out → the update fails. The pre-Core desktop flasher used unbounded blocking HID I/O and waited it out. Protocol / CRC-16 / record-filtering are otherwise identical.

The two timeouts live in **separate Core objects** and **both** must be raised — fixing only one leaves the other path broken:

| Path | Knob | Default |
|------|------|---------|
| Write (`WriteAsync` takes no timeout arg) | `HidLibraryTransport.WriteTimeout` | 10 s |
| Read (service passes it to every `ReadAsync`) | `FirmwareUpdateServiceOptions.BootloaderResponseTimeout` | 10 s |

Both are public/settable in Core 0.23.0, so this is pure desktop-side configuration — no Core release required.

## Changes

- **New** `FirmwareUpdateServiceConfig` — centralizes the `30 s` value + `CreateBootloaderHidTransport()` / `CreateOptions()`, so the 10 s default can't silently leak back in at any construction site.
- Applied at all `FirmwareUpdateService` construction sites: the production DI registration in `App.xaml.cs`, plus the two fallback factories (`DaqifiViewModel.CreateDefaultFirmwareUpdateService`, `FirmwareDialogViewModel.CreateFallbackFirmwareUpdateService`). The WiFi factory is updated too for consistency (it flashes via the external WINC tool, so the HID timeout there is cosmetic).
- The overall `ProgrammingTimeout` (10 min) is left at the Core default and still caps the whole phase.

`30 s` is hardware-tested on a bench NQ1 (per #575).

## Testing

- `dotnet build` — 0 errors.
- Fast gate `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — **367 passed, 0 failed**, including 4 new `FirmwareUpdateServiceConfigTests` (assert both transport timeouts + `BootloaderResponseTimeout` are 30 s and `ProgrammingTimeout` stays at the 10-min Core default).
- Recommended before merge: an in-app PIC32 update on the bench device to confirm it completes without a mid-`Programming` HID timeout.

## Follow-up (not in this PR)

Durable upstream fix belongs in `daqifi-core`: restore the old synchronous lock-step (wait for each record's completion, don't cancel+retry mid-op) rather than only widening the window, and/or raise Core's defaults so other consumers benefit. Related downstream desktop gap: #577 (stale "connected" UI after the bootloader handoff).

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)