### PR TITLE
chore(firmware): extract FirmwareUpdateCoordinator from DaqifiViewModel (#592)

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -4,9 +4,9 @@ using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using Daqifi.Core.Firmware;
+using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device.Firmware;
 using Daqifi.Desktop.Device.SerialDevice;
-using Daqifi.Desktop.DialogService;
 using Daqifi.Desktop.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -49,7 +49,6 @@ public class DaqifiViewModelFirmwareUpdateTests
     [TestMethod]
     public async Task UploadFirmware_ManualPackage_UsesConnectedCoreDeviceForPic32Only()
     {
-        var dialogService = new Mock<IDialogService>();
         var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
 
@@ -78,12 +77,10 @@ public class DaqifiViewModelFirmwareUpdateTests
             FirmwareFilePath = firmwareFilePath
         };
 
-        var coordinator = new FirmwareUpdateCoordinator(
+        var coordinator = CreateCoordinator(
             host,
-            dialogService.Object,
             firmwareUpdateService.Object,
             firmwareDownloadService.Object,
-            NullLogger<FirmwareUpdateService>.Instance,
             (_, _) =>
             {
                 wifiFactoryCalls++;
@@ -115,7 +112,6 @@ public class DaqifiViewModelFirmwareUpdateTests
     [TestMethod]
     public async Task UploadFirmware_DownloadedPackage_UsesConnectedCoreDeviceForPic32AndWifi()
     {
-        var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
@@ -179,12 +175,10 @@ public class DaqifiViewModelFirmwareUpdateTests
             SelectedDevice = serialDevice
         };
 
-        var coordinator = new FirmwareUpdateCoordinator(
+        var coordinator = CreateCoordinator(
             host,
-            dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
-            NullLogger<FirmwareUpdateService>.Instance,
             (version, port) =>
             {
                 wifiVersion = version;
@@ -238,7 +232,6 @@ public class DaqifiViewModelFirmwareUpdateTests
         // stay empty so subsequent runs remain auto-updates.
 
         // Arrange
-        var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
@@ -294,12 +287,10 @@ public class DaqifiViewModelFirmwareUpdateTests
             SelectedDevice = serialDevice
         };
 
-        var coordinator = new FirmwareUpdateCoordinator(
+        var coordinator = CreateCoordinator(
             host,
-            dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
-            NullLogger<FirmwareUpdateService>.Instance,
             (_, _) =>
             {
                 wifiFactoryCalls++;
@@ -354,7 +345,6 @@ public class DaqifiViewModelFirmwareUpdateTests
         // selection so a subsequent run defaults to a full auto-update.
 
         // Arrange
-        var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
@@ -412,12 +402,10 @@ public class DaqifiViewModelFirmwareUpdateTests
             FirmwareFilePath = manualFirmwarePath
         };
 
-        var coordinator = new FirmwareUpdateCoordinator(
+        var coordinator = CreateCoordinator(
             host,
-            dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
-            NullLogger<FirmwareUpdateService>.Instance,
             (_, _) =>
             {
                 wifiFactoryCalls++;
@@ -468,7 +456,6 @@ public class DaqifiViewModelFirmwareUpdateTests
     [TestMethod]
     public async Task UploadFirmware_WifiFirmwareUpToDate_SkipsWifiFlash()
     {
-        var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
 
@@ -506,12 +493,10 @@ public class DaqifiViewModelFirmwareUpdateTests
             SelectedDevice = serialDevice
         };
 
-        var coordinator = new FirmwareUpdateCoordinator(
+        var coordinator = CreateCoordinator(
             host,
-            dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
-            NullLogger<FirmwareUpdateService>.Instance,
             (_, _) =>
             {
                 wifiFactoryCalls++;
@@ -571,7 +556,6 @@ public class DaqifiViewModelFirmwareUpdateTests
         Action<Mock<IFirmwareUpdateService>> configureStatusCheck,
         bool expectsUnavailableStatusText)
     {
-        var dialogService = new Mock<IDialogService>();
         var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
@@ -622,12 +606,10 @@ public class DaqifiViewModelFirmwareUpdateTests
             SelectedDevice = serialDevice
         };
 
-        var coordinator = new FirmwareUpdateCoordinator(
+        var coordinator = CreateCoordinator(
             host,
-            dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
-            NullLogger<FirmwareUpdateService>.Instance,
             (_, _) => wifiFirmwareUpdateService.Object);
 
         await coordinator.UploadFirmwareAsync();
@@ -649,12 +631,11 @@ public class DaqifiViewModelFirmwareUpdateTests
     [TestMethod]
     public async Task RefreshFirmwareUpdates_NoConnectedDevices_DoesNotQueryReleases()
     {
-        var dialogService = new Mock<IDialogService>();
         var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
 
         var host = new FakeFirmwareUpdateHost();
-        var coordinator = CreateVersionCheckCoordinator(host, dialogService, firmwareUpdateService, firmwareDownloadService);
+        var coordinator = CreateCoordinator(host, firmwareUpdateService.Object, firmwareDownloadService.Object);
 
         await coordinator.RefreshFirmwareUpdatesAsync();
 
@@ -666,7 +647,6 @@ public class DaqifiViewModelFirmwareUpdateTests
     [TestMethod]
     public async Task RefreshFirmwareUpdates_OutdatedDevice_FlagsDeviceAndAddsNotification()
     {
-        var dialogService = new Mock<IDialogService>();
         var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
 
@@ -685,7 +665,7 @@ public class DaqifiViewModelFirmwareUpdateTests
 
         var device = CreateDeviceMock("SN-OUTDATED", "1.0.0");
         var host = new FakeFirmwareUpdateHost { ConnectedDevices = [device.Object] };
-        var coordinator = CreateVersionCheckCoordinator(host, dialogService, firmwareUpdateService, firmwareDownloadService);
+        var coordinator = CreateCoordinator(host, firmwareUpdateService.Object, firmwareDownloadService.Object);
 
         await coordinator.RefreshFirmwareUpdatesAsync();
 
@@ -700,7 +680,6 @@ public class DaqifiViewModelFirmwareUpdateTests
     [TestMethod]
     public async Task RefreshFirmwareUpdates_UpToDateDevice_ClearsFlagAndRemovesNotification()
     {
-        var dialogService = new Mock<IDialogService>();
         var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
         var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
 
@@ -727,7 +706,7 @@ public class DaqifiViewModelFirmwareUpdateTests
             IsFirmwareUpdate = true
         });
 
-        var coordinator = CreateVersionCheckCoordinator(host, dialogService, firmwareUpdateService, firmwareDownloadService);
+        var coordinator = CreateCoordinator(host, firmwareUpdateService.Object, firmwareDownloadService.Object);
 
         await coordinator.RefreshFirmwareUpdatesAsync();
 
@@ -735,19 +714,26 @@ public class DaqifiViewModelFirmwareUpdateTests
         Assert.AreEqual(0, host.Notifications.Count);
     }
 
-    private static FirmwareUpdateCoordinator CreateVersionCheckCoordinator(
+    /// <summary>
+    /// Builds a coordinator with no-op test loggers and a throwaway firmware data directory.
+    /// Dialog/flyout host operations are captured by <see cref="FakeFirmwareUpdateHost"/>, so no
+    /// dialog service is needed; the WiFi factory defaults to null (the WiFi path is only reached by
+    /// tests that pass one explicitly).
+    /// </summary>
+    private FirmwareUpdateCoordinator CreateCoordinator(
         FakeFirmwareUpdateHost host,
-        Mock<IDialogService> dialogService,
-        Mock<IFirmwareUpdateService> firmwareUpdateService,
-        Mock<IFirmwareDownloadService> firmwareDownloadService)
+        IFirmwareUpdateService firmwareUpdateService,
+        IFirmwareDownloadService firmwareDownloadService,
+        Func<string, string, IFirmwareUpdateService>? wifiFirmwareUpdateServiceFactory = null)
     {
         return new FirmwareUpdateCoordinator(
             host,
-            dialogService.Object,
-            firmwareUpdateService.Object,
-            firmwareDownloadService.Object,
+            firmwareUpdateService,
+            firmwareDownloadService,
             NullLogger<FirmwareUpdateService>.Instance,
-            (_, _) => Mock.Of<IFirmwareUpdateService>());
+            Mock.Of<IAppLogger>(),
+            CreateTempDirectory(),
+            wifiFirmwareUpdateServiceFactory);
     }
 
     private static Mock<Daqifi.Desktop.Device.IStreamingDevice> CreateDeviceMock(string serialNo, string version)
@@ -900,13 +886,19 @@ public class DaqifiViewModelFirmwareUpdateTests
 
         public Daqifi.Desktop.Device.IStreamingDevice? DeviceBeingUpdated { get; set; }
 
-        public int CloseFlyoutsCallCount { get; private set; }
-
         public int NotificationCount { get; private set; }
 
-        public void CloseFlyouts() => CloseFlyoutsCallCount++;
+        /// <summary>Messages passed to <see cref="ShowFirmwareError"/>, in order.</summary>
+        public List<string> FirmwareErrors { get; } = [];
+
+        /// <summary>Number of times <see cref="ShowFirmwareUpdateSucceeded"/> was invoked.</summary>
+        public int SucceededCallCount { get; private set; }
 
         public void RefreshNotificationCount() => NotificationCount = Notifications.Count;
+
+        public void ShowFirmwareError(string message) => FirmwareErrors.Add(message);
+
+        public void ShowFirmwareUpdateSucceeded() => SucceededCallCount++;
     }
 
     private sealed class TestCoreStreamingDevice : DaqifiStreamingDevice, ILanChipInfoProvider

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -1,16 +1,25 @@
+using System.Collections.ObjectModel;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Producers;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
 using Daqifi.Core.Firmware;
+using Daqifi.Desktop.Device.Firmware;
 using Daqifi.Desktop.Device.SerialDevice;
 using Daqifi.Desktop.DialogService;
-using Daqifi.Desktop.ViewModels;
+using Daqifi.Desktop.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace Daqifi.Desktop.Test.ViewModels;
 
+/// <summary>
+/// Behavior contract for <see cref="FirmwareUpdateCoordinator"/>. These tests originally drove the
+/// firmware flow through <c>DaqifiViewModel</c>; after the coordinator extraction (issue #592) they
+/// target the coordinator directly through a lightweight <see cref="FakeFirmwareUpdateHost"/>, with
+/// no WPF dependency. The asserted behavior (PIC32/WiFi flash sequencing, the auto-vs-manual rule,
+/// the WiFi version-check verdicts, and progress/status state) is unchanged.
+/// </summary>
 [TestClass]
 public class DaqifiViewModelFirmwareUpdateTests
 {
@@ -63,7 +72,14 @@ public class DaqifiViewModelFirmwareUpdateTests
                 (device, _, _, _) => pic32Device = device)
             .Returns(Task.CompletedTask);
 
-        var viewModel = new DaqifiViewModel(
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice,
+            FirmwareFilePath = firmwareFilePath
+        };
+
+        var coordinator = new FirmwareUpdateCoordinator(
+            host,
             dialogService.Object,
             firmwareUpdateService.Object,
             firmwareDownloadService.Object,
@@ -72,18 +88,14 @@ public class DaqifiViewModelFirmwareUpdateTests
             {
                 wifiFactoryCalls++;
                 return Mock.Of<IFirmwareUpdateService>();
-            })
-        {
-            SelectedDevice = serialDevice,
-            FirmwareFilePath = firmwareFilePath
-        };
+            });
 
-        await InvokeUploadFirmwareAsync(viewModel);
+        await coordinator.UploadFirmwareAsync();
 
         Assert.AreSame(coreDevice, pic32Device);
         Assert.AreEqual(0, wifiFactoryCalls);
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.IsTrue(host.IsUploadComplete);
+        Assert.IsFalse(host.HasErrorOccured);
 
         firmwareUpdateService.Verify(service => service.UpdateFirmwareAsync(
             It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
@@ -162,7 +174,13 @@ public class DaqifiViewModelFirmwareUpdateTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
 
-        var viewModel = new DaqifiViewModel(
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice
+        };
+
+        var coordinator = new FirmwareUpdateCoordinator(
+            host,
             dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
@@ -172,19 +190,16 @@ public class DaqifiViewModelFirmwareUpdateTests
                 wifiVersion = version;
                 wifiPort = port;
                 return wifiFirmwareUpdateService.Object;
-            })
-        {
-            SelectedDevice = serialDevice
-        };
+            });
 
-        await InvokeUploadFirmwareAsync(viewModel);
+        await coordinator.UploadFirmwareAsync();
 
         Assert.AreSame(coreDevice, pic32Device);
         Assert.AreSame(coreDevice, wifiDevice);
         Assert.AreEqual("19.7.0", wifiVersion);
         Assert.AreEqual("COM9", wifiPort);
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.IsTrue(host.IsUploadComplete);
+        Assert.IsFalse(host.HasErrorOccured);
 
         AssertCommandSent(coreDevice, ScpiMessageProducer.TurnDeviceOn);
         AssertCommandSent(coreDevice, ScpiMessageProducer.SetLanFirmwareUpdateMode);
@@ -274,7 +289,13 @@ public class DaqifiViewModelFirmwareUpdateTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
 
-        var viewModel = new DaqifiViewModel(
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice
+        };
+
+        var coordinator = new FirmwareUpdateCoordinator(
+            host,
             dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
@@ -283,22 +304,19 @@ public class DaqifiViewModelFirmwareUpdateTests
             {
                 wifiFactoryCalls++;
                 return wifiFirmwareUpdateService.Object;
-            })
-        {
-            SelectedDevice = serialDevice
-        };
+            });
 
         // Act: two consecutive in-session auto-updates with no app restart between them.
-        await InvokeUploadFirmwareAsync(viewModel);
-        await InvokeUploadFirmwareAsync(viewModel);
+        await coordinator.UploadFirmwareAsync();
+        await coordinator.UploadFirmwareAsync();
 
         // Assert: each run performed a full auto-update and the bound path was never populated.
         // (The per-run state is proven by the Times.Exactly(2) counts below: had run 1 left
         // FirmwareFilePath set, run 2 would be classified manual and these would be Times.Once.)
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.IsTrue(host.IsUploadComplete);
+        Assert.IsFalse(host.HasErrorOccured);
         Assert.IsTrue(
-            string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
+            string.IsNullOrWhiteSpace(host.FirmwareFilePath),
             "Auto-update must not populate FirmwareFilePath; doing so reclassifies the next run as a manual upload.");
         // The WiFi module must be flashed on BOTH runs, not just the first.
         Assert.AreEqual(2, wifiFactoryCalls);
@@ -388,7 +406,14 @@ public class DaqifiViewModelFirmwareUpdateTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
 
-        var viewModel = new DaqifiViewModel(
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice,
+            FirmwareFilePath = manualFirmwarePath
+        };
+
+        var coordinator = new FirmwareUpdateCoordinator(
+            host,
             dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
@@ -397,28 +422,24 @@ public class DaqifiViewModelFirmwareUpdateTests
             {
                 wifiFactoryCalls++;
                 return wifiFirmwareUpdateService.Object;
-            })
-        {
-            SelectedDevice = serialDevice,
-            FirmwareFilePath = manualFirmwarePath
-        };
+            });
 
         // Arrange (cont.): drive a manual upload so the session is left in the post-manual state.
         // A manual upload is PIC32-only and must consume the selection; these guards confirm the
         // precondition the Act below depends on.
-        await InvokeUploadFirmwareAsync(viewModel);
+        await coordinator.UploadFirmwareAsync();
         Assert.AreEqual(0, wifiFactoryCalls, "A manual upload must not flash the WiFi module.");
         Assert.IsTrue(
-            string.IsNullOrWhiteSpace(viewModel.FirmwareFilePath),
+            string.IsNullOrWhiteSpace(host.FirmwareFilePath),
             "A manual upload must be consumed so the next run is not silently trapped in manual mode.");
 
         // Act: the next in-session update, without restarting the app and without re-selecting a
         // file. With the selection consumed it must default to a full auto-update.
-        await InvokeUploadFirmwareAsync(viewModel);
+        await coordinator.UploadFirmwareAsync();
 
         // Assert: the second run downloaded firmware and flashed the WiFi module.
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.IsTrue(host.IsUploadComplete);
+        Assert.IsFalse(host.HasErrorOccured);
         Assert.AreEqual(1, wifiFactoryCalls);
 
         pic32FirmwareUpdateService.Verify(service => service.UpdateFirmwareAsync(
@@ -480,7 +501,13 @@ public class DaqifiViewModelFirmwareUpdateTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(pic32FirmwarePath);
 
-        var viewModel = new DaqifiViewModel(
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice
+        };
+
+        var coordinator = new FirmwareUpdateCoordinator(
+            host,
             dialogService.Object,
             pic32FirmwareUpdateService.Object,
             firmwareDownloadService.Object,
@@ -489,18 +516,15 @@ public class DaqifiViewModelFirmwareUpdateTests
             {
                 wifiFactoryCalls++;
                 return Mock.Of<IFirmwareUpdateService>();
-            })
-        {
-            SelectedDevice = serialDevice
-        };
+            });
 
-        await InvokeUploadFirmwareAsync(viewModel);
+        await coordinator.UploadFirmwareAsync();
 
         Assert.AreEqual(0, wifiFactoryCalls);
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
-        Assert.AreEqual(100, viewModel.UploadWiFiProgress);
-        Assert.AreEqual("WiFi firmware already up to date (19.7.0).", viewModel.FirmwareUpdateStatusText);
+        Assert.IsTrue(host.IsUploadComplete);
+        Assert.IsFalse(host.HasErrorOccured);
+        Assert.AreEqual(100, host.UploadWiFiProgress);
+        Assert.AreEqual("WiFi firmware already up to date (19.7.0).", host.FirmwareUpdateStatusText);
 
         firmwareDownloadService.Verify(service => service.DownloadWifiFirmwareAsync(
             It.IsAny<string>(),
@@ -593,32 +617,26 @@ public class DaqifiViewModelFirmwareUpdateTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
 
-        var viewModel = new DaqifiViewModel(
-            dialogService.Object,
-            pic32FirmwareUpdateService.Object,
-            firmwareDownloadService.Object,
-            NullLogger<FirmwareUpdateService>.Instance,
-            (_, _) => wifiFirmwareUpdateService.Object)
+        var host = new FakeFirmwareUpdateHost
         {
             SelectedDevice = serialDevice
         };
 
-        var statusTextHistory = new List<string>();
-        viewModel.PropertyChanged += (_, args) =>
-        {
-            if (args.PropertyName == nameof(DaqifiViewModel.FirmwareUpdateStatusText))
-            {
-                statusTextHistory.Add(viewModel.FirmwareUpdateStatusText);
-            }
-        };
+        var coordinator = new FirmwareUpdateCoordinator(
+            host,
+            dialogService.Object,
+            pic32FirmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            NullLogger<FirmwareUpdateService>.Instance,
+            (_, _) => wifiFirmwareUpdateService.Object);
 
-        await InvokeUploadFirmwareAsync(viewModel);
+        await coordinator.UploadFirmwareAsync();
 
-        Assert.IsTrue(viewModel.IsUploadComplete);
-        Assert.IsFalse(viewModel.HasErrorOccured);
+        Assert.IsTrue(host.IsUploadComplete);
+        Assert.IsFalse(host.HasErrorOccured);
         Assert.AreEqual(
             expectsUnavailableStatusText,
-            statusTextHistory.Contains("WiFi firmware version unavailable; continuing with update."));
+            host.StatusTextHistory.Contains("WiFi firmware version unavailable; continuing with update."));
 
         wifiFirmwareUpdateService.Verify(service => service.UpdateWifiModuleAsync(
             It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
@@ -626,6 +644,119 @@ public class DaqifiViewModelFirmwareUpdateTests
             It.IsAny<IProgress<FirmwareUpdateProgress>>(),
             It.IsAny<CancellationToken>(),
             true), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RefreshFirmwareUpdates_NoConnectedDevices_DoesNotQueryReleases()
+    {
+        var dialogService = new Mock<IDialogService>();
+        var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+
+        var host = new FakeFirmwareUpdateHost();
+        var coordinator = CreateVersionCheckCoordinator(host, dialogService, firmwareUpdateService, firmwareDownloadService);
+
+        await coordinator.RefreshFirmwareUpdatesAsync();
+
+        Assert.AreEqual(string.Empty, coordinator.LatestFirmwareVersion);
+        firmwareDownloadService.Verify(service => service.GetLatestReleaseAsync(
+            It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task RefreshFirmwareUpdates_OutdatedDevice_FlagsDeviceAndAddsNotification()
+    {
+        var dialogService = new Mock<IDialogService>();
+        var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+
+        var latestRelease = new FirmwareReleaseInfo
+        {
+            Version = new FirmwareVersion(2, 0, 0, null, 0),
+            TagName = "v2.0.0",
+            IsPreRelease = false
+        };
+        firmwareDownloadService
+            .Setup(service => service.GetLatestReleaseAsync(true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestRelease);
+        firmwareDownloadService
+            .Setup(service => service.CheckForUpdateAsync(It.IsAny<string>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FirmwareUpdateCheckResult { UpdateAvailable = true });
+
+        var device = CreateDeviceMock("SN-OUTDATED", "1.0.0");
+        var host = new FakeFirmwareUpdateHost { ConnectedDevices = [device.Object] };
+        var coordinator = CreateVersionCheckCoordinator(host, dialogService, firmwareUpdateService, firmwareDownloadService);
+
+        await coordinator.RefreshFirmwareUpdatesAsync();
+
+        Assert.AreEqual(latestRelease.Version.ToString(), coordinator.LatestFirmwareVersion);
+        Assert.IsTrue(device.Object.IsFirmwareOutdated);
+        Assert.AreEqual(1, host.Notifications.Count);
+        Assert.IsTrue(host.Notifications[0].IsFirmwareUpdate);
+        Assert.AreEqual("SN-OUTDATED", host.Notifications[0].DeviceSerialNo);
+        Assert.AreEqual(1, host.NotificationCount);
+    }
+
+    [TestMethod]
+    public async Task RefreshFirmwareUpdates_UpToDateDevice_ClearsFlagAndRemovesNotification()
+    {
+        var dialogService = new Mock<IDialogService>();
+        var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+
+        firmwareDownloadService
+            .Setup(service => service.GetLatestReleaseAsync(true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FirmwareReleaseInfo
+            {
+                Version = new FirmwareVersion(2, 0, 0, null, 0),
+                TagName = "v2.0.0",
+                IsPreRelease = false
+            });
+        firmwareDownloadService
+            .Setup(service => service.CheckForUpdateAsync(It.IsAny<string>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FirmwareUpdateCheckResult { UpdateAvailable = false });
+
+        var device = CreateDeviceMock("SN-CURRENT", "2.0.0");
+        device.Object.IsFirmwareOutdated = true;
+        var host = new FakeFirmwareUpdateHost { ConnectedDevices = [device.Object] };
+        // Pre-existing stale notification for this device that the refresh must clear.
+        host.Notifications.Add(new Notifications
+        {
+            DeviceSerialNo = "SN-CURRENT",
+            Message = "stale",
+            IsFirmwareUpdate = true
+        });
+
+        var coordinator = CreateVersionCheckCoordinator(host, dialogService, firmwareUpdateService, firmwareDownloadService);
+
+        await coordinator.RefreshFirmwareUpdatesAsync();
+
+        Assert.IsFalse(device.Object.IsFirmwareOutdated);
+        Assert.AreEqual(0, host.Notifications.Count);
+    }
+
+    private static FirmwareUpdateCoordinator CreateVersionCheckCoordinator(
+        FakeFirmwareUpdateHost host,
+        Mock<IDialogService> dialogService,
+        Mock<IFirmwareUpdateService> firmwareUpdateService,
+        Mock<IFirmwareDownloadService> firmwareDownloadService)
+    {
+        return new FirmwareUpdateCoordinator(
+            host,
+            dialogService.Object,
+            firmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            NullLogger<FirmwareUpdateService>.Instance,
+            (_, _) => Mock.Of<IFirmwareUpdateService>());
+    }
+
+    private static Mock<Daqifi.Desktop.Device.IStreamingDevice> CreateDeviceMock(string serialNo, string version)
+    {
+        var device = new Mock<Daqifi.Desktop.Device.IStreamingDevice>();
+        device.SetupGet(d => d.DeviceSerialNo).Returns(serialNo);
+        device.SetupGet(d => d.DeviceVersion).Returns(version);
+        device.SetupProperty(d => d.IsFirmwareOutdated);
+        return device;
     }
 
     private static SerialStreamingDevice CreateSerialDeviceWithCoreDevice(string portName, TestCoreStreamingDevice coreDevice)
@@ -697,11 +828,6 @@ public class DaqifiViewModelFirmwareUpdateTests
         };
     }
 
-    private static async Task InvokeUploadFirmwareAsync(DaqifiViewModel viewModel)
-    {
-        await viewModel.UploadFirmwareCommand.ExecuteAsync(null);
-    }
-
     private string CreateTempFile(string extension)
     {
         var tempFile = Path.GetTempFileName();
@@ -728,6 +854,59 @@ public class DaqifiViewModelFirmwareUpdateTests
         Assert.IsTrue(
             coreDevice.SentCommands.Any(command => command.Contains(expectedCommandText, StringComparison.Ordinal)),
             $"Expected command '{expectedCommandText}' to be sent.");
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IFirmwareUpdateHost"/> for driving the coordinator without WPF.
+    /// Captures the progress/status writes (and a full history of status text) the firmware
+    /// flow pushes, and exposes the inputs the coordinator reads.
+    /// </summary>
+    private sealed class FakeFirmwareUpdateHost : IFirmwareUpdateHost
+    {
+        private string _firmwareUpdateStatusText = string.Empty;
+
+        public Daqifi.Desktop.Device.IStreamingDevice? SelectedDevice { get; set; }
+
+        public IReadOnlyList<Daqifi.Desktop.Device.IStreamingDevice> ConnectedDevices { get; set; } = [];
+
+        public string FirmwareFilePath { get; set; } = string.Empty;
+
+        public bool SelectedDeviceSupportsFirmwareUpdate { get; set; }
+
+        public bool IsFirmwareUploading { get; set; }
+
+        public bool IsUploadComplete { get; set; }
+
+        public bool HasErrorOccured { get; set; }
+
+        public int UploadFirmwareProgress { get; set; }
+
+        public int UploadWiFiProgress { get; set; }
+
+        public string FirmwareUpdateStatusText
+        {
+            get => _firmwareUpdateStatusText;
+            set
+            {
+                _firmwareUpdateStatusText = value;
+                StatusTextHistory.Add(value);
+            }
+        }
+
+        /// <summary>Every value written to <see cref="FirmwareUpdateStatusText"/>, in order.</summary>
+        public List<string> StatusTextHistory { get; } = [];
+
+        public ObservableCollection<Notifications> Notifications { get; } = [];
+
+        public Daqifi.Desktop.Device.IStreamingDevice? DeviceBeingUpdated { get; set; }
+
+        public int CloseFlyoutsCallCount { get; private set; }
+
+        public int NotificationCount { get; private set; }
+
+        public void CloseFlyouts() => CloseFlyoutsCallCount++;
+
+        public void RefreshNotificationCount() => NotificationCount = Notifications.Count;
     }
 
     private sealed class TestCoreStreamingDevice : DaqifiStreamingDevice, ILanChipInfoProvider

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -1,0 +1,675 @@
+using System.IO;
+using System.IO.Ports;
+using System.Net.Http;
+using System.Windows;
+using Daqifi.Core.Firmware;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Device.SerialDevice;
+using Daqifi.Desktop.DialogService;
+using Daqifi.Desktop.Helpers;
+using Daqifi.Desktop.Models;
+using Daqifi.Desktop.View;
+using Daqifi.Desktop.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Application = System.Windows.Application;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Owns the full PIC32 + WiFi firmware update flow (download, bootloader/HID session, progress,
+/// cancellation, WiFi-module update) and the firmware version-check / outdated-device notifications.
+/// <para>
+/// Extracted from <c>DaqifiViewModel</c> (issue #592) so the orchestration is unit-testable without
+/// WPF: every collaborator is constructor-injected, and all bound progress/status state is reached
+/// through the <see cref="IFirmwareUpdateHost"/> seam rather than touching the view model or desktop
+/// singletons directly. The view model keeps the bound properties and thin command bindings.
+/// </para>
+/// </summary>
+public class FirmwareUpdateCoordinator
+{
+    #region Private Fields
+    private readonly IFirmwareUpdateHost _host;
+    private readonly IDialogService _dialogService;
+    private readonly IFirmwareUpdateService _firmwareUpdateService;
+    private readonly IFirmwareDownloadService _firmwareDownloadService;
+    private readonly Func<string, string, IFirmwareUpdateService> _wifiFirmwareUpdateServiceFactory;
+    private readonly AppLogger _appLogger = AppLogger.Instance;
+    private CancellationTokenSource? _firmwareUploadCts;
+    private string _latestFirmwareVersion = string.Empty;
+    #endregion
+
+    #region Constructor
+    /// <summary>
+    /// Creates the coordinator. The firmware services and WiFi-update factory are optional so the
+    /// view model can forward whatever the DI container resolved (or <c>null</c> for the default
+    /// production wiring), mirroring the previous in-view-model construction.
+    /// </summary>
+    /// <param name="host">The host view model surface the coordinator reads input from and pushes state to.</param>
+    /// <param name="dialogService">Dialog service used for firmware error/success dialogs.</param>
+    /// <param name="firmwareUpdateService">PIC32 firmware update service; a default is built when null.</param>
+    /// <param name="firmwareDownloadService">Firmware package download service; a default is built when null.</param>
+    /// <param name="firmwareLogger">Logger used when constructing the default update service.</param>
+    /// <param name="wifiFirmwareUpdateServiceFactory">
+    /// Factory used to build the WiFi firmware update service for a specific firmware version and COM port.
+    /// </param>
+    public FirmwareUpdateCoordinator(
+        IFirmwareUpdateHost host,
+        IDialogService dialogService,
+        IFirmwareUpdateService? firmwareUpdateService = null,
+        IFirmwareDownloadService? firmwareDownloadService = null,
+        ILogger<FirmwareUpdateService>? firmwareLogger = null,
+        Func<string, string, IFirmwareUpdateService>? wifiFirmwareUpdateServiceFactory = null)
+    {
+        _host = host ?? throw new ArgumentNullException(nameof(host));
+        _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
+        _firmwareDownloadService = firmwareDownloadService ?? CreateDefaultFirmwareDownloadService();
+        var resolvedLogger = firmwareLogger ?? NullLogger<FirmwareUpdateService>.Instance;
+        _firmwareUpdateService = firmwareUpdateService ?? CreateDefaultFirmwareUpdateService(_firmwareDownloadService, resolvedLogger);
+        _wifiFirmwareUpdateServiceFactory = wifiFirmwareUpdateServiceFactory ?? CreateWifiFirmwareUpdateService;
+    }
+    #endregion
+
+    #region Public Properties
+    /// <summary>
+    /// The latest firmware version discovered by <see cref="RefreshFirmwareUpdatesAsync"/>, or an
+    /// empty string if no check has succeeded yet. Read by the host to flag outdated devices.
+    /// </summary>
+    public string LatestFirmwareVersion => _latestFirmwareVersion;
+    #endregion
+
+    #region Upload firmware and update processes
+    /// <summary>
+    /// Runs a firmware update for the host's selected device. A user-selected <c>.hex</c> file
+    /// triggers a manual (PIC32-only) upload; otherwise the latest package is downloaded and both the
+    /// PIC32 and WiFi modules are flashed.
+    /// </summary>
+    public async Task UploadFirmwareAsync()
+    {
+        if (_host.IsFirmwareUploading)
+        {
+            return;
+        }
+
+        if (_host.SelectedDevice?.ConnectionType != ConnectionType.Usb)
+        {
+            return;
+        }
+
+        if (_host.SelectedDevice is not SerialStreamingDevice serialStreamingDevice)
+        {
+            return;
+        }
+
+        _host.SelectedDeviceSupportsFirmwareUpdate = true;
+        _host.HasErrorOccured = false;
+        _host.IsUploadComplete = false;
+        _host.UploadFirmwareProgress = 0;
+        _host.UploadWiFiProgress = 0;
+        _host.FirmwareUpdateStatusText = "Preparing firmware update...";
+
+        _host.DeviceBeingUpdated = _host.SelectedDevice;
+
+        var isManualUpload = !string.IsNullOrWhiteSpace(_host.FirmwareFilePath);
+
+        _firmwareUploadCts?.Dispose();
+        _firmwareUploadCts = new CancellationTokenSource();
+        _host.IsFirmwareUploading = true;
+        _appLogger.AddBreadcrumb("firmware", $"Firmware update started for {serialStreamingDevice.Name}");
+
+        try
+        {
+            var coreDevice = serialStreamingDevice.ConnectedCoreStreamingDevice;
+
+            if (!coreDevice.IsConnected)
+            {
+                _appLogger.Error($"Device {serialStreamingDevice.Name} is not connected. Cannot update firmware on a disconnected device.");
+                _host.Notifications.Add(new Notifications
+                {
+                    Message = $"Please connect device {serialStreamingDevice.Name} before attempting firmware update.",
+                    DeviceSerialNo = serialStreamingDevice.DeviceSerialNo
+                });
+
+                return;
+            }
+
+            // For an auto-update, download into a LOCAL variable rather than the bound
+            // FirmwareFilePath property. Writing the downloaded path back into the property
+            // would make the NEXT in-session update look like a manual upload (isManualUpload
+            // is derived from FirmwareFilePath being non-empty), silently skipping the
+            // WiFi-module step until the app is restarted. See issue #599.
+            string effectiveFirmwarePath;
+            if (!isManualUpload)
+            {
+                _host.FirmwareUpdateStatusText = "Downloading latest firmware package...";
+                effectiveFirmwarePath = await _firmwareDownloadService.DownloadLatestFirmwareAsync(
+                    GetFirmwareDownloadDirectory(),
+                    includePreRelease: true,
+                    cancellationToken: _firmwareUploadCts.Token);
+            }
+            else
+            {
+                effectiveFirmwarePath = _host.FirmwareFilePath;
+            }
+
+            if (string.IsNullOrWhiteSpace(effectiveFirmwarePath) || !File.Exists(effectiveFirmwarePath))
+            {
+                throw new FileNotFoundException("Firmware file path is invalid or does not exist.", effectiveFirmwarePath);
+            }
+
+            var pic32Progress = new Progress<FirmwareUpdateProgress>(report =>
+            {
+                _host.UploadFirmwareProgress = Math.Clamp((int)Math.Round(report.PercentComplete), 0, 100);
+                if (!string.IsNullOrWhiteSpace(report.CurrentOperation))
+                {
+                    _host.FirmwareUpdateStatusText = report.CurrentOperation;
+                }
+            });
+
+            await _firmwareUpdateService.UpdateFirmwareAsync(
+                coreDevice,
+                effectiveFirmwarePath,
+                pic32Progress,
+                _firmwareUploadCts.Token);
+
+            if (!isManualUpload)
+            {
+                await UpdateWifiModuleAsync(coreDevice, serialStreamingDevice, _firmwareUploadCts.Token);
+            }
+
+            _host.IsUploadComplete = true;
+            _appLogger.AddBreadcrumb("firmware", "Firmware update completed");
+            ShowUploadSuccessMessage();
+        }
+        catch (OperationCanceledException)
+        {
+            _host.FirmwareUpdateStatusText = "Firmware update canceled.";
+            _appLogger.Warning("Firmware update canceled by user.");
+            _appLogger.AddBreadcrumb("firmware", "Firmware update cancelled", Common.Loggers.BreadcrumbLevel.Warning);
+        }
+        catch (FirmwareUpdateException ex)
+        {
+            _appLogger.AddBreadcrumb("firmware", $"Firmware update failed: {ex.FailedState}", Common.Loggers.BreadcrumbLevel.Error);
+            HandleFirmwareUpdateException(ex);
+        }
+        catch (Exception ex)
+        {
+            _host.HasErrorOccured = true;
+            _appLogger.Error(ex, "Problem Uploading Firmware");
+            _appLogger.AddBreadcrumb("firmware", "Firmware update failed", Common.Loggers.BreadcrumbLevel.Error);
+            ShowFirmwareErrorDialog("Firmware update failed. Please try again.");
+        }
+        finally
+        {
+            _host.IsFirmwareUploading = false;
+            _firmwareUploadCts?.Dispose();
+            _firmwareUploadCts = null;
+            _host.DeviceBeingUpdated = null;
+
+            // Consume any manual .hex selection so the auto/manual decision is a per-run input,
+            // not sticky session state. A manual upload is intentionally PIC32-only (no WiFi),
+            // and isManualUpload is derived from FirmwareFilePath being non-empty. Without this
+            // reset a prior manual selection would trap every later run in manual mode and
+            // silently skip the WiFi-module flash until the app is restarted — the symmetric
+            // case of issue #599. The next run defaults to a full auto-update unless the user
+            // explicitly re-selects a file. (The auto path never writes this property.)
+            _host.FirmwareFilePath = string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Requests cancellation of an in-flight firmware upload. No-op when nothing is uploading.
+    /// </summary>
+    public void CancelUpload()
+    {
+        if (!_host.IsFirmwareUploading)
+        {
+            return;
+        }
+
+        _host.FirmwareUpdateStatusText = "Canceling firmware update...";
+        _firmwareUploadCts?.Cancel();
+    }
+
+    private async Task UpdateWifiModuleAsync(
+        Daqifi.Core.Device.IStreamingDevice coreDevice,
+        SerialStreamingDevice serialStreamingDevice,
+        CancellationToken cancellationToken)
+    {
+        // Let Core probe the WiFi version and look up the latest release in one call so the desktop
+        // can skip unnecessary downloads and surface the current/update versions in the UI. Core owns
+        // the startup retry policy for the chip-info probe (the chip may still be booting right after
+        // a PIC32 update; see FirmwareUpdateServiceOptions.LanChipInfoMaxAttempts/LanChipInfoRetryDelay).
+        // Because the desktop owns this check, the Core flash call below passes skipVersionCheck: true
+        // so the device isn't queried a second time.
+        const string versionUnavailableStatus = "WiFi firmware version unavailable; continuing with update.";
+
+        _host.FirmwareUpdateStatusText = "Checking WiFi firmware version...";
+        _appLogger.Information("Checking WiFi firmware version before deciding whether to flash the WiFi module.");
+
+        WifiFirmwareStatus? wifiStatus = null;
+        try
+        {
+            wifiStatus = await _firmwareUpdateService.CheckWifiFirmwareStatusAsync(coreDevice, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The status check is a UX optimization and expected failures already surface as Reason
+            // values, so this guards only unexpected faults (e.g. a broken service instance). Never
+            // let those abort the flash below, which runs on its own freshly created service.
+            _appLogger.Warning($"WiFi firmware status check failed ({ex.Message}); continuing with WiFi update.");
+            _host.FirmwareUpdateStatusText = versionUnavailableStatus;
+        }
+
+        if (wifiStatus != null)
+        {
+            if (wifiStatus.CurrentChipInfo != null)
+            {
+                _appLogger.Information(
+                    "WiFi chip info query succeeded. " +
+                    $"Device WiFi firmware version: {wifiStatus.CurrentChipInfo.FwVersion}.");
+            }
+
+            switch (wifiStatus.Reason)
+            {
+                case WifiFirmwareStatusReason.UpToDate:
+                {
+                    var deviceVersion = wifiStatus.CurrentChipInfo!.FwVersion;
+                    var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
+                    _host.FirmwareUpdateStatusText = $"WiFi firmware already up to date ({deviceVersion}).";
+                    _appLogger.Information(
+                        $"WiFi firmware is already up to date (device: {deviceVersion}, latest: {latestVersion}); " +
+                        "skipping WiFi flash.");
+                    _host.UploadWiFiProgress = 100;
+                    return;
+                }
+
+                case WifiFirmwareStatusReason.UpdateAvailable:
+                {
+                    var deviceVersion = wifiStatus.CurrentChipInfo!.FwVersion;
+                    var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
+                    _host.FirmwareUpdateStatusText =
+                        $"WiFi update available ({deviceVersion} → {latestVersion}). Downloading...";
+                    _appLogger.Information(
+                        $"WiFi firmware update required (device: {deviceVersion}, latest: {latestVersion}); " +
+                        "proceeding with WiFi flash.");
+                    break;
+                }
+
+                case WifiFirmwareStatusReason.ChipInfoUnavailable:
+                    _appLogger.Warning(
+                        "WiFi chip info unavailable after startup retries; continuing with WiFi update.");
+                    _host.FirmwareUpdateStatusText = versionUnavailableStatus;
+                    break;
+
+                case WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery:
+                    _appLogger.Warning(
+                        "Device does not support WiFi chip info queries; continuing with WiFi update.");
+                    _host.FirmwareUpdateStatusText = versionUnavailableStatus;
+                    break;
+
+                case WifiFirmwareStatusReason.LatestReleaseUnavailable:
+                    _appLogger.Warning(
+                        "Latest WiFi firmware release metadata was unavailable; continuing with WiFi update.");
+                    break;
+
+                default:
+                    // VersionUnparseable or future reasons — the comparison was inconclusive,
+                    // so conservatively continue with the flash.
+                    _appLogger.Warning(
+                        $"WiFi firmware version check was inconclusive ({wifiStatus.Reason}); " +
+                        "continuing with WiFi update.");
+                    _host.FirmwareUpdateStatusText = versionUnavailableStatus;
+                    break;
+            }
+        }
+
+        _host.FirmwareUpdateStatusText = "Downloading WiFi firmware package...";
+        var wifiDownloadProgress = new Progress<int>(percent =>
+        {
+            // Map download progress into the initial segment of the WiFi bar.
+            _host.UploadWiFiProgress = Math.Clamp((int)Math.Round(percent * 0.2), 0, 20);
+        });
+
+        var wifiPackage = await _firmwareDownloadService.DownloadWifiFirmwareAsync(
+            GetWifiDownloadDirectory(),
+            wifiDownloadProgress,
+            cancellationToken);
+
+        if (wifiPackage == null)
+        {
+            throw new InvalidOperationException("No WiFi firmware package was found for update.");
+        }
+
+        var wifiVersion = NormalizeWifiFirmwareVersion(wifiPackage.Value.Version);
+        _host.FirmwareUpdateStatusText = $"Updating WiFi module ({wifiVersion})...";
+        var wifiUpdateProgress = new Progress<FirmwareUpdateProgress>(report =>
+        {
+            _host.UploadWiFiProgress = Math.Clamp((int)Math.Round(report.PercentComplete), 0, 100);
+            if (!string.IsNullOrWhiteSpace(report.CurrentOperation))
+            {
+                _host.FirmwareUpdateStatusText = report.CurrentOperation;
+            }
+        });
+
+        // Preserve the legacy serial prep/reset sequence now that the firmware flow uses the
+        // underlying Core device directly instead of routing through a desktop-shaped adapter.
+        var lanUpdateModeEnabled = false;
+        try
+        {
+            lanUpdateModeEnabled = serialStreamingDevice.EnableLanUpdateMode();
+
+            var wifiUpdateService = _wifiFirmwareUpdateServiceFactory(wifiVersion, serialStreamingDevice.PortName);
+            try
+            {
+                await wifiUpdateService.UpdateWifiModuleAsync(
+                    coreDevice,
+                    wifiPackage.Value.ExtractedPath,
+                    wifiUpdateProgress,
+                    cancellationToken,
+                    skipVersionCheck: true);
+            }
+            finally
+            {
+                (wifiUpdateService as IDisposable)?.Dispose();
+            }
+        }
+        finally
+        {
+            if (lanUpdateModeEnabled)
+            {
+                serialStreamingDevice.ResetLanAfterUpdate();
+            }
+        }
+    }
+
+    private FirmwareUpdateService CreateWifiFirmwareUpdateService(string wifiVersion, string portName)
+    {
+        var firmwareLogger = App.ServiceProvider?.GetService<ILogger<FirmwareUpdateService>>()
+            ?? NullLogger<FirmwareUpdateService>.Instance;
+
+        // Bridge activation action: opened at the "Power cycle WINC" prompt to trigger the
+        // device's bridge-mode state machine right before the flash tool starts programming.
+        // By deferring APPLY (SYSTem:COMMunicate:LAN:APPLY) until this point we give the
+        // firmware a guaranteed promptResponseDelay window (2 s) to complete the WiFi
+        // deinit/reinit cycle and call wifi_serial_bridge_Init() before the flash tool
+        // issues its first serial bridge query.
+        Action bridgeActivationAction = () =>
+        {
+            _appLogger.Information($"Opening {portName} to send bridge activation commands.");
+            try
+            {
+                // USB CDC virtual ports ignore the baud rate; match the Core transport defaults.
+                using var port = new SerialPort(portName, 9600, Parity.None, 8, StopBits.One)
+                {
+                    DtrEnable = true,
+                    RtsEnable = false,
+                    WriteTimeout = 2000
+                };
+                port.Open();
+                // Brief pause to allow the DTR signal to be recognised by the firmware
+                // before we send commands (firmware checks isCdcHostConnected via DTR).
+                Thread.Sleep(200);
+                // Re-assert the FW-update-requested flag (idempotent; belt-and-suspenders).
+                port.Write("SYSTem:COMMUnicate:LAN:FWUpdate\n");
+                Thread.Sleep(100);
+                // Trigger the WiFi manager REINIT → bridge-mode state machine.
+                port.Write("SYSTem:COMMUnicate:LAN:APPLY\n");
+                // Give the firmware a moment to enqueue the APPLY before we close the port.
+                Thread.Sleep(300);
+                _appLogger.Information("Bridge activation commands sent successfully.");
+            }
+            catch (Exception ex)
+            {
+                _appLogger.Warning($"Bridge activation failed for {portName}: {ex.Message}");
+            }
+        };
+
+        // Start from the shared firmware config so the bootloader HID timeouts stay aligned with
+        // the transport (keeps read and write windows symmetric), then layer on WiFi-specific
+        // settings. The WiFi flow flashes via the external WINC tool rather than the HID loop, so
+        // the bootloader timeout is inert here, but starting from CreateOptions() keeps every
+        // construction site uniform (issue #575).
+        var wifiOptions = FirmwareUpdateServiceConfig.CreateOptions();
+        // winc_flash_tool.cmd requires an explicit release version folder.
+        // Keep legacy argument profile used by shipped WINC tool bundle.
+        wifiOptions.WifiFlashToolArgumentsTemplate = $"/p {{port}} /d WINC1500 /v {wifiVersion} /k /e /i aio /w";
+        wifiOptions.WifiPortOverride = portName;
+        // After sending FWUpdate (flag-only, no APPLY), disconnect quickly so the
+        // COM port is free for the bridge activation raw write at the "Power cycle
+        // WINC" prompt.  The FWUpdate flag persists in firmware RAM until APPLY fires.
+        wifiOptions.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(100);
+        // Give Windows a little more time to re-enumerate the UART before reconnect attempts.
+        wifiOptions.PostWifiReconnectDelay = TimeSpan.FromSeconds(3);
+
+        return new FirmwareUpdateService(
+            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
+            _firmwareDownloadService,
+            new WifiPromptDelayProcessRunner(
+                new ProcessExternalProcessRunner(),
+                promptResponseDelay: TimeSpan.FromSeconds(2),
+                bridgeActivationAction: bridgeActivationAction),
+            firmwareLogger,
+            options: wifiOptions);
+    }
+
+    private static string NormalizeWifiFirmwareVersion(string rawVersion)
+    {
+        var normalized = (rawVersion ?? string.Empty).Trim();
+        if (normalized.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[1..];
+        }
+
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            throw new InvalidOperationException("WiFi firmware version metadata is missing.");
+        }
+
+        // Keep command argument safe even if an unexpected tag format appears.
+        var invalidChars = new[] { ' ', '\t', '\r', '\n', '"', '\'', ';' };
+        if (normalized.IndexOfAny(invalidChars) >= 0)
+        {
+            throw new InvalidOperationException($"Invalid WiFi firmware version tag '{rawVersion}'.");
+        }
+
+        return normalized;
+    }
+
+    private void HandleFirmwareUpdateException(FirmwareUpdateException exception)
+    {
+        _host.HasErrorOccured = true;
+
+        var summary = $"Firmware update failed during '{exception.Operation}' ({exception.FailedState}).";
+        _appLogger.Error(exception, summary);
+
+        if (!string.IsNullOrWhiteSpace(exception.RecoveryGuidance))
+        {
+            _appLogger.Warning($"Firmware recovery guidance: {exception.RecoveryGuidance}");
+        }
+
+        var dialogMessage = summary;
+        if (!string.IsNullOrWhiteSpace(exception.RecoveryGuidance))
+        {
+            dialogMessage += $"{Environment.NewLine}{Environment.NewLine}Suggested recovery: {exception.RecoveryGuidance}";
+        }
+
+        ShowFirmwareErrorDialog(dialogMessage);
+    }
+
+    private void ShowFirmwareErrorDialog(string message)
+    {
+        void ShowDialog()
+        {
+            var errorDialogViewModel = new ErrorDialogViewModel(message);
+            _dialogService.ShowDialog<ErrorDialog>(_host, errorDialogViewModel);
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null)
+        {
+            ShowDialog();
+            return;
+        }
+
+        dispatcher.Invoke(ShowDialog);
+    }
+
+    private void ShowUploadSuccessMessage()
+    {
+        void ShowDialog()
+        {
+            var successDialogViewModel =
+                new SuccessDialogViewModel("Firmware update completed successfully.");
+            _dialogService.ShowDialog<SuccessDialog>(_host, successDialogViewModel);
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null)
+        {
+            ShowDialog();
+            _host.CloseFlyouts();
+            return;
+        }
+
+        dispatcher.Invoke(ShowDialog);
+        _host.CloseFlyouts();
+    }
+
+    private static string GetFirmwareDownloadDirectory()
+    {
+        var firmwareDirectory = Path.Combine(
+            App.DaqifiDataDirectory,
+            "Firmware",
+            "PIC32");
+        Directory.CreateDirectory(firmwareDirectory);
+        return firmwareDirectory;
+    }
+
+    private static string GetWifiDownloadDirectory()
+    {
+        var wifiDirectory = Path.Combine(
+            App.DaqifiDataDirectory,
+            "Firmware",
+            "WiFi");
+        Directory.CreateDirectory(wifiDirectory);
+        return wifiDirectory;
+    }
+
+    private static IFirmwareDownloadService CreateDefaultFirmwareDownloadService()
+    {
+        return new GitHubFirmwareDownloadService(new HttpClient());
+    }
+
+    private static IFirmwareUpdateService CreateDefaultFirmwareUpdateService(
+        IFirmwareDownloadService firmwareDownloadService,
+        ILogger<FirmwareUpdateService> logger)
+    {
+        return new FirmwareUpdateService(
+            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
+            firmwareDownloadService,
+            new ProcessExternalProcessRunner(),
+            logger,
+            options: FirmwareUpdateServiceConfig.CreateOptions());
+    }
+    #endregion
+
+    #region Firmware version checking
+    /// <summary>
+    /// Checks the latest published firmware against every connected device, flags outdated devices,
+    /// and adds/removes the corresponding "outdated firmware" notifications. Failures are logged and
+    /// swallowed so a transient network error never disrupts the UI update path.
+    /// </summary>
+    public async Task RefreshFirmwareUpdatesAsync()
+    {
+        var connectedDevices = _host.ConnectedDevices;
+        if (connectedDevices.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var latestRelease = await _firmwareDownloadService.GetLatestReleaseAsync(includePreRelease: true);
+            _latestFirmwareVersion = latestRelease?.Version.ToString() ?? string.Empty;
+
+            if (latestRelease == null)
+            {
+                return;
+            }
+
+            foreach (var device in connectedDevices)
+            {
+                var updateCheck = await _firmwareDownloadService.CheckForUpdateAsync(
+                    device.DeviceVersion ?? string.Empty,
+                    includePreRelease: true);
+                var isOutdated = updateCheck.UpdateAvailable;
+                device.IsFirmwareOutdated = isOutdated;
+
+                if (!string.IsNullOrWhiteSpace(device.DeviceSerialNo))
+                {
+                    if (isOutdated)
+                    {
+                        AddNotification(device, latestRelease.Version.ToString());
+                    }
+                    else
+                    {
+                        RemoveFirmwareNotification(device);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _appLogger.Warning($"Failed to check firmware updates: {ex.Message}");
+        }
+    }
+
+    private void AddNotification(IStreamingDevice device, string latestFirmware)
+    {
+        var message = $"Device With Serial {device.DeviceSerialNo} has Outdated Firmware. Please Update to Version {latestFirmware}.";
+
+        var existingNotification = _host.Notifications.FirstOrDefault(n => n.DeviceSerialNo != null
+                                                                        && n.IsFirmwareUpdate
+                                                                        && n.DeviceSerialNo == device.DeviceSerialNo);
+
+        if (existingNotification == null)
+        {
+            _host.Notifications.Add(new Notifications
+            {
+                DeviceSerialNo = device.DeviceSerialNo,
+                Message = message,
+                IsFirmwareUpdate = true
+            });
+        }
+
+        _host.RefreshNotificationCount();
+    }
+
+    /// <summary>
+    /// Removes the outdated-firmware notification for a specific device, if present. Called when the
+    /// device's firmware is up to date or when it disconnects.
+    /// </summary>
+    public void RemoveFirmwareNotification(IStreamingDevice deviceToRemove)
+    {
+        if (deviceToRemove?.DeviceSerialNo == null)
+        {
+            return;
+        }
+
+        var notificationsToRemove = _host.Notifications
+            .FirstOrDefault(x => x.DeviceSerialNo != null && x.DeviceSerialNo == deviceToRemove.DeviceSerialNo && x.IsFirmwareUpdate);
+
+        if (notificationsToRemove != null)
+        {
+            _host.Notifications.Remove(notificationsToRemove);
+            _host.RefreshNotificationCount();
+        }
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -1,19 +1,10 @@
 using System.IO;
 using System.IO.Ports;
-using System.Net.Http;
-using System.Windows;
 using Daqifi.Core.Firmware;
 using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device.SerialDevice;
-using Daqifi.Desktop.DialogService;
-using Daqifi.Desktop.Helpers;
 using Daqifi.Desktop.Models;
-using Daqifi.Desktop.View;
-using Daqifi.Desktop.ViewModels;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Application = System.Windows.Application;
 
 namespace Daqifi.Desktop.Device.Firmware;
 
@@ -21,52 +12,60 @@ namespace Daqifi.Desktop.Device.Firmware;
 /// Owns the full PIC32 + WiFi firmware update flow (download, bootloader/HID session, progress,
 /// cancellation, WiFi-module update) and the firmware version-check / outdated-device notifications.
 /// <para>
-/// Extracted from <c>DaqifiViewModel</c> (issue #592) so the orchestration is unit-testable without
-/// WPF: every collaborator is constructor-injected, and all bound progress/status state is reached
-/// through the <see cref="IFirmwareUpdateHost"/> seam rather than touching the view model or desktop
-/// singletons directly. The view model keeps the bound properties and thin command bindings.
+/// Extracted from <c>DaqifiViewModel</c> (issue #592). Every collaborator is constructor-injected
+/// (firmware services, loggers, the firmware data directory), all bound progress/status state is
+/// reached through the <see cref="IFirmwareUpdateHost"/> seam, and dialog presentation is delegated
+/// to the host — so the coordinator has no dependency on WPF or on desktop singletons
+/// (<c>AppLogger.Instance</c>, <c>App.ServiceProvider</c>, <c>App.DaqifiDataDirectory</c>) and is
+/// unit-testable in isolation.
 /// </para>
 /// </summary>
 public class FirmwareUpdateCoordinator
 {
     #region Private Fields
     private readonly IFirmwareUpdateHost _host;
-    private readonly IDialogService _dialogService;
     private readonly IFirmwareUpdateService _firmwareUpdateService;
     private readonly IFirmwareDownloadService _firmwareDownloadService;
+    private readonly ILogger<FirmwareUpdateService> _firmwareLogger;
+    private readonly IAppLogger _appLogger;
+    private readonly string _firmwareDataDirectory;
     private readonly Func<string, string, IFirmwareUpdateService> _wifiFirmwareUpdateServiceFactory;
-    private readonly AppLogger _appLogger = AppLogger.Instance;
     private CancellationTokenSource? _firmwareUploadCts;
     private string _latestFirmwareVersion = string.Empty;
     #endregion
 
     #region Constructor
     /// <summary>
-    /// Creates the coordinator. The firmware services and WiFi-update factory are optional so the
-    /// view model can forward whatever the DI container resolved (or <c>null</c> for the default
-    /// production wiring), mirroring the previous in-view-model construction.
+    /// Creates the coordinator. All firmware collaborators are required and injected; the
+    /// composition root (the view model / DI container) is responsible for building the production
+    /// defaults so this class never news up service clients or reaches into singletons.
     /// </summary>
-    /// <param name="host">The host view model surface the coordinator reads input from and pushes state to.</param>
-    /// <param name="dialogService">Dialog service used for firmware error/success dialogs.</param>
-    /// <param name="firmwareUpdateService">PIC32 firmware update service; a default is built when null.</param>
-    /// <param name="firmwareDownloadService">Firmware package download service; a default is built when null.</param>
-    /// <param name="firmwareLogger">Logger used when constructing the default update service.</param>
+    /// <param name="host">The host view-model surface the coordinator reads input from and pushes state to.</param>
+    /// <param name="firmwareUpdateService">PIC32 firmware update service.</param>
+    /// <param name="firmwareDownloadService">Firmware package download service.</param>
+    /// <param name="firmwareLogger">Logger passed to the WiFi update service built by the default factory.</param>
+    /// <param name="appLogger">Application logger used for diagnostics and Sentry breadcrumbs.</param>
+    /// <param name="firmwareDataDirectory">Base directory under which firmware packages are downloaded.</param>
     /// <param name="wifiFirmwareUpdateServiceFactory">
-    /// Factory used to build the WiFi firmware update service for a specific firmware version and COM port.
+    /// Factory used to build the WiFi firmware update service for a specific firmware version and COM
+    /// port. When null, the built-in desktop factory (<see cref="CreateWifiFirmwareUpdateService"/>)
+    /// is used; tests inject a fake to assert WiFi sequencing without hardware.
     /// </param>
     public FirmwareUpdateCoordinator(
         IFirmwareUpdateHost host,
-        IDialogService dialogService,
-        IFirmwareUpdateService? firmwareUpdateService = null,
-        IFirmwareDownloadService? firmwareDownloadService = null,
-        ILogger<FirmwareUpdateService>? firmwareLogger = null,
+        IFirmwareUpdateService firmwareUpdateService,
+        IFirmwareDownloadService firmwareDownloadService,
+        ILogger<FirmwareUpdateService> firmwareLogger,
+        IAppLogger appLogger,
+        string firmwareDataDirectory,
         Func<string, string, IFirmwareUpdateService>? wifiFirmwareUpdateServiceFactory = null)
     {
         _host = host ?? throw new ArgumentNullException(nameof(host));
-        _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
-        _firmwareDownloadService = firmwareDownloadService ?? CreateDefaultFirmwareDownloadService();
-        var resolvedLogger = firmwareLogger ?? NullLogger<FirmwareUpdateService>.Instance;
-        _firmwareUpdateService = firmwareUpdateService ?? CreateDefaultFirmwareUpdateService(_firmwareDownloadService, resolvedLogger);
+        _firmwareUpdateService = firmwareUpdateService ?? throw new ArgumentNullException(nameof(firmwareUpdateService));
+        _firmwareDownloadService = firmwareDownloadService ?? throw new ArgumentNullException(nameof(firmwareDownloadService));
+        _firmwareLogger = firmwareLogger ?? throw new ArgumentNullException(nameof(firmwareLogger));
+        _appLogger = appLogger ?? throw new ArgumentNullException(nameof(appLogger));
+        _firmwareDataDirectory = firmwareDataDirectory ?? throw new ArgumentNullException(nameof(firmwareDataDirectory));
         _wifiFirmwareUpdateServiceFactory = wifiFirmwareUpdateServiceFactory ?? CreateWifiFirmwareUpdateService;
     }
     #endregion
@@ -180,7 +179,7 @@ public class FirmwareUpdateCoordinator
 
             _host.IsUploadComplete = true;
             _appLogger.AddBreadcrumb("firmware", "Firmware update completed");
-            ShowUploadSuccessMessage();
+            _host.ShowFirmwareUpdateSucceeded();
         }
         catch (OperationCanceledException)
         {
@@ -198,7 +197,7 @@ public class FirmwareUpdateCoordinator
             _host.HasErrorOccured = true;
             _appLogger.Error(ex, "Problem Uploading Firmware");
             _appLogger.AddBreadcrumb("firmware", "Firmware update failed", Common.Loggers.BreadcrumbLevel.Error);
-            ShowFirmwareErrorDialog("Firmware update failed. Please try again.");
+            _host.ShowFirmwareError("Firmware update failed. Please try again.");
         }
         finally
         {
@@ -390,9 +389,6 @@ public class FirmwareUpdateCoordinator
 
     private FirmwareUpdateService CreateWifiFirmwareUpdateService(string wifiVersion, string portName)
     {
-        var firmwareLogger = App.ServiceProvider?.GetService<ILogger<FirmwareUpdateService>>()
-            ?? NullLogger<FirmwareUpdateService>.Instance;
-
         // Bridge activation action: opened at the "Power cycle WINC" prompt to trigger the
         // device's bridge-mode state machine right before the flash tool starts programming.
         // By deferring APPLY (SYSTem:COMMunicate:LAN:APPLY) until this point we give the
@@ -454,7 +450,7 @@ public class FirmwareUpdateCoordinator
                 new ProcessExternalProcessRunner(),
                 promptResponseDelay: TimeSpan.FromSeconds(2),
                 bridgeActivationAction: bridgeActivationAction),
-            firmwareLogger,
+            _firmwareLogger,
             options: wifiOptions);
     }
 
@@ -499,83 +495,21 @@ public class FirmwareUpdateCoordinator
             dialogMessage += $"{Environment.NewLine}{Environment.NewLine}Suggested recovery: {exception.RecoveryGuidance}";
         }
 
-        ShowFirmwareErrorDialog(dialogMessage);
+        _host.ShowFirmwareError(dialogMessage);
     }
 
-    private void ShowFirmwareErrorDialog(string message)
+    private string GetFirmwareDownloadDirectory()
     {
-        void ShowDialog()
-        {
-            var errorDialogViewModel = new ErrorDialogViewModel(message);
-            _dialogService.ShowDialog<ErrorDialog>(_host, errorDialogViewModel);
-        }
-
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher == null)
-        {
-            ShowDialog();
-            return;
-        }
-
-        dispatcher.Invoke(ShowDialog);
-    }
-
-    private void ShowUploadSuccessMessage()
-    {
-        void ShowDialog()
-        {
-            var successDialogViewModel =
-                new SuccessDialogViewModel("Firmware update completed successfully.");
-            _dialogService.ShowDialog<SuccessDialog>(_host, successDialogViewModel);
-        }
-
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher == null)
-        {
-            ShowDialog();
-            _host.CloseFlyouts();
-            return;
-        }
-
-        dispatcher.Invoke(ShowDialog);
-        _host.CloseFlyouts();
-    }
-
-    private static string GetFirmwareDownloadDirectory()
-    {
-        var firmwareDirectory = Path.Combine(
-            App.DaqifiDataDirectory,
-            "Firmware",
-            "PIC32");
+        var firmwareDirectory = Path.Combine(_firmwareDataDirectory, "Firmware", "PIC32");
         Directory.CreateDirectory(firmwareDirectory);
         return firmwareDirectory;
     }
 
-    private static string GetWifiDownloadDirectory()
+    private string GetWifiDownloadDirectory()
     {
-        var wifiDirectory = Path.Combine(
-            App.DaqifiDataDirectory,
-            "Firmware",
-            "WiFi");
+        var wifiDirectory = Path.Combine(_firmwareDataDirectory, "Firmware", "WiFi");
         Directory.CreateDirectory(wifiDirectory);
         return wifiDirectory;
-    }
-
-    private static IFirmwareDownloadService CreateDefaultFirmwareDownloadService()
-    {
-        return new GitHubFirmwareDownloadService(new HttpClient());
-    }
-
-    private static IFirmwareUpdateService CreateDefaultFirmwareUpdateService(
-        IFirmwareDownloadService firmwareDownloadService,
-        ILogger<FirmwareUpdateService> logger)
-    {
-        return new FirmwareUpdateService(
-            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
-            firmwareDownloadService,
-            new ProcessExternalProcessRunner(),
-            logger,
-            options: FirmwareUpdateServiceConfig.CreateOptions());
     }
     #endregion
 

--- a/Daqifi.Desktop/Device/Firmware/IFirmwareUpdateHost.cs
+++ b/Daqifi.Desktop/Device/Firmware/IFirmwareUpdateHost.cs
@@ -1,0 +1,76 @@
+using System.Collections.ObjectModel;
+using Daqifi.Desktop.Models;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Narrow seam the <see cref="FirmwareUpdateCoordinator"/> uses to read user input and push
+/// progress/status/result state back to the host view model.
+/// <para>
+/// Implemented by <c>DaqifiViewModel</c> so its existing bound <c>[ObservableProperty]</c> fields
+/// remain the binding source (firmware XAML is unchanged), while the firmware orchestration and
+/// version-check logic live in the coordinator and are unit-testable against a lightweight fake.
+/// Only firmware-relevant members are exposed here — the coordinator never reaches into desktop
+/// singletons (<c>ConnectionManager.Instance</c> etc.) directly.
+/// </para>
+/// </summary>
+public interface IFirmwareUpdateHost
+{
+    #region Inputs
+    /// <summary>The device the firmware flyout is currently acting on.</summary>
+    IStreamingDevice? SelectedDevice { get; }
+
+    /// <summary>
+    /// Devices currently connected. Sourced from the host so the coordinator never reaches into
+    /// <c>ConnectionManager.Instance</c>; used by the firmware-update version check.
+    /// </summary>
+    IReadOnlyList<IStreamingDevice> ConnectedDevices { get; }
+
+    /// <summary>
+    /// Path to a user-selected <c>.hex</c> file. A non-empty value selects a manual (PIC32-only)
+    /// upload; the coordinator clears it after each run so the next run defaults to a full
+    /// auto-update (issue #599).
+    /// </summary>
+    string FirmwareFilePath { get; set; }
+    #endregion
+
+    #region Bound progress / status state
+    /// <summary>Whether the selected device supports the firmware-update path (USB-connected).</summary>
+    bool SelectedDeviceSupportsFirmwareUpdate { set; }
+
+    /// <summary>True while an upload is in progress. Read for the re-entrancy and cancel guards.</summary>
+    bool IsFirmwareUploading { get; set; }
+
+    /// <summary>True once an upload has finished successfully.</summary>
+    bool IsUploadComplete { set; }
+
+    /// <summary>True when the most recent upload failed.</summary>
+    bool HasErrorOccured { set; }
+
+    /// <summary>PIC32 flash progress, 0–100.</summary>
+    int UploadFirmwareProgress { set; }
+
+    /// <summary>WiFi-module flash progress, 0–100.</summary>
+    int UploadWiFiProgress { set; }
+
+    /// <summary>Status line shown beneath the firmware progress bars.</summary>
+    string FirmwareUpdateStatusText { set; }
+    #endregion
+
+    #region Collaborators
+    /// <summary>The shared, bound notification list. The coordinator adds/removes firmware notifications.</summary>
+    ObservableCollection<Notifications> Notifications { get; }
+
+    /// <summary>
+    /// The device being flashed, surfaced so the connection manager can suppress reconnect churn
+    /// while an update runs. Set to the device at start and back to <c>null</c> when finished.
+    /// </summary>
+    IStreamingDevice? DeviceBeingUpdated { set; }
+
+    /// <summary>Closes all open flyouts (used after a successful upload).</summary>
+    void CloseFlyouts();
+
+    /// <summary>Re-syncs the notification badge count after the coordinator mutates the list.</summary>
+    void RefreshNotificationCount();
+    #endregion
+}

--- a/Daqifi.Desktop/Device/Firmware/IFirmwareUpdateHost.cs
+++ b/Daqifi.Desktop/Device/Firmware/IFirmwareUpdateHost.cs
@@ -67,10 +67,20 @@ public interface IFirmwareUpdateHost
     /// </summary>
     IStreamingDevice? DeviceBeingUpdated { set; }
 
-    /// <summary>Closes all open flyouts (used after a successful upload).</summary>
-    void CloseFlyouts();
-
     /// <summary>Re-syncs the notification badge count after the coordinator mutates the list.</summary>
     void RefreshNotificationCount();
+
+    /// <summary>
+    /// Presents a firmware error dialog. Dialog presentation (and its UI-thread marshalling) is a
+    /// view concern, so the coordinator delegates it here rather than touching WPF directly.
+    /// </summary>
+    /// <param name="message">The error message to display.</param>
+    void ShowFirmwareError(string message);
+
+    /// <summary>
+    /// Presents the firmware-update success dialog and closes the firmware flyout. Kept on the host
+    /// so the coordinator stays free of WPF dependencies.
+    /// </summary>
+    void ShowFirmwareUpdateSucceeded();
     #endregion
 }

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -15,6 +15,7 @@ using MahApps.Metro.Controls.Dialogs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Daqifi.Core.Firmware;
 using Daqifi.Desktop.Device.Firmware;
 using Microsoft.Data.Sqlite;
@@ -22,6 +23,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
+using System.Net.Http;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
@@ -532,15 +534,21 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
         _loggingContextFactory = loggingContextFactory;
 
         // Firmware update orchestration and version-checking live in the coordinator (issue #592).
-        // It resolves the production defaults itself when the injected services are null, mirroring
-        // the previous in-view-model construction; this view model keeps only the bound properties
-        // and thin command bindings, and feeds the coordinator through the IFirmwareUpdateHost seam.
+        // The view model is the composition root: it builds the production service defaults here when
+        // DI supplied none, so the coordinator itself never news up service clients or reaches into
+        // singletons. The view model keeps only the bound properties + thin command bindings and
+        // feeds the coordinator through the IFirmwareUpdateHost seam (which it implements below).
+        var firmwareDownload = firmwareDownloadService ?? CreateDefaultFirmwareDownloadService();
+        var resolvedFirmwareLogger = firmwareLogger ?? NullLogger<FirmwareUpdateService>.Instance;
+        var firmwareUpdate = firmwareUpdateService
+            ?? CreateDefaultFirmwareUpdateService(firmwareDownload, resolvedFirmwareLogger);
         _firmwareCoordinator = new FirmwareUpdateCoordinator(
             this,
-            _dialogService,
-            firmwareUpdateService,
-            firmwareDownloadService,
-            firmwareLogger,
+            firmwareUpdate,
+            firmwareDownload,
+            resolvedFirmwareLogger,
+            _appLogger,
+            App.DaqifiDataDirectory,
             wifiFirmwareUpdateServiceFactory);
 
         ConfirmAffirmativeCommand = new RelayCommand(() => CompleteConfirm(true));
@@ -628,6 +636,31 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
         return App.ServiceProvider?.GetService<IDbContextFactory<LoggingContext>>() == null
             ? null
             : LoggingManager.Instance;
+    }
+
+    /// <summary>
+    /// Builds the production firmware download service used when DI supplies none. Lives here at the
+    /// composition root so <see cref="FirmwareUpdateCoordinator"/> receives a ready-made instance
+    /// rather than constructing its own service clients.
+    /// </summary>
+    private static IFirmwareDownloadService CreateDefaultFirmwareDownloadService()
+    {
+        return new GitHubFirmwareDownloadService(new HttpClient());
+    }
+
+    /// <summary>
+    /// Builds the production PIC32 firmware update service used when DI supplies none.
+    /// </summary>
+    private static IFirmwareUpdateService CreateDefaultFirmwareUpdateService(
+        IFirmwareDownloadService firmwareDownloadService,
+        ILogger<FirmwareUpdateService> logger)
+    {
+        return new FirmwareUpdateService(
+            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
+            firmwareDownloadService,
+            new ProcessExternalProcessRunner(),
+            logger,
+            options: FirmwareUpdateServiceConfig.CreateOptions());
     }
 
     #endregion
@@ -1586,6 +1619,52 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
 
     /// <summary>Re-syncs the notification badge after the coordinator adds/removes a notification.</summary>
     void IFirmwareUpdateHost.RefreshNotificationCount() => NotificationCount = NotificationList.Count;
+
+    /// <summary>
+    /// Presents a firmware error dialog on the UI thread. Dialog presentation is a view concern,
+    /// so the coordinator delegates it here and stays free of WPF dependencies.
+    /// </summary>
+    void IFirmwareUpdateHost.ShowFirmwareError(string message)
+    {
+        void ShowDialog()
+        {
+            var errorDialogViewModel = new ErrorDialogViewModel(message);
+            _dialogService.ShowDialog<ErrorDialog>(this, errorDialogViewModel);
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null)
+        {
+            ShowDialog();
+            return;
+        }
+
+        dispatcher.Invoke(ShowDialog);
+    }
+
+    /// <summary>
+    /// Presents the firmware-update success dialog on the UI thread and closes the firmware flyout.
+    /// </summary>
+    void IFirmwareUpdateHost.ShowFirmwareUpdateSucceeded()
+    {
+        void ShowDialog()
+        {
+            var successDialogViewModel =
+                new SuccessDialogViewModel("Firmware update completed successfully.");
+            _dialogService.ShowDialog<SuccessDialog>(this, successDialogViewModel);
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null)
+        {
+            ShowDialog();
+            CloseFlyouts();
+            return;
+        }
+
+        dispatcher.Invoke(ShowDialog);
+        CloseFlyouts();
+    }
 
     #endregion
 

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -15,22 +15,17 @@ using MahApps.Metro.Controls.Dialogs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Daqifi.Core.Firmware;
-using Daqifi.Core.Communication.Transport;
 using Daqifi.Desktop.Device.Firmware;
 using Microsoft.Data.Sqlite;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
-using System.Net.Http;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Daqifi.Desktop.Device.SerialDevice;
-using System.IO.Ports;
 using Application = System.Windows.Application;
 using File = System.IO.File;
 using CommunityToolkit.Mvvm.Input;
@@ -38,7 +33,7 @@ using Daqifi.Core.Device.SdCard;
 
 namespace Daqifi.Desktop.ViewModels;
 
-public partial class DaqifiViewModel : ObservableObject
+public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
 {
     private readonly AppLogger _appLogger = AppLogger.Instance;
 
@@ -155,16 +150,12 @@ public partial class DaqifiViewModel : ObservableObject
     private string _firmwareUpdateStatusText = string.Empty;
     [ObservableProperty]
     private bool _selectedDeviceSupportsFirmwareUpdate;
-    private readonly IFirmwareUpdateService _firmwareUpdateService;
-    private readonly IFirmwareDownloadService _firmwareDownloadService;
     private readonly IDbContextFactory<LoggingContext>? _loggingContextFactory;
-    private readonly Func<string, string, IFirmwareUpdateService> _wifiFirmwareUpdateServiceFactory;
-    private CancellationTokenSource? _firmwareUploadCts;
+    private readonly FirmwareUpdateCoordinator _firmwareCoordinator;
     private ConnectionDialogViewModel _connectionDialogViewModel;
     private string _selectedLoggingMode = "Stream to App";
     private bool _isLogToDeviceMode;
     private SdCardLogFormat _selectedSdCardLogFormat = SdCardLogFormat.Protobuf;
-    private IStreamingDevice? _deviceBeingUpdated;
     private IDiskSpaceMonitor? _diskSpaceMonitor;
     private ObservableCollection<LoggingSession>? _observedLoggingSessions;
     private CancellationTokenSource? _networkSettingsAppliedCts;
@@ -538,11 +529,19 @@ public partial class DaqifiViewModel : ObservableObject
         IDbContextFactory<LoggingContext>? loggingContextFactory = null)
     {
         _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
-        _firmwareDownloadService = firmwareDownloadService ?? CreateDefaultFirmwareDownloadService();
-        var resolvedLogger = firmwareLogger ?? NullLogger<FirmwareUpdateService>.Instance;
-        _firmwareUpdateService = firmwareUpdateService ?? CreateDefaultFirmwareUpdateService(_firmwareDownloadService, resolvedLogger);
         _loggingContextFactory = loggingContextFactory;
-        _wifiFirmwareUpdateServiceFactory = wifiFirmwareUpdateServiceFactory ?? CreateWifiFirmwareUpdateService;
+
+        // Firmware update orchestration and version-checking live in the coordinator (issue #592).
+        // It resolves the production defaults itself when the injected services are null, mirroring
+        // the previous in-view-model construction; this view model keeps only the bound properties
+        // and thin command bindings, and feeds the coordinator through the IFirmwareUpdateHost seam.
+        _firmwareCoordinator = new FirmwareUpdateCoordinator(
+            this,
+            _dialogService,
+            firmwareUpdateService,
+            firmwareDownloadService,
+            firmwareLogger,
+            wifiFirmwareUpdateServiceFactory);
 
         ConfirmAffirmativeCommand = new RelayCommand(() => CompleteConfirm(true));
         ConfirmNegativeCommand = new RelayCommand(() => CompleteConfirm(false));
@@ -674,481 +673,14 @@ public partial class DaqifiViewModel : ObservableObject
     #region Updload firmware and update processes
 
     [RelayCommand]
-    private async Task UploadFirmware()
-    {
-        if (IsFirmwareUploading)
-        {
-            return;
-        }
-
-        if (SelectedDevice?.ConnectionType != Device.ConnectionType.Usb)
-        {
-            return;
-        }
-
-        if (SelectedDevice is not SerialStreamingDevice serialStreamingDevice)
-        {
-            return;
-        }
-
-        SelectedDeviceSupportsFirmwareUpdate = true;
-        HasErrorOccured = false;
-        IsUploadComplete = false;
-        UploadFirmwareProgress = 0;
-        UploadWiFiProgress = 0;
-        FirmwareUpdateStatusText = "Preparing firmware update...";
-
-        _deviceBeingUpdated = SelectedDevice;
-        ConnectionManager.Instance.DeviceBeingUpdated = _deviceBeingUpdated;
-
-        var isManualUpload = !string.IsNullOrWhiteSpace(FirmwareFilePath);
-
-        _firmwareUploadCts?.Dispose();
-        _firmwareUploadCts = new CancellationTokenSource();
-        IsFirmwareUploading = true;
-        _appLogger.AddBreadcrumb("firmware", $"Firmware update started for {serialStreamingDevice.Name}");
-
-        try
-        {
-            var coreDevice = serialStreamingDevice.ConnectedCoreStreamingDevice;
-
-            if (!coreDevice.IsConnected)
-            {
-                _appLogger.Error($"Device {serialStreamingDevice.Name} is not connected. Cannot update firmware on a disconnected device.");
-                NotificationList.Add(new Notifications
-                {
-                    Message = $"Please connect device {serialStreamingDevice.Name} before attempting firmware update.",
-                    DeviceSerialNo = serialStreamingDevice.DeviceSerialNo
-                });
-
-                return;
-            }
-
-            // For an auto-update, download into a LOCAL variable rather than the bound
-            // FirmwareFilePath property. Writing the downloaded path back into the property
-            // would make the NEXT in-session update look like a manual upload (isManualUpload
-            // is derived from FirmwareFilePath being non-empty), silently skipping the
-            // WiFi-module step until the app is restarted. See issue #599.
-            string effectiveFirmwarePath;
-            if (!isManualUpload)
-            {
-                FirmwareUpdateStatusText = "Downloading latest firmware package...";
-                effectiveFirmwarePath = await _firmwareDownloadService.DownloadLatestFirmwareAsync(
-                    GetFirmwareDownloadDirectory(),
-                    includePreRelease: true,
-                    cancellationToken: _firmwareUploadCts.Token);
-            }
-            else
-            {
-                effectiveFirmwarePath = FirmwareFilePath;
-            }
-
-            if (string.IsNullOrWhiteSpace(effectiveFirmwarePath) || !File.Exists(effectiveFirmwarePath))
-            {
-                throw new FileNotFoundException("Firmware file path is invalid or does not exist.", effectiveFirmwarePath);
-            }
-
-            var pic32Progress = new Progress<FirmwareUpdateProgress>(report =>
-            {
-                UploadFirmwareProgress = Math.Clamp((int)Math.Round(report.PercentComplete), 0, 100);
-                if (!string.IsNullOrWhiteSpace(report.CurrentOperation))
-                {
-                    FirmwareUpdateStatusText = report.CurrentOperation;
-                }
-            });
-
-            await _firmwareUpdateService.UpdateFirmwareAsync(
-                coreDevice,
-                effectiveFirmwarePath,
-                pic32Progress,
-                _firmwareUploadCts.Token);
-
-            if (!isManualUpload)
-            {
-                await UpdateWifiModuleAsync(coreDevice, serialStreamingDevice, _firmwareUploadCts.Token);
-            }
-
-            IsUploadComplete = true;
-            _appLogger.AddBreadcrumb("firmware", "Firmware update completed");
-            ShowUploadSuccessMessage();
-        }
-        catch (OperationCanceledException)
-        {
-            FirmwareUpdateStatusText = "Firmware update canceled.";
-            _appLogger.Warning("Firmware update canceled by user.");
-            _appLogger.AddBreadcrumb("firmware", "Firmware update cancelled", Common.Loggers.BreadcrumbLevel.Warning);
-        }
-        catch (FirmwareUpdateException ex)
-        {
-            _appLogger.AddBreadcrumb("firmware", $"Firmware update failed: {ex.FailedState}", Common.Loggers.BreadcrumbLevel.Error);
-            HandleFirmwareUpdateException(ex);
-        }
-        catch (Exception ex)
-        {
-            HasErrorOccured = true;
-            _appLogger.Error(ex, "Problem Uploading Firmware");
-            _appLogger.AddBreadcrumb("firmware", "Firmware update failed", Common.Loggers.BreadcrumbLevel.Error);
-            ShowFirmwareErrorDialog("Firmware update failed. Please try again.");
-        }
-        finally
-        {
-            IsFirmwareUploading = false;
-            _firmwareUploadCts?.Dispose();
-            _firmwareUploadCts = null;
-            _deviceBeingUpdated = null;
-            ConnectionManager.Instance.DeviceBeingUpdated = null;
-
-            // Consume any manual .hex selection so the auto/manual decision is a per-run input,
-            // not sticky session state. A manual upload is intentionally PIC32-only (no WiFi),
-            // and isManualUpload is derived from FirmwareFilePath being non-empty. Without this
-            // reset a prior manual selection would trap every later run in manual mode and
-            // silently skip the WiFi-module flash until the app is restarted — the symmetric
-            // case of issue #599. The next run defaults to a full auto-update unless the user
-            // explicitly re-selects a file. (The auto path never writes this property.)
-            FirmwareFilePath = string.Empty;
-        }
-    }
+    private Task UploadFirmware() => _firmwareCoordinator.UploadFirmwareAsync();
 
     [RelayCommand(CanExecute = nameof(CanCancelFirmwareUpload))]
-    private void CancelFirmwareUpload()
-    {
-        if (!IsFirmwareUploading)
-        {
-            return;
-        }
-
-        FirmwareUpdateStatusText = "Canceling firmware update...";
-        _firmwareUploadCts?.Cancel();
-    }
+    private void CancelFirmwareUpload() => _firmwareCoordinator.CancelUpload();
 
     private bool CanCancelFirmwareUpload()
     {
         return IsFirmwareUploading;
-    }
-
-    private async Task UpdateWifiModuleAsync(
-        Daqifi.Core.Device.IStreamingDevice coreDevice,
-        SerialStreamingDevice serialStreamingDevice,
-        CancellationToken cancellationToken)
-    {
-        // Let Core probe the WiFi version and look up the latest release in one call so the desktop
-        // can skip unnecessary downloads and surface the current/update versions in the UI. Core owns
-        // the startup retry policy for the chip-info probe (the chip may still be booting right after
-        // a PIC32 update; see FirmwareUpdateServiceOptions.LanChipInfoMaxAttempts/LanChipInfoRetryDelay).
-        // Because the desktop owns this check, the Core flash call below passes skipVersionCheck: true
-        // so the device isn't queried a second time.
-        const string versionUnavailableStatus = "WiFi firmware version unavailable; continuing with update.";
-
-        FirmwareUpdateStatusText = "Checking WiFi firmware version...";
-        _appLogger.Information("Checking WiFi firmware version before deciding whether to flash the WiFi module.");
-
-        WifiFirmwareStatus? wifiStatus = null;
-        try
-        {
-            wifiStatus = await _firmwareUpdateService.CheckWifiFirmwareStatusAsync(coreDevice, cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            // The status check is a UX optimization and expected failures already surface as Reason
-            // values, so this guards only unexpected faults (e.g. a broken service instance). Never
-            // let those abort the flash below, which runs on its own freshly created service.
-            _appLogger.Warning($"WiFi firmware status check failed ({ex.Message}); continuing with WiFi update.");
-            FirmwareUpdateStatusText = versionUnavailableStatus;
-        }
-
-        if (wifiStatus != null)
-        {
-            if (wifiStatus.CurrentChipInfo != null)
-            {
-                _appLogger.Information(
-                    "WiFi chip info query succeeded. " +
-                    $"Device WiFi firmware version: {wifiStatus.CurrentChipInfo.FwVersion}.");
-            }
-
-            switch (wifiStatus.Reason)
-            {
-                case WifiFirmwareStatusReason.UpToDate:
-                {
-                    var deviceVersion = wifiStatus.CurrentChipInfo!.FwVersion;
-                    var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
-                    FirmwareUpdateStatusText = $"WiFi firmware already up to date ({deviceVersion}).";
-                    _appLogger.Information(
-                        $"WiFi firmware is already up to date (device: {deviceVersion}, latest: {latestVersion}); " +
-                        "skipping WiFi flash.");
-                    UploadWiFiProgress = 100;
-                    return;
-                }
-
-                case WifiFirmwareStatusReason.UpdateAvailable:
-                {
-                    var deviceVersion = wifiStatus.CurrentChipInfo!.FwVersion;
-                    var latestVersion = NormalizeWifiFirmwareVersion(wifiStatus.LatestRelease!.TagName);
-                    FirmwareUpdateStatusText =
-                        $"WiFi update available ({deviceVersion} → {latestVersion}). Downloading...";
-                    _appLogger.Information(
-                        $"WiFi firmware update required (device: {deviceVersion}, latest: {latestVersion}); " +
-                        "proceeding with WiFi flash.");
-                    break;
-                }
-
-                case WifiFirmwareStatusReason.ChipInfoUnavailable:
-                    _appLogger.Warning(
-                        "WiFi chip info unavailable after startup retries; continuing with WiFi update.");
-                    FirmwareUpdateStatusText = versionUnavailableStatus;
-                    break;
-
-                case WifiFirmwareStatusReason.DeviceDoesNotSupportLanQuery:
-                    _appLogger.Warning(
-                        "Device does not support WiFi chip info queries; continuing with WiFi update.");
-                    FirmwareUpdateStatusText = versionUnavailableStatus;
-                    break;
-
-                case WifiFirmwareStatusReason.LatestReleaseUnavailable:
-                    _appLogger.Warning(
-                        "Latest WiFi firmware release metadata was unavailable; continuing with WiFi update.");
-                    break;
-
-                default:
-                    // VersionUnparseable or future reasons — the comparison was inconclusive,
-                    // so conservatively continue with the flash.
-                    _appLogger.Warning(
-                        $"WiFi firmware version check was inconclusive ({wifiStatus.Reason}); " +
-                        "continuing with WiFi update.");
-                    FirmwareUpdateStatusText = versionUnavailableStatus;
-                    break;
-            }
-        }
-
-        FirmwareUpdateStatusText = "Downloading WiFi firmware package...";
-        var wifiDownloadProgress = new Progress<int>(percent =>
-        {
-            // Map download progress into the initial segment of the WiFi bar.
-            UploadWiFiProgress = Math.Clamp((int)Math.Round(percent * 0.2), 0, 20);
-        });
-
-        var wifiPackage = await _firmwareDownloadService.DownloadWifiFirmwareAsync(
-            GetWifiDownloadDirectory(),
-            wifiDownloadProgress,
-            cancellationToken);
-
-        if (wifiPackage == null)
-        {
-            throw new InvalidOperationException("No WiFi firmware package was found for update.");
-        }
-
-        var wifiVersion = NormalizeWifiFirmwareVersion(wifiPackage.Value.Version);
-        FirmwareUpdateStatusText = $"Updating WiFi module ({wifiVersion})...";
-        var wifiUpdateProgress = new Progress<FirmwareUpdateProgress>(report =>
-        {
-            UploadWiFiProgress = Math.Clamp((int)Math.Round(report.PercentComplete), 0, 100);
-            if (!string.IsNullOrWhiteSpace(report.CurrentOperation))
-            {
-                FirmwareUpdateStatusText = report.CurrentOperation;
-            }
-        });
-
-        // Preserve the legacy serial prep/reset sequence now that the firmware flow uses the
-        // underlying Core device directly instead of routing through a desktop-shaped adapter.
-        var lanUpdateModeEnabled = false;
-        try
-        {
-            lanUpdateModeEnabled = serialStreamingDevice.EnableLanUpdateMode();
-
-            var wifiUpdateService = _wifiFirmwareUpdateServiceFactory(wifiVersion, serialStreamingDevice.PortName);
-            try
-            {
-                await wifiUpdateService.UpdateWifiModuleAsync(
-                    coreDevice,
-                    wifiPackage.Value.ExtractedPath,
-                    wifiUpdateProgress,
-                    cancellationToken,
-                    skipVersionCheck: true);
-            }
-            finally
-            {
-                (wifiUpdateService as IDisposable)?.Dispose();
-            }
-        }
-        finally
-        {
-            if (lanUpdateModeEnabled)
-            {
-                serialStreamingDevice.ResetLanAfterUpdate();
-            }
-        }
-    }
-
-    private FirmwareUpdateService CreateWifiFirmwareUpdateService(string wifiVersion, string portName)
-    {
-        var firmwareLogger = App.ServiceProvider?.GetService<ILogger<FirmwareUpdateService>>()
-            ?? NullLogger<FirmwareUpdateService>.Instance;
-
-        // Bridge activation action: opened at the "Power cycle WINC" prompt to trigger the
-        // device's bridge-mode state machine right before the flash tool starts programming.
-        // By deferring APPLY (SYSTem:COMMunicate:LAN:APPLY) until this point we give the
-        // firmware a guaranteed promptResponseDelay window (2 s) to complete the WiFi
-        // deinit/reinit cycle and call wifi_serial_bridge_Init() before the flash tool
-        // issues its first serial bridge query.
-        Action bridgeActivationAction = () =>
-        {
-            _appLogger.Information($"Opening {portName} to send bridge activation commands.");
-            try
-            {
-                // USB CDC virtual ports ignore the baud rate; match the Core transport defaults.
-                using var port = new SerialPort(portName, 9600, Parity.None, 8, StopBits.One)
-                {
-                    DtrEnable = true,
-                    RtsEnable = false,
-                    WriteTimeout = 2000
-                };
-                port.Open();
-                // Brief pause to allow the DTR signal to be recognised by the firmware
-                // before we send commands (firmware checks isCdcHostConnected via DTR).
-                Thread.Sleep(200);
-                // Re-assert the FW-update-requested flag (idempotent; belt-and-suspenders).
-                port.Write("SYSTem:COMMUnicate:LAN:FWUpdate\n");
-                Thread.Sleep(100);
-                // Trigger the WiFi manager REINIT → bridge-mode state machine.
-                port.Write("SYSTem:COMMunicate:LAN:APPLY\n");
-                // Give the firmware a moment to enqueue the APPLY before we close the port.
-                Thread.Sleep(300);
-                _appLogger.Information("Bridge activation commands sent successfully.");
-            }
-            catch (Exception ex)
-            {
-                _appLogger.Warning($"Bridge activation failed for {portName}: {ex.Message}");
-            }
-        };
-
-        // Start from the shared firmware config so the bootloader HID timeouts stay aligned with
-        // the transport (keeps read and write windows symmetric), then layer on WiFi-specific
-        // settings. The WiFi flow flashes via the external WINC tool rather than the HID loop, so
-        // the bootloader timeout is inert here, but starting from CreateOptions() keeps every
-        // construction site uniform (issue #575).
-        var wifiOptions = FirmwareUpdateServiceConfig.CreateOptions();
-        // winc_flash_tool.cmd requires an explicit release version folder.
-        // Keep legacy argument profile used by shipped WINC tool bundle.
-        wifiOptions.WifiFlashToolArgumentsTemplate = $"/p {{port}} /d WINC1500 /v {wifiVersion} /k /e /i aio /w";
-        wifiOptions.WifiPortOverride = portName;
-        // After sending FWUpdate (flag-only, no APPLY), disconnect quickly so the
-        // COM port is free for the bridge activation raw write at the "Power cycle
-        // WINC" prompt.  The FWUpdate flag persists in firmware RAM until APPLY fires.
-        wifiOptions.PostLanFirmwareModeDelay = TimeSpan.FromMilliseconds(100);
-        // Give Windows a little more time to re-enumerate the UART before reconnect attempts.
-        wifiOptions.PostWifiReconnectDelay = TimeSpan.FromSeconds(3);
-
-        return new FirmwareUpdateService(
-            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
-            _firmwareDownloadService,
-            new WifiPromptDelayProcessRunner(
-                new ProcessExternalProcessRunner(),
-                promptResponseDelay: TimeSpan.FromSeconds(2),
-                bridgeActivationAction: bridgeActivationAction),
-            firmwareLogger,
-            options: wifiOptions);
-    }
-
-    private static string NormalizeWifiFirmwareVersion(string rawVersion)
-    {
-        var normalized = (rawVersion ?? string.Empty).Trim();
-        if (normalized.StartsWith("v", StringComparison.OrdinalIgnoreCase))
-        {
-            normalized = normalized[1..];
-        }
-
-        if (string.IsNullOrWhiteSpace(normalized))
-        {
-            throw new InvalidOperationException("WiFi firmware version metadata is missing.");
-        }
-
-        // Keep command argument safe even if an unexpected tag format appears.
-        var invalidChars = new[] { ' ', '\t', '\r', '\n', '"', '\'', ';' };
-        if (normalized.IndexOfAny(invalidChars) >= 0)
-        {
-            throw new InvalidOperationException($"Invalid WiFi firmware version tag '{rawVersion}'.");
-        }
-
-        return normalized;
-    }
-
-    private void HandleFirmwareUpdateException(FirmwareUpdateException exception)
-    {
-        HasErrorOccured = true;
-
-        var summary = $"Firmware update failed during '{exception.Operation}' ({exception.FailedState}).";
-        _appLogger.Error(exception, summary);
-
-        if (!string.IsNullOrWhiteSpace(exception.RecoveryGuidance))
-        {
-            _appLogger.Warning($"Firmware recovery guidance: {exception.RecoveryGuidance}");
-        }
-
-        var dialogMessage = summary;
-        if (!string.IsNullOrWhiteSpace(exception.RecoveryGuidance))
-        {
-            dialogMessage += $"{Environment.NewLine}{Environment.NewLine}Suggested recovery: {exception.RecoveryGuidance}";
-        }
-
-        ShowFirmwareErrorDialog(dialogMessage);
-    }
-
-    private void ShowFirmwareErrorDialog(string message)
-    {
-        void ShowDialog()
-        {
-            var errorDialogViewModel = new ErrorDialogViewModel(message);
-            _dialogService.ShowDialog<ErrorDialog>(this, errorDialogViewModel);
-        }
-
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher == null)
-        {
-            ShowDialog();
-            return;
-        }
-
-        dispatcher.Invoke(ShowDialog);
-    }
-
-    private static string GetFirmwareDownloadDirectory()
-    {
-        var firmwareDirectory = Path.Combine(
-            App.DaqifiDataDirectory,
-            "Firmware",
-            "PIC32");
-        Directory.CreateDirectory(firmwareDirectory);
-        return firmwareDirectory;
-    }
-
-    private static string GetWifiDownloadDirectory()
-    {
-        var wifiDirectory = Path.Combine(
-            App.DaqifiDataDirectory,
-            "Firmware",
-            "WiFi");
-        Directory.CreateDirectory(wifiDirectory);
-        return wifiDirectory;
-    }
-
-    private static IFirmwareDownloadService CreateDefaultFirmwareDownloadService()
-    {
-        return new GitHubFirmwareDownloadService(new HttpClient());
-    }
-
-    private static IFirmwareUpdateService CreateDefaultFirmwareUpdateService(
-        IFirmwareDownloadService firmwareDownloadService,
-        ILogger<FirmwareUpdateService> logger)
-    {
-        return new FirmwareUpdateService(
-            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
-            firmwareDownloadService,
-            new ProcessExternalProcessRunner(),
-            logger,
-            options: FirmwareUpdateServiceConfig.CreateOptions());
     }
 
     #endregion
@@ -1191,7 +723,7 @@ public partial class DaqifiViewModel : ObservableObject
             }
         }
         ConnectionManager.Instance.Disconnect(deviceToDisconnect);
-        RemoveNotification(deviceToDisconnect);
+        _firmwareCoordinator.RemoveFirmwareNotification(deviceToDisconnect);
 
         if (deviceToDisconnect.Equals(SelectedDevice))
         {
@@ -1736,54 +1268,18 @@ public partial class DaqifiViewModel : ObservableObject
 
     #region Firmware version checking methods
 
-    private string _latestFirmwareVersion;
-    public string LatestFirmwareVersionText => _latestFirmwareVersion;
-    [RelayCommand]
-    public async Task GetFirmwareupdatationList()
-    {
-        var connectedDevices = ConnectionManager.Instance.ConnectedDevices;
-        if (connectedDevices.Count == 0)
-        {
-            return;
-        }
+    /// <summary>
+    /// The latest published firmware version, surfaced for display. The firmware coordinator
+    /// owns the value and performs the underlying version check via
+    /// <see cref="FirmwareUpdateCoordinator.RefreshFirmwareUpdatesAsync"/>.
+    /// </summary>
+    public string LatestFirmwareVersionText => _firmwareCoordinator.LatestFirmwareVersion;
 
-        try
-        {
-            var latestRelease = await _firmwareDownloadService.GetLatestReleaseAsync(includePreRelease: true);
-            _latestFirmwareVersion = latestRelease?.Version.ToString() ?? string.Empty;
-            OnPropertyChanged(nameof(LatestFirmwareVersionText));
-
-            if (latestRelease == null)
-            {
-                return;
-            }
-
-            foreach (var device in connectedDevices)
-            {
-                var updateCheck = await _firmwareDownloadService.CheckForUpdateAsync(
-                    device.DeviceVersion ?? string.Empty,
-                    includePreRelease: true);
-                var isOutdated = updateCheck.UpdateAvailable;
-                device.IsFirmwareOutdated = isOutdated;
-
-                if (!string.IsNullOrWhiteSpace(device.DeviceSerialNo))
-                {
-                    if (isOutdated)
-                    {
-                        AddNotification(device, latestRelease.Version.ToString());
-                    }
-                    else
-                    {
-                        RemoveNotification(device);
-                    }
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _appLogger.Warning($"Failed to check firmware updates: {ex.Message}");
-        }
-    }
+    /// <summary>
+    /// Prunes notifications whose owning device is no longer connected. General-purpose
+    /// (covers both app-version and firmware notifications); firmware-specific add/remove
+    /// now lives in the firmware coordinator.
+    /// </summary>
     private void RemoveNotification()
     {
         foreach (var notification in NotificationList.ToList())
@@ -1799,70 +1295,12 @@ public partial class DaqifiViewModel : ObservableObject
         NotificationCount = NotificationList.Count;
     }
 
-    private void AddNotification(IStreamingDevice device, string latestFirmware)
-    {
-        var message = $"Device With Serial {device.DeviceSerialNo} has Outdated Firmware. Please Update to Version {latestFirmware}.";
-
-        var existingNotification = NotificationList.FirstOrDefault(n => n.DeviceSerialNo != null
-                                                                        && n.IsFirmwareUpdate
-                                                                        && n.DeviceSerialNo == device.DeviceSerialNo);
-
-        if (existingNotification == null)
-        {
-            NotificationList.Add(new Notifications
-            {
-                DeviceSerialNo = device.DeviceSerialNo,
-                Message = message,
-                IsFirmwareUpdate = true
-            });
-        }
-
-        NotificationCount = NotificationList.Count;
-    }
-    private void RemoveNotification(IStreamingDevice deviceToRemove)
-    {
-        if (deviceToRemove?.DeviceSerialNo == null)
-        {
-            return;
-        }
-
-        var notificationsToRemove = NotificationList
-            .FirstOrDefault(x => x.DeviceSerialNo != null && x.DeviceSerialNo == deviceToRemove.DeviceSerialNo && x.IsFirmwareUpdate);
-
-        if (notificationsToRemove != null)
-        {
-            NotificationList.Remove(notificationsToRemove);
-            NotificationCount = NotificationList.Count;
-        }
-    }
-
     #endregion
 
     [RelayCommand]
     private void OpenNotifications()
     {
         IsNotificationsOpen = true;
-    }
-
-    private void ShowUploadSuccessMessage()
-    {
-        void ShowDialog()
-        {
-            var successDialogViewModel =
-                new SuccessDialogViewModel("Firmware update completed successfully.");
-            _dialogService.ShowDialog<SuccessDialog>(this, successDialogViewModel);
-        }
-
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher == null)
-        {
-            ShowDialog();
-            CloseFlyouts();
-            return;
-        }
-
-        dispatcher.Invoke(ShowDialog);
-        CloseFlyouts();
     }
 
     #endregion
@@ -1888,9 +1326,10 @@ public partial class DaqifiViewModel : ObservableObject
         {
             var SerailDeviceProperty = connectedDevice.GetType().GetProperty("DeviceVersion");
             var DeviceVersion = SerailDeviceProperty.GetValue(connectedDevice)?.ToString();
-            if (!string.IsNullOrEmpty(_latestFirmwareVersion))
+            var latestFirmwareVersion = _firmwareCoordinator.LatestFirmwareVersion;
+            if (!string.IsNullOrEmpty(latestFirmwareVersion))
             {
-                connectedDevice.IsFirmwareOutdated = VersionHelper.Compare(DeviceVersion, _latestFirmwareVersion) < 0;
+                connectedDevice.IsFirmwareOutdated = VersionHelper.Compare(DeviceVersion, latestFirmwareVersion) < 0;
             }
 
             ConnectedDevices.Add(connectedDevice);
@@ -2066,7 +1505,7 @@ public partial class DaqifiViewModel : ObservableObject
                 break;
         }
         CanToggleLogging = ActiveChannels.Count > 0;
-        _ = GetFirmwareupdatationList();
+        _ = _firmwareCoordinator.RefreshFirmwareUpdatesAsync();
         RemoveNotification();
     }
     public async Task<MessageDialogResult> ShowMessage(string title, string message, MessageDialogStyle dialogStyle)
@@ -2118,6 +1557,37 @@ public partial class DaqifiViewModel : ObservableObject
         IsNotificationsOpen = false;
         IsFirmwareUpdatationFlyoutOpen = false;
     }
+
+    #region IFirmwareUpdateHost implementation
+
+    // The firmware coordinator reaches the view model's bound progress/status properties
+    // (SelectedDevice, FirmwareFilePath, IsFirmwareUploading, UploadFirmwareProgress, etc.)
+    // through their existing public [ObservableProperty] members, which already satisfy the
+    // IFirmwareUpdateHost setters implicitly. Only the members below need an explicit bridge
+    // because they map onto differently-named state or onto desktop singletons the coordinator
+    // intentionally never touches directly.
+
+    /// <summary>
+    /// Devices the firmware version check iterates. Sourced from <see cref="ConnectionManager"/>
+    /// (not the UI-facing <see cref="ConnectedDevices"/> collection) to exactly preserve the
+    /// pre-refactor behavior.
+    /// </summary>
+    IReadOnlyList<IStreamingDevice> IFirmwareUpdateHost.ConnectedDevices =>
+        ConnectionManager.Instance.ConnectedDevices;
+
+    /// <summary>The shared, bound notification collection the coordinator mutates.</summary>
+    ObservableCollection<Notifications> IFirmwareUpdateHost.Notifications => NotificationList;
+
+    /// <summary>Routes the in-progress-update flag to the connection manager.</summary>
+    IStreamingDevice? IFirmwareUpdateHost.DeviceBeingUpdated
+    {
+        set => ConnectionManager.Instance.DeviceBeingUpdated = value;
+    }
+
+    /// <summary>Re-syncs the notification badge after the coordinator adds/removes a notification.</summary>
+    void IFirmwareUpdateHost.RefreshNotificationCount() => NotificationCount = NotificationList.Count;
+
+    #endregion
 
     private bool CanExportAllLoggingSession()
     {


### PR DESCRIPTION
## What

First behavior-preserving extraction from #592 (the highest-value item:
**`FirmwareUpdateCoordinator`**). Moves the PIC32 + WiFi firmware update
orchestration and the firmware version-check / outdated-device notification
logic out of the 2,254-line `DaqifiViewModel` god class into a dedicated,
unit-testable coordinator under `Device/Firmware/`.

`DaqifiViewModel` drops ~530 lines (**2,254 → 1,724**) and keeps only the
bound progress/status properties and thin command bindings.

## Why it's low-risk

- **Firmware XAML is untouched.** The view model keeps every bound property
  (`UploadFirmwareProgress`, `UploadWiFiProgress`, `FirmwareUpdateStatusText`,
  `IsFirmwareUploading`, `SelectedDeviceSupportsFirmwareUpdate`,
  `FirmwareFilePath`, …) and every command (`UploadFirmwareCommand`,
  `CancelFirmwareUploadCommand`, `BrowseForFirmwareCommand`). The coordinator
  drives that state through a new `IFirmwareUpdateHost` seam that the view
  model implements, so its existing `[ObservableProperty]` members stay the
  binding source — no `Binding`/`DataContext` changes.
- **Constructor signature unchanged.** `new DaqifiViewModel()` and the
  firmware-service overload used in tests still work; the view model just
  forwards the injected services to the coordinator, which resolves the same
  production defaults it used to build.
- The coordinator never reaches into `ConnectionManager.Instance` directly —
  it reads connected devices / routes `DeviceBeingUpdated` through the host —
  so it is unit-testable without WPF or desktop singletons.

## Notable

- Fixed the `GetFirmwareupdatationList` typo → `RefreshFirmwareUpdatesAsync`
  (it has no XAML binding; only an internal caller, repointed).
- The existing firmware test asset (`DaqifiViewModelFirmwareUpdateTests.cs`,
  per the issue's "adapt those tests to target the coordinator directly")
  now drives `FirmwareUpdateCoordinator` through a lightweight fake host
  instead of a full view model — same behavior contract, now WPF-free.
- Added unit coverage for the newly-testable version-check / notification
  path (outdated → flags + notifies; up-to-date → clears; no-devices → no-op).

## Verification

- Full solution builds (0 errors).
- Unit gate green: **372 passed**
  (`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`),
  including the 13 firmware tests (retargeted + new).
- App launches without startup regressions (the coordinator is constructed at
  the same point the view model used to build the services).

## Scope / follow-ups

Per #592's "one PR per extraction", the remaining extractions
(logging-session list, disk-space monitor, confirm overlay; and the separate
`DatabaseLogger` split) are left for their own PRs.

Closes part of #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
