### PR TITLE
chore(device): delegate SD/LAN interface prep to Core (#619)

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -355,7 +355,8 @@ public class AbstractStreamingDeviceTests
                 $"desktop:{ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface.SdCard).Data}"
             },
             device.SentCommands.TakeLast(4).ToArray(),
-            "Core should own the SD/LAN interface SCPI pair; the desktop only adds the USB stream-interface switch when restoring the SD interface in LogToDevice mode.");
+            "Core should own the SD/LAN interface SCPI pair; the desktop only adds the USB " +
+            "stream-interface switch when restoring the SD interface in LogToDevice mode.");
     }
 
     [TestMethod]
@@ -389,7 +390,40 @@ public class AbstractStreamingDeviceTests
                 $"desktop:{ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface.SdCard).Data}"
             },
             device.SentCommands.TakeLast(3).ToArray(),
-            "Desktop should restore the full SD interface even when the Core network update fails (Core owns the LAN-disable/SD-enable pair).");
+            "Desktop should restore the full SD interface even when the Core network update fails " +
+            "(Core owns the LAN-disable/SD-enable pair).");
+    }
+
+    [TestMethod]
+    public async Task UpdateNetworkConfiguration_WhenSdRestoreFailsAfterDisconnect_PreservesOriginalException()
+    {
+        // Arrange — USB + LogToDevice so the finally restores the SD interface. The injected Core
+        // update failure also drops the Core device (as a mid-update disconnect would, via
+        // CleanupConnection nulling CoreDevice), so the finally's PrepareSdInterface would throw
+        // "Device is not connected." if the restore were not best-effort.
+        var device = new NetworkConfigurationTestDevice(
+            throwOnCommandData: ScpiMessageProducer.SaveNetworkLan.Data,
+            dropCoreDeviceOnThrow: true);
+        device.NetworkConfiguration = new NetworkConfiguration(
+            WifiMode.SelfHosted,
+            WifiSecurityType.None,
+            "DAQiFi_Device",
+            string.Empty);
+        device.SwitchMode(DeviceMode.LogToDevice);
+
+        // Act + Assert — the original Core update failure must surface, not the restore failure.
+        try
+        {
+            await device.UpdateNetworkConfiguration();
+            Assert.Fail("Expected the Core update failure to propagate.");
+        }
+        catch (InvalidOperationException exception)
+        {
+            Assert.AreEqual(
+                "Injected test failure.",
+                exception.Message,
+                "The best-effort SD restore must not mask the original network update failure.");
+        }
     }
 
     [TestMethod]
@@ -623,7 +657,8 @@ public class AbstractStreamingDeviceTests
                 $"desktop:{ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface.Usb).Data}"
             },
             device.SentCommands,
-            "Core should own the SD-disable/LAN-enable pair when returning to StreamToApp; the desktop only adds the USB stream-interface switch.");
+            "Core should own the SD-disable/LAN-enable pair when returning to StreamToApp; " +
+            "the desktop only adds the USB stream-interface switch.");
     }
 
     [TestMethod]
@@ -744,10 +779,20 @@ public class AbstractStreamingDeviceTests
     {
         private readonly RecordingCoreStreamingDevice _coreDevice;
         private readonly ConnectionType _connectionType;
+        private bool _coreDeviceAvailable = true;
 
-        public NetworkConfigurationTestDevice(string? throwOnCommandData = null, ConnectionType connectionType = ConnectionType.Usb)
+        public NetworkConfigurationTestDevice(
+            string? throwOnCommandData = null,
+            ConnectionType connectionType = ConnectionType.Usb,
+            bool dropCoreDeviceOnThrow = false)
         {
-            _coreDevice = new RecordingCoreStreamingDevice(SentCommands, throwOnCommandData);
+            // When dropCoreDeviceOnThrow is set, the injected failure also drops the Core device,
+            // mirroring a mid-update disconnect where CleanupConnection nulls CoreDevice. The
+            // finally-block SD restore then sees a null Core device.
+            _coreDevice = new RecordingCoreStreamingDevice(
+                SentCommands,
+                throwOnCommandData,
+                onThrow: dropCoreDeviceOnThrow ? () => _coreDeviceAvailable = false : null);
             _coreDevice.Connect();
             _connectionType = connectionType;
         }
@@ -756,7 +801,8 @@ public class AbstractStreamingDeviceTests
 
         public override ConnectionType ConnectionType => _connectionType;
 
-        protected override CoreStreamingDevice? CoreDeviceForNetworkConfiguration => _coreDevice;
+        protected override CoreStreamingDevice? CoreDeviceForNetworkConfiguration =>
+            _coreDeviceAvailable ? _coreDevice : null;
 
         protected override CoreStreamingDevice? CoreDeviceForStreaming => _coreDevice;
 
@@ -858,7 +904,10 @@ public class AbstractStreamingDeviceTests
         }
     }
 
-    private sealed class RecordingCoreStreamingDevice(List<string> sentCommands, string? throwOnCommandData) : CoreStreamingDevice("TestDevice")
+    private sealed class RecordingCoreStreamingDevice(
+        List<string> sentCommands,
+        string? throwOnCommandData,
+        Action? onThrow = null) : CoreStreamingDevice("TestDevice")
     {
         public override bool IsUsbConnection => true;
 
@@ -870,6 +919,7 @@ public class AbstractStreamingDeviceTests
 
                 if (throwOnCommandData == stringMessage.Data)
                 {
+                    onThrow?.Invoke();
                     throw new InvalidOperationException("Injected test failure.");
                 }
             }

--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -318,13 +318,15 @@ public class AbstractStreamingDeviceTests
         // Act
         await device.UpdateNetworkConfiguration();
 
-        // Assert
-        Assert.IsFalse(
-            device.SentCommands.Contains($"desktop:{ScpiMessageProducer.DisableNetworkLan.Data}"),
-            "Desktop should not disable LAN for a WiFi device after a network update.");
+        // Assert — the SD-restore path (PrepareSdInterface) must not run for a WiFi device.
+        // EnableStorageSd is emitted only by PrepareSdInterface, never by Core's network update,
+        // so its absence in either layer proves the SD interface was not restored.
         Assert.IsFalse(
             device.SentCommands.Contains($"desktop:{ScpiMessageProducer.EnableStorageSd.Data}"),
             "Desktop should not re-enable SD for a WiFi device; it shares no SPI bus with the desktop transport.");
+        Assert.IsFalse(
+            device.SentCommands.Contains($"core:{ScpiMessageProducer.EnableStorageSd.Data}"),
+            "Core's SD-enable command must not run for a WiFi device; the SD interface is never restored.");
     }
 
     [TestMethod]
@@ -348,12 +350,12 @@ public class AbstractStreamingDeviceTests
             new[]
             {
                 $"core:{ScpiMessageProducer.SaveNetworkLan.Data}",
-                $"desktop:{ScpiMessageProducer.DisableNetworkLan.Data}",
-                $"desktop:{ScpiMessageProducer.EnableStorageSd.Data}",
+                $"core:{ScpiMessageProducer.DisableNetworkLan.Data}",
+                $"core:{ScpiMessageProducer.EnableStorageSd.Data}",
                 $"desktop:{ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface.SdCard).Data}"
             },
             device.SentCommands.TakeLast(4).ToArray(),
-            "Desktop should restore the full SD interface after the Core network update when the device is in LogToDevice mode.");
+            "Core should own the SD/LAN interface SCPI pair; the desktop only adds the USB stream-interface switch when restoring the SD interface in LogToDevice mode.");
     }
 
     [TestMethod]
@@ -382,12 +384,12 @@ public class AbstractStreamingDeviceTests
         CollectionAssert.AreEqual(
             new[]
             {
-                $"desktop:{ScpiMessageProducer.DisableNetworkLan.Data}",
-                $"desktop:{ScpiMessageProducer.EnableStorageSd.Data}",
+                $"core:{ScpiMessageProducer.DisableNetworkLan.Data}",
+                $"core:{ScpiMessageProducer.EnableStorageSd.Data}",
                 $"desktop:{ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface.SdCard).Data}"
             },
             device.SentCommands.TakeLast(3).ToArray(),
-            "Desktop should restore the full SD interface even when the Core network update fails.");
+            "Desktop should restore the full SD interface even when the Core network update fails (Core owns the LAN-disable/SD-enable pair).");
     }
 
     [TestMethod]
@@ -605,7 +607,9 @@ public class AbstractStreamingDeviceTests
     [TestMethod]
     public void SwitchMode_WhenReturningToStreamToApp_SetsUsbStreamInterface()
     {
-        var device = new TestStreamingDevice();
+        // PrepareLanInterface now delegates the SD/LAN pair to the connected Core device,
+        // so this scenario needs a Core-backed harness rather than the bare TestStreamingDevice.
+        var device = new NetworkConfigurationTestDevice();
         device.SwitchMode(DeviceMode.LogToDevice);
         device.SentCommands.Clear();
 
@@ -614,11 +618,12 @@ public class AbstractStreamingDeviceTests
         CollectionAssert.AreEqual(
             new[]
             {
-                ScpiMessageProducer.DisableStorageSd.Data,
-                ScpiMessageProducer.EnableNetworkLan.Data,
-                ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface.Usb).Data
+                $"core:{ScpiMessageProducer.DisableStorageSd.Data}",
+                $"core:{ScpiMessageProducer.EnableNetworkLan.Data}",
+                $"desktop:{ScpiMessageProducer.SetStreamInterface(Daqifi.Core.Communication.StreamInterface.Usb).Data}"
             },
-            device.SentCommands);
+            device.SentCommands,
+            "Core should own the SD-disable/LAN-enable pair when returning to StreamToApp; the desktop only adds the USB stream-interface switch.");
     }
 
     [TestMethod]
@@ -710,7 +715,7 @@ public class AbstractStreamingDeviceTests
     /// <summary>
     /// Test implementation of AbstractStreamingDevice for testing purposes
     /// </summary>
-    private class TestStreamingDevice : AbstractStreamingDevice
+    private sealed class TestStreamingDevice : AbstractStreamingDevice
     {
         public List<string> SentCommands { get; } = [];
 

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1409,11 +1409,13 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         Disconnect();
     }
 
-    // SD and LAN can't both be enabled due to hardware limitations
+    // SD and LAN share one SPI bus and can't both be enabled (hardware limitation).
+    // Core owns the LAN-disable/SD-enable SCPI pair; the desktop only adds the USB-only
+    // stream-interface switch (Core's base method omits it by design).
     private void PrepareSdInterface()
     {
-        SendMessage(ScpiMessageProducer.DisableNetworkLan);
-        SendMessage(ScpiMessageProducer.EnableStorageSd);
+        var coreDevice = GetCoreDevice(CoreDeviceForNetworkConfiguration, NOT_CONNECTED_MESSAGE);
+        coreDevice.PrepareSdInterface();
 
         if (ConnectionType == ConnectionType.Usb)
         {
@@ -1421,11 +1423,13 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         }
     }
 
-    // SD and LAN can't both be enabled due to hardware limitations
+    // SD and LAN share one SPI bus and can't both be enabled (hardware limitation).
+    // Core owns the SD-disable/LAN-enable SCPI pair; the desktop only adds the USB-only
+    // stream-interface switch (Core's base method omits it by design).
     private void PrepareLanInterface()
     {
-        SendMessage(ScpiMessageProducer.DisableStorageSd);
-        SendMessage(ScpiMessageProducer.EnableNetworkLan);
+        var coreDevice = GetCoreDevice(CoreDeviceForNetworkConfiguration, NOT_CONNECTED_MESSAGE);
+        coreDevice.PrepareLanInterface();
 
         if (ConnectionType == ConnectionType.Usb)
         {

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1396,9 +1396,24 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             // Core always restores LAN after applying settings. USB devices that are currently
             // logging to the SD card need the desktop wrapper to switch the shared SPI bus back,
             // even if the Core update fails after toggling the shared SPI bus to LAN.
+            //
+            // This restore is best-effort: PrepareSdInterface delegates to the Core device and
+            // throws when it is gone (e.g. a mid-update disconnect nulls CoreDevice). Inside a
+            // finally that would mask the original UpdateNetworkConfigurationAsync failure, so
+            // swallow-and-log here — the SPI bus is moot once the device is disconnected anyway.
             if (restoreSdInterface)
             {
-                PrepareSdInterface();
+                try
+                {
+                    PrepareSdInterface();
+                }
+                catch (Exception restoreException)
+                {
+                    AppLogger.Warning(
+                        restoreException,
+                        "Failed to restore the SD interface for device " +
+                        $"{DeviceSerialNo} after a network configuration update.");
+                }
             }
         }
     }


### PR DESCRIPTION
## What

Closes #619.

`AbstractStreamingDevice.PrepareSdInterface`/`PrepareLanInterface` reissued raw SCPI
(`DisableNetworkLan`+`EnableStorageSd` / `DisableStorageSd`+`EnableNetworkLan`) that is
byte-for-byte identical to Core's `INetworkConfigurable.PrepareSdInterface()`/
`PrepareLanInterface()`. This PR delegates that pair to the connected Core device and keeps
only the USB-only `SetStreamInterface(SdCard/Usb)` call inline (Core's base methods omit it
by design), continuing the effort to make daqifi-desktop a thin wrapper over Daqifi.Core.

```csharp
private void PrepareSdInterface()
{
    var coreDevice = GetCoreDevice(CoreDeviceForNetworkConfiguration, NOT_CONNECTED_MESSAGE);
    coreDevice.PrepareSdInterface();

    if (ConnectionType == ConnectionType.Usb)
    {
        SendMessage(ScpiMessageProducer.SetStreamInterface(StreamInterface.SdCard));
    }
}
```

(`PrepareLanInterface` mirrors this with `SetStreamInterface(Usb)`.)

## Why it's safe

- **Wire SCPI is unchanged.** Core's `PrepareSdInterface`/`PrepareLanInterface` send the exact
  same SCPI commands the desktop previously sent; the only difference is they now flow through
  Core's `Send()` instead of the desktop `SendMessage()` override.
- **No settle-delay regression** — per the issue, Core applies the settle delay at the call
  site, not inside these methods.
- **Callers unchanged.** `SwitchMode` (StreamToApp → `PrepareLanInterface`) and the
  network-config restore `finally` (USB+LogToDevice → `PrepareSdInterface`); the
  `StartSdCardLogging` path already delegated.
- **Only behavioral delta:** Core's methods throw `InvalidOperationException("Device is not
  connected.")` if the device is disconnected, whereas the desktop `SendMessage` logged a
  warning and returned. Both call sites run on a connected device in production
  (`SwitchMode` is only invoked on `ConnectedDevices`; the restore path is USB-only and USB
  stays connected through WiFi reconfiguration), so this guard does not trip in practice.

## Tests

- Updated `AbstractStreamingDeviceTests` so the SD/LAN SCPI pair is now expected via the Core
  layer (`core:` prefix) instead of `desktop:`, and pointed the StreamToApp round-trip test
  at the Core-backed harness (it now needs a connected Core device).
- Fast unit gate: **452 passed**.

## Real-device validation (COM3, S/N 9090539562006014104)

- A **temporary** Stream→Log→Stream mode round-trip test passed against the attached USB
  device: after the Log→Stream restore (the refactored `PrepareLanInterface`), the device
  streamed real, finite sample data to the live plot — direct proof the SD/LAN SPI interface
  was correctly switched back. (Temp test removed; not part of this PR.)
- The existing `SdCardLogging_LogsToSdCard_ThenImportsToSession` UI gate exercised the
  LogToDevice direction cleanly (connect, "Enabled/Disabled SD card logging", overlay) and
  failed **only** at the SD-file-count assertion — the known wedged-bench issue #593
  (`before=after=12`), which reproduces on `main` and is unrelated to this change.

## Related

- May relate to #589 (SCPI error setting stream interface to USB). The USB-only
  `SetStreamInterface` call is kept inline and unchanged, so this PR does not alter that
  behavior.
