### PR TITLE
chore(viewmodels): extract ConfirmOverlayViewModel from DaqifiViewModel (#592)

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/ConfirmOverlayViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConfirmOverlayViewModelTests.cs
@@ -1,0 +1,225 @@
+using Daqifi.Desktop.ViewModels;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Behavior contract for <see cref="ConfirmOverlayViewModel"/> — the reusable in-pane confirm
+/// overlay extracted from <c>DaqifiViewModel</c> (issue #592). The overlay is driven with no WPF
+/// dependency: await <see cref="ConfirmOverlayViewModel.ShowAsync"/> and fire the affirmative /
+/// negative commands (or <see cref="ConfirmOverlayViewModel.Cancel"/>). Covers the opening state,
+/// the two command resolutions, the re-entrancy guard, the host reset path, and the
+/// RunContinuationsAsynchronously contract.
+/// </summary>
+[TestClass]
+public class ConfirmOverlayViewModelTests
+{
+    #region Initial state / ShowAsync
+
+    [TestMethod]
+    public void NewOverlay_IsClosedWithDefaults()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+
+        Assert.IsFalse(overlay.IsOpen);
+        Assert.AreEqual(string.Empty, overlay.Title);
+        Assert.AreEqual(string.Empty, overlay.Message);
+        Assert.AreEqual("OK", overlay.AffirmativeLabel);
+        Assert.IsFalse(overlay.AffirmativeIsDestructive);
+    }
+
+    [TestMethod]
+    public void ShowAsync_OpensOverlayWithSuppliedContent()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+
+        var task = overlay.ShowAsync(
+            "Delete Confirmation",
+            "Are you sure you want to delete Bench Run?",
+            affirmativeLabel: "DELETE",
+            isDestructive: true);
+
+        Assert.IsTrue(overlay.IsOpen);
+        Assert.AreEqual("Delete Confirmation", overlay.Title);
+        Assert.AreEqual("Are you sure you want to delete Bench Run?", overlay.Message);
+        Assert.AreEqual("DELETE", overlay.AffirmativeLabel);
+        Assert.IsTrue(overlay.AffirmativeIsDestructive);
+        Assert.IsFalse(task.IsCompleted, "The task stays pending until the user responds.");
+    }
+
+    [TestMethod]
+    public void ShowAsync_DefaultsToNonDestructiveOkLabel()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+
+        overlay.ShowAsync("Switch profile?", "Switch to 'Bench'?");
+
+        Assert.AreEqual("OK", overlay.AffirmativeLabel);
+        Assert.IsFalse(overlay.AffirmativeIsDestructive);
+        Assert.IsTrue(overlay.IsOpen);
+    }
+
+    [TestMethod]
+    public async Task ReopeningNonDestructive_ResetsDestructiveStyleAndLabel()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+
+        // A destructive confirm leaves AffirmativeIsDestructive == true and a custom label.
+        var first = overlay.ShowAsync("Delete Confirmation", "Delete it?", "DELETE", isDestructive: true);
+        overlay.Cancel();
+        await first;
+
+        // Re-opening with defaults must clear both so the destructive styling/label do not leak
+        // into the next non-destructive confirm — this flag drives which affirmative button
+        // (accent vs danger/red) the overlay shows.
+        overlay.ShowAsync("Switch profile?", "Switch to 'Bench'?");
+
+        Assert.IsFalse(overlay.AffirmativeIsDestructive, "Re-opening non-destructive must clear the danger style.");
+        Assert.AreEqual("OK", overlay.AffirmativeLabel, "Re-opening must reset the affirmative label to the default.");
+        Assert.AreEqual("Switch profile?", overlay.Title);
+        Assert.AreEqual("Switch to 'Bench'?", overlay.Message);
+    }
+
+    #endregion
+
+    #region Command resolutions
+
+    [TestMethod]
+    public async Task AffirmativeCommand_ResolvesTaskTrueAndClosesOverlay()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+        var task = overlay.ShowAsync("T", "M", "DELETE", isDestructive: true);
+
+        overlay.AffirmativeCommand.Execute(null);
+
+        Assert.IsTrue(await task, "The affirmative command must resolve the awaiter with true.");
+        Assert.IsFalse(overlay.IsOpen, "Choosing the affirmative button must close the overlay.");
+    }
+
+    [TestMethod]
+    public async Task NegativeCommand_ResolvesTaskFalseAndClosesOverlay()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+        var task = overlay.ShowAsync("T", "M");
+
+        overlay.NegativeCommand.Execute(null);
+
+        Assert.IsFalse(await task, "The negative command must resolve the awaiter with false.");
+        Assert.IsFalse(overlay.IsOpen, "Cancelling must close the overlay.");
+    }
+
+    [TestMethod]
+    public async Task SecondCommandAfterResolution_IsNoOp_AndFirstResultWins()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+        var task = overlay.ShowAsync("T", "M", "DELETE", isDestructive: true);
+
+        overlay.AffirmativeCommand.Execute(null);
+        Assert.IsTrue(await task);
+
+        // A late second response (stray click, or a host reset via Cancel) must not throw and must
+        // not change the already-observed result. Complete() nulls the TCS before resolving it, so
+        // these are no-ops rather than a double-set that would throw.
+        overlay.NegativeCommand.Execute(null);
+        overlay.Cancel();
+
+        Assert.IsTrue(task.Result, "The first resolution must win; later commands are no-ops.");
+        Assert.IsFalse(overlay.IsOpen);
+    }
+
+    #endregion
+
+    #region Re-entrancy guard / host reset
+
+    [TestMethod]
+    public async Task SecondShowAsync_WhilePending_ResolvesTheFirstWithFalse()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+        var first = overlay.ShowAsync("First", "first message", "YES");
+
+        var second = overlay.ShowAsync("Second", "second message", "DELETE", isDestructive: true);
+
+        Assert.IsFalse(await first, "A still-pending confirm must be resolved false when a new one opens.");
+        Assert.IsFalse(second.IsCompleted, "The newly opened confirm stays pending.");
+
+        // The overlay now reflects the second confirm, and that confirm resolves independently.
+        Assert.IsTrue(overlay.IsOpen);
+        Assert.AreEqual("Second", overlay.Title);
+        Assert.IsTrue(overlay.AffirmativeIsDestructive);
+
+        overlay.AffirmativeCommand.Execute(null);
+        Assert.IsTrue(await second);
+    }
+
+    [TestMethod]
+    public async Task Cancel_ResolvesPendingConfirmFalseAndClosesOverlay()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+        var task = overlay.ShowAsync("T", "M", "DELETE", isDestructive: true);
+
+        overlay.Cancel();
+
+        Assert.IsFalse(await task, "Cancel must resolve the pending awaiter with false.");
+        Assert.IsFalse(overlay.IsOpen);
+    }
+
+    [TestMethod]
+    public void Cancel_WithNothingPending_IsANoOp()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+
+        overlay.Cancel(); // must not throw
+
+        Assert.IsFalse(overlay.IsOpen);
+    }
+
+    #endregion
+
+    #region RunContinuationsAsynchronously
+
+    [TestMethod]
+    public async Task Complete_RunsContinuationsAsynchronously()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+        var task = overlay.ShowAsync("T", "M");
+
+        // A continuation that *requests* synchronous execution. Because the underlying TCS is
+        // created with TaskCreationOptions.RunContinuationsAsynchronously, that request is
+        // overridden — the continuation is queued rather than run inline on the thread that
+        // completes the task. So the flag is still unset the instant Execute() returns. (Without
+        // the flag this would be true: the continuation would run inline inside TrySetResult.)
+        var ranInline = false;
+        var continuation = task.ContinueWith(
+            _ => ranInline = true,
+            TaskContinuationOptions.ExecuteSynchronously);
+
+        overlay.AffirmativeCommand.Execute(null);
+
+        Assert.IsTrue(task.IsCompleted, "The result is set synchronously when the command fires.");
+        Assert.IsFalse(ranInline,
+            "RunContinuationsAsynchronously must keep continuations off the completing thread.");
+
+        await continuation;
+        Assert.IsTrue(ranInline, "The continuation still runs — just asynchronously.");
+        Assert.IsTrue(task.Result);
+    }
+
+    [TestMethod]
+    public async Task AwaitedResult_IsObservedCorrectly()
+    {
+        var overlay = new ConfirmOverlayViewModel();
+
+        // Mirror a caller that awaits ShowConfirm(...) and resumes when a command fires.
+        var resultTask = AwaitConfirm(overlay);
+
+        overlay.NegativeCommand.Execute(null);
+
+        Assert.IsFalse(await resultTask);
+    }
+
+    private static async Task<bool> AwaitConfirm(ConfirmOverlayViewModel overlay)
+    {
+        return await overlay.ShowAsync("T", "M", "DELETE", isDestructive: true);
+    }
+
+    #endregion
+}

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -1333,12 +1333,12 @@ public abstract class DaqifiAppFixture
     }
 
     /// <summary>
-    /// Accepts the app's in-pane confirm overlay (<c>IsConfirmOpen</c>) by invoking its affirmative
-    /// button (<c>ConfirmAffirmativeButton</c> — its label is e.g. "DELETE"), then waits for the
-    /// overlay to close. This overlay is the dark, in-window card the app uses instead of a MahApps
-    /// modal for destructive confirmations; its accent/danger style variants share the id and only
-    /// the visible one is in the UIA tree. A plain Button's InvokePattern raises a real click, so
-    /// the bound <c>ConfirmAffirmativeCommand</c> runs (cf. gotcha #12).
+    /// Accepts the app's in-pane confirm overlay (<c>ConfirmOverlay.IsOpen</c>) by invoking its
+    /// affirmative button (<c>ConfirmAffirmativeButton</c> — its label is e.g. "DELETE"), then waits
+    /// for the overlay to close. This overlay is the dark, in-window card the app uses instead of a
+    /// MahApps modal for destructive confirmations; its accent/danger style variants share the id and
+    /// only the visible one is in the UIA tree. A plain Button's InvokePattern raises a real click, so
+    /// the bound <c>ConfirmOverlay.AffirmativeCommand</c> runs (cf. gotcha #12).
     /// </summary>
     protected void ConfirmInPaneDialog(TimeSpan? timeout = null)
     {

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -355,11 +355,12 @@ why.
 
 17. **Destructive confirmations use a dark *in-pane* overlay, not a MahApps modal.** Delete actions
     (the per-row session delete, "Delete All") route through `DaqifiViewModel.ShowConfirm`, which
-    drives an in-window confirm card (`IsConfirmOpen` + `ConfirmAffirmativeCommand`) — **not**
+    forwards to the reusable `ConfirmOverlayViewModel` exposed as `ConfirmOverlay` and drives an
+    in-window confirm card (`ConfirmOverlay.IsOpen` + `ConfirmOverlay.AffirmativeCommand`) — **not**
     `ShowMessageAsync` (cf. #14, which still applies to the SD-import completion dialog). Its
     affirmative button carries `AutomationProperties.AutomationId="ConfirmAffirmativeButton"` on
     **both** style variants (accent for non-destructive, danger/red for destructive); their
-    `Visibility` binds to `ConfirmAffirmativeIsDestructive`, and a `Collapsed` subtree is absent from
+    `Visibility` binds to `ConfirmOverlay.AffirmativeIsDestructive`, and a `Collapsed` subtree is absent from
     the UIA tree, so an id lookup returns whichever is currently shown. The card is a plain `Button`,
     so `InvokePattern` raises a real click and runs the bound command (cf. #12). `ConfirmInPaneDialog`
     invokes it and then waits for the overlay to leave the tree so its scrim no longer blocks later

--- a/Daqifi.Desktop/View/ProfilesPane.xaml
+++ b/Daqifi.Desktop/View/ProfilesPane.xaml
@@ -922,12 +922,12 @@
         </Grid>
 
         <!-- ========== CONFIRM DIALOG (over everything) ========== -->
-        <Grid Visibility="{Binding IsConfirmOpen, Converter={StaticResource BoolToVis}}"
+        <Grid Visibility="{Binding ConfirmOverlay.IsOpen, Converter={StaticResource BoolToVis}}"
               Panel.ZIndex="20">
             <!-- Scrim. Click = cancel (same pattern as the drawer). -->
             <Rectangle Fill="#A0000000">
                 <Rectangle.InputBindings>
-                    <MouseBinding MouseAction="LeftClick" Command="{Binding ConfirmNegativeCommand}"/>
+                    <MouseBinding MouseAction="LeftClick" Command="{Binding ConfirmOverlay.NegativeCommand}"/>
                 </Rectangle.InputBindings>
             </Rectangle>
 
@@ -941,11 +941,11 @@
                     CornerRadius="4"
                     Padding="24">
                 <StackPanel>
-                    <TextBlock Text="{Binding ConfirmTitle}"
+                    <TextBlock Text="{Binding ConfirmOverlay.Title}"
                                FontSize="16"
                                FontWeight="SemiBold"
                                Foreground="{StaticResource TextPrimary}"/>
-                    <TextBlock Text="{Binding ConfirmMessage}"
+                    <TextBlock Text="{Binding ConfirmOverlay.Message}"
                                FontSize="13"
                                Foreground="{StaticResource TextSecondary}"
                                TextWrapping="Wrap"
@@ -954,11 +954,11 @@
                                 HorizontalAlignment="Right">
                         <Button Content="CANCEL"
                                 Style="{StaticResource PillButton}"
-                                Command="{Binding ConfirmNegativeCommand}"/>
-                        <Button Content="{Binding ConfirmAffirmativeLabel}"
+                                Command="{Binding ConfirmOverlay.NegativeCommand}"/>
+                        <Button Content="{Binding ConfirmOverlay.AffirmativeLabel}"
                                 Style="{StaticResource AccentPillButton}"
                                 Margin="10,0,0,0"
-                                Command="{Binding ConfirmAffirmativeCommand}"/>
+                                Command="{Binding ConfirmOverlay.AffirmativeCommand}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -1040,8 +1040,8 @@
         <!-- Focusable + Cycle traps Tab inside the overlay so keyboard focus can't reach
              the now-scrim-covered controls behind. Initial focus is moved to the Cancel
              button by code-behind on IsVisibleChanged so the safe option is the default. -->
-        <Grid x:Name="ConfirmOverlay"
-              Visibility="{Binding IsConfirmOpen, Converter={StaticResource BoolToVis}}"
+        <Grid x:Name="ConfirmOverlayHost"
+              Visibility="{Binding ConfirmOverlay.IsOpen, Converter={StaticResource BoolToVis}}"
               Panel.ZIndex="30"
               Focusable="True"
               KeyboardNavigation.TabNavigation="Cycle"
@@ -1049,7 +1049,7 @@
             <!-- Scrim. Click = cancel (same pattern as the drawer). -->
             <Rectangle Fill="#A0000000">
                 <Rectangle.InputBindings>
-                    <MouseBinding MouseAction="LeftClick" Command="{Binding ConfirmNegativeCommand}"/>
+                    <MouseBinding MouseAction="LeftClick" Command="{Binding ConfirmOverlay.NegativeCommand}"/>
                 </Rectangle.InputBindings>
             </Rectangle>
 
@@ -1063,11 +1063,11 @@
                     CornerRadius="4"
                     Padding="24">
                 <StackPanel>
-                    <TextBlock Text="{Binding ConfirmTitle}"
+                    <TextBlock Text="{Binding ConfirmOverlay.Title}"
                                FontSize="16"
                                FontWeight="SemiBold"
                                Foreground="{StaticResource TextPrimary}"/>
-                    <TextBlock Text="{Binding ConfirmMessage}"
+                    <TextBlock Text="{Binding ConfirmOverlay.Message}"
                                FontSize="13"
                                Foreground="{StaticResource TextSecondary}"
                                TextWrapping="Wrap"
@@ -1078,21 +1078,21 @@
                                 Content="CANCEL"
                                 Style="{StaticResource PillButton}"
                                 IsCancel="True"
-                                Command="{Binding ConfirmNegativeCommand}"/>
+                                Command="{Binding ConfirmOverlay.NegativeCommand}"/>
                         <!-- Affirmative is one of two styles depending on whether the
                              confirmed action is destructive; only one is visible at a time. -->
-                        <Button Content="{Binding ConfirmAffirmativeLabel}"
+                        <Button Content="{Binding ConfirmOverlay.AffirmativeLabel}"
                                 AutomationProperties.AutomationId="ConfirmAffirmativeButton"
                                 Style="{StaticResource AccentPillButton}"
                                 Margin="10,0,0,0"
-                                Command="{Binding ConfirmAffirmativeCommand}"
-                                Visibility="{Binding ConfirmAffirmativeIsDestructive, Converter={StaticResource InvertedBoolToVis}}"/>
-                        <Button Content="{Binding ConfirmAffirmativeLabel}"
+                                Command="{Binding ConfirmOverlay.AffirmativeCommand}"
+                                Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive, Converter={StaticResource InvertedBoolToVis}}"/>
+                        <Button Content="{Binding ConfirmOverlay.AffirmativeLabel}"
                                 AutomationProperties.AutomationId="ConfirmAffirmativeButton"
                                 Style="{StaticResource DangerPillButton}"
                                 Margin="10,0,0,0"
-                                Command="{Binding ConfirmAffirmativeCommand}"
-                                Visibility="{Binding ConfirmAffirmativeIsDestructive, Converter={StaticResource BoolToVis}}"/>
+                                Command="{Binding ConfirmOverlay.AffirmativeCommand}"
+                                Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive, Converter={StaticResource BoolToVis}}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -1086,13 +1086,15 @@
                                 Style="{StaticResource AccentPillButton}"
                                 Margin="10,0,0,0"
                                 Command="{Binding ConfirmOverlay.AffirmativeCommand}"
-                                Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive, Converter={StaticResource InvertedBoolToVis}}"/>
+                                Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive,
+                                             Converter={StaticResource InvertedBoolToVis}}"/>
                         <Button Content="{Binding ConfirmOverlay.AffirmativeLabel}"
                                 AutomationProperties.AutomationId="ConfirmAffirmativeButton"
                                 Style="{StaticResource DangerPillButton}"
                                 Margin="10,0,0,0"
                                 Command="{Binding ConfirmOverlay.AffirmativeCommand}"
-                                Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive, Converter={StaticResource BoolToVis}}"/>
+                                Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive,
+                                             Converter={StaticResource BoolToVis}}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Daqifi.Desktop/ViewModels/ConfirmOverlayViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConfirmOverlayViewModel.cs
@@ -1,0 +1,120 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Daqifi.Desktop.ViewModels;
+
+/// <summary>
+/// Reusable view model for the in-pane dark confirm overlay — the destructive-action
+/// confirmation pattern shared by the logged-data and profiles panes. It replaces the MahApps
+/// MessageDialog (white card / blue theme) which clashed with the dark, tile-based design system.
+/// <para>
+/// Owns the bound overlay state (<see cref="IsOpen"/>, <see cref="Title"/>, <see cref="Message"/>,
+/// <see cref="AffirmativeLabel"/>, <see cref="AffirmativeIsDestructive"/>), the affirmative/negative
+/// commands, and an awaitable <see cref="ShowAsync"/> built on a
+/// <see cref="TaskCompletionSource{TResult}"/>. Extracted from <c>DaqifiViewModel</c> (issue #592).
+/// </para>
+/// <para>
+/// It is WPF-free — no <c>Application.Current</c>, dispatcher, or singletons — so a host view model
+/// exposes it as a nested bindable property (<c>ConfirmOverlay</c>) and the overlay binds to
+/// <c>ConfirmOverlay.*</c>; the result resolves when the two commands fire. That keeps the class
+/// unit-testable in isolation: await <see cref="ShowAsync"/> and execute a command.
+/// </para>
+/// </summary>
+public partial class ConfirmOverlayViewModel : ObservableObject
+{
+    #region Observable Properties
+    /// <summary>True while the confirm overlay is visible.</summary>
+    [ObservableProperty] private bool _isOpen;
+
+    /// <summary>Title shown at the top of the confirm overlay card.</summary>
+    [ObservableProperty] private string _title = string.Empty;
+
+    /// <summary>Body message shown in the confirm overlay card.</summary>
+    [ObservableProperty] private string _message = string.Empty;
+
+    /// <summary>Label shown on the affirmative button of the confirm overlay (e.g. "DELETE").</summary>
+    [ObservableProperty] private string _affirmativeLabel = "OK";
+
+    /// <summary>
+    /// When true, the affirmative button uses the danger style (red outline) instead of the
+    /// accent style (filled blue). Set by destructive callers of <see cref="ShowAsync"/>.
+    /// </summary>
+    [ObservableProperty] private bool _affirmativeIsDestructive;
+    #endregion
+
+    #region Private Fields
+    private TaskCompletionSource<bool>? _confirmTcs;
+    #endregion
+
+    #region Commands
+    /// <summary>
+    /// Resolves the pending <see cref="ShowAsync"/> task with <c>true</c>.
+    /// Bound to the affirmative button.
+    /// </summary>
+    public IRelayCommand AffirmativeCommand { get; }
+
+    /// <summary>
+    /// Resolves the pending <see cref="ShowAsync"/> task with <c>false</c>.
+    /// Bound to the cancel button and the scrim.
+    /// </summary>
+    public IRelayCommand NegativeCommand { get; }
+    #endregion
+
+    #region Constructor
+    /// <summary>Initializes the overlay view model and wires the affirmative/negative commands.</summary>
+    public ConfirmOverlayViewModel()
+    {
+        AffirmativeCommand = new RelayCommand(() => Complete(true));
+        NegativeCommand = new RelayCommand(() => Complete(false));
+    }
+    #endregion
+
+    #region Public Methods
+    /// <summary>
+    /// Opens the confirm overlay with the supplied content and returns a task that resolves to
+    /// <c>true</c> when the user chooses the affirmative button and <c>false</c> when they cancel
+    /// (cancel button, scrim, or a host reset via <see cref="Cancel"/>).
+    /// </summary>
+    /// <param name="title">Title shown at the top of the card.</param>
+    /// <param name="message">Body message shown in the card.</param>
+    /// <param name="affirmativeLabel">Label for the affirmative button (e.g. "DELETE").</param>
+    /// <param name="isDestructive">When true, the affirmative button uses the danger style.</param>
+    public Task<bool> ShowAsync(
+        string title,
+        string message,
+        string affirmativeLabel = "OK",
+        bool isDestructive = false)
+    {
+        // Defensive: if a prior confirm is somehow still pending, cancel it with a negative so the
+        // previous awaiter unwinds cleanly before this new one opens.
+        _confirmTcs?.TrySetResult(false);
+
+        // RunContinuationsAsynchronously avoids re-entrancy/deadlocks when the awaiter resumes
+        // synchronously on the UI thread from inside the command handler that completes the task.
+        _confirmTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Title = title;
+        Message = message;
+        AffirmativeLabel = affirmativeLabel;
+        AffirmativeIsDestructive = isDestructive;
+        IsOpen = true;
+        return _confirmTcs.Task;
+    }
+
+    /// <summary>
+    /// Cancels any pending confirmation, resolving its awaiter with <c>false</c> and closing the
+    /// overlay. Used by host reset/close paths (pane navigation, view unload) so an in-flight
+    /// awaiter is not stranded. Safe to call when nothing is pending.
+    /// </summary>
+    public void Cancel() => Complete(false);
+    #endregion
+
+    #region Private Methods
+    private void Complete(bool result)
+    {
+        IsOpen = false;
+        var tcs = _confirmTcs;
+        _confirmTcs = null;
+        tcs?.TrySetResult(result);
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -70,30 +70,18 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     [ObservableProperty]
     private bool _isAppSettingsOpen;
 
-    // In-pane confirm dialog state (used by ShowConfirm for delete confirmations, etc.).
-    // Bound by the LoggedDataPane confirm overlay; replaces the MahApps MessageDialog
-    // (white card / blue theme) which clashed with the dark, tile-based design system.
-
-    /// <summary>True while the in-pane confirm overlay is visible.</summary>
-    [ObservableProperty] private bool _isConfirmOpen;
-
-    /// <summary>Title shown at the top of the confirm overlay card.</summary>
-    [ObservableProperty] private string _confirmTitle = string.Empty;
-
-    /// <summary>Body message shown in the confirm overlay card.</summary>
-    [ObservableProperty] private string _confirmMessage = string.Empty;
-
-    /// <summary>Label shown on the affirmative button of the confirm overlay (e.g. "DELETE").</summary>
-    [ObservableProperty] private string _confirmAffirmativeLabel = "OK";
+    // In-pane confirm overlay (delete confirmations, etc.). The reusable ConfirmOverlayViewModel
+    // owns the bound state, the affirmative/negative commands, and the awaitable ShowAsync
+    // (issue #592); the LoggedDataPane overlay binds ConfirmOverlay.*. It replaces the MahApps
+    // MessageDialog (white card / blue theme) which clashed with the dark, tile-based design system.
 
     /// <summary>
-    /// When true, the confirm overlay's affirmative button uses the danger style
-    /// (red outline) instead of the accent style (filled blue). Set by destructive
-    /// callers of <see cref="ShowConfirm"/>.
+    /// Backs the in-pane confirm overlay. Bound by the LoggedDataPane confirm overlay via
+    /// <c>ConfirmOverlay.IsOpen</c> / <c>ConfirmOverlay.Title</c> / <c>ConfirmOverlay.Message</c> /
+    /// <c>ConfirmOverlay.AffirmativeLabel</c> / <c>ConfirmOverlay.AffirmativeIsDestructive</c> and
+    /// the affirmative/negative button commands.
     /// </summary>
-    [ObservableProperty] private bool _confirmAffirmativeIsDestructive;
-
-    private TaskCompletionSource<bool>? _confirmTcs;
+    public ConfirmOverlayViewModel ConfirmOverlay { get; } = new();
 
     private SettingsViewModel? _appSettings;
 
@@ -322,7 +310,7 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             // Cancel any pending confirm overlay so its awaiter (e.g. an in-flight
             // delete) doesn't get stranded when the user navigates away from the
             // pane that owns the overlay.
-            CompleteConfirm(false);
+            ConfirmOverlay.Cancel();
             OnPropertyChanged();
         }
     }
@@ -483,17 +471,6 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     public AsyncRelayCommand DeleteAllLoggingSessionCommand { get; private set; }
     public ICommand ToggleChannelVisibilityCommand { get; private set; }
     public ICommand ToggleLoggedSeriesVisibilityCommand { get; private set; }
-    /// <summary>
-    /// Resolves the confirm overlay's awaitable Task with <c>true</c>.
-    /// Bound to the affirmative button.
-    /// </summary>
-    public IRelayCommand ConfirmAffirmativeCommand { get; }
-
-    /// <summary>
-    /// Resolves the confirm overlay's awaitable Task with <c>false</c>.
-    /// Bound to the cancel button and the scrim.
-    /// </summary>
-    public IRelayCommand ConfirmNegativeCommand { get; }
     #endregion
 
     #region Constructor
@@ -558,9 +535,6 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             GetLoggingContextFactory,
             App.DatabasePath,
             _appLogger);
-
-        ConfirmAffirmativeCommand = new RelayCommand(() => CompleteConfirm(true));
-        ConfirmNegativeCommand = new RelayCommand(() => CompleteConfirm(false));
 
         // Track device-side logging/streaming state so the toggle and the Live Graph
         // overlay reflect what's *actually* happening, not just what the user clicked.
@@ -1313,39 +1287,17 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     }
 
     /// <summary>
-    /// Displays the in-pane dark confirm overlay and returns true if the user
-    /// chose the affirmative button. Bound by the LoggedDataPane confirm overlay
-    /// via <see cref="IsConfirmOpen"/>, <see cref="ConfirmTitle"/>,
-    /// <see cref="ConfirmMessage"/>, and <see cref="ConfirmAffirmativeLabel"/>;
-    /// the two button commands complete the underlying
-    /// <see cref="TaskCompletionSource{TResult}"/>.
+    /// Displays the in-pane dark confirm overlay and returns true if the user chose the affirmative
+    /// button. Thin forwarder to <see cref="ConfirmOverlay"/> (issue #592); the existing
+    /// <see cref="ILoggingSessionListHost.ShowConfirmAsync"/> caller stays unchanged.
     /// </summary>
     private Task<bool> ShowConfirm(
         string title,
         string message,
         string affirmativeLabel = "OK",
         bool isDestructive = false)
-    {
-        // Defensive: if a prior confirm is somehow still pending, cancel it
-        // with a negative so the previous awaiter unwinds cleanly.
-        _confirmTcs?.TrySetResult(false);
+        => ConfirmOverlay.ShowAsync(title, message, affirmativeLabel, isDestructive);
 
-        _confirmTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        ConfirmTitle = title;
-        ConfirmMessage = message;
-        ConfirmAffirmativeLabel = affirmativeLabel;
-        ConfirmAffirmativeIsDestructive = isDestructive;
-        IsConfirmOpen = true;
-        return _confirmTcs.Task;
-    }
-
-    private void CompleteConfirm(bool result)
-    {
-        IsConfirmOpen = false;
-        var tcs = _confirmTcs;
-        _confirmTcs = null;
-        tcs?.TrySetResult(result);
-    }
     public void CloseFlyouts()
     {
         IsDeviceSettingsOpen = false;

--- a/Daqifi.Desktop/ViewModels/ProfilesPaneViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ProfilesPaneViewModel.cs
@@ -19,7 +19,6 @@ public partial class ProfilesPaneViewModel : ObservableObject
 {
     #region Private Fields
     private readonly AppLogger _logger = AppLogger.Instance;
-    private TaskCompletionSource<bool>? _confirmTcs;
     #endregion
 
     #region Observable Properties
@@ -46,20 +45,6 @@ public partial class ProfilesPaneViewModel : ObservableObject
     /// <summary>Name of the currently active profile (null when none is active).</summary>
     [ObservableProperty] private string? _activeProfileName;
 
-    // In-pane confirm dialog state (used by ShowConfirm for profile switch, etc.).
-
-    /// <summary>True while the in-pane confirm overlay is being displayed.</summary>
-    [ObservableProperty] private bool _isConfirmOpen;
-
-    /// <summary>Title shown on the confirm overlay.</summary>
-    [ObservableProperty] private string _confirmTitle = string.Empty;
-
-    /// <summary>Body message shown on the confirm overlay.</summary>
-    [ObservableProperty] private string _confirmMessage = string.Empty;
-
-    /// <summary>Text displayed on the affirmative (primary) button of the confirm overlay.</summary>
-    [ObservableProperty] private string _confirmAffirmativeLabel = "OK";
-
     // New-profile form fields (active only when IsNewProfile = true)
 
     /// <summary>Name bound to the new-profile form.</summary>
@@ -82,6 +67,13 @@ public partial class ProfilesPaneViewModel : ObservableObject
 
     /// <summary>Devices available to include when building a new profile.</summary>
     public ObservableCollection<NewProfileDeviceItem> NewDeviceItems { get; } = [];
+
+    /// <summary>
+    /// Backs the in-pane confirm overlay. Bound by the Profiles confirm overlay via
+    /// <c>ConfirmOverlay.IsOpen</c> / <c>ConfirmOverlay.Title</c> / <c>ConfirmOverlay.Message</c> /
+    /// <c>ConfirmOverlay.AffirmativeLabel</c> and the affirmative/negative button commands.
+    /// </summary>
+    public ConfirmOverlayViewModel ConfirmOverlay { get; } = new();
     #endregion
 
     #region Commands
@@ -105,12 +97,6 @@ public partial class ProfilesPaneViewModel : ObservableObject
 
     /// <summary>Snapshots the current device configuration into a new profile.</summary>
     public IRelayCommand SaveCurrentSettingsCommand { get; }
-
-    /// <summary>Affirmative response for the in-pane confirm overlay.</summary>
-    public IRelayCommand ConfirmAffirmativeCommand { get; }
-
-    /// <summary>Negative response for the in-pane confirm overlay.</summary>
-    public IRelayCommand ConfirmNegativeCommand { get; }
     #endregion
 
     #region Constructor
@@ -128,8 +114,6 @@ public partial class ProfilesPaneViewModel : ObservableObject
         DeleteProfileCommand = new RelayCommand<Profile>(DeleteProfile);
         SaveNewProfileCommand = new RelayCommand(SaveNewProfile, CanSaveNewProfile);
         SaveCurrentSettingsCommand = new RelayCommand(SaveCurrentSettings);
-        ConfirmAffirmativeCommand = new RelayCommand(() => CompleteConfirm(true));
-        ConfirmNegativeCommand = new RelayCommand(() => CompleteConfirm(false));
 
         LoggingManager.Instance.PropertyChanged += OnLoggingManagerPropertyChanged;
         IsLoggingActive = LoggingManager.Instance.Active;
@@ -386,34 +370,11 @@ public partial class ProfilesPaneViewModel : ObservableObject
 
     #region Confirm Overlay
     /// <summary>
-    /// Displays the in-pane dark confirm overlay and returns true if the user
-    /// chose the affirmative button. The overlay is bound to
-    /// <see cref="IsConfirmOpen"/>, <see cref="ConfirmTitle"/>,
-    /// <see cref="ConfirmMessage"/>, and <see cref="ConfirmAffirmativeLabel"/>;
-    /// the two button commands complete the underlying
-    /// <see cref="TaskCompletionSource{TResult}"/>.
+    /// Displays the in-pane dark confirm overlay and returns true if the user chose the affirmative
+    /// button. Thin forwarder to <see cref="ConfirmOverlay"/> (issue #592).
     /// </summary>
     private Task<bool> ShowConfirm(string title, string message, string affirmativeLabel = "OK")
-    {
-        // Defensive: if a prior confirm is somehow still pending, cancel it
-        // with a negative so the previous awaiter unwinds cleanly.
-        _confirmTcs?.TrySetResult(false);
-
-        _confirmTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        ConfirmTitle = title;
-        ConfirmMessage = message;
-        ConfirmAffirmativeLabel = affirmativeLabel;
-        IsConfirmOpen = true;
-        return _confirmTcs.Task;
-    }
-
-    private void CompleteConfirm(bool result)
-    {
-        IsConfirmOpen = false;
-        var tcs = _confirmTcs;
-        _confirmTcs = null;
-        tcs?.TrySetResult(result);
-    }
+        => ConfirmOverlay.ShowAsync(title, message, affirmativeLabel);
     #endregion
 
     #region Profile CRUD
@@ -562,8 +523,7 @@ public partial class ProfilesPaneViewModel : ObservableObject
         foreach (var item in NewDeviceItems)
             item.PropertyChanged -= OnNewDeviceItemPropertyChanged;
         // Release any awaiter on an unresolved confirm dialog.
-        _confirmTcs?.TrySetResult(false);
-        _confirmTcs = null;
+        ConfirmOverlay.Cancel();
     }
     #endregion
 }


### PR DESCRIPTION
## Summary

Third "small extraction" from #592 (after `FirmwareUpdateCoordinator` #601 and `LoggingSessionListViewModel` #602). Extracts the in-pane confirm-overlay cluster out of `DaqifiViewModel` into a new reusable, **WPF-free, unit-testable** `ConfirmOverlayViewModel : ObservableObject`.

The new class owns the bound state (`IsOpen`, `Title`, `Message`, `AffirmativeLabel`, `AffirmativeIsDestructive`), the affirmative/negative commands, and an awaitable `ShowAsync(...)` built on the `TaskCompletionSource` pattern (`RunContinuationsAsynchronously`). No `Application.Current`, dispatcher, or singletons — the result resolves purely when the two commands fire.

## What changed

- **`DaqifiViewModel`** exposes the overlay as a nested `public ConfirmOverlayViewModel ConfirmOverlay { get; }` and keeps `ShowConfirm` as a **thin forwarder**, so the existing `ILoggingSessionListHost.ShowConfirmAsync` caller is unchanged. The pane-navigation reset path (`SelectedIndex` setter, formerly `CompleteConfirm(false)`) now calls `ConfirmOverlay.Cancel()`.
- **`ProfilesPaneViewModel`** *also* adopts the same `ConfirmOverlayViewModel`. ⚠️ Note: the Profiles pane binds **its own** `ProfilesPaneViewModel` (set in `ProfilesPane.xaml.cs` on `Loaded`), **not** `DaqifiViewModel` — and it carried a complete **duplicate** confirm-overlay implementation. This PR deletes that duplicate and routes it through the shared component, which is exactly the cross-pane reuse #592 calls for. Its `Cleanup()` reset path now calls `ConfirmOverlay.Cancel()`.
- **XAML** — both confirm-overlay blocks re-pointed to bind `ConfirmOverlay.*`:
  - `Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml`
  - `Daqifi.Desktop/View/ProfilesPane.xaml`
  - In `LoggedDataPanePrototype.xaml` the overlay `Grid`'s `x:Name` was renamed `ConfirmOverlay` → `ConfirmOverlayHost` to avoid colliding with the new DataContext property (the generated field was unreferenced in code-behind; `ConfirmCancelButton` and `OnConfirmOverlayIsVisibleChanged` are unchanged).
- **Docs** — `Daqifi.Desktop.UITest` comment/README references updated to the new binding names. The `ConfirmAffirmativeButton` AutomationId the FlaUI harness drives is unchanged.

## Behavior preservation

Logic is preserved verbatim: the re-entrancy guard (a still-pending confirm resolves `false` before a new one opens), `TaskCreationOptions.RunContinuationsAsynchronously`, and the open/close sequencing all carry over unchanged. `ShowMessage` / `ShowDiskSpaceMessage` (MahApps `MetroWindow.ShowMessageAsync` modals) are intentionally **left in place** — a separate mechanism.

`DaqifiViewModel` shrinks further toward the issue's ~800-line target.

## Tests

New `Daqifi.Desktop.Test/ViewModels/ConfirmOverlayViewModelTests.cs` drives the VM with no WPF:
`ShowAsync` opens with the right title/message/label/destructive flag (+ `IsOpen`); affirmative resolves `true` & closes; negative resolves `false` & closes; a second `ShowAsync` while one is pending resolves the first `false`; `Cancel()` reset path; `RunContinuationsAsynchronously` (continuation not run inline); destructive-flag/label reset on non-destructive re-open; and double-resolve idempotency.

## Verification

- `dotnet build "DAQiFi Desktop.sln"` — **0 errors**.
- Unit gate `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — **all pass** (incl. the 12 new `ConfirmOverlayViewModel` tests; existing `DaqifiViewModel` / `LoggingSessionListViewModel` tests stay green).
- Multi-agent adversarial review (behavior / XAML-binding / tests / standards dimensions) — clean on code; the two test-coverage findings it surfaced are included here.
- The freshly-built app launches and loads both panes' XAML without error.
- ⚠️ The interactive click-through of both live overlays could not be completed in this environment (the computer-use screen-access approval dialog timed out). Binding correctness is otherwise covered by the exact property-name match, the adversarial binding review, and the clean app launch; a manual click-through (delete-confirm in Logged Data, switch-confirm in Profiles) is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
