### PR TITLE
fix(loggers): discard stranded retry batch on delete-all purge

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SessionSampleWriterTests.cs
@@ -18,8 +18,10 @@ namespace Daqifi.Desktop.Test.Loggers;
 /// <c>SuspendConsumer</c> halts draining while <c>ResumeConsumer</c> resumes it, <c>ClearBuffer</c>
 /// drops pending samples, <c>Dispose</c> stops the consumer thread cleanly and is idempotent, and —
 /// via an injected transient DB failure — a failed batch is retained, keeps <c>WaitForIdle</c> from
-/// reporting idle, is retried to completion exactly once (no lost or duplicate rows) on recovery, and
-/// is logged only once (not on every poll) while it stays stranded on a persistently failing DB.
+/// reporting idle, is retried to completion exactly once (no lost or duplicate rows) on recovery, is
+/// logged only once (not on every poll) while it stays stranded on a persistently failing DB, has its
+/// retry backoff overridden by a waiting <c>WaitForIdle</c>, and is dropped by <c>DiscardPendingBatch</c>
+/// so a delete-all purge is not repopulated.
 /// </summary>
 [TestClass]
 public class SessionSampleWriterTests
@@ -302,6 +304,44 @@ public class SessionSampleWriterTests
             "window; otherwise the persisted SampleCount would undercount.");
         Assert.AreEqual(0, writer.PendingRetryCount,
             "The flushed batch must clear the pending-retry count.");
+    }
+
+    [TestMethod]
+    public void DiscardPendingBatch_DropsStrandedBatch_SoAPurgeIsNotRepopulated()
+    {
+        const int sampleCount = 5;
+        using var inner = NewFactory();
+        SeedSession(inner);
+
+        var failing = new FailUntilReleasedContextFactory(inner);
+        using var writer = new SessionSampleWriter(failing, Mock.Of<IAppLogger>());
+
+        for (var i = 0; i < sampleCount; i++)
+        {
+            writer.Add(MakeSample("AI0", i));
+        }
+
+        // Strand the batch in the consumer's retry list via the injected failure.
+        Assert.IsTrue(
+            WaitUntil(() => writer.PendingRetryCount == sampleCount, TimeSpan.FromSeconds(5)),
+            "Consumer should strand the batch after the injected commit failure.");
+
+        // Mirror the delete-all purge ordering, including the discard step. Unlike ClearBuffer (which
+        // empties only the producer buffer), DiscardPendingBatch must drop the stranded batch the
+        // consumer is holding so it is not re-inserted into the recreated database on resume — even
+        // once the database is healthy again.
+        writer.SuspendConsumer();
+        writer.ClearBuffer();
+        writer.DiscardPendingBatch();
+        failing.Release();
+        writer.ResumeConsumer();
+
+        writer.WaitForIdle(TimeSpan.FromSeconds(5));
+
+        Assert.AreEqual(0, CountSamples(inner),
+            "A discarded stranded batch must NOT be re-inserted after the purge, even once the DB recovers.");
+        Assert.AreEqual(0, writer.PendingRetryCount,
+            "Discarding the stranded batch must reset the pending-retry count.");
     }
 
     #region Helpers

--- a/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
@@ -302,7 +302,16 @@ public class LoggingSessionListViewModelTests
         // The consumer thread must be suspended around the purge and resumed afterward.
         Assert.AreEqual(1, host.SuspendConsumerCount);
         Assert.AreEqual(1, host.ClearBufferCount);
+        Assert.AreEqual(1, host.DiscardPendingBatchCount,
+            "The purge must discard any retained retry batch so it cannot repopulate the wiped database.");
         Assert.AreEqual(1, host.ResumeConsumerCount);
+
+        // Order matters: the discard must happen inside the suspend window, after the buffer is
+        // cleared and before the consumer resumes — otherwise a stranded batch could slip through.
+        CollectionAssert.AreEqual(
+            new[] { "Suspend", "ClearBuffer", "DiscardPendingBatch", "Resume" },
+            host.ConsumerCallLog,
+            "The purge must suspend, clear the buffer, discard the retained batch, then resume — in order.");
         Assert.IsTrue(host.SuspendBeforeResume, "Consumer must be suspended before it is resumed.");
 
         // The database file is deleted and re-migrated, the bound collection is emptied, and the plot reset.
@@ -311,6 +320,33 @@ public class LoggingSessionListViewModelTests
         Assert.IsTrue(host.NotifyCount >= 1);
         Assert.AreEqual(1, host.ClearPlotCount);
         Assert.IsFalse(host.IsLoggedDataBusyValue, "Busy must clear after the purge completes.");
+    }
+
+    [TestMethod]
+    public async Task DeleteAll_WhenPurgeFails_DoesNotDiscardRetainedBatch_AndKeepsSessions()
+    {
+        var host = new FakeLoggingSessionListHost { ConfirmResult = true };
+        host.LoggingSessions.Add(new LoggingSession { ID = 1, Name = "A" });
+
+        // A context factory that cannot create a context models a purge that fails to recreate the
+        // database (e.g. the file is locked). The recreate step throws, so the purge does not complete.
+        var failingFactory = new Mock<IDbContextFactory<LoggingContext>>();
+        failingFactory.Setup(f => f.CreateDbContext()).Throws(new IOException("database file is in use"));
+
+        var dbPath = NewTempDbPath();
+        var list = new LoggingSessionListViewModel(host, () => failingFactory.Object, dbPath, Mock.Of<IAppLogger>());
+
+        await list.DeleteAllSessionsAsync();
+
+        // The consumer must still be suspended and resumed around the (failed) purge...
+        Assert.AreEqual(1, host.SuspendConsumerCount);
+        Assert.AreEqual(1, host.ResumeConsumerCount, "The consumer must always be resumed, even on failure.");
+
+        // ...but the retained retry batch must NOT be discarded: the database is still intact and the
+        // sessions remain, so dropping the batch would silently lose unflushed samples.
+        Assert.AreEqual(0, host.DiscardPendingBatchCount,
+            "A failed purge must not discard the retained retry batch.");
+        Assert.AreEqual(1, host.LoggingSessions.Count, "A failed purge must leave the sessions intact.");
     }
 
     #endregion
@@ -456,7 +492,15 @@ public class LoggingSessionListViewModelTests
 
         public int ClearBufferCount { get; private set; }
 
+        public int DiscardPendingBatchCount { get; private set; }
+
         public bool SuspendBeforeResume { get; private set; }
+
+        /// <summary>
+        /// Ordered log of the consumer-control calls (Suspend/ClearBuffer/DiscardPendingBatch/Resume)
+        /// so a test can assert the purge invokes them in the right order, not merely the right counts.
+        /// </summary>
+        public List<string> ConsumerCallLog { get; } = [];
 
         public List<int> ExportSessionIds { get; } = [];
 
@@ -498,6 +542,7 @@ public class LoggingSessionListViewModelTests
         {
             SuspendConsumerCount++;
             _suspendedAtLeastOnce = true;
+            ConsumerCallLog.Add("Suspend");
         }
 
         public void ResumeConsumer()
@@ -507,9 +552,20 @@ public class LoggingSessionListViewModelTests
             {
                 SuspendBeforeResume = true;
             }
+            ConsumerCallLog.Add("Resume");
         }
 
-        public void ClearBuffer() => ClearBufferCount++;
+        public void ClearBuffer()
+        {
+            ClearBufferCount++;
+            ConsumerCallLog.Add("ClearBuffer");
+        }
+
+        public void DiscardPendingBatch()
+        {
+            DiscardPendingBatchCount++;
+            ConsumerCallLog.Add("DiscardPendingBatch");
+        }
 
         public Task ShowExportDialogForSessionAsync(int sessionId)
         {

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -1055,6 +1055,12 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     public void ClearBuffer() => _sampleWriter.ClearBuffer();
 
     /// <summary>
+    /// Drops any batch the writer has retained for retry after a failed commit, so a delete-all purge
+    /// does not repopulate the freshly recreated database with stranded rows.
+    /// </summary>
+    public void DiscardPendingBatch() => _sampleWriter.DiscardPendingBatch();
+
+    /// <summary>
     /// Blocks until the buffered samples have been flushed to the database, or
     /// the timeout elapses. Used by <c>LoggingManager</c> when finalizing a
     /// session so the persisted <c>SampleCount</c> reflects every row that was

--- a/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
+++ b/Daqifi.Desktop/Loggers/SessionSampleWriter.cs
@@ -68,6 +68,15 @@ public sealed class SessionSampleWriter : IDisposable
     /// cooldown that could outlast the caller's timeout and persist a sample undercount.
     /// </summary>
     private volatile bool _expediteRetry;
+
+    /// <summary>
+    /// Set by <see cref="DiscardPendingBatch"/> to ask the consumer to drop any batch retained for
+    /// retry instead of committing it. Honored by the consumer the moment it next passes the gate,
+    /// so a batch stranded by a failed commit is not re-inserted into a database that a delete-all
+    /// purge has just wiped and recreated. Written under suspension by the purge; the consumer is the
+    /// only reader/clearer.
+    /// </summary>
+    private volatile bool _discardRequested;
     #endregion
 
     #region Constructor
@@ -135,7 +144,13 @@ public sealed class SessionSampleWriter : IDisposable
                 // so without the samples.Count check it would be retried only when *new* samples
                 // happened to arrive — stranding unsaved rows indefinitely and letting WaitForIdle
                 // report idle while they are still pending.
-                if (bufferCount < 1 && samples.Count == 0) { continue; }
+                if (bufferCount < 1 && samples.Count == 0)
+                {
+                    // Nothing is held, so any discard request is already satisfied; clear it here so
+                    // a request raised while idle cannot linger and affect a future batch.
+                    _discardRequested = false;
+                    continue;
+                }
 
                 // Wait if the consumer is suspended (e.g. during delete-all)
                 _consumerGate.Wait(_consumerCts.Token);
@@ -143,6 +158,20 @@ public sealed class SessionSampleWriter : IDisposable
                 _consumerBusy = true;
                 try
                 {
+                    // Honor a delete-all purge's discard request. Checked here — right after the gate,
+                    // before draining or inserting — because a batch stranded by a failed commit is
+                    // held by this thread while it is parked at the gate during SuspendConsumer();
+                    // dropping it now keeps those stale rows out of the freshly recreated database.
+                    if (_discardRequested)
+                    {
+                        samples.Clear();
+                        _pendingRetryCount = 0;
+                        consecutiveFailures = 0;
+                        _pollsUntilRetry = 0;
+                        _discardRequested = false;
+                        continue;
+                    }
+
                     // Drain whatever is newly buffered onto the (possibly retained) batch. On a
                     // pure retry pass bufferCount is 0 and the existing batch is re-attempted.
                     for (var i = 0; i < bufferCount; i++)
@@ -248,6 +277,19 @@ public sealed class SessionSampleWriter : IDisposable
         while (_buffer.TryTake(out _))
         {
         }
+    }
+
+    /// <summary>
+    /// Drops any batch the consumer has retained for retry after a failed commit, so it is not
+    /// re-inserted into the database. <see cref="ClearBuffer"/> only empties the producer buffer; a
+    /// failed batch lives in the consumer's local list and survives it. The delete-all storage purge
+    /// calls this (under suspension, after <see cref="ClearBuffer"/>) so a stranded batch does not
+    /// repopulate the freshly wiped database when the consumer resumes. The drop happens
+    /// asynchronously the next time the consumer passes the gate; it is honored before any insert.
+    /// </summary>
+    public void DiscardPendingBatch()
+    {
+        _discardRequested = true;
     }
 
     /// <summary>

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1424,6 +1424,8 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
 
     void ILoggingSessionListHost.ClearBuffer() => DbLogger.ClearBuffer();
 
+    void ILoggingSessionListHost.DiscardPendingBatch() => DbLogger.DiscardPendingBatch();
+
     /// <summary>
     /// Builds and presents the single-session export dialog. Kept on the host because the dialog view
     /// model resolves services from the desktop container and presentation is a WPF concern.

--- a/Daqifi.Desktop/ViewModels/ILoggingSessionListHost.cs
+++ b/Daqifi.Desktop/ViewModels/ILoggingSessionListHost.cs
@@ -70,6 +70,12 @@ public interface ILoggingSessionListHost
 
     /// <summary>Clears the pending sample buffer before a bulk storage purge (routes to <c>DbLogger</c>).</summary>
     void ClearBuffer();
+
+    /// <summary>
+    /// Discards any batch retained for retry after a failed commit, so a bulk storage purge does not
+    /// repopulate the freshly recreated database with stranded rows (routes to <c>DbLogger</c>).
+    /// </summary>
+    void DiscardPendingBatch();
     #endregion
 
     #region Dialogs

--- a/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
@@ -254,6 +254,7 @@ public class LoggingSessionListViewModel
     private void DeleteAllLoggingSessionsFromStorage(IDbContextFactory<LoggingContext> contextFactory)
     {
         _host.SuspendConsumer();
+        var purgeSucceeded = false;
         try
         {
             _host.ClearBuffer();
@@ -271,9 +272,22 @@ public class LoggingSessionListViewModel
             // throws "no such table: Samples".
             using var context = contextFactory.CreateDbContext();
             context.Database.Migrate();
+            purgeSucceeded = true;
         }
         finally
         {
+            // Discard any batch the consumer retained after a failed commit — but ONLY when the wipe
+            // actually succeeded. ClearBuffer empties just the producer buffer; a stranded batch lives
+            // in the consumer's local list and would otherwise repopulate the recreated database on
+            // resume. If the purge failed (e.g. the file was locked), the database is still intact and
+            // the sessions remain, so dropping the batch would silently lose unflushed samples —
+            // leaving it lets the consumer commit them to the surviving database instead. Requested
+            // before ResumeConsumer so the consumer honors it before its next insert.
+            if (purgeSucceeded)
+            {
+                _host.DiscardPendingBatch();
+            }
+
             _host.ResumeConsumer();
         }
     }


### PR DESCRIPTION
## What

Fixes a Delete-All storage purge that can leave **phantom `Samples` rows** in a freshly wiped database. Pre-existing, surfaced during review of the durability work and widened by its eager retry.

> Originally stacked on #605; #605 has merged, so this is rebased onto `main` (single commit).

## The gap

`DeleteAllLoggingSessionsFromStorage` runs: `SuspendConsumer()` → `ClearBuffer()` → delete + recreate DB → `ResumeConsumer()`. `ClearBuffer()` empties only the producer buffer. A batch the consumer retained after a **failed commit** lives in its loop-local list, not the buffer — the consumer parks at the gate holding it during suspension, then `BulkInsert`s it into the recreated database on resume.

Bounded harm (verified): no data loss; orphan rows have no `Sessions` row so they don't appear in the session list, and the next-session-ID query takes `MAX(LoggingSessionID)` over `Samples` so there's no ID reuse. The damage is silent phantom rows + wasted storage in a DB the user explicitly cleared.

## The fix

- `SessionSampleWriter.DiscardPendingBatch()` sets a `volatile` flag the consumer honors **the moment it next passes the gate — before draining or inserting** (so a batch held by a consumer parked during `SuspendConsumer()` is dropped on resume, never re-inserted). It clears the retained batch and resets `_pendingRetryCount`, the backoff, and the failure streak. A flag raised while idle is cleared on the next idle poll so it can't linger onto a future batch.
- Routed through the existing purge seam: `DatabaseLogger` passthrough → `ILoggingSessionListHost.DiscardPendingBatch()` → `DaqifiViewModel` bridge → called in `DeleteAllLoggingSessionsFromStorage`.
- **Gated on the purge succeeding** (Qodo review): requested in the `finally` only after `delete` + `Migrate()` complete, still before `ResumeConsumer()`. If the purge fails (e.g. the file is locked) the database and sessions are left intact, so the retained batch is kept and committed to the surviving database instead of being silently dropped.

## Tests

- `DiscardPendingBatch_DropsStrandedBatch_SoAPurgeIsNotRepopulated` — strands a batch (failure-injection factory), runs the purge ordering (Suspend → ClearBuffer → Discard → recover → Resume), asserts **0 rows inserted** and `PendingRetryCount == 0` even after the DB recovers.
- `DeleteAll_WhenPurgeFails_DoesNotDiscardRetainedBatch_AndKeepsSessions` — a failed purge (mocked failing `IDbContextFactory`) resumes the consumer but does **not** discard the batch and keeps the sessions.
- `DeleteAll_Confirmed_...` (existing) now also asserts the purge call ordering (Suspend → ClearBuffer → DiscardPendingBatch → Resume).

Unit gate green: `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
