### PR TITLE
fix(firmware): re-evaluate WiFi-module update on every in-session run (#599)

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -212,6 +212,237 @@ public class DaqifiViewModelFirmwareUpdateTests
     }
 
     [TestMethod]
+    public async Task UploadFirmware_RunTwiceInSession_UpdatesWifiOnEachRun()
+    {
+        // Regression test for issue #599. The auto-update path used to write the downloaded
+        // package path into the bound FirmwareFilePath property. Because the manual-vs-auto
+        // decision is derived from FirmwareFilePath being non-empty, the SECOND in-session
+        // update was misclassified as a manual upload and silently skipped the WiFi-module
+        // flash (only an app restart restored correct behavior). Each auto-update run must
+        // download firmware and flash the WiFi module independently, and FirmwareFilePath must
+        // stay empty so subsequent runs remain auto-updates.
+        var dialogService = new Mock<IDialogService>();
+        var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM9", coreDevice);
+        var pic32FirmwarePath = CreateTempFile(".hex");
+        var wifiPackageDirectory = CreateTempDirectory();
+        var wifiFactoryCalls = 0;
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.UpdateFirmwareAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                pic32FirmwarePath,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.CheckWifiFirmwareStatusAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateWifiStatus(WifiFirmwareStatusReason.UpdateAvailable, "19.3.0", "v19.7.0"));
+
+        wifiFirmwareUpdateService
+            .Setup(service => service.UpdateWifiModuleAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                wifiPackageDirectory,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadLatestFirmwareAsync(
+                It.IsAny<string>(),
+                true,
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pic32FirmwarePath);
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadWifiFirmwareAsync(
+                It.IsAny<string>(),
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
+
+        var viewModel = new DaqifiViewModel(
+            dialogService.Object,
+            pic32FirmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            NullLogger<FirmwareUpdateService>.Instance,
+            (_, _) =>
+            {
+                wifiFactoryCalls++;
+                return wifiFirmwareUpdateService.Object;
+            })
+        {
+            SelectedDevice = serialDevice
+        };
+
+        // First in-session update.
+        await InvokeUploadFirmwareAsync(viewModel);
+        Assert.IsTrue(viewModel.IsUploadComplete);
+        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.IsTrue(
+            string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
+            "Auto-update must not populate FirmwareFilePath; doing so reclassifies the next run as a manual upload.");
+
+        // Second in-session update WITHOUT restarting the app.
+        await InvokeUploadFirmwareAsync(viewModel);
+        Assert.IsTrue(viewModel.IsUploadComplete);
+        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.IsTrue(
+            string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
+            "Auto-update must not populate FirmwareFilePath; doing so reclassifies the next run as a manual upload.");
+
+        // The WiFi module must be flashed on BOTH runs, not just the first.
+        Assert.AreEqual(2, wifiFactoryCalls);
+        // The main (PIC32) firmware flash is not gated by the auto/manual classification, so it
+        // must run on both passes; counting it guards against a future regression that gates it.
+        pic32FirmwareUpdateService.Verify(service => service.UpdateFirmwareAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            pic32FirmwarePath,
+            It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+        firmwareDownloadService.Verify(service => service.DownloadLatestFirmwareAsync(
+            It.IsAny<string>(),
+            true,
+            It.IsAny<IProgress<int>>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+        pic32FirmwareUpdateService.Verify(service => service.CheckWifiFirmwareStatusAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+        wifiFirmwareUpdateService.Verify(service => service.UpdateWifiModuleAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            wifiPackageDirectory,
+            It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>(),
+            true), Times.Exactly(2));
+    }
+
+    [TestMethod]
+    public async Task UploadFirmware_ManualThenAuto_FlashesWifiOnAutoRun()
+    {
+        // Regression test for the symmetric case of issue #599. A manual .hex upload is
+        // intentionally PIC32-only (no WiFi), and the auto/manual decision is derived from
+        // FirmwareFilePath being non-empty. If a manual selection persisted across runs, the
+        // NEXT (intended auto) update would be misclassified as manual and silently skip the
+        // WiFi-module flash until the app restart. UploadFirmware must consume the manual
+        // selection so a subsequent run defaults to a full auto-update.
+        var dialogService = new Mock<IDialogService>();
+        var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM9", coreDevice);
+        var manualFirmwarePath = CreateTempFile(".hex");
+        var downloadedFirmwarePath = CreateTempFile(".hex");
+        var wifiPackageDirectory = CreateTempDirectory();
+        var wifiFactoryCalls = 0;
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.UpdateFirmwareAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.CheckWifiFirmwareStatusAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateWifiStatus(WifiFirmwareStatusReason.UpdateAvailable, "19.3.0", "v19.7.0"));
+
+        wifiFirmwareUpdateService
+            .Setup(service => service.UpdateWifiModuleAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                wifiPackageDirectory,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadLatestFirmwareAsync(
+                It.IsAny<string>(),
+                true,
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(downloadedFirmwarePath);
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadWifiFirmwareAsync(
+                It.IsAny<string>(),
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
+
+        var viewModel = new DaqifiViewModel(
+            dialogService.Object,
+            pic32FirmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            NullLogger<FirmwareUpdateService>.Instance,
+            (_, _) =>
+            {
+                wifiFactoryCalls++;
+                return wifiFirmwareUpdateService.Object;
+            })
+        {
+            SelectedDevice = serialDevice,
+            FirmwareFilePath = manualFirmwarePath
+        };
+
+        // First run: manual upload (PIC32 only, no WiFi, no download).
+        await InvokeUploadFirmwareAsync(viewModel);
+        Assert.IsTrue(viewModel.IsUploadComplete);
+        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.AreEqual(0, wifiFactoryCalls);
+        Assert.IsTrue(
+            string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
+            "A manual upload must be consumed so the next run is not silently trapped in manual mode.");
+
+        // Second run WITHOUT restarting the app and without re-selecting a file: must be a full
+        // auto-update that downloads firmware and flashes the WiFi module.
+        await InvokeUploadFirmwareAsync(viewModel);
+        Assert.IsTrue(viewModel.IsUploadComplete);
+        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.AreEqual(1, wifiFactoryCalls);
+
+        pic32FirmwareUpdateService.Verify(service => service.UpdateFirmwareAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            manualFirmwarePath,
+            It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        firmwareDownloadService.Verify(service => service.DownloadLatestFirmwareAsync(
+            It.IsAny<string>(),
+            true,
+            It.IsAny<IProgress<int>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        pic32FirmwareUpdateService.Verify(service => service.UpdateFirmwareAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            downloadedFirmwarePath,
+            It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        wifiFirmwareUpdateService.Verify(service => service.UpdateWifiModuleAsync(
+            It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+            wifiPackageDirectory,
+            It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>(),
+            true), Times.Once);
+    }
+
+    [TestMethod]
     public async Task UploadFirmware_WifiFirmwareUpToDate_SkipsWifiFlash()
     {
         var dialogService = new Mock<IDialogService>();

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -221,6 +221,8 @@ public class DaqifiViewModelFirmwareUpdateTests
         // flash (only an app restart restored correct behavior). Each auto-update run must
         // download firmware and flash the WiFi module independently, and FirmwareFilePath must
         // stay empty so subsequent runs remain auto-updates.
+
+        // Arrange
         var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
@@ -286,22 +288,18 @@ public class DaqifiViewModelFirmwareUpdateTests
             SelectedDevice = serialDevice
         };
 
-        // First in-session update.
+        // Act: two consecutive in-session auto-updates with no app restart between them.
         await InvokeUploadFirmwareAsync(viewModel);
+        await InvokeUploadFirmwareAsync(viewModel);
+
+        // Assert: each run performed a full auto-update and the bound path was never populated.
+        // (The per-run state is proven by the Times.Exactly(2) counts below: had run 1 left
+        // FirmwareFilePath set, run 2 would be classified manual and these would be Times.Once.)
         Assert.IsTrue(viewModel.IsUploadComplete);
         Assert.IsFalse(viewModel.HasErrorOccured);
         Assert.IsTrue(
             string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
             "Auto-update must not populate FirmwareFilePath; doing so reclassifies the next run as a manual upload.");
-
-        // Second in-session update WITHOUT restarting the app.
-        await InvokeUploadFirmwareAsync(viewModel);
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
-        Assert.IsTrue(
-            string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
-            "Auto-update must not populate FirmwareFilePath; doing so reclassifies the next run as a manual upload.");
-
         // The WiFi module must be flashed on BOTH runs, not just the first.
         Assert.AreEqual(2, wifiFactoryCalls);
         // The main (PIC32) firmware flash is not gated by the auto/manual classification, so it
@@ -336,6 +334,8 @@ public class DaqifiViewModelFirmwareUpdateTests
         // NEXT (intended auto) update would be misclassified as manual and silently skip the
         // WiFi-module flash until the app restart. UploadFirmware must consume the manual
         // selection so a subsequent run defaults to a full auto-update.
+
+        // Arrange
         var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
@@ -403,18 +403,20 @@ public class DaqifiViewModelFirmwareUpdateTests
             FirmwareFilePath = manualFirmwarePath
         };
 
-        // First run: manual upload (PIC32 only, no WiFi, no download).
+        // Arrange (cont.): drive a manual upload so the session is left in the post-manual state.
+        // A manual upload is PIC32-only and must consume the selection; these guards confirm the
+        // precondition the Act below depends on.
         await InvokeUploadFirmwareAsync(viewModel);
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
-        Assert.AreEqual(0, wifiFactoryCalls);
+        Assert.AreEqual(0, wifiFactoryCalls, "A manual upload must not flash the WiFi module.");
         Assert.IsTrue(
             string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
             "A manual upload must be consumed so the next run is not silently trapped in manual mode.");
 
-        // Second run WITHOUT restarting the app and without re-selecting a file: must be a full
-        // auto-update that downloads firmware and flashes the WiFi module.
+        // Act: the next in-session update, without restarting the app and without re-selecting a
+        // file. With the selection consumed it must default to a full auto-update.
         await InvokeUploadFirmwareAsync(viewModel);
+
+        // Assert: the second run downloaded firmware and flashed the WiFi module.
         Assert.IsTrue(viewModel.IsUploadComplete);
         Assert.IsFalse(viewModel.HasErrorOccured);
         Assert.AreEqual(1, wifiFactoryCalls);

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -724,18 +724,28 @@ public partial class DaqifiViewModel : ObservableObject
                 return;
             }
 
+            // For an auto-update, download into a LOCAL variable rather than the bound
+            // FirmwareFilePath property. Writing the downloaded path back into the property
+            // would make the NEXT in-session update look like a manual upload (isManualUpload
+            // is derived from FirmwareFilePath being non-empty), silently skipping the
+            // WiFi-module step until the app is restarted. See issue #599.
+            string effectiveFirmwarePath;
             if (!isManualUpload)
             {
                 FirmwareUpdateStatusText = "Downloading latest firmware package...";
-                FirmwareFilePath = await _firmwareDownloadService.DownloadLatestFirmwareAsync(
+                effectiveFirmwarePath = await _firmwareDownloadService.DownloadLatestFirmwareAsync(
                     GetFirmwareDownloadDirectory(),
                     includePreRelease: true,
                     cancellationToken: _firmwareUploadCts.Token);
             }
-
-            if (string.IsNullOrWhiteSpace(FirmwareFilePath) || !File.Exists(FirmwareFilePath))
+            else
             {
-                throw new FileNotFoundException("Firmware file path is invalid or does not exist.", FirmwareFilePath);
+                effectiveFirmwarePath = FirmwareFilePath;
+            }
+
+            if (string.IsNullOrWhiteSpace(effectiveFirmwarePath) || !File.Exists(effectiveFirmwarePath))
+            {
+                throw new FileNotFoundException("Firmware file path is invalid or does not exist.", effectiveFirmwarePath);
             }
 
             var pic32Progress = new Progress<FirmwareUpdateProgress>(report =>
@@ -749,7 +759,7 @@ public partial class DaqifiViewModel : ObservableObject
 
             await _firmwareUpdateService.UpdateFirmwareAsync(
                 coreDevice,
-                FirmwareFilePath,
+                effectiveFirmwarePath,
                 pic32Progress,
                 _firmwareUploadCts.Token);
 
@@ -787,6 +797,15 @@ public partial class DaqifiViewModel : ObservableObject
             _firmwareUploadCts = null;
             _deviceBeingUpdated = null;
             ConnectionManager.Instance.DeviceBeingUpdated = null;
+
+            // Consume any manual .hex selection so the auto/manual decision is a per-run input,
+            // not sticky session state. A manual upload is intentionally PIC32-only (no WiFi),
+            // and isManualUpload is derived from FirmwareFilePath being non-empty. Without this
+            // reset a prior manual selection would trap every later run in manual mode and
+            // silently skip the WiFi-module flash until the app is restarted — the symmetric
+            // case of issue #599. The next run defaults to a full auto-update unless the user
+            // explicitly re-selects a file. (The auto path never writes this property.)
+            FirmwareFilePath = string.Empty;
         }
     }
 


### PR DESCRIPTION
@
## Summary

Fixes #599 — the in-app firmware update skipped the WiFi (WINC) module flash on the **second and subsequent** firmware updates within a single app session; only a restart restored correct behavior.

## Root cause

`DaqifiViewModel.UploadFirmware()` decides between an **auto-update** (download latest, flash main **+** WiFi) and a **manual upload** (flash a user-picked `.hex`, PIC32 only) from:

```csharp
var isManualUpload = !string.IsNullOrWhiteSpace(FirmwareFilePath);
...
if (!isManualUpload) { await UpdateWifiModuleAsync(...); }   // WiFi flash gated here
```

The auto path wrote the **downloaded** package path back into the bound `FirmwareFilePath` `[ObservableProperty]`, which persists for the app session. So on the next in-session run `FirmwareFilePath` was non-empty → the run was misclassified as a *manual* upload → the WiFi-module flash was skipped (while the main firmware still flashed from the cached file). Restarting the app reset the field, which is why the first-of-session update always worked.

This exactly matches the report: first update does both, subsequent updates skip WiFi, restart fixes it.

## Fix

1. **Stop the auto path from poisoning the classifier** — download into a local `effectiveFirmwarePath` variable and use it for the existence check and PIC32 flash; never mutate the bound `FirmwareFilePath`.
2. **Consume manual selections per run** — reset `FirmwareFilePath` in the `finally` block so the auto/manual decision is a per-run input rather than sticky session state. This also closes the **symmetric** latent bug (surfaced in review): once a user did a manual `.hex` upload, every later run in the session was trapped in manual mode and silently skipped WiFi too. This satisfies the issues stated expectation that *every* run evaluates the WiFi update independently of session history.

## Tests

- `UploadFirmware_RunTwiceInSession_UpdatesWifiOnEachRun` — two auto-updates; asserts download, WiFi-status check, PIC32 flash, and WiFi flash each run **twice**, and `FirmwareFilePath` stays empty.
- `UploadFirmware_ManualThenAuto_FlashesWifiOnAutoRun` — a manual run skips WiFi and is consumed; the next run is a full auto-update that flashes WiFi.

Both fail against the unfixed code (true regression guards). Full fast gate: **365/365 passing**, build clean.

## Verification

Confirmed by static analysis (the gating is pure control flow), a multi-agent adversarial review of the diff (which caught the symmetric manual→auto leak and a test-coverage gap, both addressed), and the unit-test coverage above. Not hardware-re-flashed: reproducing requires two full firmware flashes and the defect lives entirely in ViewModel orchestration that the tests model precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@