### PR TITLE
fix(loggers): durable, self-throttling sample-writer retry path

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
@@ -18,7 +18,8 @@ namespace Daqifi.Desktop.Test.Loggers;
 /// <c>SuspendConsumer</c> halts draining while <c>ResumeConsumer</c> resumes it, <c>ClearBuffer</c>
 /// drops pending samples, <c>Dispose</c> stops the consumer thread cleanly and is idempotent, and —
 /// via an injected transient DB failure — a failed batch is retained, keeps <c>WaitForIdle</c> from
-/// reporting idle, and is retried to completion exactly once (no lost or duplicate rows) on recovery.
+/// reporting idle, is retried to completion exactly once (no lost or duplicate rows) on recovery, and
+/// is logged only once (not on every poll) while it stays stranded on a persistently failing DB.
 /// </summary>
 [TestClass]
 public class SessionSampleWriterTests
@@ -222,6 +223,85 @@ public class SessionSampleWriterTests
             "no duplicate rows.");
         Assert.AreEqual(0, writer.PendingRetryCount,
             "A successful commit must clear the pending-retry count.");
+    }
+
+    [TestMethod]
+    public void PersistentFailure_LogsErrorOnce_NotOnEveryPoll()
+    {
+        const int sampleCount = 5;
+        using var inner = NewFactory();
+        SeedSession(inner);
+
+        // A real mock logger (not Mock.Of) so we can count how often Error is invoked.
+        var logger = new Mock<IAppLogger>();
+        var failing = new FailUntilReleasedContextFactory(inner);
+        using var writer = new SessionSampleWriter(failing, logger.Object);
+
+        for (var i = 0; i < sampleCount; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        // Strand the batch, then let the consumer keep polling the broken DB for several more
+        // ~100ms cycles. Pre-throttle, each poll re-attempted the insert and logged Error — at the
+        // poll rate that floods both the NLog file and (via Error -> Sentry) Sentry.
+        Assert.IsTrue(
+            WaitUntil(() => writer.PendingRetryCount == sampleCount, TimeSpan.FromSeconds(5)),
+            "Consumer should strand the batch after the injected commit failure.");
+        Thread.Sleep(800); // ~8 poll intervals of sustained failure
+
+        Assert.AreEqual(0, CountSamples(inner), "Nothing should persist while the DB is failing.");
+        logger.Verify(
+            l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()),
+            Times.Once(),
+            "A batch that stays stranded on a persistently failing DB must be logged once, " +
+            "not on every poll.");
+
+        // Durability is preserved: once the DB recovers the stranded batch still persists exactly
+        // once, and recovery adds no further error logs.
+        failing.Release();
+        writer.WaitForIdle(TimeSpan.FromSeconds(5));
+
+        Assert.AreEqual(sampleCount, CountSamples(inner),
+            "The retained batch must still persist after recovery — log throttling must not drop data.");
+        logger.Verify(
+            l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()),
+            Times.Once(),
+            "Recovery must not add further error logs.");
+    }
+
+    [TestMethod]
+    public void WaitForIdle_OverridesRetryBackoff_ToFlushARecoveredBatch()
+    {
+        const int sampleCount = 5;
+        using var inner = NewFactory();
+        SeedSession(inner);
+
+        var failing = new FailUntilReleasedContextFactory(inner);
+        using var writer = new SessionSampleWriter(failing, Mock.Of<IAppLogger>());
+
+        for (var i = 0; i < sampleCount; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        // Let the failure streak grow until the retry backoff is at least ~16 poll cycles (~1.6s).
+        // A plain cooldown of that length would NOT re-attempt within the 1s WaitForIdle window below.
+        Assert.IsTrue(
+            WaitUntil(() => writer.PollsUntilRetry >= 16, TimeSpan.FromSeconds(8)),
+            "The retry backoff should grow while the database keeps failing.");
+
+        // The database recovers. WaitForIdle must override the multi-second backoff and flush the
+        // batch within its (shorter) window — without the override, the next retry would not fire
+        // until the cooldown elapsed, and PersistSessionSampleCount would COUNT an undercount.
+        failing.Release();
+        writer.WaitForIdle(TimeSpan.FromSeconds(1));
+
+        Assert.AreEqual(sampleCount, CountSamples(inner),
+            "WaitForIdle must override the retry backoff so a recovered batch is flushed within its " +
+            "window; otherwise the persisted SampleCount would undercount.");
+        Assert.AreEqual(0, writer.PendingRetryCount,
+            "The flushed batch must clear the pending-retry count.");
     }
 
     #region Helpers

--- a/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
@@ -16,7 +16,9 @@ namespace Daqifi.Desktop.Test.Loggers;
 /// background bulk-insert, and the suspend/resume/clear controls the session-list purge relies on are
 /// all exercised end-to-end. Covers: buffered samples reach the database after <c>WaitForIdle</c>,
 /// <c>SuspendConsumer</c> halts draining while <c>ResumeConsumer</c> resumes it, <c>ClearBuffer</c>
-/// drops pending samples, and <c>Dispose</c> stops the consumer thread cleanly and is idempotent.
+/// drops pending samples, <c>Dispose</c> stops the consumer thread cleanly and is idempotent, and —
+/// via an injected transient DB failure — a failed batch is retained, keeps <c>WaitForIdle</c> from
+/// reporting idle, and is retried to completion exactly once (no lost or duplicate rows) on recovery.
 /// </summary>
 [TestClass]
 public class SessionSampleWriterTests
@@ -147,6 +149,81 @@ public class SessionSampleWriterTests
         writer.Add(MakeSample("AI0", 2));
     }
 
+    [TestMethod]
+    public void WaitForIdle_DoesNotReportIdle_WhileFailedBatchAwaitsRetry()
+    {
+        const int sampleCount = 10;
+        using var inner = NewFactory();
+        SeedSession(inner);
+
+        // The consumer's first commit attempt fails, so the batch is retained for retry. Because
+        // that retained batch lives outside the buffer, WaitForIdle must still treat the writer as
+        // not-idle until the batch is committed.
+        var failing = new FailUntilReleasedContextFactory(inner);
+        using var writer = new SessionSampleWriter(failing, Mock.Of<IAppLogger>());
+
+        for (var i = 0; i < sampleCount; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        // Wait until the consumer has drained the buffer into a retained batch after the injected
+        // failure — nothing should have reached the database.
+        Assert.IsTrue(
+            WaitUntil(() => writer.PendingRetryCount == sampleCount, TimeSpan.FromSeconds(5)),
+            "Consumer should drain the buffer into a retained batch after the injected commit failure.");
+        Assert.AreEqual(0, CountSamples(inner),
+            "A failed commit must not leave any rows in the database.");
+
+        // With the batch unsaved, WaitForIdle must NOT report idle — it must block for the full
+        // timeout. (The pre-fix code inspected only the buffer count and the busy flag, so it
+        // returned almost immediately, falsely reporting idle while rows were still pending.)
+        var timeout = TimeSpan.FromMilliseconds(400);
+        var stopwatch = Stopwatch.StartNew();
+        writer.WaitForIdle(timeout);
+        stopwatch.Stop();
+
+        Assert.IsTrue(stopwatch.ElapsedMilliseconds >= 300,
+            "WaitForIdle must block while a failed batch is pending retry rather than report idle " +
+            $"(it returned after only {stopwatch.ElapsedMilliseconds}ms).");
+
+        // Release so the consumer recovers and the writer disposes from a clean state.
+        failing.Release();
+    }
+
+    [TestMethod]
+    public void FailedBatch_IsRetriedAndPersistedExactlyOnce_AfterRecovery()
+    {
+        const int sampleCount = 10;
+        using var inner = NewFactory();
+        SeedSession(inner);
+
+        var failing = new FailUntilReleasedContextFactory(inner);
+        using var writer = new SessionSampleWriter(failing, Mock.Of<IAppLogger>());
+
+        for (var i = 0; i < sampleCount; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        // The first commit attempt fails and the batch is stranded for retry.
+        Assert.IsTrue(
+            WaitUntil(() => writer.PendingRetryCount == sampleCount, TimeSpan.FromSeconds(5)),
+            "Consumer should retain the batch for retry after the injected commit failure.");
+        Assert.AreEqual(0, CountSamples(inner), "Nothing should be persisted while the DB is failing.");
+
+        // Recover: the consumer must retry the retained batch on its own, with NO new samples
+        // arriving. (The pre-fix code only retried when fresh samples were later enqueued.)
+        failing.Release();
+        writer.WaitForIdle(TimeSpan.FromSeconds(5));
+
+        Assert.AreEqual(sampleCount, CountSamples(inner),
+            "The retained batch must be persisted exactly once after recovery — no lost rows and " +
+            "no duplicate rows.");
+        Assert.AreEqual(0, writer.PendingRetryCount,
+            "A successful commit must clear the pending-retry count.");
+    }
+
     #region Helpers
 
     private static void SeedSession(IDbContextFactory<LoggingContext> factory)
@@ -182,6 +259,49 @@ public class SessionSampleWriterTests
         var path = Path.Combine(Path.GetTempPath(), $"daqifi_samplewriter_{Guid.NewGuid():N}.db");
         _tempDbPaths.Add(path);
         return new TempSqliteLoggingContextFactory(path);
+    }
+
+    /// <summary>
+    /// Polls <paramref name="condition"/> until it is true or <paramref name="timeout"/> elapses.
+    /// Returns the final evaluation so callers can assert on it. Used to observe consumer-thread
+    /// state deterministically instead of racing its fixed poll interval.
+    /// </summary>
+    private static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) { return true; }
+            Thread.Sleep(20);
+        }
+        return condition();
+    }
+
+    /// <summary>
+    /// Wraps a real SQLite factory and throws from <see cref="CreateDbContext"/> while armed, then
+    /// delegates once <see cref="Release"/> is called — simulating a transient database failure that
+    /// later recovers. The consumer opens the context before any insert, so a throw here means the
+    /// batch is never partially written; recovery re-inserts it exactly once with no duplicate rows.
+    /// Does not own (dispose) the inner factory — the test's own <c>using</c> handles that, and
+    /// <see cref="SessionSampleWriter"/> never disposes its factory.
+    /// </summary>
+    private sealed class FailUntilReleasedContextFactory : IDbContextFactory<LoggingContext>
+    {
+        private readonly IDbContextFactory<LoggingContext> _inner;
+        private volatile bool _failing = true;
+
+        public FailUntilReleasedContextFactory(IDbContextFactory<LoggingContext> inner) => _inner = inner;
+
+        public void Release() => _failing = false;
+
+        public LoggingContext CreateDbContext()
+        {
+            if (_failing)
+            {
+                throw new InvalidOperationException("Injected transient database failure.");
+            }
+            return _inner.CreateDbContext();
+        }
     }
 
     /// <summary>

--- a/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
+++ b/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
@@ -22,6 +22,19 @@ namespace Daqifi.Desktop.Logger;
 /// </summary>
 public sealed class SessionSampleWriter : IDisposable
 {
+    #region Constants
+    /// <summary>
+    /// Upper bound, in consumer poll cycles (~100ms each), on the exponential backoff applied to a
+    /// persistently failing batch during normal background operation. Caps the re-attempt interval at
+    /// roughly 5s so a permanently broken database (disk full, file locked) is retried at a low rate
+    /// instead of on every poll, without ever abandoning the batch, and so a transient failure while
+    /// logging keeps at most ~5s of samples in memory before they land. While a <see cref="WaitForIdle"/>
+    /// caller is waiting for the flush, the backoff is overridden entirely (see <see cref="_expediteRetry"/>)
+    /// so a recovered database is committed at the full poll rate within the caller's timeout.
+    /// </summary>
+    private const int MAX_RETRY_BACKOFF_POLLS = 50;
+    #endregion
+
     #region Private Fields
     private readonly BlockingCollection<DataSample> _buffer = new();
     private readonly ManualResetEventSlim _consumerGate = new(true);
@@ -40,6 +53,21 @@ public sealed class SessionSampleWriter : IDisposable
     /// count alone cannot see it).
     /// </summary>
     private volatile int _pendingRetryCount;
+
+    /// <summary>
+    /// Consumer poll cycles still to skip before the next bulk-insert attempt of a failed batch — the
+    /// exponential backoff that throttles retries on a persistently failing database. Written only by
+    /// the consumer thread; exposed (read-only) for tests via <see cref="PollsUntilRetry"/>.
+    /// </summary>
+    private volatile int _pollsUntilRetry;
+
+    /// <summary>
+    /// Set by <see cref="WaitForIdle"/> while a caller is waiting for the buffer to flush. The consumer
+    /// ignores <see cref="_pollsUntilRetry"/> (the retry backoff) while this is set, so a database that
+    /// recovers during the wait is committed at the full poll rate rather than after a multi-second
+    /// cooldown that could outlast the caller's timeout and persist a sample undercount.
+    /// </summary>
+    private volatile bool _expediteRetry;
     #endregion
 
     #region Constructor
@@ -85,6 +113,13 @@ public sealed class SessionSampleWriter : IDisposable
         // commit, so a batch whose commit failed is retained here and retried on a later pass.
         var samples = new List<DataSample>();
         int bufferCount;
+
+        // Failure-streak length for a persistently failing batch. Loop-local because the consumer is
+        // single-threaded. Drives both log-once (only the first failure of a streak is logged) and the
+        // exponential backoff (_pollsUntilRetry). Reset to 0 after a successful commit. The backoff
+        // counter itself is the field _pollsUntilRetry so WaitForIdle/tests can observe it.
+        var consecutiveFailures = 0;
+
         while (!_consumerCts.IsCancellationRequested)
         {
             try
@@ -120,6 +155,18 @@ public sealed class SessionSampleWriter : IDisposable
                     // until a later pass commits the batch.
                     _pendingRetryCount = samples.Count;
 
+                    // Back off a persistently failing batch: skip this DB attempt while the backoff
+                    // is cooling down. New samples were still drained above (so the buffer stays
+                    // bounded) and _pendingRetryCount is still set (so WaitForIdle keeps waiting),
+                    // we just avoid re-opening a connection and re-failing at the full poll rate.
+                    // Exception: while a WaitForIdle caller is waiting (_expediteRetry), ignore the
+                    // backoff and attempt every poll so a recovered DB is flushed within its timeout.
+                    if (_pollsUntilRetry > 0 && !_expediteRetry)
+                    {
+                        _pollsUntilRetry--;
+                        continue;
+                    }
+
                     using (var context = _loggingContext.CreateDbContext())
                     {
                         // Start a new transaction for bulk insert
@@ -139,6 +186,18 @@ public sealed class SessionSampleWriter : IDisposable
                         // even when no new samples have arrived).
                         samples.Clear();
                         _pendingRetryCount = 0;
+
+                        // Clear the retry-throttle state and emit a single all-clear on the
+                        // proven-commit path — inside the using, before disposal could throw — so a
+                        // recovered batch always logs its recovery and re-arms the log-once gate even
+                        // if context/transaction Dispose() then fails.
+                        if (consecutiveFailures > 0)
+                        {
+                            _appLogger.Information(
+                                $"Consumer thread recovered after {consecutiveFailures} failed batch insert attempt(s).");
+                        }
+                        consecutiveFailures = 0;
+                        _pollsUntilRetry = 0;
                     }
                 }
                 finally
@@ -156,7 +215,25 @@ public sealed class SessionSampleWriter : IDisposable
             catch (Exception ex)
             {
                 if (_consumerCts.IsCancellationRequested) { break; }
-                _appLogger.Error(ex, "Failed in Consumer Thread");
+
+                // Log only the first failure of a streak. A persistently failing database (disk
+                // full, file locked, etc.) would otherwise flood the NLog file — and, because
+                // Error() also reports to Sentry, flood Sentry — at the ~10Hz poll rate. The streak
+                // resets on the next successful commit, so a later, distinct failure is logged anew.
+                consecutiveFailures++;
+                if (consecutiveFailures == 1)
+                {
+                    _appLogger.Error(ex,
+                        "Failed in Consumer Thread; retaining the batch for retry. Further " +
+                        "consecutive failures of this batch are suppressed until it succeeds.");
+                }
+
+                // Re-attempt with bounded exponential backoff (in poll cycles): 1, 2, 4, 8, ...
+                // capped at MAX_RETRY_BACKOFF_POLLS, so a permanently failing batch is retried at a
+                // decreasing rate instead of on every poll. The shift is clamped to avoid overflow.
+                // A waiting WaitForIdle caller overrides this cooldown (see the gate above).
+                var shift = Math.Min(consecutiveFailures - 1, 30);
+                _pollsUntilRetry = (int)Math.Min(1L << shift, MAX_RETRY_BACKOFF_POLLS);
             }
         }
     }
@@ -183,17 +260,30 @@ public sealed class SessionSampleWriter : IDisposable
     /// <param name="timeout">Maximum time to wait for the buffer to drain before returning.</param>
     public void WaitForIdle(TimeSpan timeout)
     {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
+        // While we wait, tell the consumer to ignore its retry backoff so a stranded batch whose
+        // database has recovered is committed at the full poll rate. Without this, the batch's
+        // exponential cooldown could exceed this timeout, leaving rows unflushed when the caller
+        // (PersistSessionSampleCount) runs its COUNT — persisting a SampleCount undercount that the
+        // null-only backfill never repairs.
+        _expediteRetry = true;
+        try
         {
-            if (IsDrained())
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
             {
-                // Sleep one consumer poll interval to ensure no in-flight item
-                // slipped between TryTake and the busy flag being set.
-                Thread.Sleep(120);
-                if (IsDrained()) { return; }
+                if (IsDrained())
+                {
+                    // Sleep one consumer poll interval to ensure no in-flight item
+                    // slipped between TryTake and the busy flag being set.
+                    Thread.Sleep(120);
+                    if (IsDrained()) { return; }
+                }
+                Thread.Sleep(50);
             }
-            Thread.Sleep(50);
+        }
+        finally
+        {
+            _expediteRetry = false;
         }
     }
 
@@ -238,6 +328,13 @@ public sealed class SessionSampleWriter : IDisposable
     /// observe a stranded batch deterministically rather than racing the consumer's poll interval.
     /// </summary>
     internal int PendingRetryCount => _pendingRetryCount;
+
+    /// <summary>
+    /// Consumer poll cycles still to skip before the next retry of a failed batch (the exponential
+    /// backoff). Exposed so a test can wait until the backoff has grown before asserting that
+    /// <see cref="WaitForIdle"/> overrides it.
+    /// </summary>
+    internal int PollsUntilRetry => _pollsUntilRetry;
     #endregion
 
     #region IDisposable

--- a/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
+++ b/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
@@ -31,6 +31,15 @@ public sealed class SessionSampleWriter : IDisposable
     private readonly Thread _consumerThread;
     private volatile bool _disposed;
     private volatile bool _consumerBusy;
+
+    /// <summary>
+    /// Number of samples drained from the buffer that have not yet been committed — non-zero only
+    /// while a batch is in flight or has been retained for retry after a failed commit. Read by
+    /// <see cref="WaitForIdle"/> so it cannot report idle while unsaved rows are stranded in the
+    /// consumer's local batch (a failed batch lives outside <see cref="_buffer"/>, so the buffer
+    /// count alone cannot see it).
+    /// </summary>
+    private volatile int _pendingRetryCount;
     #endregion
 
     #region Constructor
@@ -72,6 +81,8 @@ public sealed class SessionSampleWriter : IDisposable
     #region Consumer
     private void Consumer()
     {
+        // Persists across loop iterations on purpose: a batch is cleared only after a successful
+        // commit, so a batch whose commit failed is retained here and retried on a later pass.
         var samples = new List<DataSample>();
         int bufferCount;
         while (!_consumerCts.IsCancellationRequested)
@@ -84,46 +95,66 @@ public sealed class SessionSampleWriter : IDisposable
 
                 bufferCount = _buffer.Count;
 
-                if (bufferCount < 1) { continue; }
+                // Stay idle only when nothing is buffered AND no previously failed batch is
+                // awaiting retry. A retained batch (samples.Count > 0) lives outside the buffer,
+                // so without the samples.Count check it would be retried only when *new* samples
+                // happened to arrive — stranding unsaved rows indefinitely and letting WaitForIdle
+                // report idle while they are still pending.
+                if (bufferCount < 1 && samples.Count == 0) { continue; }
 
                 // Wait if the consumer is suspended (e.g. during delete-all)
                 _consumerGate.Wait(_consumerCts.Token);
 
                 _consumerBusy = true;
-
-                // Remove the samples from the collection
-                for (var i = 0; i < bufferCount; i++)
+                try
                 {
-                    if (_buffer.TryTake(out var sample)) { samples.Add(sample); }
-                }
+                    // Drain whatever is newly buffered onto the (possibly retained) batch. On a
+                    // pure retry pass bufferCount is 0 and the existing batch is re-attempted.
+                    for (var i = 0; i < bufferCount; i++)
+                    {
+                        if (_buffer.TryTake(out var sample)) { samples.Add(sample); }
+                    }
 
-                using (var context = _loggingContext.CreateDbContext())
+                    // Publish the at-risk count before opening the connection so WaitForIdle cannot
+                    // observe a momentary all-clear: if the insert below throws, this stays non-zero
+                    // until a later pass commits the batch.
+                    _pendingRetryCount = samples.Count;
+
+                    using (var context = _loggingContext.CreateDbContext())
+                    {
+                        // Start a new transaction for bulk insert
+                        using var transaction = context.Database.BeginTransaction();
+                        // Perform the bulk insert
+                        context.BulkInsert(samples);
+
+                        // Commit the transaction after the bulk insert
+                        transaction.Commit();
+
+                        // Clear only after a successful commit. If disposal of the transaction or
+                        // context throws past this point, the batch is already cleared and
+                        // _pendingRetryCount is 0, so it is not re-inserted — re-inserting an
+                        // already-committed batch would write duplicate rows. A failure before the
+                        // commit leaves both intact, so the loop-local batch is retried on a later
+                        // pass (the bufferCount < 1 && samples.Count == 0 gate above lets it run
+                        // even when no new samples have arrived).
+                        samples.Clear();
+                        _pendingRetryCount = 0;
+                    }
+                }
+                finally
                 {
-
-                    // Start a new transaction for bulk insert
-                    using var transaction = context.Database.BeginTransaction();
-                    // Perform the bulk insert
-                    context.BulkInsert(samples);
-
-                    // Commit the transaction after the bulk insert
-                    transaction.Commit();
-
-                    // Clear immediately after a successful commit: if disposal of the
-                    // transaction or context throws, the catch below keeps the list for
-                    // retry — re-inserting an already-committed batch would write
-                    // duplicate rows. A failure before the commit still retries.
-                    samples.Clear();
+                    // Reset busy on every exit path (success or exception) so it can never get
+                    // stuck true and wedge WaitForIdle. The retained batch is tracked separately
+                    // by _pendingRetryCount, which is only cleared after a committed batch.
+                    _consumerBusy = false;
                 }
-                _consumerBusy = false;
             }
             catch (OperationCanceledException)
             {
-                _consumerBusy = false;
                 break;
             }
             catch (Exception ex)
             {
-                _consumerBusy = false;
                 if (_consumerCts.IsCancellationRequested) { break; }
                 _appLogger.Error(ex, "Failed in Consumer Thread");
             }
@@ -155,16 +186,24 @@ public sealed class SessionSampleWriter : IDisposable
         var deadline = DateTime.UtcNow + timeout;
         while (DateTime.UtcNow < deadline)
         {
-            if (_buffer.Count == 0 && !_consumerBusy)
+            if (IsDrained())
             {
                 // Sleep one consumer poll interval to ensure no in-flight item
                 // slipped between TryTake and the busy flag being set.
                 Thread.Sleep(120);
-                if (_buffer.Count == 0 && !_consumerBusy) { return; }
+                if (IsDrained()) { return; }
             }
             Thread.Sleep(50);
         }
     }
+
+    /// <summary>
+    /// True only when there is genuinely nothing left to persist: the buffer is empty, the consumer
+    /// is not mid-insert, and no failed batch is retained for retry. The last check is what makes
+    /// <see cref="WaitForIdle"/> durability-correct — a batch whose commit failed lives in the
+    /// consumer's local list, invisible to <see cref="_buffer"/>, and must not be reported as idle.
+    /// </summary>
+    private bool IsDrained() => _buffer.Count == 0 && !_consumerBusy && _pendingRetryCount == 0;
 
     /// <summary>
     /// Suspends the background consumer thread so no new database connections are opened.
@@ -192,6 +231,13 @@ public sealed class SessionSampleWriter : IDisposable
     /// <see cref="Dispose"/> joins the thread cleanly.
     /// </summary>
     internal bool IsConsumerThreadAlive => _consumerThread.IsAlive;
+
+    /// <summary>
+    /// Number of samples drained from the buffer but not yet committed — non-zero while a batch is
+    /// in flight or retained for retry after a failed commit. Exposed so failure-injection tests can
+    /// observe a stranded batch deterministically rather than racing the consumer's poll interval.
+    /// </summary>
+    internal int PendingRetryCount => _pendingRetryCount;
     #endregion
 
     #region IDisposable


### PR DESCRIPTION
## What

Makes `SessionSampleWriter`'s background write path **durable** (a failed batch is retried, not silently lost or undercounted) and **self-throttling** (a persistently failing DB doesn't flood logs/Sentry or churn connections). The core bug was pre-existing — moved verbatim from `DatabaseLogger` during the #592 extraction and flagged by Qodo on #604.

> Originally opened stacked on #604; since #604 merged this is rebased onto `main`. Kept deliberately separate from the behavior-preserving #592 extraction. Two logical commits (see below).

## Commit 1 — durability fix (`WaitForIdle` correctness)

The consumer drains `_buffer` into a long-lived `samples` list and clears it **only after a successful commit**, so a failed `BulkInsert`/commit intentionally retains the batch for retry. But the loop early-`continue`d whenever `_buffer.Count < 1` (so a retained batch was retried only if *new* samples later arrived), and `WaitForIdle()` checked only `_buffer.Count == 0 && !_consumerBusy` (so it couldn't see rows stranded in `samples`). Since `LoggingManager.PersistSessionSampleCount()` calls `WaitForIdle()` before its `COUNT`/`UPDATE`, this could persist a **permanent sample undercount**.

- Gate the idle-skip on `bufferCount < 1 && samples.Count == 0` — a failed batch is retried on its own.
- `volatile int _pendingRetryCount` (published before the insert, cleared only after a committed batch); `WaitForIdle` gates on it via `IsDrained()`.
- `try/finally` so `_consumerBusy` resets on every exit path.

## Commit 2 — retry/log throttling (folds in the log-spam follow-up)

The eager retry above re-attempts every ~100ms. On a persistently failing DB that re-opened a `DbContext`, re-ran the insert, and logged `Error` ~10×/s — and since `AppLogger.Error` also reports to Sentry, it flooded both the NLog file and Sentry.

- **Log-once per failure streak** (reset on the next successful commit; one `Information` line on recovery).
- **Bounded exponential backoff** (1, 2, 4, … poll cycles, capped at ~5s) so a persistent failure is retried at a low rate, not every poll.
- **Backoff is durability-safe:** `WaitForIdle` sets a flag that makes the consumer ignore the backoff while a caller is waiting, so a DB that recovers mid-wait is committed at the full poll rate. Without this, a multi-second cooldown could outlast the 10s `WaitForIdle` window and reintroduce the undercount — so the backoff can't regress the very bug Commit 1 fixes.
- Recovery log + counter reset moved onto the proven-commit path (inside the `using`) so a post-commit `Dispose()` throw can't skip them.

No change in steady-state behavior: when commits succeed, `samples` is empty, `_pendingRetryCount`/`_pollsUntilRetry` are 0, and `WaitForIdle`/suspend-resume behave exactly as before. The new paths engage only on an actual commit failure.

## Tests

Failure-injection tests in `SessionSampleWriterTests` (temp-SQLite factory that throws on `CreateDbContext()` until released):

- `WaitForIdle_DoesNotReportIdle_WhileFailedBatchAwaitsRetry` — a stranded batch keeps `WaitForIdle` from reporting idle.
- `FailedBatch_IsRetriedAndPersistedExactlyOnce_AfterRecovery` — recovers with no lost/duplicate rows.
- `PersistentFailure_LogsErrorOnce_NotOnEveryPoll` — `Error` logged once (not per poll) while stranded; still persists exactly once on recovery.
- `WaitForIdle_OverridesRetryBackoff_ToFlushARecoveredBatch` — builds a multi-second backoff, then asserts `WaitForIdle` flushes within a shorter window (guards the undercount regression).

Unit gate green: `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → 410 passed in `Daqifi.Desktop.Test`, 0 failed.

> A separate stacked PR follows for the Delete-All purge interaction (a stranded retry batch surviving a storage wipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
