### PR TITLE
chore(loggers): extract SessionSampleWriter from DatabaseLogger (#592)

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
@@ -1,0 +1,214 @@
+using System.Diagnostics;
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Logger;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Moq;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Behavior contract for <see cref="SessionSampleWriter"/> — the SQLite sample write path extracted
+/// from <c>DatabaseLogger</c> (issue #592). The writer is driven directly against a real temp SQLite
+/// <see cref="IDbContextFactory{TContext}"/> (no mock DB), so the producer/consumer buffer, the
+/// background bulk-insert, and the suspend/resume/clear controls the session-list purge relies on are
+/// all exercised end-to-end. Covers: buffered samples reach the database after <c>WaitForIdle</c>,
+/// <c>SuspendConsumer</c> halts draining while <c>ResumeConsumer</c> resumes it, <c>ClearBuffer</c>
+/// drops pending samples, and <c>Dispose</c> stops the consumer thread cleanly and is idempotent.
+/// </summary>
+[TestClass]
+public class SessionSampleWriterTests
+{
+    private const string Serial = "9090684023231015079";
+    private const long Tick = 638_000_000_000_000_000;
+    private const int SessionId = 1;
+
+    private readonly List<string> _tempDbPaths = [];
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var path in _tempDbPaths)
+        {
+            foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+            {
+                try
+                {
+                    if (File.Exists(path + suffix))
+                    {
+                        File.Delete(path + suffix);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
+            }
+        }
+    }
+
+    [TestMethod]
+    public void EnqueuedSamples_ArePersisted_AfterWaitForIdle()
+    {
+        using var factory = NewFactory();
+        SeedSession(factory);
+        using var writer = new SessionSampleWriter(factory, Mock.Of<IAppLogger>());
+
+        for (var i = 0; i < 25; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        writer.WaitForIdle(TimeSpan.FromSeconds(5));
+
+        Assert.AreEqual(25, CountSamples(factory),
+            "Every enqueued sample must be flushed to the database by the time WaitForIdle returns.");
+    }
+
+    [TestMethod]
+    public void SuspendConsumer_HaltsDraining_AndResumeConsumerResumesIt()
+    {
+        using var factory = NewFactory();
+        SeedSession(factory);
+        using var writer = new SessionSampleWriter(factory, Mock.Of<IAppLogger>());
+
+        // Suspend before enqueueing: the consumer must park at the gate and never open a DB
+        // connection while suspended.
+        writer.SuspendConsumer();
+
+        for (var i = 0; i < 10; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        // Give the consumer several poll cycles; while suspended it must not drain anything.
+        Thread.Sleep(500);
+        Assert.AreEqual(0, CountSamples(factory),
+            "A suspended consumer must not persist any buffered samples.");
+
+        // Resuming lets the parked consumer drain the backlog.
+        writer.ResumeConsumer();
+        writer.WaitForIdle(TimeSpan.FromSeconds(5));
+
+        Assert.AreEqual(10, CountSamples(factory),
+            "Resuming the consumer must flush the samples buffered while it was suspended.");
+    }
+
+    [TestMethod]
+    public void ClearBuffer_DropsPendingSamples()
+    {
+        using var factory = NewFactory();
+        SeedSession(factory);
+        using var writer = new SessionSampleWriter(factory, Mock.Of<IAppLogger>());
+
+        // Mirror the delete-all purge ordering: suspend, drain the buffer, resume.
+        writer.SuspendConsumer();
+
+        for (var i = 0; i < 10; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        writer.ClearBuffer();
+        writer.ResumeConsumer();
+        writer.WaitForIdle(TimeSpan.FromSeconds(2));
+
+        Assert.AreEqual(0, CountSamples(factory),
+            "ClearBuffer must drop the pending samples so none of them reach the database.");
+    }
+
+    [TestMethod]
+    public void Dispose_StopsConsumerThreadCleanly_AndIsIdempotent()
+    {
+        using var factory = NewFactory();
+        SeedSession(factory);
+        var writer = new SessionSampleWriter(factory, Mock.Of<IAppLogger>());
+        writer.Add(MakeSample("AI0", 1));
+
+        var stopwatch = Stopwatch.StartNew();
+        writer.Dispose();
+        stopwatch.Stop();
+
+        // Dispose is capped by Join(2s); a clean shutdown wakes the polling thread and returns in
+        // well under that. The bound only guards against a pathological overrun — the load-bearing
+        // proof that the thread actually stopped is the IsConsumerThreadAlive check below.
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds < 2500,
+            $"Dispose must not hang; it took {stopwatch.ElapsedMilliseconds}ms.");
+        Assert.IsFalse(writer.IsConsumerThreadAlive,
+            "Dispose must join the consumer thread so it is no longer running.");
+
+        // Idempotent: a second dispose must not throw on the already-disposed primitives.
+        writer.Dispose();
+
+        // And enqueueing after disposal is a silent no-op rather than throwing.
+        writer.Add(MakeSample("AI0", 2));
+    }
+
+    #region Helpers
+
+    private static void SeedSession(IDbContextFactory<LoggingContext> factory)
+    {
+        using var context = factory.CreateDbContext();
+        context.Sessions.Add(new LoggingSession(SessionId, "writer-test"));
+        context.SaveChanges();
+    }
+
+    private static int CountSamples(IDbContextFactory<LoggingContext> factory)
+    {
+        using var context = factory.CreateDbContext();
+        return context.Samples.AsNoTracking().Count(s => s.LoggingSessionID == SessionId);
+    }
+
+    private static DataSample MakeSample(string channelName, double value)
+    {
+        return new DataSample
+        {
+            LoggingSessionID = SessionId,
+            ChannelName = channelName,
+            DeviceName = "Nq1",
+            DeviceSerialNo = Serial,
+            Color = "#FFD32F2F",
+            Type = ChannelType.Analog,
+            Value = value,
+            TimestampTicks = Tick
+        };
+    }
+
+    private TempSqliteLoggingContextFactory NewFactory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"daqifi_samplewriter_{Guid.NewGuid():N}.db");
+        _tempDbPaths.Add(path);
+        return new TempSqliteLoggingContextFactory(path);
+    }
+
+    /// <summary>
+    /// A real file-backed SQLite <see cref="IDbContextFactory{TContext}"/> so the consumer's bulk
+    /// insert runs through the actual EF-to-SQLite translation, not a mock. Mirrors the production
+    /// factory registration (App.xaml.cs) by suppressing the PendingModelChangesWarning. The .db
+    /// file is removed by the test cleanup.
+    /// </summary>
+    private sealed class TempSqliteLoggingContextFactory : IDbContextFactory<LoggingContext>, IDisposable
+    {
+        private readonly DbContextOptions<LoggingContext> _options;
+
+        public TempSqliteLoggingContextFactory(string dbPath)
+        {
+            _options = new DbContextOptionsBuilder<LoggingContext>()
+                .UseSqlite($"Data Source={dbPath}")
+                .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+                .Options;
+
+            using var ctx = new LoggingContext(_options);
+            ctx.Database.EnsureCreated();
+        }
+
+        public LoggingContext CreateDbContext() => new(_options);
+
+        public void Dispose() => Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+    }
+
+    #endregion
+}

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -8,7 +8,6 @@ using OxyPlot;
 using OxyPlot.Annotations;
 using OxyPlot.Axes;
 using OxyPlot.Series;
-using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Exception = System.Exception;
@@ -123,13 +122,12 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     private Dictionary<string, int> _sessionDeviceFrequencyHz = new();
     private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _allSessionPoints = new();
     private readonly Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _downsampledCache = new();
-    private readonly BlockingCollection<DataSample> _buffer = new();
     private readonly Dictionary<(string deviceSerial, string channelName), LineSeries> _minimapSeries = new();
 
     private DateTime? _firstTime;
     private readonly AppLogger _appLogger = AppLogger.Instance;
     private readonly IDbContextFactory<LoggingContext> _loggingContext;
-    private readonly ManualResetEventSlim _consumerGate = new(true);
+    private readonly SessionSampleWriter _sampleWriter;
     private RectangleAnnotation _minimapSelectionRect;
     private RectangleAnnotation _minimapDimLeft;
     private RectangleAnnotation _minimapDimRight;
@@ -142,10 +140,6 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     private DispatcherTimer _settleTimer;
     private int? _currentSessionId;
     private CancellationTokenSource _fetchCts;
-    private readonly CancellationTokenSource _consumerCts = new();
-    private Thread _consumerThread;
-    private volatile bool _disposed;
-    private volatile bool _consumerBusy;
 
     [ObservableProperty]
     private PlotModel _plotModel;
@@ -314,8 +308,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         // Initialize minimap PlotModel
         InitializeMinimapPlotModel();
 
-        _consumerThread = new Thread(Consumer) { IsBackground = true };
-        _consumerThread.Start();
+        // The sample write path (buffer + background consumer thread + SQLite bulk insert) lives in
+        // SessionSampleWriter. Constructing it here starts the consumer thread, matching the original
+        // startup timing.
+        _sampleWriter = new SessionSampleWriter(_loggingContext, _appLogger);
     }
     #endregion
 
@@ -418,19 +414,13 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     #endregion
 
     /// <summary>
-    /// Producer
+    /// Producer. Enqueues a sample onto the <see cref="SessionSampleWriter"/> for the background
+    /// consumer thread to persist.
     /// </summary>
     /// <param name="dataSample"></param>
     public void Log(DataSample dataSample)
     {
-        if (_disposed) { return; }
-
-        try
-        {
-            _buffer.Add(dataSample);
-        }
-        catch (ObjectDisposedException) { }
-        catch (InvalidOperationException) { }
+        _sampleWriter.Add(dataSample);
     }
 
     /// <summary>
@@ -441,68 +431,6 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     {
         // No-op
     }
-
-    #region Private Data
-    private void Consumer()
-    {
-        var samples = new List<DataSample>();
-        int bufferCount;
-        while (!_consumerCts.IsCancellationRequested)
-        {
-            try
-            {
-                Thread.Sleep(100);
-
-                if (_consumerCts.IsCancellationRequested) { break; }
-
-                bufferCount = _buffer.Count;
-
-                if (bufferCount < 1) { continue; }
-
-                // Wait if the consumer is suspended (e.g. during delete-all)
-                _consumerGate.Wait(_consumerCts.Token);
-
-                _consumerBusy = true;
-
-                // Remove the samples from the collection
-                for (var i = 0; i < bufferCount; i++)
-                {
-                    if (_buffer.TryTake(out var sample)) { samples.Add(sample); }
-                }
-
-                using (var context = _loggingContext.CreateDbContext())
-                {
-
-                    // Start a new transaction for bulk insert
-                    using var transaction = context.Database.BeginTransaction();
-                    // Perform the bulk insert
-                    context.BulkInsert(samples);
-
-                    // Commit the transaction after the bulk insert
-                    transaction.Commit();
-
-                    // Clear immediately after a successful commit: if disposal of the
-                    // transaction or context throws, the catch below keeps the list for
-                    // retry — re-inserting an already-committed batch would write
-                    // duplicate rows. A failure before the commit still retries.
-                    samples.Clear();
-                }
-                _consumerBusy = false;
-            }
-            catch (OperationCanceledException)
-            {
-                _consumerBusy = false;
-                break;
-            }
-            catch (Exception ex)
-            {
-                _consumerBusy = false;
-                if (_consumerCts.IsCancellationRequested) { break; }
-                _appLogger.Error(ex, "Failed in Consumer Thread");
-            }
-        }
-    }
-    #endregion
 
     public void ClearPlot()
     {
@@ -1124,12 +1052,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     /// <summary>
     /// Drains the sample buffer to prevent stale data from being inserted after a database reset.
     /// </summary>
-    public void ClearBuffer()
-    {
-        while (_buffer.TryTake(out _))
-        {
-        }
-    }
+    public void ClearBuffer() => _sampleWriter.ClearBuffer();
 
     /// <summary>
     /// Blocks until the buffered samples have been flushed to the database, or
@@ -1138,40 +1061,18 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     /// actually written, not just the rows the consumer happened to have
     /// drained at the moment Active flipped to false.
     /// </summary>
-    public void WaitForIdle(TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            if (_buffer.Count == 0 && !_consumerBusy)
-            {
-                // Sleep one consumer poll interval to ensure no in-flight item
-                // slipped between TryTake and the busy flag being set.
-                Thread.Sleep(120);
-                if (_buffer.Count == 0 && !_consumerBusy) { return; }
-            }
-            Thread.Sleep(50);
-        }
-    }
+    public void WaitForIdle(TimeSpan timeout) => _sampleWriter.WaitForIdle(timeout);
 
     /// <summary>
     /// Suspends the background consumer thread so no new database connections are opened.
     /// Must be followed by <see cref="ResumeConsumer"/>.
     /// </summary>
-    public void SuspendConsumer()
-    {
-        _consumerGate.Reset();
-        // Give the consumer time to finish any in-flight DB operation
-        Thread.Sleep(200);
-    }
+    public void SuspendConsumer() => _sampleWriter.SuspendConsumer();
 
     /// <summary>
     /// Resumes the background consumer thread after a <see cref="SuspendConsumer"/> call.
     /// </summary>
-    public void ResumeConsumer()
-    {
-        _consumerGate.Set();
-    }
+    public void ResumeConsumer() => _sampleWriter.ResumeConsumer();
 
     /// <summary>
     /// Collapses duplicate (device serial, channel name) rows to a single entry,
@@ -1809,13 +1710,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         }
 
         _minimapInteraction?.Dispose();
-        _disposed = true;
-        _consumerCts.Cancel();
-        _buffer.CompleteAdding();
-        _consumerThread?.Join(TimeSpan.FromSeconds(2));
-        _buffer.Dispose();
-        _consumerCts.Dispose();
-        _consumerGate.Dispose();
+        _sampleWriter.Dispose();
     }
     #endregion
 }

--- a/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
+++ b/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
@@ -149,6 +149,7 @@ public sealed class SessionSampleWriter : IDisposable
     /// actually written, not just the rows the consumer happened to have
     /// drained at the moment Active flipped to false.
     /// </summary>
+    /// <param name="timeout">Maximum time to wait for the buffer to drain before returning.</param>
     public void WaitForIdle(TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
+++ b/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
@@ -1,0 +1,214 @@
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Common.Loggers;
+using EFCore.BulkExtensions;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Concurrent;
+
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// Owns the sample write path extracted from <see cref="DatabaseLogger"/> (issue #592): a
+/// producer/consumer buffer, the background consumer thread that bulk-inserts buffered
+/// <see cref="DataSample"/>s into SQLite, and the suspend/resume/clear controls the session
+/// list relies on when purging storage.
+/// <para>
+/// The database context factory and application logger are constructor-injected, so the writer
+/// has no dependency on WPF or on desktop singletons (<c>App.ServiceProvider</c>,
+/// <c>AppLogger.Instance</c>) and is unit-testable in isolation. <see cref="DatabaseLogger"/> is
+/// the composition root: it builds the writer with the factory it already receives and delegates
+/// its <c>Log</c>/<c>ClearBuffer</c>/<c>WaitForIdle</c>/<c>SuspendConsumer</c>/<c>ResumeConsumer</c>
+/// members straight through.
+/// </para>
+/// </summary>
+public sealed class SessionSampleWriter : IDisposable
+{
+    #region Private Fields
+    private readonly BlockingCollection<DataSample> _buffer = new();
+    private readonly ManualResetEventSlim _consumerGate = new(true);
+    private readonly CancellationTokenSource _consumerCts = new();
+    private readonly IDbContextFactory<LoggingContext> _loggingContext;
+    private readonly IAppLogger _appLogger;
+    private readonly Thread _consumerThread;
+    private volatile bool _disposed;
+    private volatile bool _consumerBusy;
+    #endregion
+
+    #region Constructor
+    /// <summary>
+    /// Creates the writer and starts its background consumer thread immediately, matching the
+    /// startup timing of the original inline implementation in <see cref="DatabaseLogger"/>.
+    /// </summary>
+    /// <param name="loggingContext">Factory for the logging database context used by the bulk insert.</param>
+    /// <param name="appLogger">Application logger used to report consumer-thread failures.</param>
+    public SessionSampleWriter(IDbContextFactory<LoggingContext> loggingContext, IAppLogger appLogger)
+    {
+        _loggingContext = loggingContext ?? throw new ArgumentNullException(nameof(loggingContext));
+        _appLogger = appLogger ?? throw new ArgumentNullException(nameof(appLogger));
+
+        _consumerThread = new Thread(Consumer) { IsBackground = true };
+        _consumerThread.Start();
+    }
+    #endregion
+
+    #region Enqueue
+    /// <summary>
+    /// Producer. Enqueues a sample for the background consumer to persist. A no-op once the writer
+    /// has been disposed.
+    /// </summary>
+    /// <param name="dataSample">The sample to buffer for insertion.</param>
+    public void Add(DataSample dataSample)
+    {
+        if (_disposed) { return; }
+
+        try
+        {
+            _buffer.Add(dataSample);
+        }
+        catch (ObjectDisposedException) { }
+        catch (InvalidOperationException) { }
+    }
+    #endregion
+
+    #region Consumer
+    private void Consumer()
+    {
+        var samples = new List<DataSample>();
+        int bufferCount;
+        while (!_consumerCts.IsCancellationRequested)
+        {
+            try
+            {
+                Thread.Sleep(100);
+
+                if (_consumerCts.IsCancellationRequested) { break; }
+
+                bufferCount = _buffer.Count;
+
+                if (bufferCount < 1) { continue; }
+
+                // Wait if the consumer is suspended (e.g. during delete-all)
+                _consumerGate.Wait(_consumerCts.Token);
+
+                _consumerBusy = true;
+
+                // Remove the samples from the collection
+                for (var i = 0; i < bufferCount; i++)
+                {
+                    if (_buffer.TryTake(out var sample)) { samples.Add(sample); }
+                }
+
+                using (var context = _loggingContext.CreateDbContext())
+                {
+
+                    // Start a new transaction for bulk insert
+                    using var transaction = context.Database.BeginTransaction();
+                    // Perform the bulk insert
+                    context.BulkInsert(samples);
+
+                    // Commit the transaction after the bulk insert
+                    transaction.Commit();
+
+                    // Clear immediately after a successful commit: if disposal of the
+                    // transaction or context throws, the catch below keeps the list for
+                    // retry — re-inserting an already-committed batch would write
+                    // duplicate rows. A failure before the commit still retries.
+                    samples.Clear();
+                }
+                _consumerBusy = false;
+            }
+            catch (OperationCanceledException)
+            {
+                _consumerBusy = false;
+                break;
+            }
+            catch (Exception ex)
+            {
+                _consumerBusy = false;
+                if (_consumerCts.IsCancellationRequested) { break; }
+                _appLogger.Error(ex, "Failed in Consumer Thread");
+            }
+        }
+    }
+    #endregion
+
+    #region Buffer Controls
+    /// <summary>
+    /// Drains the sample buffer to prevent stale data from being inserted after a database reset.
+    /// </summary>
+    public void ClearBuffer()
+    {
+        while (_buffer.TryTake(out _))
+        {
+        }
+    }
+
+    /// <summary>
+    /// Blocks until the buffered samples have been flushed to the database, or
+    /// the timeout elapses. Used by <c>LoggingManager</c> when finalizing a
+    /// session so the persisted <c>SampleCount</c> reflects every row that was
+    /// actually written, not just the rows the consumer happened to have
+    /// drained at the moment Active flipped to false.
+    /// </summary>
+    public void WaitForIdle(TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_buffer.Count == 0 && !_consumerBusy)
+            {
+                // Sleep one consumer poll interval to ensure no in-flight item
+                // slipped between TryTake and the busy flag being set.
+                Thread.Sleep(120);
+                if (_buffer.Count == 0 && !_consumerBusy) { return; }
+            }
+            Thread.Sleep(50);
+        }
+    }
+
+    /// <summary>
+    /// Suspends the background consumer thread so no new database connections are opened.
+    /// Must be followed by <see cref="ResumeConsumer"/>.
+    /// </summary>
+    public void SuspendConsumer()
+    {
+        _consumerGate.Reset();
+        // Give the consumer time to finish any in-flight DB operation
+        Thread.Sleep(200);
+    }
+
+    /// <summary>
+    /// Resumes the background consumer thread after a <see cref="SuspendConsumer"/> call.
+    /// </summary>
+    public void ResumeConsumer()
+    {
+        _consumerGate.Set();
+    }
+    #endregion
+
+    #region Test Seam
+    /// <summary>
+    /// Whether the background consumer thread is still running. Exposed for tests to confirm that
+    /// <see cref="Dispose"/> joins the thread cleanly.
+    /// </summary>
+    internal bool IsConsumerThreadAlive => _consumerThread.IsAlive;
+    #endregion
+
+    #region IDisposable
+    /// <summary>
+    /// Signals the consumer thread to stop, completes the producer side, and waits up to two
+    /// seconds for the thread to exit before releasing the buffer and synchronization primitives.
+    /// Idempotent.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) { return; }
+        _disposed = true;
+        _consumerCts.Cancel();
+        _buffer.CompleteAdding();
+        _consumerThread?.Join(TimeSpan.FromSeconds(2));
+        _buffer.Dispose();
+        _consumerCts.Dispose();
+        _consumerGate.Dispose();
+    }
+    #endregion
+}


### PR DESCRIPTION
## What

Extracts the SQLite **sample write path** out of `Daqifi.Desktop/Loggers/DatabaseLogger.cs` into a new WPF-free `SessionSampleWriter`. This is Part 2 / extraction #1 of issue #592 (the first time `DatabaseLogger` is touched) and is **behavior-preserving** — one PR per extraction, per the issue.

## Why

`DatabaseLogger` is a ~1.8k-line god-object mixing the OxyPlot read/plot machinery with the background SQLite write path. Splitting the write path out gives a standalone, unit-testable infrastructure component with no WPF dependency and starts shrinking `DatabaseLogger` toward the issue's ~800-line target.

## How

`SessionSampleWriter` (plain class, not `ObservableObject` — no bound state) owns:
- the producer/consumer buffer (`BlockingCollection<DataSample>`), the suspend gate, the cancellation source, the consumer thread, and the `_consumerBusy`/`_disposed` flags;
- the background consumer drain → SQLite bulk-insert loop;
- `Add` (enqueue), `ClearBuffer`, `WaitForIdle`, `SuspendConsumer`, `ResumeConsumer`, and `IDisposable` for the shutdown sequence.

`IDbContextFactory<LoggingContext>` and `IAppLogger` are **constructor-injected** by `DatabaseLogger` (the composition root, which already receives the factory and passes it down). The writer never reaches into `App.ServiceProvider` / `AppLogger.Instance`. The consumer thread starts in the writer's constructor, matching the original startup timing (it was started at the end of `DatabaseLogger`'s constructor).

`DatabaseLogger` keeps implementing `ILogger`; `Log(DataSample)`, `ClearBuffer`, `WaitForIdle`, `SuspendConsumer`, and `ResumeConsumer` become thin delegators, and `Dispose()` disposes the writer. `Log(DeviceMessage)` stays a no-op. This leaves the `ILoggingSessionListHost` suspend/resume/clear seam (routed through `DbLogger`) and the `LoggingSessionListViewModel` delete-all purge unchanged.

### Behavior preserved verbatim
- The consumer-shutdown ordering — `Cancel()` → `CompleteAdding()` → `Join(2s)` → dispose buffer/cts/gate — is moved unchanged (only an idempotency guard was added at the top of the writer's `Dispose`, which does not alter single-dispose behavior).
- The silent enqueue catches (`catch (ObjectDisposedException) {} catch (InvalidOperationException) {}`) are moved as-is. Fixing the silent sample drops is explicitly **out of scope** for this PR.
- The gate `Reset`/`Set` suspend/resume semantics, `_consumerBusy`/`WaitForIdle` (120ms double-check + 50ms poll), and `ClearBuffer` are byte-for-byte equivalent — the delete-all purge relies on `Suspend → ClearBuffer → Resume`.

This PR touches only the write path: no plot/read code, no XAML, no OxyPlot/ADR-001 invariants. No CLAUDE.md key-file update is needed (the plot-machinery PRs will handle that).

## Tests

Adds `Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs`, driving the writer directly against a real temp SQLite `IDbContextFactory<LoggingContext>` (mirrors `TempSqliteLoggingContextFactory` from `LoggingSessionListViewModelTests`):
- enqueued samples persist after `WaitForIdle`;
- `SuspendConsumer` halts draining and `ResumeConsumer` resumes it;
- `ClearBuffer` drops pending samples (suspend → clear → resume);
- `Dispose` stops the consumer thread cleanly (no hang) and is idempotent.

All existing tests stay green. Unit gate (`TestCategory!=Ui & !~WindowsFirewallWrapperTests`): **407 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
