### PR TITLE
chore(viewmodels): make DaqifiViewModel implement IDisposable (#592)

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
@@ -424,13 +424,19 @@ public class LoggingSessionListViewModelTests
     }
 
     [TestMethod]
-    public void DetachCollection_WhenNothingAttached_DoesNotThrow()
+    public void DetachCollection_WhenNothingAttached_IsSafeNoOp()
     {
         var host = new FakeLoggingSessionListHost();
         var list = CreateList(host);
 
         // Mirrors the non-window-init path where AttachCollection was never called.
         list.DetachCollection();
+
+        // The no-op detach must leave the list usable: a later attach still wires notifications.
+        var collection = new ObservableCollection<LoggingSession>();
+        list.AttachCollection(collection);
+        collection.Add(new LoggingSession { ID = 1, Name = "A" });
+        Assert.AreEqual(1, host.NotifyCount);
     }
 
     #endregion

--- a/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/LoggingSessionListViewModelTests.cs
@@ -407,6 +407,32 @@ public class LoggingSessionListViewModelTests
             "Re-attaching the same collection must not add a second subscription.");
     }
 
+    [TestMethod]
+    public void DetachCollection_UnsubscribesFromTheObservedCollection()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+        var collection = new ObservableCollection<LoggingSession>();
+
+        list.AttachCollection(collection);
+        list.DetachCollection();
+        var baseline = host.NotifyCount;
+
+        // After detaching, mutations of the previously-observed collection must not notify.
+        collection.Add(new LoggingSession { ID = 1, Name = "A" });
+        Assert.AreEqual(baseline, host.NotifyCount);
+    }
+
+    [TestMethod]
+    public void DetachCollection_WhenNothingAttached_DoesNotThrow()
+    {
+        var host = new FakeLoggingSessionListHost();
+        var list = CreateList(host);
+
+        // Mirrors the non-window-init path where AttachCollection was never called.
+        list.DetachCollection();
+    }
+
     #endregion
 
     #region Helpers

--- a/Daqifi.Desktop/MainWindow.xaml.cs
+++ b/Daqifi.Desktop/MainWindow.xaml.cs
@@ -25,7 +25,7 @@ public partial class MainWindow
             {
                 if (DataContext is DaqifiViewModel viewModel)
                 {
-                    viewModel.DisposeDiskSpaceMonitor();
+                    viewModel.Dispose();
                 }
 
                 if (HostCommands.ShutdownCommand.CanExecute(e))

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -32,7 +32,7 @@ using Daqifi.Core.Device.SdCard;
 
 namespace Daqifi.Desktop.ViewModels;
 
-public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, ILoggingSessionListHost, IDiskSpaceMonitorHost
+public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, ILoggingSessionListHost, IDiskSpaceMonitorHost, IDisposable
 {
     private readonly AppLogger _appLogger = AppLogger.Instance;
 
@@ -1541,15 +1541,6 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
 
     #region Disk Space Monitoring
 
-    /// <summary>
-    /// Disposes disk space monitoring resources. Call on application shutdown.
-    /// </summary>
-    public void DisposeDiskSpaceMonitor()
-    {
-        _diskSpaceCoordinator?.Dispose();
-        _diskSpaceCoordinator = null;
-    }
-
     // IDiskSpaceMonitorHost implementation. The coordinator owns the gate/monitor/event logic and
     // reaches back here only to stop the session and present dialogs — both of which are WPF concerns
     // and must be marshalled to the UI thread because the monitor's threshold events fire on its
@@ -1610,6 +1601,64 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         {
             _appLogger.Error(ex, "Failed to show disk space warning dialog");
         }
+    }
+
+    #endregion
+
+    #region IDisposable
+
+    private bool _disposed;
+
+    /// <summary>
+    /// Tears down the resources and event subscriptions this view model owns. Invoked once when the
+    /// main window closes (see <c>MainWindow</c>). Consolidates the previously ad-hoc cleanup into a
+    /// single deterministic path (issue #592): the disk-space coordinator, the transient
+    /// network-settings status timer, the SD-card elapsed-time timer, and the long-lived singleton /
+    /// per-device event subscriptions wired up in the constructor (which would otherwise pin this view
+    /// model for the life of the process).
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+
+        // Disk-space gating/monitoring coordinator (owns the IDiskSpaceMonitor and its subscriptions).
+        _diskSpaceCoordinator?.Dispose();
+        _diskSpaceCoordinator = null;
+
+        // Transient WiFi-settings "applied" status timer.
+        CancelAndDisposeNetworkSettingsCts();
+
+        // SD-card elapsed-time DispatcherTimer.
+        if (_sdLoggingElapsedTimer != null)
+        {
+            _sdLoggingElapsedTimer.Stop();
+            _sdLoggingElapsedTimer.Tick -= OnSdLoggingTimerTick;
+            _sdLoggingElapsedTimer = null;
+            _sdLoggingStartedAt = null;
+        }
+
+        // Unsubscribe from the long-lived singletons + the VM's own collection so they don't keep this
+        // view model alive after the window closes. (-= is a no-op for handlers that were never wired,
+        // e.g. in non-window-init construction paths.)
+        ConnectionManager.Instance.PropertyChanged -= UpdateUi;
+        LoggingManager.Instance.PropertyChanged -= UpdateUi;
+        ConnectedDevices.CollectionChanged -= OnConnectedDevicesCollectionChanged;
+
+        // Per-device logging-state subscriptions tracked across collection changes.
+        foreach (var device in _loggingStateSubscribedDevices)
+        {
+            device.PropertyChanged -= OnDeviceLoggingStateChanged;
+        }
+        _loggingStateSubscribedDevices.Clear();
+
+        // The session-list view model observes the singleton LoggingManager.LoggingSessions collection.
+        _loggingSessionList.DetachCollection();
+
+        GC.SuppressFinalize(this);
     }
 
     #endregion

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1655,6 +1655,17 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         }
         _loggingStateSubscribedDevices.Clear();
 
+        // Per-device debug-data subscriptions wired up in UpdateConnectedDeviceUI. Left subscribed,
+        // a device keeps this VM rooted and a late debug callback would marshal onto the UI thread
+        // during shutdown (OnDebugDataReceived -> DebugData.AddEntry uses Dispatcher.Invoke).
+        foreach (var device in ConnectedDevices)
+        {
+            if (device is AbstractStreamingDevice streamingDevice)
+            {
+                streamingDevice.DebugDataReceived -= OnDebugDataReceived;
+            }
+        }
+
         // The session-list view model observes the singleton LoggingManager.LoggingSessions collection.
         _loggingSessionList.DetachCollection();
 

--- a/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/LoggingSessionListViewModel.cs
@@ -321,6 +321,22 @@ public class LoggingSessionListViewModel
         _observedLoggingSessions.CollectionChanged += OnLoggingSessionsCollectionChanged;
     }
 
+    /// <summary>
+    /// Unsubscribes from the currently-observed session collection, if any. Called by the host on
+    /// teardown so the long-lived <c>LoggingManager.Instance.LoggingSessions</c> collection does not
+    /// keep this view model (and, through it, the host) alive (issue #592).
+    /// </summary>
+    public void DetachCollection()
+    {
+        if (_observedLoggingSessions == null)
+        {
+            return;
+        }
+
+        _observedLoggingSessions.CollectionChanged -= OnLoggingSessionsCollectionChanged;
+        _observedLoggingSessions = null;
+    }
+
     private void OnLoggingSessionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         // The host owns the UI-thread marshalling so this class stays dispatcher-free.


### PR DESCRIPTION
## What

Makes `DaqifiViewModel` implement `IDisposable`, consolidating its ad-hoc teardown into a single `Dispose()`. Follow-up to #609 — Qodo flagged the VM owning an `IDisposable` (`DiskSpaceMonitorCoordinator`) without implementing `IDisposable` (rule 244824, citing the accepted `VersionNotification` precedent in #519); it was deferred out of #609 to keep that extraction behavior-preserving.

> **Stacked on #609.** Base is `claude/kind-curie-b9e5ac` so the diff shows only this change; GitHub will auto-retarget to `main` once #609 merges. Review/merge #609 first.

## Change

- Replaces the bespoke public `DisposeDiskSpaceMonitor()` with `IDisposable.Dispose()`; `MainWindow`'s `Closing` handler now calls `Dispose()` (single disposal entry point, same position relative to `ShutdownCommand`).
- `Dispose()` now releases everything the VM owns, in one place:
  - the `DiskSpaceMonitorCoordinator` (all `DisposeDiskSpaceMonitor` did),
  - the transient network-settings status `CancellationTokenSource` (via the existing `CancelAndDisposeNetworkSettingsCts`),
  - the SD-card elapsed-time `DispatcherTimer`,
  - the long-lived `ConnectionManager`/`LoggingManager` `PropertyChanged` handlers + the per-device logging-state handlers, and detaches the session-list VM from the singleton `LoggingManager.LoggingSessions` collection — all of which otherwise pin the VM (and its object graph) for the process lifetime.
- Adds `LoggingSessionListViewModel.DetachCollection()` (mirror of `AttachCollection`) so the list VM can release its singleton-collection subscription.

A `_disposed` guard makes `Dispose()` idempotent; `-=` on never-wired handlers is a no-op, so non-window-init paths (tests) dispose cleanly.

## Behavior-preserving

Disposal still happens once, at window close, in the same order relative to `ShutdownCommand`. The added cleanup only releases resources/subscriptions at shutdown — no runtime behavior changes. `Shutdown()` still disconnects every device (`Dispose()` doesn't clear `ConnectedDevices`, only unsubscribes its change handler).

## Tests

Adds two `DetachCollection` unit tests (unsubscribes the observed collection; safe no-op when nothing was attached). Build clean; full unit gate **452 passed / 0 failed** (`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`).

Relates to #592. Addresses a Qodo finding on #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
