### PR TITLE
chore(viewmodels): extract LoggingSessionListViewModel from DaqifiViewModel (#592)

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
@@ -31,7 +31,10 @@ public class LoggingSessionListViewModelTests
             {
                 try
                 {
-                    if (File.Exists(path + suffix)) { File.Delete(path + suffix); }
+                    if (File.Exists(path + suffix))
+                    {
+                        File.Delete(path + suffix);
+                    }
                 }
                 catch
                 {

--- a/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
@@ -1,0 +1,564 @@
+using System.Collections.ObjectModel;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Behavior contract for <see cref="LoggingSessionListViewModel"/> — the logged-data pane's
+/// session-list actions extracted from <c>DaqifiViewModel</c> (issue #592). The list is driven
+/// through a lightweight <see cref="FakeLoggingSessionListHost"/> with no WPF dependency; the
+/// "delete all" storage purge is exercised against a real temp SQLite database. Covers display,
+/// export, delete-one, delete-all (including the "stop logging" guard), and the
+/// collection-changed notifications.
+/// </summary>
+[TestClass]
+public class LoggingSessionListViewModelTests
+{
+    private readonly List<string> _tempDbPaths = [];
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var path in _tempDbPaths)
+        {
+            foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+            {
+                try
+                {
+                    if (File.Exists(path + suffix)) { File.Delete(path + suffix); }
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+            }
+        }
+    }
+
+    #region Display
+
+    [TestMethod]
+    public async Task DisplaySession_NullSession_ClearsPlotAndDoesNotTouchBusy()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+
+        await list.DisplaySessionAsync(null);
+
+        Assert.AreEqual(1, host.ClearPlotCount);
+        Assert.AreEqual(0, host.DisplayOnPlotCount);
+        Assert.IsNull(host.SelectedLoggingSession);
+        CollectionAssert.AreEqual(new List<bool>(), host.BusyHistory,
+            "A null session must short-circuit before the busy flag is ever set.");
+    }
+
+    [TestMethod]
+    public async Task DisplaySession_LoadsSessionUnderBusyFlag_AndClearsBusyWhenDone()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+        var session = new LoggingSession { ID = 7, Name = "Bench Run" };
+
+        await list.DisplaySessionAsync(session);
+
+        Assert.AreSame(session, host.SelectedLoggingSession);
+        Assert.AreSame(session, host.DisplayedSession);
+        Assert.AreEqual(1, host.DisplayOnPlotCount);
+        Assert.AreEqual("Loading Bench Run", host.BusyReasonHistory[0]);
+        CollectionAssert.Contains(host.BusyHistory, true, "The busy flag must be raised during the load.");
+        Assert.IsFalse(host.IsLoggedDataBusyValue, "The busy flag must be cleared once the load completes.");
+        Assert.AreEqual(string.Empty, host.LoggedDataBusyReasonValue);
+    }
+
+    [TestMethod]
+    public async Task DisplaySession_LoadThrows_LogsErrorAndStillClearsBusy()
+    {
+        var appLogger = new Mock<IAppLogger>();
+        var host = new FakeLoggingSessionListHost
+        {
+            DisplayOnPlotAction = _ => throw new InvalidOperationException("plot blew up")
+        };
+        var list = CreateList(host, appLogger.Object);
+        var session = new LoggingSession { ID = 9, Name = "Faulty" };
+
+        await list.DisplaySessionAsync(session);
+
+        Assert.IsFalse(host.IsLoggedDataBusyValue, "The busy flag must be cleared even when the load throws.");
+        Assert.AreEqual(string.Empty, host.LoggedDataBusyReasonValue);
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(),
+            It.Is<string>(m => m.Contains("Failed to display logging session 9"))), Times.Once);
+    }
+
+    #endregion
+
+    #region Export
+
+    [TestMethod]
+    public async Task ExportSession_NullSession_LogsErrorAndShowsNoDialog()
+    {
+        var appLogger = new Mock<IAppLogger>();
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host, appLogger.Object);
+
+        await list.ExportSessionAsync(null);
+
+        Assert.AreEqual(0, host.ExportSessionIds.Count);
+        Assert.IsNull(host.SelectedLoggingSession);
+        appLogger.Verify(l => l.Error("Error exporting logging session"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ExportSession_ShowsExportDialogForThatSession()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+        var session = new LoggingSession { ID = 42, Name = "Export Me" };
+
+        await list.ExportSessionAsync(session);
+
+        Assert.AreSame(session, host.SelectedLoggingSession);
+        CollectionAssert.AreEqual(new List<int> { 42 }, host.ExportSessionIds);
+    }
+
+    [TestMethod]
+    public async Task ExportAll_NoSessions_LogsErrorAndShowsNoDialog()
+    {
+        var appLogger = new Mock<IAppLogger>();
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host, appLogger.Object);
+
+        await list.ExportAllSessionsAsync();
+
+        Assert.AreEqual(0, host.ExportAllInvocations.Count);
+        appLogger.Verify(l => l.Error("Error exporting all logging sessions"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ExportAll_ShowsExportDialogForEverySession()
+    {
+        var host = new FakeLoggingSessionListHost();
+        host.LoggingSessions.Add(new LoggingSession { ID = 1, Name = "A" });
+        host.LoggingSessions.Add(new LoggingSession { ID = 2, Name = "B" });
+        var list = CreateList(host);
+
+        await list.ExportAllSessionsAsync();
+
+        Assert.AreEqual(1, host.ExportAllInvocations.Count);
+        CollectionAssert.AreEqual(new List<int> { 1, 2 }, host.ExportAllInvocations[0].Select(s => s.ID).ToList());
+    }
+
+    #endregion
+
+    #region Delete one
+
+    [TestMethod]
+    public async Task DeleteSession_NullSession_LogsErrorAndDoesNotConfirm()
+    {
+        var appLogger = new Mock<IAppLogger>();
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host, appLogger.Object);
+
+        await list.DeleteSessionAsync(null);
+
+        Assert.AreEqual(0, host.ConfirmCallCount);
+        Assert.AreEqual(0, host.DeleteFromDatabaseCount);
+        appLogger.Verify(l => l.Error("Error deleting logging session: Invalid object provided."), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeleteSession_NotConfirmed_DoesNotDeleteOrModifyCollection()
+    {
+        var host = new FakeLoggingSessionListHost { ConfirmResult = false };
+        var session = new LoggingSession { ID = 3, Name = "Keep Me" };
+        host.LoggingSessions.Add(session);
+        var list = CreateList(host);
+
+        await list.DeleteSessionAsync(session);
+
+        Assert.AreEqual(1, host.ConfirmCallCount);
+        Assert.AreEqual(0, host.DeleteFromDatabaseCount);
+        CollectionAssert.Contains(host.LoggingSessions, session);
+        CollectionAssert.AreEqual(new List<bool>(), host.BusyHistory,
+            "Busy must not be raised when the user cancels the confirmation.");
+    }
+
+    [TestMethod]
+    public async Task DeleteSession_Confirmed_DeletesRemovesAndNotifies()
+    {
+        var host = new FakeLoggingSessionListHost { ConfirmResult = true };
+        var session = new LoggingSession { ID = 5, Name = "Delete Me" };
+        host.LoggingSessions.Add(session);
+        var list = CreateList(host);
+
+        await list.DeleteSessionAsync(session);
+
+        Assert.AreSame(session, host.SelectedLoggingSession);
+        Assert.AreEqual(1, host.DeleteFromDatabaseCount);
+        Assert.AreSame(session, host.DeletedFromDatabaseSession);
+        CollectionAssert.DoesNotContain(host.LoggingSessions, session);
+        Assert.IsTrue(host.NotifyCount >= 1, "Removing a session must raise the change notification.");
+        Assert.IsFalse(host.IsLoggedDataBusyValue, "Busy must clear after the delete completes.");
+        Assert.AreEqual(string.Empty, host.LoggedDataBusyReasonValue);
+    }
+
+    [TestMethod]
+    public async Task DeleteSession_DatabaseThrows_LogsErrorAndKeepsSession()
+    {
+        var appLogger = new Mock<IAppLogger>();
+        var host = new FakeLoggingSessionListHost
+        {
+            ConfirmResult = true,
+            DeleteFromDatabaseAction = _ => throw new InvalidOperationException("db locked")
+        };
+        var session = new LoggingSession { ID = 8, Name = "Stubborn" };
+        host.LoggingSessions.Add(session);
+        var list = CreateList(host, appLogger.Object);
+
+        await list.DeleteSessionAsync(session);
+
+        CollectionAssert.Contains(host.LoggingSessions, session,
+            "A failed database delete must not remove the session from the bound collection.");
+        Assert.IsFalse(host.IsLoggedDataBusyValue, "Busy must clear even when the database delete throws.");
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(),
+            It.Is<string>(m => m.Contains("Failed to delete session 8 from database"))), Times.Once);
+    }
+
+    #endregion
+
+    #region Delete all
+
+    [TestMethod]
+    public async Task DeleteAll_NoSessions_DoesNothing()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+
+        await list.DeleteAllSessionsAsync();
+
+        Assert.AreEqual(0, host.MessageCallCount);
+        Assert.AreEqual(0, host.ConfirmCallCount);
+        Assert.AreEqual(0, host.SuspendConsumerCount);
+    }
+
+    [TestMethod]
+    public async Task DeleteAll_WhileLogging_ShowsStopLoggingMessageAndDoesNotPurge()
+    {
+        var host = new FakeLoggingSessionListHost { IsLoggingActive = true };
+        host.LoggingSessions.Add(new LoggingSession { ID = 1, Name = "A" });
+        var list = CreateList(host);
+
+        await list.DeleteAllSessionsAsync();
+
+        Assert.AreEqual(1, host.MessageCallCount);
+        Assert.AreEqual("Cannot Delete", host.LastMessageTitle);
+        Assert.AreEqual(0, host.ConfirmCallCount, "The destructive confirm must not appear while logging is active.");
+        Assert.AreEqual(0, host.SuspendConsumerCount, "Storage must not be purged while logging is active.");
+        Assert.AreEqual(1, host.LoggingSessions.Count);
+    }
+
+    [TestMethod]
+    public async Task DeleteAll_NotConfirmed_DoesNotPurge()
+    {
+        var host = new FakeLoggingSessionListHost { ConfirmResult = false };
+        host.LoggingSessions.Add(new LoggingSession { ID = 1, Name = "A" });
+        var list = CreateList(host);
+
+        await list.DeleteAllSessionsAsync();
+
+        Assert.AreEqual(1, host.ConfirmCallCount);
+        Assert.AreEqual(0, host.SuspendConsumerCount);
+        Assert.AreEqual(1, host.LoggingSessions.Count);
+    }
+
+    [TestMethod]
+    public async Task DeleteAll_Confirmed_PurgesStorageClearsCollectionAndResetsPlot()
+    {
+        var host = new FakeLoggingSessionListHost { ConfirmResult = true };
+        host.LoggingSessions.Add(new LoggingSession { ID = 1, Name = "A" });
+        host.LoggingSessions.Add(new LoggingSession { ID = 2, Name = "B" });
+
+        var loggedErrors = new List<string>();
+        var appLogger = new Mock<IAppLogger>();
+        appLogger.Setup(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()))
+            .Callback<Exception, string>((e, m) => loggedErrors.Add($"{m}: {e}"));
+
+        var dbPath = NewTempDbPath();
+        using var factory = new TempSqliteLoggingContextFactory(dbPath);
+        var list = new LoggingSessionListViewModel(host, () => factory, dbPath, appLogger.Object);
+
+        await list.DeleteAllSessionsAsync();
+
+        Assert.AreEqual(0, loggedErrors.Count, $"Purge logged errors: {string.Join(" || ", loggedErrors)}");
+
+        // The consumer thread must be suspended around the purge and resumed afterward.
+        Assert.AreEqual(1, host.SuspendConsumerCount);
+        Assert.AreEqual(1, host.ClearBufferCount);
+        Assert.AreEqual(1, host.ResumeConsumerCount);
+        Assert.IsTrue(host.SuspendBeforeResume, "Consumer must be suspended before it is resumed.");
+
+        // The database file is deleted and re-migrated, the bound collection is emptied, and the plot reset.
+        Assert.IsTrue(File.Exists(dbPath), "The purge must recreate the database schema.");
+        Assert.AreEqual(0, host.LoggingSessions.Count);
+        Assert.IsTrue(host.NotifyCount >= 1);
+        Assert.AreEqual(1, host.ClearPlotCount);
+        Assert.IsFalse(host.IsLoggedDataBusyValue, "Busy must clear after the purge completes.");
+    }
+
+    #endregion
+
+    #region Collection-changed notifications
+
+    [TestMethod]
+    public void AttachedCollectionChange_RaisesNotification()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+        var collection = new ObservableCollection<LoggingSession>();
+
+        list.AttachCollection(collection);
+        var baseline = host.NotifyCount;
+
+        collection.Add(new LoggingSession { ID = 1, Name = "A" });
+        Assert.AreEqual(baseline + 1, host.NotifyCount);
+
+        collection.RemoveAt(0);
+        Assert.AreEqual(baseline + 2, host.NotifyCount);
+    }
+
+    [TestMethod]
+    public void Reattaching_UnsubscribesFromThePreviousCollection()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+        var first = new ObservableCollection<LoggingSession>();
+        var second = new ObservableCollection<LoggingSession>();
+
+        list.AttachCollection(first);
+        list.AttachCollection(second);
+        var baseline = host.NotifyCount;
+
+        // Mutating the now-detached first collection must not notify.
+        first.Add(new LoggingSession { ID = 1, Name = "A" });
+        Assert.AreEqual(baseline, host.NotifyCount);
+
+        // The currently-attached collection still notifies.
+        second.Add(new LoggingSession { ID = 2, Name = "B" });
+        Assert.AreEqual(baseline + 1, host.NotifyCount);
+    }
+
+    [TestMethod]
+    public void AttachingTheSameCollectionTwice_DoesNotDoubleSubscribe()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+        var collection = new ObservableCollection<LoggingSession>();
+
+        list.AttachCollection(collection);
+        list.AttachCollection(collection);
+        var baseline = host.NotifyCount;
+
+        collection.Add(new LoggingSession { ID = 1, Name = "A" });
+        Assert.AreEqual(baseline + 1, host.NotifyCount,
+            "Re-attaching the same collection must not add a second subscription.");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private LoggingSessionListViewModel CreateList(FakeLoggingSessionListHost host, IAppLogger? appLogger = null)
+    {
+        // The factory resolver throws if invoked: only the delete-all path needs it, and those tests
+        // build the list with a real temp factory explicitly.
+        return new LoggingSessionListViewModel(
+            host,
+            () => throw new InvalidOperationException("Logging context factory should not be resolved in this test."),
+            NewTempDbPath(),
+            appLogger ?? Mock.Of<IAppLogger>());
+    }
+
+    private string NewTempDbPath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"daqifi_sessionlist_{Guid.NewGuid():N}.db");
+        _tempDbPaths.Add(path);
+        return path;
+    }
+
+    /// <summary>
+    /// In-memory <see cref="ILoggingSessionListHost"/> for driving the list view model without WPF.
+    /// Captures the state writes, dialog/notification calls, and database/plot operations the
+    /// session-list actions push, and lets a test stub the confirm result and inject failures.
+    /// </summary>
+    private sealed class FakeLoggingSessionListHost : ILoggingSessionListHost
+    {
+        private bool _isLoggedDataBusy;
+        private string _loggedDataBusyReason = string.Empty;
+        private bool _suspendedAtLeastOnce;
+
+        // get+set implicitly implements the interface's set-only member while letting tests read the
+        // captured selection. Starts null (no session selected yet).
+        public LoggingSession SelectedLoggingSession { get; set; } = null!;
+
+        public bool IsLoggedDataBusy
+        {
+            set
+            {
+                _isLoggedDataBusy = value;
+                BusyHistory.Add(value);
+            }
+        }
+
+        public bool IsLoggedDataBusyValue => _isLoggedDataBusy;
+
+        public string LoggedDataBusyReason
+        {
+            set
+            {
+                _loggedDataBusyReason = value;
+                BusyReasonHistory.Add(value);
+            }
+        }
+
+        public string LoggedDataBusyReasonValue => _loggedDataBusyReason;
+
+        public ObservableCollection<LoggingSession> LoggingSessions { get; } = [];
+
+        public bool IsLoggingActive { get; set; }
+
+        public List<bool> BusyHistory { get; } = [];
+
+        public List<string> BusyReasonHistory { get; } = [];
+
+        public int NotifyCount { get; private set; }
+
+        public int ClearPlotCount { get; private set; }
+
+        public int DisplayOnPlotCount { get; private set; }
+
+        public LoggingSession? DisplayedSession { get; private set; }
+
+        public int DeleteFromDatabaseCount { get; private set; }
+
+        public LoggingSession? DeletedFromDatabaseSession { get; private set; }
+
+        public int SuspendConsumerCount { get; private set; }
+
+        public int ResumeConsumerCount { get; private set; }
+
+        public int ClearBufferCount { get; private set; }
+
+        public bool SuspendBeforeResume { get; private set; }
+
+        public List<int> ExportSessionIds { get; } = [];
+
+        public List<IReadOnlyList<LoggingSession>> ExportAllInvocations { get; } = [];
+
+        public int ConfirmCallCount { get; private set; }
+
+        public bool ConfirmResult { get; set; } = true;
+
+        public int MessageCallCount { get; private set; }
+
+        public string? LastMessageTitle { get; private set; }
+
+        /// <summary>When set, runs in place of recording a successful plot load (used to inject a fault).</summary>
+        public Action<LoggingSession>? DisplayOnPlotAction { get; set; }
+
+        /// <summary>When set, runs in place of recording a successful database delete (used to inject a fault).</summary>
+        public Action<LoggingSession>? DeleteFromDatabaseAction { get; set; }
+
+        public void NotifyLoggingSessionsChanged() => NotifyCount++;
+
+        public void DisplaySessionOnPlot(LoggingSession session)
+        {
+            DisplayOnPlotCount++;
+            DisplayedSession = session;
+            DisplayOnPlotAction?.Invoke(session);
+        }
+
+        public void DeleteSessionFromDatabase(LoggingSession session)
+        {
+            DeleteFromDatabaseCount++;
+            DeletedFromDatabaseSession = session;
+            DeleteFromDatabaseAction?.Invoke(session);
+        }
+
+        public void ClearPlot() => ClearPlotCount++;
+
+        public void SuspendConsumer()
+        {
+            SuspendConsumerCount++;
+            _suspendedAtLeastOnce = true;
+        }
+
+        public void ResumeConsumer()
+        {
+            ResumeConsumerCount++;
+            if (_suspendedAtLeastOnce)
+            {
+                SuspendBeforeResume = true;
+            }
+        }
+
+        public void ClearBuffer() => ClearBufferCount++;
+
+        public Task ShowExportDialogForSessionAsync(int sessionId)
+        {
+            ExportSessionIds.Add(sessionId);
+            return Task.CompletedTask;
+        }
+
+        public Task ShowExportDialogForSessionsAsync(IReadOnlyList<LoggingSession> sessions)
+        {
+            ExportAllInvocations.Add(sessions);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ShowConfirmAsync(string title, string message, string affirmativeLabel, bool isDestructive)
+        {
+            ConfirmCallCount++;
+            return Task.FromResult(ConfirmResult);
+        }
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            MessageCallCount++;
+            LastMessageTitle = title;
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Real-SQLite logging-context factory over a caller-supplied path so the "delete all" storage
+    /// purge (which deletes the file and re-migrates the schema) can be exercised end-to-end.
+    /// </summary>
+    private sealed class TempSqliteLoggingContextFactory : IDbContextFactory<LoggingContext>, IDisposable
+    {
+        private readonly DbContextOptions<LoggingContext> _options;
+
+        public TempSqliteLoggingContextFactory(string dbPath)
+        {
+            // Mirror the production factory registration (App.xaml.cs): suppress the
+            // PendingModelChangesWarning so Migrate() doesn't throw on model/snapshot drift.
+            _options = new DbContextOptionsBuilder<LoggingContext>()
+                .UseSqlite($"Data Source={dbPath}")
+                .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+                .Options;
+
+            using var ctx = new LoggingContext(_options);
+            ctx.Database.EnsureCreated();
+        }
+
+        public LoggingContext CreateDbContext() => new(_options);
+
+        public void Dispose() => Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+    }
+
+    #endregion
+}

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -18,24 +18,21 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Daqifi.Core.Firmware;
 using Daqifi.Desktop.Device.Firmware;
-using Microsoft.Data.Sqlite;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.IO;
 using System.Net.Http;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Application = System.Windows.Application;
-using File = System.IO.File;
 using CommunityToolkit.Mvvm.Input;
 using Daqifi.Core.Device.SdCard;
 
 namespace Daqifi.Desktop.ViewModels;
 
-public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
+public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, ILoggingSessionListHost
 {
     private readonly AppLogger _appLogger = AppLogger.Instance;
 
@@ -154,12 +151,12 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
     private bool _selectedDeviceSupportsFirmwareUpdate;
     private readonly IDbContextFactory<LoggingContext>? _loggingContextFactory;
     private readonly FirmwareUpdateCoordinator _firmwareCoordinator;
+    private readonly LoggingSessionListViewModel _loggingSessionList;
     private ConnectionDialogViewModel _connectionDialogViewModel;
     private string _selectedLoggingMode = "Stream to App";
     private bool _isLogToDeviceMode;
     private SdCardLogFormat _selectedSdCardLogFormat = SdCardLogFormat.Protobuf;
     private IDiskSpaceMonitor? _diskSpaceMonitor;
-    private ObservableCollection<LoggingSession>? _observedLoggingSessions;
     private CancellationTokenSource? _networkSettingsAppliedCts;
     private DispatcherTimer? _sdLoggingElapsedTimer;
     private DateTime? _sdLoggingStartedAt;
@@ -551,6 +548,17 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
             App.DaqifiDataDirectory,
             wifiFirmwareUpdateServiceFactory);
 
+        // Logged-data session-list actions (display/export/delete + collection plumbing) live in the
+        // list view model (issue #592). The view model keeps the bound properties + thin command
+        // bindings and feeds the list through the ILoggingSessionListHost seam (implemented below);
+        // the storage purge collaborators are injected here so the list never reaches into
+        // App.DatabasePath / App.ServiceProvider directly.
+        _loggingSessionList = new LoggingSessionListViewModel(
+            this,
+            GetLoggingContextFactory,
+            App.DatabasePath,
+            _appLogger);
+
         ConfirmAffirmativeCommand = new RelayCommand(() => CompleteConfirm(true));
         ConfirmNegativeCommand = new RelayCommand(() => CompleteConfirm(false));
 
@@ -574,7 +582,7 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
 
                     // Manage data for plotting
                     LoggingManager.Instance.PropertyChanged += UpdateUi;
-                    AttachLoggingSessionsCollection(LoggingManager.Instance.LoggingSessions);
+                    _loggingSessionList.AttachCollection(LoggingManager.Instance.LoggingSessions);
                     Plotter = new PlotLogger();
                     LoggingManager.Instance.AddLogger(Plotter);
 
@@ -669,8 +677,8 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
 
     private void RegisterCommands()
     {
-        DeleteLoggingSessionCommand = new AsyncRelayCommand<LoggingSession?>(DeleteLoggingSessionAsync);
-        DeleteAllLoggingSessionCommand = new AsyncRelayCommand(DeleteAllLoggingSessionAsync, CanDeleteAllLoggingSession);
+        DeleteLoggingSessionCommand = new AsyncRelayCommand<LoggingSession?>(_loggingSessionList.DeleteSessionAsync);
+        DeleteAllLoggingSessionCommand = new AsyncRelayCommand(_loggingSessionList.DeleteAllSessionsAsync, CanDeleteAllLoggingSession);
         ToggleChannelVisibilityCommand = new RelayCommand<IChannel>(ToggleChannelVisibility);
         ToggleLoggedSeriesVisibilityCommand = new RelayCommand<LoggedSeriesLegendItem>(ToggleLoggedSeriesVisibility);
 
@@ -915,85 +923,17 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
         IsLoggingSessionSettingsOpen = true;
     }
 
+    // Thin command bindings: the logged-data session-list logic lives in _loggingSessionList
+    // (issue #592). XAML still binds DisplayLoggingSessionCommand / ExportLoggingSessionCommand /
+    // ExportAllLoggingSessionCommand on this view model, so DataContext bindings are unchanged.
     [RelayCommand]
-    private void DisplayLoggingSession(LoggingSession? session)
-    {
-        if (session == null)
-        {
-            DbLogger.ClearPlot();
-            return;
-        }
-
-        SelectedLoggingSession = session;
-        IsLoggedDataBusy = true;
-        LoggedDataBusyReason = "Loading " + SelectedLoggingSession.Name;
-        var bw = new BackgroundWorker();
-        bw.DoWork += delegate
-        {
-            try
-            {
-                DbLogger.DisplayLoggingSession(SelectedLoggingSession);
-            }
-            catch (Exception ex)
-            {
-                _appLogger.Error(ex, $"Failed to display logging session {SelectedLoggingSession.ID}.");
-            }
-        };
-
-        bw.RunWorkerCompleted += (s, e) =>
-        {
-            IsLoggedDataBusy = false;
-            LoggedDataBusyReason = string.Empty;
-        };
-
-        bw.RunWorkerAsync();
-    }
+    private Task DisplayLoggingSession(LoggingSession? session) => _loggingSessionList.DisplaySessionAsync(session);
 
     [RelayCommand]
-    private async Task ExportLoggingSession(LoggingSession? session)
-    {
-        if (session == null)
-        {
-            _appLogger.Error("Error exporting logging session");
-            return;
-        }
-
-        SelectedLoggingSession = session;
-        var exportDialogViewModel = new ExportDialogViewModel(SelectedLoggingSession.ID);
-
-        // UI-test hook: when DAQIFI_TEST_EXPORT_PATH is set, export straight to that directory
-        // with no SaveFileDialog (mirrors DAQIFI_TEST_MODE / AppDataPaths). Unset in production,
-        // where the interactive dialog below is used unchanged.
-        if (Common.AppDataPaths.TestExportPath != null)
-        {
-            await exportDialogViewModel.ExportToDirectoryAsync(Common.AppDataPaths.TestExportPath);
-            return;
-        }
-
-        _dialogService.ShowDialog<ExportDialog>(this, exportDialogViewModel);
-    }
+    private Task ExportLoggingSession(LoggingSession? session) => _loggingSessionList.ExportSessionAsync(session);
 
     [RelayCommand(CanExecute = nameof(CanExportAllLoggingSession))]
-    private async Task ExportAllLoggingSession()
-    {
-        if (LoggingSessions.Count == 0)
-        {
-            _appLogger.Error("Error exporting all logging sessions");
-            return;
-        }
-
-        var exportDialogViewModel = new ExportDialogViewModel(LoggingSessions);
-
-        // UI-test hook: see ExportLoggingSession above. Same seam, so "Export All" is equally
-        // dialog-free and deterministic under automation when the env var is set.
-        if (Common.AppDataPaths.TestExportPath != null)
-        {
-            await exportDialogViewModel.ExportToDirectoryAsync(Common.AppDataPaths.TestExportPath);
-            return;
-        }
-
-        _dialogService.ShowDialog<ExportDialog>(this, exportDialogViewModel);
-    }
+    private Task ExportAllLoggingSession() => _loggingSessionList.ExportAllSessionsAsync();
 
     [RelayCommand]
     private async Task ImportSdCardLogFile()
@@ -1054,152 +994,6 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
         }
     }
 
-    private async Task DeleteLoggingSessionAsync(LoggingSession? session)
-    {
-        try
-        {
-            if (session == null)
-            {
-                _appLogger.Error("Error deleting logging session: Invalid object provided.");
-                return;
-            }
-
-            SelectedLoggingSession = session;
-
-            var confirmed = await ShowConfirm(
-                "Delete Confirmation",
-                $"Are you sure you want to delete {SelectedLoggingSession.Name}?",
-                affirmativeLabel: "DELETE",
-                isDestructive: true);
-            if (!confirmed)
-            {
-                return;
-            }
-
-            IsLoggedDataBusy = true;
-            LoggedDataBusyReason = $"Deleting Logging Session #{SelectedLoggingSession.ID}";
-            var bw = new BackgroundWorker();
-            var sessionToDelete = SelectedLoggingSession;
-            bw.DoWork += delegate
-            {
-                var deleteSucceeded = false;
-                try
-                {
-                    DbLogger.DeleteLoggingSession(sessionToDelete);
-                    deleteSucceeded = true;
-                }
-                catch (Exception dbEx)
-                {
-                    _appLogger.Error(dbEx, $"Failed to delete session {sessionToDelete.ID} from database.");
-                }
-
-                if (deleteSucceeded)
-                {
-                    Application.Current.Dispatcher.Invoke(delegate
-                    {
-                        LoggingManager.Instance.LoggingSessions.Remove(sessionToDelete);
-                        NotifyLoggingSessionsChanged();
-                    });
-                }
-            };
-
-            bw.RunWorkerCompleted += (s, e) =>
-            {
-                IsLoggedDataBusy = false;
-                LoggedDataBusyReason = string.Empty;
-            };
-
-            bw.RunWorkerAsync();
-        }
-        catch (Exception ex)
-        {
-            _appLogger.Error(ex, "Error initiating logging session deletion");
-        }
-    }
-
-    private async Task DeleteAllLoggingSessionAsync()
-    {
-        try
-        {
-            if (LoggingSessions.Count == 0)
-            {
-                return;
-            }
-
-            if (LoggingManager.Instance.Active)
-            {
-                await ShowMessage(
-                    "Cannot Delete",
-                    "Please stop logging before deleting all sessions.",
-                    MessageDialogStyle.Affirmative);
-                return;
-            }
-
-            var confirmed = await ShowConfirm(
-                "Delete Confirmation",
-                "Are you sure you want to delete all logging sessions? This cannot be undone.",
-                affirmativeLabel: "DELETE ALL",
-                isDestructive: true);
-            if (!confirmed)
-            {
-                return;
-            }
-
-            IsLoggedDataBusy = true;
-            LoggedDataBusyReason = "Deleting All Logging Sessions";
-
-            try
-            {
-                var contextFactory = GetLoggingContextFactory();
-                await Task.Run(() => DeleteAllLoggingSessionsFromStorage(contextFactory));
-                LoggingManager.Instance.LoggingSessions.Clear();
-                NotifyLoggingSessionsChanged();
-                DbLogger.ClearPlot();
-            }
-            catch (IOException ioEx)
-            {
-                _appLogger.Error(ioEx, "Database file is in use. Please try again.");
-            }
-        }
-        catch (Exception ex)
-        {
-            _appLogger.Error(ex, "Error during deletion of all logging sessions");
-        }
-        finally
-        {
-            IsLoggedDataBusy = false;
-            LoggedDataBusyReason = string.Empty;
-        }
-    }
-
-    private void DeleteAllLoggingSessionsFromStorage(IDbContextFactory<LoggingContext> contextFactory)
-    {
-        DbLogger.SuspendConsumer();
-        try
-        {
-            DbLogger.ClearBuffer();
-
-            // Release all pooled SQLite connections so the file is not locked.
-            SqliteConnection.ClearAllPools();
-
-            var dbPath = App.DatabasePath;
-            DeleteFileIfExists(dbPath);
-            DeleteFileIfExists(dbPath + "-wal");
-            DeleteFileIfExists(dbPath + "-shm");
-
-            // Recreate the database schema. Constructing a context does not
-            // create tables — only Migrate() (or EnsureCreated) does. Without
-            // this, the next session-start query against Samples/Sessions
-            // throws "no such table: Samples".
-            using var context = contextFactory.CreateDbContext();
-            context.Database.Migrate();
-        }
-        finally
-        {
-            DbLogger.ResumeConsumer();
-        }
-    }
-
     private IDbContextFactory<LoggingContext> GetLoggingContextFactory()
     {
         return _loggingContextFactory
@@ -1207,47 +1001,18 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
             ?? throw new InvalidOperationException("Logging context factory is not available.");
     }
 
-    private void AttachLoggingSessionsCollection(ObservableCollection<LoggingSession> loggingSessions)
-    {
-        if (ReferenceEquals(_observedLoggingSessions, loggingSessions))
-        {
-            return;
-        }
-
-        if (_observedLoggingSessions != null)
-        {
-            _observedLoggingSessions.CollectionChanged -= OnLoggingSessionsCollectionChanged;
-        }
-
-        _observedLoggingSessions = loggingSessions;
-        _observedLoggingSessions.CollectionChanged += OnLoggingSessionsCollectionChanged;
-    }
-
-    private void OnLoggingSessionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-        if (Application.Current?.Dispatcher is { } dispatcher && !dispatcher.CheckAccess())
-        {
-            _ = dispatcher.InvokeAsync(NotifyLoggingSessionsChanged);
-            return;
-        }
-
-        NotifyLoggingSessionsChanged();
-    }
-
+    /// <summary>
+    /// Re-raises change notifications for the bound session collection and refreshes the
+    /// "export all" / "delete all" command CanExecute state. Internal callers (the
+    /// <see cref="UpdateUi"/> property-changed handler) invoke this directly; the
+    /// <see cref="ILoggingSessionListHost"/> seam adds UI-thread marshalling for the list view model.
+    /// </summary>
     private void NotifyLoggingSessionsChanged()
     {
         OnPropertyChanged(nameof(LoggingSessions));
         OnPropertyChanged(nameof(HasLoggingSessions));
         DeleteAllLoggingSessionCommand?.NotifyCanExecuteChanged();
         ExportAllLoggingSessionCommand.NotifyCanExecuteChanged();
-    }
-
-    private static void DeleteFileIfExists(string path)
-    {
-        if (File.Exists(path))
-        {
-            File.Delete(path);
-        }
     }
 
     private bool CanDeleteAllLoggingSession()
@@ -1505,7 +1270,7 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
                 }
                 break;
             case nameof(LoggingManager.LoggingSessions):
-                AttachLoggingSessionsCollection(LoggingManager.Instance.LoggingSessions);
+                _loggingSessionList.AttachCollection(LoggingManager.Instance.LoggingSessions);
                 NotifyLoggingSessionsChanged();
                 break;
             case "NotificationCount":
@@ -1665,6 +1430,91 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost
         dispatcher.Invoke(ShowDialog);
         CloseFlyouts();
     }
+
+    #endregion
+
+    #region ILoggingSessionListHost implementation
+
+    // The list view model reaches the view model's bound logged-data state (SelectedLoggingSession,
+    // IsLoggedDataBusy, LoggedDataBusyReason, LoggingSessions) through their existing public members,
+    // which already satisfy the ILoggingSessionListHost setters/getters implicitly. Only the members
+    // below need an explicit bridge because they map onto DbLogger, desktop singletons, or WPF the
+    // list view model intentionally never touches directly.
+
+    /// <summary>True while logging is active. Sourced from <see cref="LoggingManager"/>.</summary>
+    bool ILoggingSessionListHost.IsLoggingActive => LoggingManager.Instance.Active;
+
+    /// <summary>
+    /// Re-raises the session-collection notifications on the UI thread. The list view model calls this
+    /// off the UI thread (from a collection-changed callback or after a background delete), so this
+    /// folds in the dispatcher marshalling the old collection-changed handler performed.
+    /// </summary>
+    void ILoggingSessionListHost.NotifyLoggingSessionsChanged()
+    {
+        if (Application.Current?.Dispatcher is { } dispatcher && !dispatcher.CheckAccess())
+        {
+            _ = dispatcher.InvokeAsync(NotifyLoggingSessionsChanged);
+            return;
+        }
+
+        NotifyLoggingSessionsChanged();
+    }
+
+    void ILoggingSessionListHost.DisplaySessionOnPlot(LoggingSession session) => DbLogger.DisplayLoggingSession(session);
+
+    void ILoggingSessionListHost.DeleteSessionFromDatabase(LoggingSession session) => DbLogger.DeleteLoggingSession(session);
+
+    void ILoggingSessionListHost.ClearPlot() => DbLogger.ClearPlot();
+
+    void ILoggingSessionListHost.SuspendConsumer() => DbLogger.SuspendConsumer();
+
+    void ILoggingSessionListHost.ResumeConsumer() => DbLogger.ResumeConsumer();
+
+    void ILoggingSessionListHost.ClearBuffer() => DbLogger.ClearBuffer();
+
+    /// <summary>
+    /// Builds and presents the single-session export dialog. Kept on the host because the dialog view
+    /// model resolves services from the desktop container and presentation is a WPF concern.
+    /// </summary>
+    async Task ILoggingSessionListHost.ShowExportDialogForSessionAsync(int sessionId)
+    {
+        var exportDialogViewModel = new ExportDialogViewModel(sessionId);
+
+        // UI-test hook: when DAQIFI_TEST_EXPORT_PATH is set, export straight to that directory
+        // with no SaveFileDialog (mirrors DAQIFI_TEST_MODE / AppDataPaths). Unset in production,
+        // where the interactive dialog below is used unchanged.
+        if (Common.AppDataPaths.TestExportPath != null)
+        {
+            await exportDialogViewModel.ExportToDirectoryAsync(Common.AppDataPaths.TestExportPath);
+            return;
+        }
+
+        _dialogService.ShowDialog<ExportDialog>(this, exportDialogViewModel);
+    }
+
+    /// <summary>Builds and presents the "export all" dialog for the supplied sessions.</summary>
+    async Task ILoggingSessionListHost.ShowExportDialogForSessionsAsync(IReadOnlyList<LoggingSession> sessions)
+    {
+        var exportDialogViewModel = new ExportDialogViewModel(sessions);
+
+        // UI-test hook: see ShowExportDialogForSessionAsync above. Same seam, so "Export All" is
+        // equally dialog-free and deterministic under automation when the env var is set.
+        if (Common.AppDataPaths.TestExportPath != null)
+        {
+            await exportDialogViewModel.ExportToDirectoryAsync(Common.AppDataPaths.TestExportPath);
+            return;
+        }
+
+        _dialogService.ShowDialog<ExportDialog>(this, exportDialogViewModel);
+    }
+
+    /// <summary>Routes the list view model's confirmations through the in-pane confirm overlay.</summary>
+    Task<bool> ILoggingSessionListHost.ShowConfirmAsync(string title, string message, string affirmativeLabel, bool isDestructive)
+        => ShowConfirm(title, message, affirmativeLabel, isDestructive);
+
+    /// <summary>Routes the list view model's informational messages through the MahApps message dialog.</summary>
+    Task ILoggingSessionListHost.ShowMessageAsync(string title, string message)
+        => ShowMessage(title, message, MessageDialogStyle.Affirmative);
 
     #endregion
 

--- a/Daqifi.Desktop/ViewModels/ILoggingSessionListHost.cs
+++ b/Daqifi.Desktop/ViewModels/ILoggingSessionListHost.cs
@@ -1,0 +1,95 @@
+using System.Collections.ObjectModel;
+using Daqifi.Desktop.Logger;
+
+namespace Daqifi.Desktop.ViewModels;
+
+/// <summary>
+/// Narrow seam the <see cref="LoggingSessionListViewModel"/> uses to read the bound logged-data
+/// state and route plot/database, dialog, and notification side effects back to the host view model.
+/// <para>
+/// Implemented by <c>DaqifiViewModel</c> so its existing bound members (<c>LoggingSessions</c>,
+/// <c>HasLoggingSessions</c>, <c>SelectedLoggingSession</c>, <c>IsLoggedDataBusy</c>,
+/// <c>LoggedDataBusyReason</c>) remain the binding source — the logged-data pane XAML and its
+/// command bindings are unchanged — while the display/export/delete orchestration and the
+/// session-collection plumbing live in the list view model and are unit-testable against a
+/// lightweight fake. Only logging-session-relevant members are exposed; the list view model never
+/// reaches into desktop singletons (<c>LoggingManager.Instance</c>, <c>ConnectionManager.Instance</c>,
+/// <c>App.ServiceProvider</c>) or touches WPF (<c>Application.Current</c>, a dispatcher) directly.
+/// </para>
+/// </summary>
+public interface ILoggingSessionListHost
+{
+    #region Bound state
+    /// <summary>
+    /// The logging session the logged-data pane is currently acting on. Set by the list view model
+    /// before it displays, exports, or deletes a session so the bound selection stays in sync.
+    /// </summary>
+    LoggingSession SelectedLoggingSession { set; }
+
+    /// <summary>True while a long-running logged-data operation (load/delete) is in progress.</summary>
+    bool IsLoggedDataBusy { set; }
+
+    /// <summary>The status line shown over the logged-data pane while it is busy.</summary>
+    string LoggedDataBusyReason { set; }
+
+    /// <summary>
+    /// The shared, bound logging-session collection (the <c>LoggingManager</c>-owned list in
+    /// production). The list view model reads its count, removes/clears entries, and subscribes to
+    /// its change notifications through this property so it never touches <c>LoggingManager.Instance</c>.
+    /// </summary>
+    ObservableCollection<LoggingSession> LoggingSessions { get; }
+
+    /// <summary>True while a logging session is active. Gates the "delete all" path.</summary>
+    bool IsLoggingActive { get; }
+    #endregion
+
+    #region Notifications
+    /// <summary>
+    /// Re-raises change notifications for <c>LoggingSessions</c> / <c>HasLoggingSessions</c> and
+    /// refreshes the "export all" / "delete all" command CanExecute state. The host marshals this to
+    /// the UI thread when called off it, so the list view model never references a dispatcher.
+    /// </summary>
+    void NotifyLoggingSessionsChanged();
+    #endregion
+
+    #region Plot / database operations
+    /// <summary>Loads the given session onto the logged-data plot (routes to <c>DbLogger</c>).</summary>
+    void DisplaySessionOnPlot(LoggingSession session);
+
+    /// <summary>Deletes the given session's samples from the database (routes to <c>DbLogger</c>).</summary>
+    void DeleteSessionFromDatabase(LoggingSession session);
+
+    /// <summary>Clears the logged-data plot (routes to <c>DbLogger</c>).</summary>
+    void ClearPlot();
+
+    /// <summary>Suspends the database consumer thread before a bulk storage purge (routes to <c>DbLogger</c>).</summary>
+    void SuspendConsumer();
+
+    /// <summary>Resumes the database consumer thread after a bulk storage purge (routes to <c>DbLogger</c>).</summary>
+    void ResumeConsumer();
+
+    /// <summary>Clears the pending sample buffer before a bulk storage purge (routes to <c>DbLogger</c>).</summary>
+    void ClearBuffer();
+    #endregion
+
+    #region Dialogs
+    /// <summary>
+    /// Presents the export dialog for a single session. Dialog construction (which resolves services
+    /// from the desktop container) and presentation are view concerns, so the list view model
+    /// delegates them here rather than newing up the dialog view model itself.
+    /// </summary>
+    Task ShowExportDialogForSessionAsync(int sessionId);
+
+    /// <summary>Presents the export dialog for a batch of sessions ("export all").</summary>
+    Task ShowExportDialogForSessionsAsync(IReadOnlyList<LoggingSession> sessions);
+
+    /// <summary>
+    /// Shows the in-pane confirm overlay and returns true when the user accepts. Routed through the
+    /// host so the confirm-overlay state stays on the view model (its extraction is a separate PR).
+    /// </summary>
+    Task<bool> ShowConfirmAsync(string title, string message, string affirmativeLabel, bool isDestructive);
+
+    /// <summary>Shows an informational message dialog (e.g. the "stop logging before delete all" guard).</summary>
+    Task ShowMessageAsync(string title, string message);
+    #endregion
+}

--- a/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
@@ -157,6 +157,13 @@ public class LoggingSessionListViewModel
             _host.LoggedDataBusyReason = $"Deleting Logging Session #{session.ID}";
             try
             {
+                // Remove the bound row only when the database delete reports success — the gating is
+                // preserved verbatim from the pre-extraction DaqifiViewModel. Note the production host
+                // routes DeleteSessionFromDatabase to DatabaseLogger.DeleteLoggingSession, which today
+                // logs and swallows its own exceptions, so this catch is currently a latent guard
+                // rather than a live failure path. Surfacing delete failures (so a failed delete keeps
+                // the row) belongs to the separate DatabaseLogger extraction tracked in #592; this
+                // contract is unit-tested here so it stays correct once the host propagates failure.
                 var deleteSucceeded = false;
                 try
                 {

--- a/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
@@ -1,0 +1,310 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.IO;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Logger;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Daqifi.Desktop.ViewModels;
+
+/// <summary>
+/// Owns the logged-data pane's session-list actions — displaying a session on the plot, exporting
+/// one or all sessions, deleting one or all sessions, and keeping the bound session collection's
+/// change notifications wired.
+/// <para>
+/// Extracted from <c>DaqifiViewModel</c> (issue #592). Every collaborator is constructor-injected
+/// (the logging-context factory resolver, the database file path, the application logger) and all
+/// plot/database, dialog, and notification side effects are reached through the
+/// <see cref="ILoggingSessionListHost"/> seam — so this class has no dependency on WPF or on desktop
+/// singletons (<c>LoggingManager.Instance</c>, <c>App.ServiceProvider</c>, <c>App.DatabasePath</c>)
+/// and is unit-testable in isolation. The legacy <c>BackgroundWorker</c> the display and delete
+/// paths used has been replaced with the file's async/await + busy-flag pattern.
+/// </para>
+/// </summary>
+public class LoggingSessionListViewModel
+{
+    #region Private Fields
+    private readonly ILoggingSessionListHost _host;
+    private readonly Func<IDbContextFactory<LoggingContext>> _loggingContextFactoryResolver;
+    private readonly string _databasePath;
+    private readonly IAppLogger _appLogger;
+    private ObservableCollection<LoggingSession>? _observedLoggingSessions;
+    #endregion
+
+    #region Constructor
+    /// <summary>
+    /// Creates the list view model. The composition root (the view model / DI container) is
+    /// responsible for resolving the production collaborators so this class never reaches into
+    /// singletons.
+    /// </summary>
+    /// <param name="host">The host view-model surface the list reads state from and pushes effects to.</param>
+    /// <param name="loggingContextFactoryResolver">
+    /// Resolves the logging-context factory used by the "delete all" storage purge. A resolver
+    /// (rather than the factory itself) preserves the host's lazy resolution + clear failure when no
+    /// factory is available.
+    /// </param>
+    /// <param name="databasePath">Absolute path to the SQLite database file (and its -wal/-shm siblings).</param>
+    /// <param name="appLogger">Application logger used for diagnostics.</param>
+    public LoggingSessionListViewModel(
+        ILoggingSessionListHost host,
+        Func<IDbContextFactory<LoggingContext>> loggingContextFactoryResolver,
+        string databasePath,
+        IAppLogger appLogger)
+    {
+        _host = host ?? throw new ArgumentNullException(nameof(host));
+        _loggingContextFactoryResolver = loggingContextFactoryResolver ?? throw new ArgumentNullException(nameof(loggingContextFactoryResolver));
+        _databasePath = databasePath ?? throw new ArgumentNullException(nameof(databasePath));
+        _appLogger = appLogger ?? throw new ArgumentNullException(nameof(appLogger));
+    }
+    #endregion
+
+    #region Display
+    /// <summary>
+    /// Loads the selected session onto the logged-data plot. A null session clears the plot. The
+    /// blocking <c>DbLogger</c> load runs off the UI thread under the busy flag (replacing the legacy
+    /// <c>BackgroundWorker</c>); load failures are logged and never propagate.
+    /// </summary>
+    public async Task DisplaySessionAsync(LoggingSession? session)
+    {
+        if (session == null)
+        {
+            _host.ClearPlot();
+            return;
+        }
+
+        _host.SelectedLoggingSession = session;
+        _host.IsLoggedDataBusy = true;
+        _host.LoggedDataBusyReason = "Loading " + session.Name;
+        try
+        {
+            await Task.Run(() =>
+            {
+                try
+                {
+                    _host.DisplaySessionOnPlot(session);
+                }
+                catch (Exception ex)
+                {
+                    _appLogger.Error(ex, $"Failed to display logging session {session.ID}.");
+                }
+            });
+        }
+        finally
+        {
+            _host.IsLoggedDataBusy = false;
+            _host.LoggedDataBusyReason = string.Empty;
+        }
+    }
+    #endregion
+
+    #region Export
+    /// <summary>Exports a single session via the export dialog.</summary>
+    public async Task ExportSessionAsync(LoggingSession? session)
+    {
+        if (session == null)
+        {
+            _appLogger.Error("Error exporting logging session");
+            return;
+        }
+
+        _host.SelectedLoggingSession = session;
+        await _host.ShowExportDialogForSessionAsync(session.ID);
+    }
+
+    /// <summary>Exports every session via the export dialog.</summary>
+    public async Task ExportAllSessionsAsync()
+    {
+        if (_host.LoggingSessions.Count == 0)
+        {
+            _appLogger.Error("Error exporting all logging sessions");
+            return;
+        }
+
+        await _host.ShowExportDialogForSessionsAsync(_host.LoggingSessions.ToList());
+    }
+    #endregion
+
+    #region Delete
+    /// <summary>
+    /// Deletes a single session after confirmation. The blocking <c>DbLogger</c> delete runs off the
+    /// UI thread under the busy flag (replacing the legacy <c>BackgroundWorker</c>); the session is
+    /// removed from the bound collection only when the database delete succeeds.
+    /// </summary>
+    public async Task DeleteSessionAsync(LoggingSession? session)
+    {
+        try
+        {
+            if (session == null)
+            {
+                _appLogger.Error("Error deleting logging session: Invalid object provided.");
+                return;
+            }
+
+            _host.SelectedLoggingSession = session;
+
+            var confirmed = await _host.ShowConfirmAsync(
+                "Delete Confirmation",
+                $"Are you sure you want to delete {session.Name}?",
+                affirmativeLabel: "DELETE",
+                isDestructive: true);
+            if (!confirmed)
+            {
+                return;
+            }
+
+            _host.IsLoggedDataBusy = true;
+            _host.LoggedDataBusyReason = $"Deleting Logging Session #{session.ID}";
+            try
+            {
+                var deleteSucceeded = false;
+                try
+                {
+                    await Task.Run(() => _host.DeleteSessionFromDatabase(session));
+                    deleteSucceeded = true;
+                }
+                catch (Exception dbEx)
+                {
+                    _appLogger.Error(dbEx, $"Failed to delete session {session.ID} from database.");
+                }
+
+                if (deleteSucceeded)
+                {
+                    _host.LoggingSessions.Remove(session);
+                    _host.NotifyLoggingSessionsChanged();
+                }
+            }
+            finally
+            {
+                _host.IsLoggedDataBusy = false;
+                _host.LoggedDataBusyReason = string.Empty;
+            }
+        }
+        catch (Exception ex)
+        {
+            _appLogger.Error(ex, "Error initiating logging session deletion");
+        }
+    }
+
+    /// <summary>
+    /// Deletes every session. Refuses to run while logging is active, confirms the destructive
+    /// action, then purges the database storage off the UI thread under the busy flag.
+    /// </summary>
+    public async Task DeleteAllSessionsAsync()
+    {
+        try
+        {
+            if (_host.LoggingSessions.Count == 0)
+            {
+                return;
+            }
+
+            if (_host.IsLoggingActive)
+            {
+                await _host.ShowMessageAsync(
+                    "Cannot Delete",
+                    "Please stop logging before deleting all sessions.");
+                return;
+            }
+
+            var confirmed = await _host.ShowConfirmAsync(
+                "Delete Confirmation",
+                "Are you sure you want to delete all logging sessions? This cannot be undone.",
+                affirmativeLabel: "DELETE ALL",
+                isDestructive: true);
+            if (!confirmed)
+            {
+                return;
+            }
+
+            _host.IsLoggedDataBusy = true;
+            _host.LoggedDataBusyReason = "Deleting All Logging Sessions";
+
+            try
+            {
+                var contextFactory = _loggingContextFactoryResolver();
+                await Task.Run(() => DeleteAllLoggingSessionsFromStorage(contextFactory));
+                _host.LoggingSessions.Clear();
+                _host.NotifyLoggingSessionsChanged();
+                _host.ClearPlot();
+            }
+            catch (IOException ioEx)
+            {
+                _appLogger.Error(ioEx, "Database file is in use. Please try again.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _appLogger.Error(ex, "Error during deletion of all logging sessions");
+        }
+        finally
+        {
+            _host.IsLoggedDataBusy = false;
+            _host.LoggedDataBusyReason = string.Empty;
+        }
+    }
+
+    private void DeleteAllLoggingSessionsFromStorage(IDbContextFactory<LoggingContext> contextFactory)
+    {
+        _host.SuspendConsumer();
+        try
+        {
+            _host.ClearBuffer();
+
+            // Release all pooled SQLite connections so the file is not locked.
+            SqliteConnection.ClearAllPools();
+
+            DeleteFileIfExists(_databasePath);
+            DeleteFileIfExists(_databasePath + "-wal");
+            DeleteFileIfExists(_databasePath + "-shm");
+
+            // Recreate the database schema. Constructing a context does not
+            // create tables — only Migrate() (or EnsureCreated) does. Without
+            // this, the next session-start query against Samples/Sessions
+            // throws "no such table: Samples".
+            using var context = contextFactory.CreateDbContext();
+            context.Database.Migrate();
+        }
+        finally
+        {
+            _host.ResumeConsumer();
+        }
+    }
+
+    private static void DeleteFileIfExists(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+    #endregion
+
+    #region Collection plumbing
+    /// <summary>
+    /// Subscribes to the supplied session collection's change notifications, replacing any prior
+    /// subscription. The host re-supplies the collection whenever the logging manager swaps it out.
+    /// </summary>
+    public void AttachCollection(ObservableCollection<LoggingSession> loggingSessions)
+    {
+        if (ReferenceEquals(_observedLoggingSessions, loggingSessions))
+        {
+            return;
+        }
+
+        if (_observedLoggingSessions != null)
+        {
+            _observedLoggingSessions.CollectionChanged -= OnLoggingSessionsCollectionChanged;
+        }
+
+        _observedLoggingSessions = loggingSessions;
+        _observedLoggingSessions.CollectionChanged += OnLoggingSessionsCollectionChanged;
+    }
+
+    private void OnLoggingSessionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        // The host owns the UI-thread marshalling so this class stays dispatcher-free.
+        _host.NotifyLoggingSessionsChanged();
+    }
+    #endregion
+}


### PR DESCRIPTION
## What

Second behavior-preserving extraction from #592, following the PR #601
(`FirmwareUpdateCoordinator`) template. Moves the logged-data pane's
**logging-session list actions** out of the `DaqifiViewModel` god class into a
dedicated, WPF-free, unit-testable `LoggingSessionListViewModel`.

`DaqifiViewModel` drops from **1,803 → 1,653 lines** and keeps only the bound
properties + thin command bindings.

## What moved

Into `Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs`:

- `DisplaySession` (was `DisplayLoggingSession`), `ExportSession` /
  `ExportAllSessions`
- `DeleteSession` / `DeleteAllSessions` (+ the storage purge) with the
  **"stop logging before delete all"** guard
- the `LoggingSessions` collection plumbing (attach + change notification)

## Why it's low-risk

- **Logged-data XAML is untouched.** `DaqifiViewModel` keeps every bound
  property (`LoggingSessions`, `HasLoggingSessions`, `SelectedLoggingSession`,
  `IsLoggedDataBusy`, `LoggedDataBusyReason`) and every command
  (`DisplayLoggingSessionCommand`, `ExportLoggingSessionCommand`,
  `ExportAllLoggingSessionCommand`, `DeleteLoggingSessionCommand`,
  `DeleteAllLoggingSessionCommand`) as thin bindings that forward to the list
  view model — so `Binding`/`DataContext` are unchanged.
- The list view model drives all state and side effects through a new
  `ILoggingSessionListHost` seam that `DaqifiViewModel` implements (mirrors
  `IFirmwareUpdateHost`). It never touches WPF, `DbLogger`,
  `LoggingManager.Instance`, `App.ServiceProvider`, `App.DatabasePath`, or a
  dispatcher directly — the storage-purge collaborators (the logging-context
  factory resolver and the database path) are constructor-injected.

## Acceptance-criteria items addressed

- The legacy `BackgroundWorker` in `DisplayLoggingSession` and in the
  single-delete path is replaced with the file's async/await +
  `IsLoggedDataBusy` busy-flag pattern.
- The extracted class is unit-testable without WPF (constructor-injected
  dependencies, no new `.Instance` reach-ins).
- The in-pane confirm overlay / message dialog are reached through the seam —
  the `ConfirmOverlayViewModel` extraction stays a separate future PR.
- The SD-card import path (`ImportSdCardLogFile`) is left where it is.

## Tests

New `Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs`
(18 tests) drives the class against a fake host + a real temp-SQLite context
factory, covering:

- display (incl. null → clear plot, and a load-error that still clears the busy flag)
- export (incl. null, and export-all)
- delete-one (incl. not-confirmed, and a DB delete that throws → session kept)
- delete-all (incl. the stop-logging guard, not-confirmed, and a full storage purge
  that proves the suspend → purge → resume ordering and schema re-creation)
- collection-changed notifications (attach/re-attach/idempotent-attach)

The temp factory mirrors the production registration's
`ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))`
so the `Migrate()` in the purge behaves as it does in the app.

## Verification

- Full solution builds (0 errors).
- Unit gate green: **390 passed**
  (`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`),
  including the 18 new tests.
- App launched (no `DAQIFI_TEST_MODE`): the logged-data pane lists sessions,
  displays a session onto the plot, and opens the export dialog. (The destructive
  delete paths were left to the unit tests to avoid mutating the shared database.)

## Scope / follow-ups

Per #592's "one PR per extraction", the remaining `DaqifiViewModel` extractions
(disk-space monitor, confirm overlay, network-settings status) and the separate
`DatabaseLogger` split are left for their own PRs.

Closes part of #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
