### PR TITLE
deps: bump Daqifi.Core to 0.24.0

### DIFF
--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-	  <PackageReference Include="Daqifi.Core" Version="0.23.0" />
+	  <PackageReference Include="Daqifi.Core" Version="0.24.0" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.9" />
-		<PackageReference Include="Daqifi.Core" Version="0.23.0" />
+		<PackageReference Include="Daqifi.Core" Version="0.24.0" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
+++ b/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
@@ -264,7 +264,9 @@ public class CoreConnectionTemplateTests
     /// </summary>
     private sealed class TemplateCoreDevice(Action onInitialize) : CoreStreamingDevice("TemplateCore")
     {
-        public override Task InitializeAsync()
+        public override Task InitializeAsync(
+            TimeSpan? channelPopulationTimeout = null,
+            CancellationToken cancellationToken = default)
         {
             onInitialize();
             return Task.CompletedTask;

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-		<PackageReference Include="Daqifi.Core" Version="0.23.0" />
+		<PackageReference Include="Daqifi.Core" Version="0.24.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />
@@ -82,7 +82,7 @@
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
 		<PackageReference Include="System.IO.Ports" Version="10.0.9" />
-		<PackageReference Include="System.Management" Version="10.0.8" />
+		<PackageReference Include="System.Management" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Daqifi.Desktop/Device/Firmware/BootloaderSessionStreamingDeviceAdapter.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderSessionStreamingDeviceAdapter.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using CoreConnectionStatus = Daqifi.Core.Device.ConnectionStatus;
 using CoreDeviceStatusEventArgs = Daqifi.Core.Device.DeviceStatusEventArgs;
@@ -66,5 +67,40 @@ public sealed class BootloaderSessionStreamingDeviceAdapter : CoreStreamingDevic
     public void Send<T>(IOutboundMessage<T> message)
     {
         // No-op by design: bootloader-only flow does not use desktop serial command transport.
+    }
+
+    // Channel management and device-control members (added to Core's IStreamingDevice in 0.24.0)
+    // are intentionally no-op here: the device is already in firmware-update mode and this adapter
+    // does not configure channels, drive outputs, or reboot through the streaming command path.
+    public void EnableChannel(IChannel channel)
+    {
+    }
+
+    public void EnableChannels(IEnumerable<IChannel> channels)
+    {
+    }
+
+    public void DisableChannel(IChannel channel)
+    {
+    }
+
+    public void DisableAllChannels()
+    {
+    }
+
+    public void SetDioDirection(IChannel channel, ChannelDirection direction)
+    {
+    }
+
+    public void SetDioValue(IChannel channel, bool value)
+    {
+    }
+
+    public void SetAnalogOutput(int channelNumber, double voltage)
+    {
+    }
+
+    public void Reboot()
+    {
     }
 }


### PR DESCRIPTION
## Summary

Bumps **Daqifi.Core 0.23.0 → 0.24.0** across `Daqifi.Desktop.DataModel`, `Daqifi.Desktop.IO`, and `Daqifi.Desktop`.

The upgrade is **not drop-in source-compatible** — it required three adaptations:

| Change | Why |
|---|---|
| `System.Management` 10.0.8 → 10.0.9 (`Daqifi.Desktop.csproj`) | Core 0.24.0 raised its transitive floor to `>= 10.0.9`; the old pin produced an `NU1605` downgrade-as-error at restore. Now consistent with the other `System.*` 10.0.9 packages. |
| `BootloaderSessionStreamingDeviceAdapter` implements 8 new members | Core 0.24.0 (#250, device-level channel management) added `EnableChannel`/`EnableChannels`/`DisableChannel`/`DisableAllChannels`/`SetDioDirection`/`SetDioValue`/`SetAnalogOutput`/`Reboot` to `Daqifi.Core.Device.IStreamingDevice`. The adapter implements the Core interface by hand, so it must provide them — added as **no-ops**, matching its documented bootloader-only "intentionally no-op" design (channel management / outputs / reboot are meaningless mid-firmware-update). The real devices inherit Core's concrete base and were unaffected. |
| `CoreConnectionTemplateTests.TemplateCoreDevice` override signature | Core 0.24.0 (#247) changed `InitializeAsync()` → `InitializeAsync(TimeSpan? channelPopulationTimeout = null, CancellationToken cancellationToken = default)`. Production call sites survive on the defaults; only the test fixture's `override` needed updating. |

## Notable Core 0.24.0 behavior changes (no code change needed, but worth knowing)

- **#247** — `InitializeAsync` now blocks until the device reports its channels (re-sending `GetDeviceInfo` periodically) instead of a fixed delay, and surfaces a `TimeoutException` if channels never populate. More reliable connects; a new failure mode on connect.
- **#253 (breaking, wire-protocol)** — SD-card logging now sends `SYST:STOR:SD:FILE` instead of the pre-3.5.0 `SYST:STOR:SD:LOGging`, so **SD logging requires device firmware v3.5.0+**. No .NET API change.

## Validation (Windows, against an attached Nq1 device)

- `dotnet build "DAQiFi Desktop.sln"` — **clean, 0 errors**.
- Unit suite (fast gate filter) — **454 / 454 pass**.
- FlaUI UI integration gate — **16 / 17 pass**.
  - The single failure (`SdCardLogging_LogsToSdCard_ThenImportsToSession`) is a **pre-existing device-firmware SD-read-over-USB defect, independent of this upgrade**: on a freshly-formatted card the device writes valid log data and enumerates it correctly, but downloading the file over USB returns 0 bytes. Reproduces on pre-upgrade Core; the SD-read path is unchanged since 0.22.0. Tracked separately for firmware/Core investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
