### PR TITLE
chore(loggers): extract PlotModelFactory from DatabaseLogger (#592)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ When working on:
 - **Firewall/Network**: Ensure admin privileges handled properly, verify ports match
 - **WiFi Discovery Issues**: Check network interface detection and port configuration
 - **Manual IP Connections**: Ensure TCP port matches what device discovery reports
-- **Plot/Minimap changes**: Read the "Plot Rendering (OxyPlot)" section below — there are non-obvious gotchas with `InvalidatePlot`, auto-range, and feedback loops. Key files: `DatabaseLogger.cs`, `MinimapInteractionController.cs`, `MinMaxDownsampler.cs`
+- **Plot/Minimap changes**: Read the "Plot Rendering (OxyPlot)" section below — there are non-obvious gotchas with `InvalidatePlot`, auto-range, and feedback loops. Key files: `DatabaseLogger.cs` (orchestration + live-model mutation/binding surface), `PlotModelFactory.cs` (pure OxyPlot construction — axes, theme, minimap model + annotations, channel/minimap series), `MinimapInteractionController.cs`, `MinMaxDownsampler.cs`
 - **New features**: Add unit tests with 80% coverage minimum
 - **UI automation / running the harness against a PR with a device, or extending the UI scenarios**: Read [Daqifi.Desktop.UITest/README.md](Daqifi.Desktop.UITest/README.md) first. It is the FlaUI integration gate (drives the real GUI out-of-process against attached hardware) and documents the unattended `DAQIFI_TEST_MODE` launch, the AutomationId map, and load-bearing gotchas (e.g. `PART_SelectedContentHost` exposes tab content to UI Automation — do not remove it)
 

--- a/Daqifi.Desktop.Test/Loggers/PlotModelFactoryTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/PlotModelFactoryTests.cs
@@ -1,0 +1,238 @@
+using Daqifi.Desktop.Helpers;
+using Daqifi.Desktop.Logger;
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Behavior contract for <see cref="PlotModelFactory"/> — the pure OxyPlot construction extracted from
+/// <c>DatabaseLogger</c> (issue #592). Every factory method is a side-effect-free constructor of OxyPlot
+/// objects, so these tests run with no database, no background threads, and no WPF runtime: they simply
+/// build the models/series and assert their axis keys, positions, theme, channel-to-axis mapping, color
+/// parsing, and minimap annotation configuration. This is the first real test seam over plot
+/// construction, which previously lived inline in the logger's constructor.
+/// </summary>
+[TestClass]
+public class PlotModelFactoryTests
+{
+    private const string Serial = "9090684023231015079";
+    private const string Color = "#FFD32F2F";
+
+    private readonly PlotModelFactory _factory = new();
+
+    #region Axis key contract
+
+    [TestMethod]
+    public void AxisKeys_MatchTheStringsTheViewportMachineryLooksUpBy()
+    {
+        // The logger's viewport code and the minimap controller find axes by these exact strings, so the
+        // constants are a shared contract the factory must not drift from.
+        Assert.AreEqual("Analog", PlotModelFactory.AnalogAxisKey);
+        Assert.AreEqual("Digital", PlotModelFactory.DigitalAxisKey);
+        Assert.AreEqual("Time", PlotModelFactory.TimeAxisKey);
+        Assert.AreEqual("MinimapTime", PlotModelFactory.MinimapTimeAxisKey);
+        Assert.AreEqual("MinimapY", PlotModelFactory.MinimapYAxisKey);
+    }
+
+    #endregion
+
+    #region CreateMainPlotModel
+
+    [TestMethod]
+    public void CreateMainPlotModel_AddsAnalogDigitalTimeAxes_WithExpectedKeysAndPositions()
+    {
+        var model = _factory.CreateMainPlotModel();
+
+        Assert.AreEqual(3, model.Axes.Count, "Main plot has exactly the analog, digital, and time axes.");
+
+        var analog = GetAxis(model, PlotModelFactory.AnalogAxisKey);
+        Assert.IsInstanceOfType(analog, typeof(LinearAxis));
+        Assert.AreEqual(AxisPosition.Left, analog.Position);
+        Assert.AreEqual("Analog (V)", analog.Title);
+        Assert.AreEqual("0.###", analog.StringFormat);
+
+        var digital = GetAxis(model, PlotModelFactory.DigitalAxisKey);
+        Assert.IsInstanceOfType(digital, typeof(LinearAxis));
+        Assert.AreEqual(AxisPosition.Right, digital.Position);
+        Assert.AreEqual("Digital", digital.Title);
+        Assert.AreEqual(-0.1, digital.Minimum, "Digital axis is pinned to a fixed 0..1 range with padding.");
+        Assert.AreEqual(1.1, digital.Maximum);
+
+        var time = GetAxis(model, PlotModelFactory.TimeAxisKey);
+        Assert.IsInstanceOfType(time, typeof(LinearAxis));
+        Assert.AreEqual(AxisPosition.Bottom, time.Position);
+        Assert.AreEqual("Time (ms)", time.Title);
+    }
+
+    [TestMethod]
+    public void CreateMainPlotModel_DisablesBuiltInLegend()
+    {
+        // The legend is rendered by the WPF panel, not OxyPlot's built-in legend.
+        var model = _factory.CreateMainPlotModel();
+
+        Assert.IsFalse(model.IsLegendVisible);
+    }
+
+    [TestMethod]
+    public void CreateMainPlotModel_AppliesDarkTheme()
+    {
+        var model = _factory.CreateMainPlotModel();
+
+        Assert.AreEqual(OxyPlotDarkTheme.Surface, model.Background, "Dark theme is applied to the model.");
+        Assert.AreEqual(OxyPlotDarkTheme.TextSecondary, model.TextColor);
+
+        // The theme is also applied to each axis (gridline color is a theme value, not the OxyPlot default).
+        var time = GetAxis(model, PlotModelFactory.TimeAxisKey);
+        Assert.AreEqual(OxyPlotDarkTheme.Gridline, time.MajorGridlineColor);
+    }
+
+    #endregion
+
+    #region CreateChannelSeries
+
+    [TestMethod]
+    public void CreateChannelSeries_AnalogChannel_UsesAnalogYAxis()
+    {
+        var (series, _) = _factory.CreateChannelSeries(
+            "AI0", Serial, ChannelType.Analog, Color, _factory.CreateMainPlotModel(), null);
+
+        Assert.AreEqual(PlotModelFactory.AnalogAxisKey, series.YAxisKey);
+    }
+
+    [TestMethod]
+    public void CreateChannelSeries_DigitalChannel_UsesDigitalYAxis()
+    {
+        var (series, _) = _factory.CreateChannelSeries(
+            "DIO0", Serial, ChannelType.Digital, Color, _factory.CreateMainPlotModel(), null);
+
+        Assert.AreEqual(PlotModelFactory.DigitalAxisKey, series.YAxisKey);
+    }
+
+    [TestMethod]
+    public void CreateChannelSeries_ParsesColor_AndSetsTitleTagAndVisibility()
+    {
+        var (series, _) = _factory.CreateChannelSeries(
+            "AI0", Serial, ChannelType.Analog, Color, _factory.CreateMainPlotModel(), null);
+
+        Assert.AreEqual("AI0", series.Title);
+        Assert.AreEqual(OxyColor.Parse(Color), series.Color, "Series color is parsed from the stored hex string.");
+        Assert.IsTrue(series.IsVisible, "Newly built channel series start visible.");
+        Assert.AreEqual((Serial, "AI0"), series.Tag, "The (serial, channel) tag is what the viewport code keys on.");
+        StringAssert.Contains(series.TrackerFormatString, "AI0");
+        StringAssert.Contains(series.TrackerFormatString, "...5079", "Tracker shows the truncated serial suffix.");
+    }
+
+    [TestMethod]
+    public void CreateChannelSeries_BuildsLegendItem_MirroringTheSeries()
+    {
+        var plotModel = _factory.CreateMainPlotModel();
+
+        var (series, legendItem) = _factory.CreateChannelSeries(
+            "AI0", Serial, ChannelType.Analog, Color, plotModel, null);
+
+        Assert.AreSame(series, legendItem.ActualSeries, "Legend item controls the series it was built with.");
+        Assert.AreEqual("AI0", legendItem.DisplayName);
+        Assert.AreEqual("AI0", legendItem.ChannelName);
+        Assert.AreEqual(Serial, legendItem.DeviceSerialNo);
+        Assert.AreEqual(OxyColor.Parse(Color), legendItem.SeriesColor);
+        Assert.IsTrue(legendItem.IsVisible);
+        Assert.AreEqual("...5079", legendItem.TruncatedSerialNo);
+    }
+
+    #endregion
+
+    #region CreateMinimapPlotModel
+
+    [TestMethod]
+    public void CreateMinimapPlotModel_AddsTwoNonInteractiveAxes()
+    {
+        var minimap = _factory.CreateMinimapPlotModel();
+
+        Assert.AreEqual(2, minimap.Model.Axes.Count);
+
+        var timeAxis = GetAxis(minimap.Model, PlotModelFactory.MinimapTimeAxisKey);
+        Assert.AreEqual(AxisPosition.Bottom, timeAxis.Position);
+        Assert.IsFalse(timeAxis.IsZoomEnabled, "The minimap axis is driven programmatically, not by user zoom.");
+        Assert.IsFalse(timeAxis.IsPanEnabled);
+
+        var yAxis = GetAxis(minimap.Model, PlotModelFactory.MinimapYAxisKey);
+        Assert.AreEqual(AxisPosition.Left, yAxis.Position);
+        Assert.IsFalse(yAxis.IsZoomEnabled);
+        Assert.IsFalse(yAxis.IsPanEnabled);
+    }
+
+    [TestMethod]
+    public void CreateMinimapPlotModel_AddsTheThreeAnnotations_AndReturnsTheSameHandles()
+    {
+        var minimap = _factory.CreateMinimapPlotModel();
+
+        // The logger keeps the returned handles to mutate selection/dim bounds as the viewport moves,
+        // so the returned objects must be exactly the ones added to the model.
+        CollectionAssert.AreEqual(
+            new Annotation[] { minimap.DimLeft, minimap.DimRight, minimap.SelectionRect },
+            minimap.Model.Annotations.ToArray(),
+            "Dim overlays render beneath the selection rectangle, so z-order (add order) must be preserved.");
+    }
+
+    [TestMethod]
+    public void CreateMinimapPlotModel_ConfiguresSelectionAndDimAnnotations()
+    {
+        var minimap = _factory.CreateMinimapPlotModel();
+
+        Assert.AreEqual(OxyPlotDarkTheme.Accent, minimap.SelectionRect.Stroke, "Selection rectangle uses the accent border.");
+        Assert.AreEqual(2d, minimap.SelectionRect.StrokeThickness);
+        Assert.AreEqual(OxyColors.Transparent, minimap.SelectionRect.Fill);
+
+        Assert.AreEqual(OxyPlotDarkTheme.MinimapDim, minimap.DimLeft.Fill, "Dim overlays shade the unselected region.");
+        Assert.AreEqual(OxyPlotDarkTheme.MinimapDim, minimap.DimRight.Fill);
+
+        // Every annotation is bound to the minimap axes and drawn above the series.
+        foreach (var annotation in new[] { minimap.SelectionRect, minimap.DimLeft, minimap.DimRight })
+        {
+            Assert.AreEqual(PlotModelFactory.MinimapTimeAxisKey, annotation.XAxisKey);
+            Assert.AreEqual(PlotModelFactory.MinimapYAxisKey, annotation.YAxisKey);
+            Assert.AreEqual(AnnotationLayer.AboveSeries, annotation.Layer);
+        }
+    }
+
+    [TestMethod]
+    public void CreateMinimapPlotModel_DisablesLegend_AndAppliesTheme()
+    {
+        var minimap = _factory.CreateMinimapPlotModel();
+
+        Assert.IsFalse(minimap.Model.IsLegendVisible);
+        Assert.AreEqual(OxyPlotDarkTheme.Surface, minimap.Model.Background);
+    }
+
+    #endregion
+
+    #region CreateMinimapSeries
+
+    [TestMethod]
+    public void CreateMinimapSeries_BindsToMinimapAxes_AndUsesTheGivenPointsAndColor()
+    {
+        var color = OxyColor.Parse(Color);
+        var points = new List<DataPoint> { new(0, 1), new(1, 2) };
+
+        var series = _factory.CreateMinimapSeries(color, points);
+
+        Assert.AreEqual(color, series.Color);
+        Assert.AreEqual(1d, series.StrokeThickness);
+        Assert.AreEqual(PlotModelFactory.MinimapTimeAxisKey, series.XAxisKey);
+        Assert.AreEqual(PlotModelFactory.MinimapYAxisKey, series.YAxisKey);
+        Assert.AreSame(points, series.ItemsSource, "The downsampled list is used directly as the items source.");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Axis GetAxis(PlotModel model, string key) =>
+        model.Axes.First(a => a.Key == key);
+
+    #endregion
+}

--- a/Daqifi.Desktop.Test/Loggers/PlotModelFactoryTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/PlotModelFactoryTests.cs
@@ -31,11 +31,11 @@ public class PlotModelFactoryTests
     {
         // The logger's viewport code and the minimap controller find axes by these exact strings, so the
         // constants are a shared contract the factory must not drift from.
-        Assert.AreEqual("Analog", PlotModelFactory.AnalogAxisKey);
-        Assert.AreEqual("Digital", PlotModelFactory.DigitalAxisKey);
-        Assert.AreEqual("Time", PlotModelFactory.TimeAxisKey);
-        Assert.AreEqual("MinimapTime", PlotModelFactory.MinimapTimeAxisKey);
-        Assert.AreEqual("MinimapY", PlotModelFactory.MinimapYAxisKey);
+        Assert.AreEqual("Analog", PlotModelFactory.ANALOG_AXIS_KEY);
+        Assert.AreEqual("Digital", PlotModelFactory.DIGITAL_AXIS_KEY);
+        Assert.AreEqual("Time", PlotModelFactory.TIME_AXIS_KEY);
+        Assert.AreEqual("MinimapTime", PlotModelFactory.MINIMAP_TIME_AXIS_KEY);
+        Assert.AreEqual("MinimapY", PlotModelFactory.MINIMAP_Y_AXIS_KEY);
     }
 
     #endregion
@@ -49,20 +49,20 @@ public class PlotModelFactoryTests
 
         Assert.AreEqual(3, model.Axes.Count, "Main plot has exactly the analog, digital, and time axes.");
 
-        var analog = GetAxis(model, PlotModelFactory.AnalogAxisKey);
+        var analog = GetAxis(model, PlotModelFactory.ANALOG_AXIS_KEY);
         Assert.IsInstanceOfType(analog, typeof(LinearAxis));
         Assert.AreEqual(AxisPosition.Left, analog.Position);
         Assert.AreEqual("Analog (V)", analog.Title);
         Assert.AreEqual("0.###", analog.StringFormat);
 
-        var digital = GetAxis(model, PlotModelFactory.DigitalAxisKey);
+        var digital = GetAxis(model, PlotModelFactory.DIGITAL_AXIS_KEY);
         Assert.IsInstanceOfType(digital, typeof(LinearAxis));
         Assert.AreEqual(AxisPosition.Right, digital.Position);
         Assert.AreEqual("Digital", digital.Title);
         Assert.AreEqual(-0.1, digital.Minimum, "Digital axis is pinned to a fixed 0..1 range with padding.");
         Assert.AreEqual(1.1, digital.Maximum);
 
-        var time = GetAxis(model, PlotModelFactory.TimeAxisKey);
+        var time = GetAxis(model, PlotModelFactory.TIME_AXIS_KEY);
         Assert.IsInstanceOfType(time, typeof(LinearAxis));
         Assert.AreEqual(AxisPosition.Bottom, time.Position);
         Assert.AreEqual("Time (ms)", time.Title);
@@ -86,7 +86,7 @@ public class PlotModelFactoryTests
         Assert.AreEqual(OxyPlotDarkTheme.TextSecondary, model.TextColor);
 
         // The theme is also applied to each axis (gridline color is a theme value, not the OxyPlot default).
-        var time = GetAxis(model, PlotModelFactory.TimeAxisKey);
+        var time = GetAxis(model, PlotModelFactory.TIME_AXIS_KEY);
         Assert.AreEqual(OxyPlotDarkTheme.Gridline, time.MajorGridlineColor);
     }
 
@@ -100,7 +100,7 @@ public class PlotModelFactoryTests
         var (series, _) = _factory.CreateChannelSeries(
             "AI0", Serial, ChannelType.Analog, Color, _factory.CreateMainPlotModel(), null);
 
-        Assert.AreEqual(PlotModelFactory.AnalogAxisKey, series.YAxisKey);
+        Assert.AreEqual(PlotModelFactory.ANALOG_AXIS_KEY, series.YAxisKey);
     }
 
     [TestMethod]
@@ -109,7 +109,7 @@ public class PlotModelFactoryTests
         var (series, _) = _factory.CreateChannelSeries(
             "DIO0", Serial, ChannelType.Digital, Color, _factory.CreateMainPlotModel(), null);
 
-        Assert.AreEqual(PlotModelFactory.DigitalAxisKey, series.YAxisKey);
+        Assert.AreEqual(PlotModelFactory.DIGITAL_AXIS_KEY, series.YAxisKey);
     }
 
     [TestMethod]
@@ -143,6 +143,23 @@ public class PlotModelFactoryTests
         Assert.AreEqual("...5079", legendItem.TruncatedSerialNo);
     }
 
+    [TestMethod]
+    public void CreateChannelSeries_TogglingLegendVisibility_WithoutWpfRuntime_TogglesSeriesAndDoesNotThrow()
+    {
+        // The legend item's visibility setter normally hops to Application.Current.Dispatcher; in this
+        // WPF-runtime-free test host Application.Current is null, so the setter must run its work inline
+        // rather than dereferencing a null dispatcher. Proves the construction seam stays exercisable
+        // headless (a null databaseLogger means no minimap sync is attempted).
+        var (series, legendItem) = _factory.CreateChannelSeries(
+            "AI0", Serial, ChannelType.Analog, Color, _factory.CreateMainPlotModel(), null);
+
+        legendItem.IsVisible = false;
+        Assert.IsFalse(series.IsVisible, "Toggling the legend item flips the underlying series visibility.");
+
+        legendItem.IsVisible = true;
+        Assert.IsTrue(series.IsVisible);
+    }
+
     #endregion
 
     #region CreateMinimapPlotModel
@@ -154,12 +171,12 @@ public class PlotModelFactoryTests
 
         Assert.AreEqual(2, minimap.Model.Axes.Count);
 
-        var timeAxis = GetAxis(minimap.Model, PlotModelFactory.MinimapTimeAxisKey);
+        var timeAxis = GetAxis(minimap.Model, PlotModelFactory.MINIMAP_TIME_AXIS_KEY);
         Assert.AreEqual(AxisPosition.Bottom, timeAxis.Position);
         Assert.IsFalse(timeAxis.IsZoomEnabled, "The minimap axis is driven programmatically, not by user zoom.");
         Assert.IsFalse(timeAxis.IsPanEnabled);
 
-        var yAxis = GetAxis(minimap.Model, PlotModelFactory.MinimapYAxisKey);
+        var yAxis = GetAxis(minimap.Model, PlotModelFactory.MINIMAP_Y_AXIS_KEY);
         Assert.AreEqual(AxisPosition.Left, yAxis.Position);
         Assert.IsFalse(yAxis.IsZoomEnabled);
         Assert.IsFalse(yAxis.IsPanEnabled);
@@ -193,8 +210,8 @@ public class PlotModelFactoryTests
         // Every annotation is bound to the minimap axes and drawn above the series.
         foreach (var annotation in new[] { minimap.SelectionRect, minimap.DimLeft, minimap.DimRight })
         {
-            Assert.AreEqual(PlotModelFactory.MinimapTimeAxisKey, annotation.XAxisKey);
-            Assert.AreEqual(PlotModelFactory.MinimapYAxisKey, annotation.YAxisKey);
+            Assert.AreEqual(PlotModelFactory.MINIMAP_TIME_AXIS_KEY, annotation.XAxisKey);
+            Assert.AreEqual(PlotModelFactory.MINIMAP_Y_AXIS_KEY, annotation.YAxisKey);
             Assert.AreEqual(AnnotationLayer.AboveSeries, annotation.Layer);
         }
     }
@@ -222,8 +239,8 @@ public class PlotModelFactoryTests
 
         Assert.AreEqual(color, series.Color);
         Assert.AreEqual(1d, series.StrokeThickness);
-        Assert.AreEqual(PlotModelFactory.MinimapTimeAxisKey, series.XAxisKey);
-        Assert.AreEqual(PlotModelFactory.MinimapYAxisKey, series.YAxisKey);
+        Assert.AreEqual(PlotModelFactory.MINIMAP_TIME_AXIS_KEY, series.XAxisKey);
+        Assert.AreEqual(PlotModelFactory.MINIMAP_Y_AXIS_KEY, series.YAxisKey);
         Assert.AreSame(points, series.ItemsSource, "The downsampled list is used directly as the items source.");
     }
 

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -137,7 +137,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
 
         // Subscribe to main time axis changes for minimap sync. The axis is built by the factory; the
         // subscription — like every other viewport mutation — stays here.
-        var timeAxis = PlotModel.Axes.First(a => a.Key == PlotModelFactory.TimeAxisKey);
+        var timeAxis = PlotModel.Axes.First(a => a.Key == PlotModelFactory.TIME_AXIS_KEY);
         timeAxis.AxisChanged += OnMainTimeAxisChanged;
 
         // Throttle viewport updates from main plot interaction to 60fps
@@ -536,10 +536,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             var dataMinX = nonEmpty.Min(d => d.downsampled[0].X);
             var dataMaxX = nonEmpty.Max(d => d.downsampled[^1].X);
 
-            var minimapTimeAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.MinimapTimeAxisKey);
+            var minimapTimeAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.MINIMAP_TIME_AXIS_KEY);
             minimapTimeAxis?.Zoom(dataMinX, dataMaxX);
 
-            var minimapYAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.MinimapYAxisKey);
+            var minimapYAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.MINIMAP_Y_AXIS_KEY);
             minimapYAxis?.Reset();
 
             _minimapSelectionRect.MinimumX = dataMinX;
@@ -601,7 +601,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         // Mark viewport dirty — the throttle timer will handle the actual update at 60fps
         _viewportDirty = true;
 
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TIME_AXIS_KEY);
         if (timeAxis == null)
         {
             return;
@@ -655,7 +655,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     /// </summary>
     private void UpdateMainPlotViewport(bool highFidelity = true)
     {
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TIME_AXIS_KEY);
         if (timeAxis == null)
         {
             return;
@@ -1026,7 +1026,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         // Reset Y axes to auto-range for amplitude
         foreach (var axis in PlotModel.Axes)
         {
-            if (axis.Key != PlotModelFactory.TimeAxisKey)
+            if (axis.Key != PlotModelFactory.TIME_AXIS_KEY)
             {
                 axis.Reset();
             }
@@ -1047,7 +1047,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             }
         }
 
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TIME_AXIS_KEY);
         if (timeAxis != null && fullMin < fullMax)
         {
             timeAxis.Zoom(fullMin, fullMax);
@@ -1062,7 +1062,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomOutX()
     {
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TIME_AXIS_KEY);
         timeAxis?.ZoomAtCenter(0.8);
         UpdateMainPlotViewport();
         PlotModel.InvalidatePlot(true);
@@ -1071,7 +1071,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomInX()
     {
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TIME_AXIS_KEY);
         timeAxis?.ZoomAtCenter(1.25);
         UpdateMainPlotViewport();
         PlotModel.InvalidatePlot(true);
@@ -1080,7 +1080,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomOutY()
     {
-        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.AnalogAxisKey);
+        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.ANALOG_AXIS_KEY);
         analogAxis?.ZoomAtCenter(0.8);
         PlotModel.InvalidatePlot(true);
     }
@@ -1088,7 +1088,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomInY()
     {
-        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.AnalogAxisKey);
+        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.ANALOG_AXIS_KEY);
         analogAxis?.ZoomAtCenter(1.25);
         PlotModel.InvalidatePlot(true);
     }
@@ -1107,7 +1107,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         _fetchCts?.Cancel();
         _fetchCts?.Dispose();
 
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TIME_AXIS_KEY);
         if (timeAxis != null)
         {
             timeAxis.AxisChanged -= OnMainTimeAxisChanged;

--- a/Daqifi.Desktop/Loggers/DatabaseLogger.cs
+++ b/Daqifi.Desktop/Loggers/DatabaseLogger.cs
@@ -1,6 +1,5 @@
 ﻿using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Common.Loggers;
-using ChannelType = Daqifi.Core.Channel.ChannelType;
 using Daqifi.Desktop.Device;
 using Daqifi.Desktop.Helpers;
 using Daqifi.Desktop.View;
@@ -10,92 +9,14 @@ using OxyPlot.Axes;
 using OxyPlot.Series;
 using System.Collections.ObjectModel;
 using Exception = System.Exception;
-using TickStyle = OxyPlot.Axes.TickStyle;
 using Microsoft.EntityFrameworkCore;
 using EFCore.BulkExtensions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Windows.Threading;
 using Application = System.Windows.Application;
-using FontWeights = OxyPlot.FontWeights;
 
 namespace Daqifi.Desktop.Logger;
-
-public partial class LoggedSeriesLegendItem : ObservableObject
-{
-    [ObservableProperty]
-    private string _displayName;
-
-    [ObservableProperty]
-    private string _channelName;
-
-    [ObservableProperty]
-    private string _deviceSerialNo;
-
-    /// <summary>
-    /// Truncated serial number for compact legend display (e.g., "...4104").
-    /// </summary>
-    public string TruncatedSerialNo => _deviceSerialNo?.Length > 4
-        ? $"...{_deviceSerialNo[^4..]}"
-        : _deviceSerialNo ?? string.Empty;
-
-    [ObservableProperty]
-    private OxyColor _seriesColor;
-
-    private bool _isVisible;
-    public bool IsVisible
-    {
-        get => _isVisible;
-        set
-        {
-            if (SetProperty(ref _isVisible, value) && ActualSeries != null)
-            {
-                ActualSeries.IsVisible = _isVisible;
-                Application.Current.Dispatcher.Invoke(() =>
-                {
-                    _plotModel?.InvalidatePlot(true);
-                    _databaseLogger?.SetMinimapSeriesVisibility(_deviceSerialNo, _channelName, _isVisible);
-                });
-            }
-        }
-    }
-
-    public LineSeries ActualSeries { get; }
-    private readonly PlotModel _plotModel;
-    private readonly DatabaseLogger _databaseLogger;
-
-    /// <summary>
-    /// Initializes a new legend item linked to a plot series and optional minimap sync.
-    /// </summary>
-    /// <param name="displayName">Full display name including channel and device info.</param>
-    /// <param name="channelName">Channel identifier (e.g., "AI0").</param>
-    /// <param name="deviceSerialNo">Device serial number for grouping.</param>
-    /// <param name="seriesColor">Color of the associated plot series.</param>
-    /// <param name="isVisible">Initial visibility state of the series.</param>
-    /// <param name="actualSeries">The OxyPlot LineSeries this legend item controls.</param>
-    /// <param name="plotModel">The main PlotModel to invalidate on visibility changes.</param>
-    /// <param name="databaseLogger">Optional logger for syncing minimap series visibility.</param>
-    public LoggedSeriesLegendItem(
-        string displayName,
-        string channelName,
-        string deviceSerialNo,
-        OxyColor seriesColor,
-        bool isVisible,
-        LineSeries actualSeries,
-        PlotModel plotModel,
-        DatabaseLogger databaseLogger = null)
-    {
-        _displayName = displayName;
-        _channelName = channelName;
-        _deviceSerialNo = deviceSerialNo;
-        _seriesColor = seriesColor;
-        _isVisible = isVisible; // Initialize the backing field
-        ActualSeries = actualSeries;
-        ActualSeries.IsVisible = isVisible; // Ensure series visibility matches
-        _plotModel = plotModel;
-        _databaseLogger = databaseLogger;
-    }
-}
 
 public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
 {
@@ -115,6 +36,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     private DateTime? _firstTime;
     private readonly AppLogger _appLogger = AppLogger.Instance;
     private readonly IDbContextFactory<LoggingContext> _loggingContext;
+    private readonly PlotModelFactory _plotModelFactory;
     private readonly SessionSampleWriter _sampleWriter;
     private readonly SessionDataRepository _sessionDataRepository;
     private RectangleAnnotation _minimapSelectionRect;
@@ -206,76 +128,16 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     {
         _loggingContext = loggingContext;
 
-        PlotModel = new PlotModel();
+        // Pure OxyPlot construction (axes, theme, minimap model + annotations, series) lives in
+        // PlotModelFactory (issue #592). The logger keeps every live mutation: the axis subscription
+        // below and all viewport/minimap-sync machinery.
+        _plotModelFactory = new PlotModelFactory();
 
-        var analogAxis = new LinearAxis
-        {
-            Position = AxisPosition.Left,
-            TickStyle = TickStyle.None,
-            MajorGridlineStyle = LineStyle.Solid,
-            MinorGridlineStyle = LineStyle.Solid,
-            TitleFontSize = 12,
-            TitleFontWeight = FontWeights.Bold,
-            MinimumPadding = 0.1,
-            MaximumPadding = 0.1,
-            StringFormat = "0.###",
-            AxisDistance = 5,
-            Key = "Analog",
-            Title = "Analog (V)"
-        };
+        PlotModel = _plotModelFactory.CreateMainPlotModel();
 
-        var digitalAxis = new LinearAxis
-        {
-            Position = AxisPosition.Right,
-            TickStyle = TickStyle.None,
-            MajorGridlineStyle = LineStyle.None,
-            MinorGridlineStyle = LineStyle.None,
-            MinorGridlineThickness = 0,
-            MajorGridlineThickness = 0,
-            MajorStep = 1,
-            MinorStep = 1,
-            TitleFontSize = 12,
-            TitleFontWeight = FontWeights.Bold,
-            AxisTitleDistance = -10,
-            Minimum = -0.1,
-            Maximum = 1.1,
-            MinimumPadding = 0.1,
-            MaximumPadding = 0.1,
-            AxisDistance = 5,
-            Key = "Digital",
-            Title = "Digital"
-        };
-
-        var timeAxis = new LinearAxis
-        {
-            Position = AxisPosition.Bottom,
-            TickStyle = TickStyle.None,
-            MajorGridlineStyle = LineStyle.Solid,
-            MinorGridlineStyle = LineStyle.Solid,
-            TitleFontSize = 12,
-            TitleFontWeight = FontWeights.Bold,
-            Key = "Time",
-            Title = "Time (ms)"
-        };
-
-        // OxyPlot.Legends.Legend legend = new OxyPlot.Legends.Legend
-        // {
-        //     LegendOrientation = OxyPlot.Legends.LegendOrientation.Vertical,
-        //     LegendPlacement = OxyPlot.Legends.LegendPlacement.Outside,
-        //     LegendItemMode = LegendItemMode.ToggleVisibility // Attempt to set direct interactivity
-        // };
-
-        OxyPlotDarkTheme.ApplyTo(PlotModel);
-        OxyPlotDarkTheme.ApplyTo(analogAxis);
-        OxyPlotDarkTheme.ApplyTo(digitalAxis);
-        OxyPlotDarkTheme.ApplyTo(timeAxis);
-
-        PlotModel.Axes.Add(analogAxis);
-        PlotModel.Axes.Add(digitalAxis);
-        PlotModel.Axes.Add(timeAxis);
-        PlotModel.IsLegendVisible = false; // Disable the built-in legend
-
-        // Subscribe to main time axis changes for minimap sync
+        // Subscribe to main time axis changes for minimap sync. The axis is built by the factory; the
+        // subscription — like every other viewport mutation — stays here.
+        var timeAxis = PlotModel.Axes.First(a => a.Key == PlotModelFactory.TimeAxisKey);
         timeAxis.AxisChanged += OnMainTimeAxisChanged;
 
         // Throttle viewport updates from main plot interaction to 60fps
@@ -311,90 +173,14 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     #region Minimap Initialization
     private void InitializeMinimapPlotModel()
     {
-        MinimapPlotModel = new PlotModel
-        {
-            IsLegendVisible = false,
-            PlotMargins = new OxyThickness(4, 2, 4, 2),
-            Padding = new OxyThickness(0)
-        };
-        OxyPlotDarkTheme.ApplyTo(MinimapPlotModel);
-
-        var minimapTimeAxis = new LinearAxis
-        {
-            Position = AxisPosition.Bottom,
-            Key = "MinimapTime",
-            TickStyle = TickStyle.None,
-            MajorGridlineStyle = LineStyle.None,
-            MinorGridlineStyle = LineStyle.None,
-            TitleFontSize = 0,
-            FontSize = 0,
-            IsZoomEnabled = false,
-            IsPanEnabled = false
-        };
-
-        var minimapYAxis = new LinearAxis
-        {
-            Position = AxisPosition.Left,
-            Key = "MinimapY",
-            TickStyle = TickStyle.None,
-            MajorGridlineStyle = LineStyle.None,
-            MinorGridlineStyle = LineStyle.None,
-            TitleFontSize = 0,
-            FontSize = 0,
-            IsZoomEnabled = false,
-            IsPanEnabled = false,
-            MinimumPadding = 0.1,
-            MaximumPadding = 0.1
-        };
-
-        MinimapPlotModel.Axes.Add(minimapTimeAxis);
-        MinimapPlotModel.Axes.Add(minimapYAxis);
-
-        // Dim overlays for areas outside the selected range
-        _minimapDimLeft = new RectangleAnnotation
-        {
-            Fill = OxyPlotDarkTheme.MinimapDim,
-            Stroke = OxyColors.Transparent,
-            StrokeThickness = 0,
-            MinimumX = -1e18,
-            MaximumX = 0,
-            MinimumY = -1e18,
-            MaximumY = 1e18,
-            Layer = AnnotationLayer.AboveSeries,
-            XAxisKey = "MinimapTime",
-            YAxisKey = "MinimapY"
-        };
-
-        _minimapDimRight = new RectangleAnnotation
-        {
-            Fill = OxyPlotDarkTheme.MinimapDim,
-            Stroke = OxyColors.Transparent,
-            StrokeThickness = 0,
-            MinimumX = 0,
-            MaximumX = 1e18,
-            MinimumY = -1e18,
-            MaximumY = 1e18,
-            Layer = AnnotationLayer.AboveSeries,
-            XAxisKey = "MinimapTime",
-            YAxisKey = "MinimapY"
-        };
-
-        // Selection rectangle border
-        _minimapSelectionRect = new RectangleAnnotation
-        {
-            Fill = OxyColors.Transparent,
-            Stroke = OxyPlotDarkTheme.Accent,
-            StrokeThickness = 2,
-            MinimumY = -1e18,
-            MaximumY = 1e18,
-            Layer = AnnotationLayer.AboveSeries,
-            XAxisKey = "MinimapTime",
-            YAxisKey = "MinimapY"
-        };
-
-        MinimapPlotModel.Annotations.Add(_minimapDimLeft);
-        MinimapPlotModel.Annotations.Add(_minimapDimRight);
-        MinimapPlotModel.Annotations.Add(_minimapSelectionRect);
+        // The minimap model, its axes, and the three annotations are pure construction (PlotModelFactory).
+        // The logger keeps the annotation field references so the viewport machinery can mutate their
+        // bounds, and wires the live interaction controller below.
+        var minimap = _plotModelFactory.CreateMinimapPlotModel();
+        MinimapPlotModel = minimap.Model;
+        _minimapSelectionRect = minimap.SelectionRect;
+        _minimapDimLeft = minimap.DimLeft;
+        _minimapDimRight = minimap.DimRight;
 
         _minimapInteraction = new MinimapInteractionController(
             PlotModel,
@@ -517,7 +303,8 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
 
             foreach (var chInfo in initial.Channels)
             {
-                var (series, legendItem) = AddChannelSeries(chInfo.ChannelName, chInfo.DeviceSerialNo, chInfo.Type, chInfo.Color);
+                var (series, legendItem) = _plotModelFactory.CreateChannelSeries(
+                    chInfo.ChannelName, chInfo.DeviceSerialNo, chInfo.Type, chInfo.Color, PlotModel, this);
                 tempSeriesList.Add(series);
                 tempLegendItemsList.Add(legendItem);
             }
@@ -734,14 +521,9 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         _minimapSeries.Clear();
         foreach (var (channelName, deviceSerial, color, downsampled) in minimapData)
         {
-            var minimapLine = new LineSeries
-            {
-                Color = color,
-                StrokeThickness = 1,
-                ItemsSource = downsampled,
-                XAxisKey = "MinimapTime",
-                YAxisKey = "MinimapY"
-            };
+            // Series construction is pure (PlotModelFactory); adding it to the live model, tracking it
+            // for visibility sync, and the axis/annotation/invalidate work below all stay here.
+            var minimapLine = _plotModelFactory.CreateMinimapSeries(color, downsampled);
             MinimapPlotModel.Series.Add(minimapLine);
             _minimapSeries[(deviceSerial, channelName)] = minimapLine;
         }
@@ -754,10 +536,10 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             var dataMinX = nonEmpty.Min(d => d.downsampled[0].X);
             var dataMaxX = nonEmpty.Max(d => d.downsampled[^1].X);
 
-            var minimapTimeAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == "MinimapTime");
+            var minimapTimeAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.MinimapTimeAxisKey);
             minimapTimeAxis?.Zoom(dataMinX, dataMaxX);
 
-            var minimapYAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == "MinimapY");
+            var minimapYAxis = MinimapPlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.MinimapYAxisKey);
             minimapYAxis?.Reset();
 
             _minimapSelectionRect.MinimumX = dataMinX;
@@ -808,45 +590,6 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     /// </summary>
     public void ResumeConsumer() => _sampleWriter.ResumeConsumer();
 
-    private (LineSeries series, LoggedSeriesLegendItem legendItem) AddChannelSeries(
-        string channelName,
-        string deviceSerialNo,
-        ChannelType type,
-        string color)
-    {
-        var serialSuffix = deviceSerialNo?.Length > 4
-            ? $"...{deviceSerialNo[^4..]}"
-            : deviceSerialNo;
-
-        var newLineSeries = new LineSeries
-        {
-            Title = channelName,
-            Tag = (deviceSerialNo, channelName),
-            Color = OxyColor.Parse(color),
-            IsVisible = true,
-            TrackerFormatString = $"{channelName} ({serialSuffix})\n{{1}}: {{2:0.###}}\n{{3}}: {{4:0.######}}"
-        };
-
-        var legendItem = new LoggedSeriesLegendItem(
-            newLineSeries.Title,
-            channelName,
-            deviceSerialNo,
-            newLineSeries.Color,
-            newLineSeries.IsVisible,
-            newLineSeries,
-            PlotModel,
-            this);
-
-        newLineSeries.YAxisKey = type switch
-        {
-            ChannelType.Analog => "Analog",
-            ChannelType.Digital => "Digital",
-            _ => newLineSeries.YAxisKey
-        };
-
-        return (newLineSeries, legendItem);
-    }
-
     #region Minimap Synchronization
     private void OnMainTimeAxisChanged(object? sender, AxisChangedEventArgs e)
     {
@@ -858,7 +601,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         // Mark viewport dirty — the throttle timer will handle the actual update at 60fps
         _viewportDirty = true;
 
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Time");
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
         if (timeAxis == null)
         {
             return;
@@ -912,7 +655,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     /// </summary>
     private void UpdateMainPlotViewport(bool highFidelity = true)
     {
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Time");
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
         if (timeAxis == null)
         {
             return;
@@ -1283,7 +1026,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         // Reset Y axes to auto-range for amplitude
         foreach (var axis in PlotModel.Axes)
         {
-            if (axis.Key != "Time")
+            if (axis.Key != PlotModelFactory.TimeAxisKey)
             {
                 axis.Reset();
             }
@@ -1304,7 +1047,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
             }
         }
 
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Time");
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
         if (timeAxis != null && fullMin < fullMax)
         {
             timeAxis.Zoom(fullMin, fullMax);
@@ -1319,7 +1062,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomOutX()
     {
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Time");
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
         timeAxis?.ZoomAtCenter(0.8);
         UpdateMainPlotViewport();
         PlotModel.InvalidatePlot(true);
@@ -1328,7 +1071,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomInX()
     {
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Time");
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
         timeAxis?.ZoomAtCenter(1.25);
         UpdateMainPlotViewport();
         PlotModel.InvalidatePlot(true);
@@ -1337,7 +1080,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomOutY()
     {
-        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Analog");
+        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.AnalogAxisKey);
         analogAxis?.ZoomAtCenter(0.8);
         PlotModel.InvalidatePlot(true);
     }
@@ -1345,7 +1088,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
     [RelayCommand]
     private void ZoomInY()
     {
-        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Analog");
+        var analogAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.AnalogAxisKey);
         analogAxis?.ZoomAtCenter(1.25);
         PlotModel.InvalidatePlot(true);
     }
@@ -1364,7 +1107,7 @@ public partial class DatabaseLogger : ObservableObject, ILogger, IDisposable
         _fetchCts?.Cancel();
         _fetchCts?.Dispose();
 
-        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == "Time");
+        var timeAxis = PlotModel.Axes.FirstOrDefault(a => a.Key == PlotModelFactory.TimeAxisKey);
         if (timeAxis != null)
         {
             timeAxis.AxisChanged -= OnMainTimeAxisChanged;

--- a/Daqifi.Desktop/Loggers/LoggedSeriesLegendItem.cs
+++ b/Daqifi.Desktop/Loggers/LoggedSeriesLegendItem.cs
@@ -43,11 +43,26 @@ public partial class LoggedSeriesLegendItem : ObservableObject
             if (SetProperty(ref _isVisible, value) && ActualSeries != null)
             {
                 ActualSeries.IsVisible = _isVisible;
-                Application.Current.Dispatcher.Invoke(() =>
+
+                void ApplyVisibility()
                 {
                     _plotModel?.InvalidatePlot(true);
                     _databaseLogger?.SetMinimapSeriesVisibility(_deviceSerialNo, _channelName, _isVisible);
-                });
+                }
+
+                // In the live app Application.Current is always set, so this is a UI-thread dispatch as
+                // before. In a headless/unit-test host it is null; run the work inline instead of
+                // dereferencing a null dispatcher, so the extracted construction stays exercisable
+                // without a WPF runtime.
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher != null)
+                {
+                    dispatcher.Invoke(ApplyVisibility);
+                }
+                else
+                {
+                    ApplyVisibility();
+                }
             }
         }
     }

--- a/Daqifi.Desktop/Loggers/LoggedSeriesLegendItem.cs
+++ b/Daqifi.Desktop/Loggers/LoggedSeriesLegendItem.cs
@@ -1,0 +1,90 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using OxyPlot;
+using OxyPlot.Series;
+using Application = System.Windows.Application;
+
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// Legend item linked to a single plot <see cref="LineSeries"/>. Toggling <see cref="IsVisible"/>
+/// flips the series visibility, invalidates the main plot, and (when a <see cref="DatabaseLogger"/>
+/// is supplied) mirrors the change onto the matching minimap series. Built by
+/// <see cref="PlotModelFactory.CreateChannelSeries"/>; the typed logger reference is retained so the
+/// minimap-sync callback keeps working exactly as before this type moved out of
+/// <see cref="DatabaseLogger"/> (issue #592).
+/// </summary>
+public partial class LoggedSeriesLegendItem : ObservableObject
+{
+    [ObservableProperty]
+    private string _displayName;
+
+    [ObservableProperty]
+    private string _channelName;
+
+    [ObservableProperty]
+    private string _deviceSerialNo;
+
+    /// <summary>
+    /// Truncated serial number for compact legend display (e.g., "...4104").
+    /// </summary>
+    public string TruncatedSerialNo => _deviceSerialNo?.Length > 4
+        ? $"...{_deviceSerialNo[^4..]}"
+        : _deviceSerialNo ?? string.Empty;
+
+    [ObservableProperty]
+    private OxyColor _seriesColor;
+
+    private bool _isVisible;
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set
+        {
+            if (SetProperty(ref _isVisible, value) && ActualSeries != null)
+            {
+                ActualSeries.IsVisible = _isVisible;
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    _plotModel?.InvalidatePlot(true);
+                    _databaseLogger?.SetMinimapSeriesVisibility(_deviceSerialNo, _channelName, _isVisible);
+                });
+            }
+        }
+    }
+
+    public LineSeries ActualSeries { get; }
+    private readonly PlotModel _plotModel;
+    private readonly DatabaseLogger? _databaseLogger;
+
+    /// <summary>
+    /// Initializes a new legend item linked to a plot series and optional minimap sync.
+    /// </summary>
+    /// <param name="displayName">Full display name including channel and device info.</param>
+    /// <param name="channelName">Channel identifier (e.g., "AI0").</param>
+    /// <param name="deviceSerialNo">Device serial number for grouping.</param>
+    /// <param name="seriesColor">Color of the associated plot series.</param>
+    /// <param name="isVisible">Initial visibility state of the series.</param>
+    /// <param name="actualSeries">The OxyPlot LineSeries this legend item controls.</param>
+    /// <param name="plotModel">The main PlotModel to invalidate on visibility changes.</param>
+    /// <param name="databaseLogger">Optional logger for syncing minimap series visibility.</param>
+    public LoggedSeriesLegendItem(
+        string displayName,
+        string channelName,
+        string deviceSerialNo,
+        OxyColor seriesColor,
+        bool isVisible,
+        LineSeries actualSeries,
+        PlotModel plotModel,
+        DatabaseLogger? databaseLogger = null)
+    {
+        _displayName = displayName;
+        _channelName = channelName;
+        _deviceSerialNo = deviceSerialNo;
+        _seriesColor = seriesColor;
+        _isVisible = isVisible; // Initialize the backing field
+        ActualSeries = actualSeries;
+        ActualSeries.IsVisible = isVisible; // Ensure series visibility matches
+        _plotModel = plotModel;
+        _databaseLogger = databaseLogger;
+    }
+}

--- a/Daqifi.Desktop/Loggers/MinimapPlotComponents.cs
+++ b/Daqifi.Desktop/Loggers/MinimapPlotComponents.cs
@@ -1,0 +1,21 @@
+using OxyPlot;
+using OxyPlot.Annotations;
+
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// The minimap <see cref="PlotModel"/> together with the three annotation handles
+/// <see cref="DatabaseLogger"/> keeps mutating as the viewport changes: the selection rectangle and
+/// the two dim overlays that shade the unselected regions. Returned by
+/// <see cref="PlotModelFactory.CreateMinimapPlotModel"/> so the logger can hold the field references
+/// while the construction lives in the factory.
+/// </summary>
+/// <param name="Model">The fully configured minimap plot model (axes + annotations added).</param>
+/// <param name="SelectionRect">The accent-bordered rectangle marking the visible time range.</param>
+/// <param name="DimLeft">The dim overlay shading the range to the left of the selection.</param>
+/// <param name="DimRight">The dim overlay shading the range to the right of the selection.</param>
+public sealed record MinimapPlotComponents(
+    PlotModel Model,
+    RectangleAnnotation SelectionRect,
+    RectangleAnnotation DimLeft,
+    RectangleAnnotation DimRight);

--- a/Daqifi.Desktop/Loggers/PlotModelFactory.cs
+++ b/Daqifi.Desktop/Loggers/PlotModelFactory.cs
@@ -10,23 +10,6 @@ using TickStyle = OxyPlot.Axes.TickStyle;
 namespace Daqifi.Desktop.Logger;
 
 /// <summary>
-/// The minimap <see cref="PlotModel"/> together with the three annotation handles
-/// <see cref="DatabaseLogger"/> keeps mutating as the viewport changes: the selection rectangle and
-/// the two dim overlays that shade the unselected regions. Returned by
-/// <see cref="PlotModelFactory.CreateMinimapPlotModel"/> so the logger can hold the field references
-/// while the construction lives in the factory.
-/// </summary>
-/// <param name="Model">The fully configured minimap plot model (axes + annotations added).</param>
-/// <param name="SelectionRect">The accent-bordered rectangle marking the visible time range.</param>
-/// <param name="DimLeft">The dim overlay shading the range to the left of the selection.</param>
-/// <param name="DimRight">The dim overlay shading the range to the right of the selection.</param>
-public sealed record MinimapPlotComponents(
-    PlotModel Model,
-    RectangleAnnotation SelectionRect,
-    RectangleAnnotation DimLeft,
-    RectangleAnnotation DimRight);
-
-/// <summary>
 /// Owns the pure OxyPlot <em>construction</em> extracted from <see cref="DatabaseLogger"/> (issue #592):
 /// building the main logged-data <see cref="PlotModel"/> and its Analog/Digital/Time axes, the overview
 /// minimap model with its axes and selection/dim annotations, a channel's <see cref="LineSeries"/> plus
@@ -45,19 +28,19 @@ public sealed class PlotModelFactory
 {
     #region Axis Keys
     /// <summary>Key of the left-hand analog (volts) Y axis on the main plot.</summary>
-    public const string AnalogAxisKey = "Analog";
+    public const string ANALOG_AXIS_KEY = "Analog";
 
     /// <summary>Key of the right-hand digital Y axis on the main plot.</summary>
-    public const string DigitalAxisKey = "Digital";
+    public const string DIGITAL_AXIS_KEY = "Digital";
 
     /// <summary>Key of the bottom time (ms) X axis on the main plot.</summary>
-    public const string TimeAxisKey = "Time";
+    public const string TIME_AXIS_KEY = "Time";
 
     /// <summary>Key of the minimap's time X axis.</summary>
-    public const string MinimapTimeAxisKey = "MinimapTime";
+    public const string MINIMAP_TIME_AXIS_KEY = "MinimapTime";
 
     /// <summary>Key of the minimap's value Y axis.</summary>
-    public const string MinimapYAxisKey = "MinimapY";
+    public const string MINIMAP_Y_AXIS_KEY = "MinimapY";
     #endregion
 
     #region Main Plot
@@ -85,7 +68,7 @@ public sealed class PlotModelFactory
             MaximumPadding = 0.1,
             StringFormat = "0.###",
             AxisDistance = 5,
-            Key = AnalogAxisKey,
+            Key = ANALOG_AXIS_KEY,
             Title = "Analog (V)"
         };
 
@@ -107,7 +90,7 @@ public sealed class PlotModelFactory
             MinimumPadding = 0.1,
             MaximumPadding = 0.1,
             AxisDistance = 5,
-            Key = DigitalAxisKey,
+            Key = DIGITAL_AXIS_KEY,
             Title = "Digital"
         };
 
@@ -119,7 +102,7 @@ public sealed class PlotModelFactory
             MinorGridlineStyle = LineStyle.Solid,
             TitleFontSize = 12,
             TitleFontWeight = FontWeights.Bold,
-            Key = TimeAxisKey,
+            Key = TIME_AXIS_KEY,
             Title = "Time (ms)"
         };
 
@@ -146,7 +129,7 @@ public sealed class PlotModelFactory
     /// </summary>
     /// <param name="channelName">Channel identifier (e.g., "AI0"); also the series title.</param>
     /// <param name="deviceSerialNo">Serial number of the owning device, used for the tag and legend grouping.</param>
-    /// <param name="type">Channel type; selects the <see cref="AnalogAxisKey"/> or <see cref="DigitalAxisKey"/> Y axis.</param>
+    /// <param name="type">Channel type; selects the <see cref="ANALOG_AXIS_KEY"/> or <see cref="DIGITAL_AXIS_KEY"/> Y axis.</param>
     /// <param name="color">Series color in a format <see cref="OxyColor.Parse"/> understands (e.g., "#FFD32F2F").</param>
     /// <param name="plotModel">The live main plot model the legend item invalidates on visibility changes.</param>
     /// <param name="databaseLogger">Logger the legend item uses to sync minimap series visibility, or null to skip that sync.</param>
@@ -184,8 +167,8 @@ public sealed class PlotModelFactory
 
         newLineSeries.YAxisKey = type switch
         {
-            ChannelType.Analog => AnalogAxisKey,
-            ChannelType.Digital => DigitalAxisKey,
+            ChannelType.Analog => ANALOG_AXIS_KEY,
+            ChannelType.Digital => DIGITAL_AXIS_KEY,
             _ => newLineSeries.YAxisKey
         };
 
@@ -216,7 +199,7 @@ public sealed class PlotModelFactory
         var minimapTimeAxis = new LinearAxis
         {
             Position = AxisPosition.Bottom,
-            Key = MinimapTimeAxisKey,
+            Key = MINIMAP_TIME_AXIS_KEY,
             TickStyle = TickStyle.None,
             MajorGridlineStyle = LineStyle.None,
             MinorGridlineStyle = LineStyle.None,
@@ -229,7 +212,7 @@ public sealed class PlotModelFactory
         var minimapYAxis = new LinearAxis
         {
             Position = AxisPosition.Left,
-            Key = MinimapYAxisKey,
+            Key = MINIMAP_Y_AXIS_KEY,
             TickStyle = TickStyle.None,
             MajorGridlineStyle = LineStyle.None,
             MinorGridlineStyle = LineStyle.None,
@@ -255,8 +238,8 @@ public sealed class PlotModelFactory
             MinimumY = -1e18,
             MaximumY = 1e18,
             Layer = AnnotationLayer.AboveSeries,
-            XAxisKey = MinimapTimeAxisKey,
-            YAxisKey = MinimapYAxisKey
+            XAxisKey = MINIMAP_TIME_AXIS_KEY,
+            YAxisKey = MINIMAP_Y_AXIS_KEY
         };
 
         var dimRight = new RectangleAnnotation
@@ -269,8 +252,8 @@ public sealed class PlotModelFactory
             MinimumY = -1e18,
             MaximumY = 1e18,
             Layer = AnnotationLayer.AboveSeries,
-            XAxisKey = MinimapTimeAxisKey,
-            YAxisKey = MinimapYAxisKey
+            XAxisKey = MINIMAP_TIME_AXIS_KEY,
+            YAxisKey = MINIMAP_Y_AXIS_KEY
         };
 
         // Selection rectangle border
@@ -282,8 +265,8 @@ public sealed class PlotModelFactory
             MinimumY = -1e18,
             MaximumY = 1e18,
             Layer = AnnotationLayer.AboveSeries,
-            XAxisKey = MinimapTimeAxisKey,
-            YAxisKey = MinimapYAxisKey
+            XAxisKey = MINIMAP_TIME_AXIS_KEY,
+            YAxisKey = MINIMAP_Y_AXIS_KEY
         };
 
         minimapPlotModel.Annotations.Add(dimLeft);
@@ -300,7 +283,7 @@ public sealed class PlotModelFactory
     /// </summary>
     /// <param name="color">The series color, matched to its main-plot counterpart.</param>
     /// <param name="downsampled">The downsampled overview points to render.</param>
-    /// <returns>A minimap line series bound to the <see cref="MinimapTimeAxisKey"/>/<see cref="MinimapYAxisKey"/> axes.</returns>
+    /// <returns>A minimap line series bound to the <see cref="MINIMAP_TIME_AXIS_KEY"/>/<see cref="MINIMAP_Y_AXIS_KEY"/> axes.</returns>
     public LineSeries CreateMinimapSeries(OxyColor color, List<DataPoint> downsampled)
     {
         return new LineSeries
@@ -308,8 +291,8 @@ public sealed class PlotModelFactory
             Color = color,
             StrokeThickness = 1,
             ItemsSource = downsampled,
-            XAxisKey = MinimapTimeAxisKey,
-            YAxisKey = MinimapYAxisKey
+            XAxisKey = MINIMAP_TIME_AXIS_KEY,
+            YAxisKey = MINIMAP_Y_AXIS_KEY
         };
     }
     #endregion

--- a/Daqifi.Desktop/Loggers/PlotModelFactory.cs
+++ b/Daqifi.Desktop/Loggers/PlotModelFactory.cs
@@ -1,0 +1,316 @@
+using Daqifi.Desktop.Helpers;
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+using FontWeights = OxyPlot.FontWeights;
+using TickStyle = OxyPlot.Axes.TickStyle;
+
+namespace Daqifi.Desktop.Logger;
+
+/// <summary>
+/// The minimap <see cref="PlotModel"/> together with the three annotation handles
+/// <see cref="DatabaseLogger"/> keeps mutating as the viewport changes: the selection rectangle and
+/// the two dim overlays that shade the unselected regions. Returned by
+/// <see cref="PlotModelFactory.CreateMinimapPlotModel"/> so the logger can hold the field references
+/// while the construction lives in the factory.
+/// </summary>
+/// <param name="Model">The fully configured minimap plot model (axes + annotations added).</param>
+/// <param name="SelectionRect">The accent-bordered rectangle marking the visible time range.</param>
+/// <param name="DimLeft">The dim overlay shading the range to the left of the selection.</param>
+/// <param name="DimRight">The dim overlay shading the range to the right of the selection.</param>
+public sealed record MinimapPlotComponents(
+    PlotModel Model,
+    RectangleAnnotation SelectionRect,
+    RectangleAnnotation DimLeft,
+    RectangleAnnotation DimRight);
+
+/// <summary>
+/// Owns the pure OxyPlot <em>construction</em> extracted from <see cref="DatabaseLogger"/> (issue #592):
+/// building the main logged-data <see cref="PlotModel"/> and its Analog/Digital/Time axes, the overview
+/// minimap model with its axes and selection/dim annotations, a channel's <see cref="LineSeries"/> plus
+/// its <see cref="LoggedSeriesLegendItem"/>, and the minimap's per-channel line series.
+/// <para>
+/// Every method is a side-effect-free constructor of OxyPlot objects — no EF, no threading, no
+/// Dispatcher, no <c>InvalidatePlot</c>, no live-axis mutation — so the factory is unit-testable without
+/// a WPF runtime, a database, or background threads, and has no dependency on desktop singletons
+/// (<c>App.ServiceProvider</c>, <c>AppLogger.Instance</c>). <see cref="DatabaseLogger"/> remains the
+/// composition root and the live-model owner: it calls the factory to build the models, then keeps every
+/// viewport/minimap-sync mutation (axis subscription, <c>Zoom</c>, annotation bounds, <c>InvalidatePlot</c>)
+/// to itself.
+/// </para>
+/// </summary>
+public sealed class PlotModelFactory
+{
+    #region Axis Keys
+    /// <summary>Key of the left-hand analog (volts) Y axis on the main plot.</summary>
+    public const string AnalogAxisKey = "Analog";
+
+    /// <summary>Key of the right-hand digital Y axis on the main plot.</summary>
+    public const string DigitalAxisKey = "Digital";
+
+    /// <summary>Key of the bottom time (ms) X axis on the main plot.</summary>
+    public const string TimeAxisKey = "Time";
+
+    /// <summary>Key of the minimap's time X axis.</summary>
+    public const string MinimapTimeAxisKey = "MinimapTime";
+
+    /// <summary>Key of the minimap's value Y axis.</summary>
+    public const string MinimapYAxisKey = "MinimapY";
+    #endregion
+
+    #region Main Plot
+    /// <summary>
+    /// Builds the main logged-data plot model: a left analog (V) axis, a right digital axis, a bottom
+    /// time (ms) axis, the shared dark theme applied to the model and each axis, and the built-in legend
+    /// disabled (the legend is rendered by the WPF panel instead). The caller subscribes to the time
+    /// axis' <c>AxisChanged</c> event for minimap sync — that wiring is viewport machinery and stays in
+    /// <see cref="DatabaseLogger"/>.
+    /// </summary>
+    /// <returns>A configured main <see cref="PlotModel"/> with its three axes added.</returns>
+    public PlotModel CreateMainPlotModel()
+    {
+        var plotModel = new PlotModel();
+
+        var analogAxis = new LinearAxis
+        {
+            Position = AxisPosition.Left,
+            TickStyle = TickStyle.None,
+            MajorGridlineStyle = LineStyle.Solid,
+            MinorGridlineStyle = LineStyle.Solid,
+            TitleFontSize = 12,
+            TitleFontWeight = FontWeights.Bold,
+            MinimumPadding = 0.1,
+            MaximumPadding = 0.1,
+            StringFormat = "0.###",
+            AxisDistance = 5,
+            Key = AnalogAxisKey,
+            Title = "Analog (V)"
+        };
+
+        var digitalAxis = new LinearAxis
+        {
+            Position = AxisPosition.Right,
+            TickStyle = TickStyle.None,
+            MajorGridlineStyle = LineStyle.None,
+            MinorGridlineStyle = LineStyle.None,
+            MinorGridlineThickness = 0,
+            MajorGridlineThickness = 0,
+            MajorStep = 1,
+            MinorStep = 1,
+            TitleFontSize = 12,
+            TitleFontWeight = FontWeights.Bold,
+            AxisTitleDistance = -10,
+            Minimum = -0.1,
+            Maximum = 1.1,
+            MinimumPadding = 0.1,
+            MaximumPadding = 0.1,
+            AxisDistance = 5,
+            Key = DigitalAxisKey,
+            Title = "Digital"
+        };
+
+        var timeAxis = new LinearAxis
+        {
+            Position = AxisPosition.Bottom,
+            TickStyle = TickStyle.None,
+            MajorGridlineStyle = LineStyle.Solid,
+            MinorGridlineStyle = LineStyle.Solid,
+            TitleFontSize = 12,
+            TitleFontWeight = FontWeights.Bold,
+            Key = TimeAxisKey,
+            Title = "Time (ms)"
+        };
+
+        OxyPlotDarkTheme.ApplyTo(plotModel);
+        OxyPlotDarkTheme.ApplyTo(analogAxis);
+        OxyPlotDarkTheme.ApplyTo(digitalAxis);
+        OxyPlotDarkTheme.ApplyTo(timeAxis);
+
+        plotModel.Axes.Add(analogAxis);
+        plotModel.Axes.Add(digitalAxis);
+        plotModel.Axes.Add(timeAxis);
+        plotModel.IsLegendVisible = false; // Disable the built-in legend
+
+        return plotModel;
+    }
+
+    /// <summary>
+    /// Builds a channel's main-plot <see cref="LineSeries"/> and its paired
+    /// <see cref="LoggedSeriesLegendItem"/>, selecting the Analog or Digital Y axis from the channel
+    /// type. The series carries a <c>(deviceSerialNo, channelName)</c> tag the viewport code keys on,
+    /// and the legend item is given the live <paramref name="plotModel"/> and
+    /// <paramref name="databaseLogger"/> so toggling its visibility still invalidates the plot and mirrors
+    /// the change onto the matching minimap series.
+    /// </summary>
+    /// <param name="channelName">Channel identifier (e.g., "AI0"); also the series title.</param>
+    /// <param name="deviceSerialNo">Serial number of the owning device, used for the tag and legend grouping.</param>
+    /// <param name="type">Channel type; selects the <see cref="AnalogAxisKey"/> or <see cref="DigitalAxisKey"/> Y axis.</param>
+    /// <param name="color">Series color in a format <see cref="OxyColor.Parse"/> understands (e.g., "#FFD32F2F").</param>
+    /// <param name="plotModel">The live main plot model the legend item invalidates on visibility changes.</param>
+    /// <param name="databaseLogger">Logger the legend item uses to sync minimap series visibility, or null to skip that sync.</param>
+    /// <returns>The configured series and its legend item.</returns>
+    public (LineSeries series, LoggedSeriesLegendItem legendItem) CreateChannelSeries(
+        string channelName,
+        string deviceSerialNo,
+        ChannelType type,
+        string color,
+        PlotModel plotModel,
+        DatabaseLogger? databaseLogger)
+    {
+        var serialSuffix = deviceSerialNo?.Length > 4
+            ? $"...{deviceSerialNo[^4..]}"
+            : deviceSerialNo;
+
+        var newLineSeries = new LineSeries
+        {
+            Title = channelName,
+            Tag = (deviceSerialNo, channelName),
+            Color = OxyColor.Parse(color),
+            IsVisible = true,
+            TrackerFormatString = $"{channelName} ({serialSuffix})\n{{1}}: {{2:0.###}}\n{{3}}: {{4:0.######}}"
+        };
+
+        var legendItem = new LoggedSeriesLegendItem(
+            newLineSeries.Title,
+            channelName,
+            deviceSerialNo,
+            newLineSeries.Color,
+            newLineSeries.IsVisible,
+            newLineSeries,
+            plotModel,
+            databaseLogger);
+
+        newLineSeries.YAxisKey = type switch
+        {
+            ChannelType.Analog => AnalogAxisKey,
+            ChannelType.Digital => DigitalAxisKey,
+            _ => newLineSeries.YAxisKey
+        };
+
+        return (newLineSeries, legendItem);
+    }
+    #endregion
+
+    #region Minimap
+    /// <summary>
+    /// Builds the overview minimap plot model: a non-interactive time and value axis pair, plus the
+    /// three <see cref="RectangleAnnotation"/>s the logger drives as the viewport moves — two dim
+    /// overlays shading the unselected regions and the accent-bordered selection rectangle. The
+    /// annotations are returned alongside the model so the logger keeps its field references; setting
+    /// their bounds and invalidating the model are live mutations that stay in
+    /// <see cref="DatabaseLogger"/>.
+    /// </summary>
+    /// <returns>The minimap model with the selection and dim annotation handles.</returns>
+    public MinimapPlotComponents CreateMinimapPlotModel()
+    {
+        var minimapPlotModel = new PlotModel
+        {
+            IsLegendVisible = false,
+            PlotMargins = new OxyThickness(4, 2, 4, 2),
+            Padding = new OxyThickness(0)
+        };
+        OxyPlotDarkTheme.ApplyTo(minimapPlotModel);
+
+        var minimapTimeAxis = new LinearAxis
+        {
+            Position = AxisPosition.Bottom,
+            Key = MinimapTimeAxisKey,
+            TickStyle = TickStyle.None,
+            MajorGridlineStyle = LineStyle.None,
+            MinorGridlineStyle = LineStyle.None,
+            TitleFontSize = 0,
+            FontSize = 0,
+            IsZoomEnabled = false,
+            IsPanEnabled = false
+        };
+
+        var minimapYAxis = new LinearAxis
+        {
+            Position = AxisPosition.Left,
+            Key = MinimapYAxisKey,
+            TickStyle = TickStyle.None,
+            MajorGridlineStyle = LineStyle.None,
+            MinorGridlineStyle = LineStyle.None,
+            TitleFontSize = 0,
+            FontSize = 0,
+            IsZoomEnabled = false,
+            IsPanEnabled = false,
+            MinimumPadding = 0.1,
+            MaximumPadding = 0.1
+        };
+
+        minimapPlotModel.Axes.Add(minimapTimeAxis);
+        minimapPlotModel.Axes.Add(minimapYAxis);
+
+        // Dim overlays for areas outside the selected range
+        var dimLeft = new RectangleAnnotation
+        {
+            Fill = OxyPlotDarkTheme.MinimapDim,
+            Stroke = OxyColors.Transparent,
+            StrokeThickness = 0,
+            MinimumX = -1e18,
+            MaximumX = 0,
+            MinimumY = -1e18,
+            MaximumY = 1e18,
+            Layer = AnnotationLayer.AboveSeries,
+            XAxisKey = MinimapTimeAxisKey,
+            YAxisKey = MinimapYAxisKey
+        };
+
+        var dimRight = new RectangleAnnotation
+        {
+            Fill = OxyPlotDarkTheme.MinimapDim,
+            Stroke = OxyColors.Transparent,
+            StrokeThickness = 0,
+            MinimumX = 0,
+            MaximumX = 1e18,
+            MinimumY = -1e18,
+            MaximumY = 1e18,
+            Layer = AnnotationLayer.AboveSeries,
+            XAxisKey = MinimapTimeAxisKey,
+            YAxisKey = MinimapYAxisKey
+        };
+
+        // Selection rectangle border
+        var selectionRect = new RectangleAnnotation
+        {
+            Fill = OxyColors.Transparent,
+            Stroke = OxyPlotDarkTheme.Accent,
+            StrokeThickness = 2,
+            MinimumY = -1e18,
+            MaximumY = 1e18,
+            Layer = AnnotationLayer.AboveSeries,
+            XAxisKey = MinimapTimeAxisKey,
+            YAxisKey = MinimapYAxisKey
+        };
+
+        minimapPlotModel.Annotations.Add(dimLeft);
+        minimapPlotModel.Annotations.Add(dimRight);
+        minimapPlotModel.Annotations.Add(selectionRect);
+
+        return new MinimapPlotComponents(minimapPlotModel, selectionRect, dimLeft, dimRight);
+    }
+
+    /// <summary>
+    /// Builds a single minimap <see cref="LineSeries"/> bound to the minimap axes for a channel's
+    /// downsampled overview points. The caller adds it to the live model, tracks it for visibility
+    /// sync, and invalidates the plot — all live mutations that stay in <see cref="DatabaseLogger"/>.
+    /// </summary>
+    /// <param name="color">The series color, matched to its main-plot counterpart.</param>
+    /// <param name="downsampled">The downsampled overview points to render.</param>
+    /// <returns>A minimap line series bound to the <see cref="MinimapTimeAxisKey"/>/<see cref="MinimapYAxisKey"/> axes.</returns>
+    public LineSeries CreateMinimapSeries(OxyColor color, List<DataPoint> downsampled)
+    {
+        return new LineSeries
+        {
+            Color = color,
+            StrokeThickness = 1,
+            ItemsSource = downsampled,
+            XAxisKey = MinimapTimeAxisKey,
+            YAxisKey = MinimapYAxisKey
+        };
+    }
+    #endregion
+}


### PR DESCRIPTION
## What & why

Next behavior-preserving extraction for #592 (breaking up the app's two largest
classes, one extraction per PR, ~800-line target). Follows the playbook from the
merged `SessionSampleWriter` (#604) and `SessionDataRepository` (#607): a sealed
collaborator, constructor-only dependencies, no reach into desktop singletons,
unit-testable in isolation.

This PR moves the **pure OxyPlot construction** out of `DatabaseLogger` into a new
`PlotModelFactory`. The logger stays the orchestration + live-model
mutation/binding surface (the `LoggedDataPanePrototype.xaml` binding contract —
`PlotModel`, `MinimapPlotModel`, `DeviceLegendGroups`, `HasSessionData`,
`IsRefiningData`, `IsLegendPanelVisible`, `CurrentSession.*`, and the
`Zoom*`/`ResetZoom`/`SaveGraph`/`ToggleLegendPanel` commands — is unchanged).

`DatabaseLogger.cs`: **1,376 → 1,119 lines**.

## Moved into `PlotModelFactory` (construction only — no EF, threading, Dispatcher, `InvalidatePlot`, or axis mutation)

- **`CreateMainPlotModel`** — the main model + Analog/Digital/Time `LinearAxis`
  config, `OxyPlotDarkTheme.ApplyTo`, axis `Add`, `IsLegendVisible=false`.
- **`CreateMinimapPlotModel`** — the minimap model, its two non-interactive axes,
  and the three `RectangleAnnotation`s (selection rect + two dim overlays).
  Returns a `MinimapPlotComponents` record so the logger keeps the annotation
  handles it mutates.
- **`CreateChannelSeries`** — a channel's `LineSeries` + `LoggedSeriesLegendItem`
  with the Analog/Digital `YAxisKey` mapping. The legend item still gets the live
  `PlotModel` + `DatabaseLogger`, so its visibility toggle invalidates the plot
  and syncs the minimap exactly as before.
- **`CreateMinimapSeries`** — the per-channel minimap `LineSeries` construction
  only; the apply-to-live half of `SetupMinimapSeries` (`Series.Clear`/`Add`, the
  `_minimapSeries` map, `axis.Zoom`, annotation bounds, `InvalidatePlot`) stays in
  the logger.
- Folds **`LoggedSeriesLegendItem`** into its own file (one-main-class-per-file
  per the style guide) and annotates its optional logger as nullable.

The shared axis-key strings (`Analog`/`Digital`/`Time`/`MinimapTime`/`MinimapY`)
become `public const`s on `PlotModelFactory` — the single source of truth the
factory builds from and the logger's viewport lookups key on.

## Kept in `DatabaseLogger` (viewport/live-model coupled — untouched)

Every viewport/minimap-sync method (`OnMainTimeAxisChanged`, throttle/settle
ticks, `UpdateMainPlotViewport`, `UpdateSeriesFromMemory`,
`FetchViewportDataFromDb`, `OnMinimap*`, `SetMinimapSeriesVisibility`), the two
`DispatcherTimer`s, the `AxisChanged` subscription, the
`MinimapInteractionController` wiring, the annotation fields, and every
`InvalidatePlot`/`Zoom`/axis-mutation call. The ADR-001 viewport controller is a
deliberately separate, future extraction — **not** this PR.

## Invariants preserved (ADR-001 / CLAUDE.md "Plot Rendering")

- `InvalidatePlot(true)` on every `ItemsSource` change — all stay in the logger.
- No `ResetAllAxes()` with downsampled data; `ResetZoom` still does per-axis
  `Reset()` + explicit `timeAxis.Zoom(...)`.
- `IsSyncingFromMinimap` guard still wraps programmatic axis changes.
- `_downsampledCache` still reused — no new per-frame allocations.
- `ClearPlot()` still resets every axis on session switch.

The factory holds **zero** `InvalidatePlot`/`Zoom`/axis-mutation calls.

## Tests

- New **`PlotModelFactoryTests`** (13 tests, no DB / WPF runtime / threads — a real
  test seam where none existed): axis keys/positions, the Analog→`Analog` /
  Digital→`Digital` `YAxisKey` mapping, color parsing, minimap annotation/axis
  config, annotation z-order, and returned-handle identity.
- **Unit gate green: 434/434** (`dotnet test --filter
  "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`).
- **Integration gate green on the attached device** — both logged-data-plot FlaUI
  scenarios pass:
  `LoggingSessionTests.StartLoggingSession_RendersLivePlot_RunsStopsAndDeletesSession`
  and `LoggingSessionTests.ViewLoggedSession_LoadsStoredSessionOntoLoggedDataPlot`.

Also updates the CLAUDE.md plot-gotchas **Key files** list to name
`PlotModelFactory.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
