### PR TITLE
feat(firmware): unify firmware UX + bootloader download-latest + flash reliability

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/FirmwareDialogViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/FirmwareDialogViewModelTests.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics;
+using Daqifi.Core.Device;
+using Daqifi.Core.Firmware;
+using Daqifi.Desktop.ViewModels;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Covers the bootloader firmware dialog's "download the latest DAQiFi firmware" path: the dropdown
+/// is populated from the latest release, the Upload command is gated until there's something to flash,
+/// a no-file upload downloads the latest .hex before flashing, and a browsed .hex takes precedence
+/// (no download).
+/// </summary>
+[TestClass]
+public class FirmwareDialogViewModelTests
+{
+    private string _tempHexPath = string.Empty;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // A real file so the dialog's File.Exists guard passes; the flash service is mocked.
+        _tempHexPath = Path.Combine(Path.GetTempPath(), $"daqifi-fw-{Guid.NewGuid():N}.hex");
+        File.WriteAllText(_tempHexPath, ":00000001FF");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (File.Exists(_tempHexPath)) { File.Delete(_tempHexPath); }
+    }
+
+    private static Mock<IFirmwareDownloadService> DownloadServiceReturning(FirmwareReleaseInfo? latest)
+    {
+        var download = new Mock<IFirmwareDownloadService>();
+        download
+            .Setup(s => s.GetLatestReleaseAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latest);
+        return download;
+    }
+
+    private static FirmwareReleaseInfo Release(int major, int minor, int patch, string tag) => new()
+    {
+        Version = new FirmwareVersion(major, minor, patch, null, 0),
+        TagName = tag,
+        IsPreRelease = false
+    };
+
+    /// <summary>Waits for a fire-and-forget continuation to settle (the constructor's option load).</summary>
+    private static void WaitUntil(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var sw = Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+        {
+            Thread.Sleep(10);
+        }
+    }
+
+    [TestMethod]
+    public void Constructor_LoadsLatestFirmwareIntoDropdown()
+    {
+        var update = new Mock<IFirmwareUpdateService>();
+        var download = DownloadServiceReturning(Release(3, 6, 1, "v3.6.1"));
+
+        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+
+        WaitUntil(() => vm.AvailableFirmwares.Count > 0);
+        Assert.AreEqual(1, vm.AvailableFirmwares.Count);
+        Assert.IsNotNull(vm.SelectedFirmware);
+        Assert.AreEqual("3.6.1", vm.SelectedFirmware!.Version);
+        Assert.AreEqual("DAQiFi — 3.6.1", vm.SelectedFirmware.Display);
+    }
+
+    [TestMethod]
+    public void Constructor_NoRelease_LeavesDropdownEmpty()
+    {
+        var update = new Mock<IFirmwareUpdateService>();
+        var download = DownloadServiceReturning(null);
+
+        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+
+        // Nothing to select; the upload command must be disabled until the user browses a file.
+        Assert.AreEqual(0, vm.AvailableFirmwares.Count);
+        Assert.IsNull(vm.SelectedFirmware);
+        Assert.IsFalse(vm.UploadFirmwareCommand.CanExecute(null));
+    }
+
+    [TestMethod]
+    public void CanUploadFirmware_TrueOnceAFileIsBrowsed()
+    {
+        var update = new Mock<IFirmwareUpdateService>();
+        var download = DownloadServiceReturning(null);
+        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+
+        Assert.IsFalse(vm.UploadFirmwareCommand.CanExecute(null), "Disabled with no file and no dropdown selection.");
+
+        vm.FirmwareFilePath = _tempHexPath;
+
+        Assert.IsTrue(vm.UploadFirmwareCommand.CanExecute(null), "Enabled once a .hex is browsed.");
+    }
+
+    [TestMethod]
+    public async Task Upload_NoFileBrowsed_DownloadsLatestThenFlashes()
+    {
+        var update = new Mock<IFirmwareUpdateService>();
+        update
+            .Setup(s => s.UpdateFirmwareAsync(
+                It.IsAny<IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var download = DownloadServiceReturning(Release(3, 6, 1, "v3.6.1"));
+        download
+            .Setup(s => s.DownloadLatestFirmwareAsync(
+                It.IsAny<string>(), true, It.IsAny<IProgress<int>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_tempHexPath);
+
+        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+        // Stand in for the async dropdown load so we exercise the no-file path deterministically.
+        vm.SelectedFirmware = new Models.FirmwareOption { DeviceModel = "DAQiFi", Version = "3.6.1" };
+
+        await vm.UploadFirmwareCommand.ExecuteAsync(null);
+
+        download.Verify(s => s.DownloadLatestFirmwareAsync(
+            It.IsAny<string>(), true, It.IsAny<IProgress<int>?>(), It.IsAny<CancellationToken>()), Times.Once);
+        update.Verify(s => s.UpdateFirmwareAsync(
+            It.IsAny<IStreamingDevice>(), _tempHexPath, It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.IsTrue(vm.IsUploadComplete);
+        Assert.IsFalse(vm.HasErrorOccured);
+    }
+
+    [TestMethod]
+    public async Task Upload_FileBrowsed_TakesPrecedenceAndDoesNotDownload()
+    {
+        var update = new Mock<IFirmwareUpdateService>();
+        update
+            .Setup(s => s.UpdateFirmwareAsync(
+                It.IsAny<IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var download = DownloadServiceReturning(Release(3, 6, 1, "v3.6.1"));
+
+        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object)
+        {
+            FirmwareFilePath = _tempHexPath
+        };
+
+        await vm.UploadFirmwareCommand.ExecuteAsync(null);
+
+        download.Verify(s => s.DownloadLatestFirmwareAsync(
+            It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<IProgress<int>?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        update.Verify(s => s.UpdateFirmwareAsync(
+            It.IsAny<IStreamingDevice>(), _tempHexPath, It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.IsTrue(vm.IsUploadComplete);
+    }
+}

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -382,8 +382,63 @@ public class FirmwareUpdateCoordinator
         {
             if (lanUpdateModeEnabled)
             {
-                serialStreamingDevice.ResetLanAfterUpdate();
+                // Bring the device back out of WiFi-update / USB-transparent (bridge) mode. The managed
+                // ResetLanAfterUpdate routes through the Core device; if a failed flash has already torn
+                // that connection down, its SetTransparentMode 0 silently no-ops and the device is left
+                // stranded in transparent mode — it stops answering SCPI and vanishes from the app until
+                // it is power-cycled.
+                try
+                {
+                    serialStreamingDevice.ResetLanAfterUpdate();
+                }
+                catch (Exception ex)
+                {
+                    _appLogger.Warning($"ResetLanAfterUpdate failed for {serialStreamingDevice.PortName}: {ex.Message}");
+                }
+
+                // Safety net: only when the managed reset could NOT have worked (the Core connection is
+                // gone), also send the transparent-mode exit over a raw serial write so a failed flash
+                // can never strand the device. Run it off the calling thread — it does blocking serial
+                // I/O with short sleeps.
+                if (!coreDevice.IsConnected)
+                {
+                    await Task.Run(() => ExitWifiTransparentModeRaw(serialStreamingDevice.PortName));
+                }
             }
+        }
+    }
+
+    /// <summary>
+    /// Sends the USB-transparent-mode exit (<c>SYSTem:USB:SetTransparentMode 0</c>) directly over a raw
+    /// serial write, mirroring the bridge-activation path. This is the safety net for a failed WiFi
+    /// flash whose managed Core connection has already been torn down: the PIC32 still parses this
+    /// command even while bridging to the WINC, so it reliably pulls the device back out of transparent
+    /// mode where the managed <see cref="SerialStreamingDevice.ResetLanAfterUpdate"/> could not. No-op
+    /// if the port can't be opened (e.g. another handle still holds it).
+    /// </summary>
+    private void ExitWifiTransparentModeRaw(string portName)
+    {
+        try
+        {
+            // USB CDC virtual ports ignore the baud rate; match the bridge-activation defaults.
+            using var port = new SerialPort(portName, 9600, Parity.None, 8, StopBits.One)
+            {
+                DtrEnable = true,
+                RtsEnable = false,
+                WriteTimeout = 2000
+            };
+            port.Open();
+            Thread.Sleep(200);
+            port.Write("SYSTem:USB:SetTransparentMode 0\n");
+            Thread.Sleep(150);
+            // Re-apply normal LAN config so the module returns to its operating mode.
+            port.Write("SYSTem:COMMUnicate:LAN:APPLY\n");
+            Thread.Sleep(300);
+            _appLogger.Information($"Sent transparent-mode exit to {portName} (raw) after WiFi flash.");
+        }
+        catch (Exception ex)
+        {
+            _appLogger.Warning($"Raw transparent-mode exit could not open {portName}: {ex.Message}");
         }
     }
 

--- a/Daqifi.Desktop/Models/FirmwareOption.cs
+++ b/Daqifi.Desktop/Models/FirmwareOption.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Daqifi.Desktop.Models;
+
+/// <summary>
+/// A selectable firmware entry shown in the firmware dropdown — the latest published DAQiFi
+/// firmware the user can flash without browsing for a <c>.hex</c> file. In bootloader/recovery
+/// mode the device model is not known, so this is typically a single "DAQiFi — &lt;version&gt;" entry.
+/// </summary>
+public sealed class FirmwareOption : IEquatable<FirmwareOption>
+{
+    /// <summary>Device model the firmware targets (e.g. "Nq1"), or empty when unknown.</summary>
+    public string DeviceModel { get; init; } = string.Empty;
+
+    /// <summary>Firmware version string (e.g. "3.6.1").</summary>
+    public string Version { get; init; } = string.Empty;
+
+    /// <summary>Human-readable label shown in the dropdown.</summary>
+    public string Display => string.IsNullOrWhiteSpace(DeviceModel)
+        ? Version
+        : $"{DeviceModel} — {Version}";
+
+    /// <summary>
+    /// Value equality (case-insensitive by <see cref="DeviceModel"/> + <see cref="Version"/>) so the
+    /// dropdown's selected option survives a rebuild — <c>Contains()</c> would otherwise
+    /// reference-compare freshly constructed instances and reset the selection.
+    /// </summary>
+    public bool Equals(FirmwareOption? other) =>
+        other is not null
+        && string.Equals(DeviceModel, other.DeviceModel, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(Version, other.Version, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Value equality against any object; see <see cref="Equals(FirmwareOption)"/>.</summary>
+    public override bool Equals(object? obj) => obj is FirmwareOption other && Equals(other);
+
+    /// <summary>Hash code consistent with <see cref="Equals(FirmwareOption)"/> (case-insensitive).</summary>
+    public override int GetHashCode() => HashCode.Combine(
+        StringComparer.OrdinalIgnoreCase.GetHashCode(DeviceModel),
+        StringComparer.OrdinalIgnoreCase.GetHashCode(Version));
+
+    /// <summary>
+    /// Mirrors <see cref="Display"/> so a ComboBox's closed selection box shows the friendly label
+    /// even when its template falls back to ToString() instead of the item template.
+    /// </summary>
+    public override string ToString() => Display;
+}

--- a/Daqifi.Desktop/Resources/DarkDialog.xaml
+++ b/Daqifi.Desktop/Resources/DarkDialog.xaml
@@ -108,6 +108,128 @@
         </Setter>
     </Style>
 
+    <!-- ── Dark dropdown ────────────────────────────────────────────────────
+         Self-contained dark template. The MahApps light-theme combo brings a white
+         toggle/popup background that swallows light text, so we own the whole visual:
+         a bordered field with a chevron, over a dark popup of dark items. Keyed (opt-in)
+         and wired together via ItemContainerStyle so it never implicitly overrides other
+         ComboBoxes in dialogs that merge this dictionary. -->
+    <Style x:Key="DarkComboBoxItem" TargetType="ComboBoxItem">
+        <Setter Property="Foreground"          Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="Background"           Value="Transparent"/>
+        <Setter Property="Padding"              Value="8,5"/>
+        <Setter Property="SnapsToDevicePixels"  Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="Bd"
+                            Background="{TemplateBinding Background}"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter TextElement.Foreground="{TemplateBinding Foreground}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SurfaceActive}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SurfaceActive}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="DarkComboBox" TargetType="ComboBox">
+        <Setter Property="Foreground"               Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="Background"               Value="{DynamicResource Surface}"/>
+        <Setter Property="BorderBrush"              Value="{DynamicResource BorderDim}"/>
+        <Setter Property="BorderThickness"          Value="1"/>
+        <Setter Property="Padding"                  Value="8,4"/>
+        <Setter Property="MinHeight"                Value="28"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <!-- This template has no editable text part, so keep the control non-editable. -->
+        <Setter Property="IsEditable"               Value="False"/>
+        <Setter Property="ItemContainerStyle"       Value="{StaticResource DarkComboBoxItem}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <ToggleButton x:Name="ToggleButton"
+                                      Focusable="False"
+                                      ClickMode="Press"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border x:Name="Bd"
+                                            Background="{DynamicResource Surface}"
+                                            BorderBrush="{DynamicResource BorderDim}"
+                                            BorderThickness="1"
+                                            CornerRadius="3">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="22"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Path Grid.Column="1"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Data="M 0 0 L 4 4 L 8 0 Z"
+                                                  Fill="{DynamicResource TextSecondary}"/>
+                                        </Grid>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+                        <ContentPresenter x:Name="ContentSite"
+                                          IsHitTestVisible="False"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                          Margin="{TemplateBinding Padding}"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Left"
+                                          TextElement.Foreground="{DynamicResource TextPrimary}"/>
+                        <Popup x:Name="PART_Popup"
+                               Placement="Bottom"
+                               PlacementTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               AllowsTransparency="True"
+                               Focusable="False"
+                               PopupAnimation="Slide">
+                            <Border x:Name="DropDownBorder"
+                                    MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                    MaxHeight="200"
+                                    Margin="0,2,0,0"
+                                    Background="{DynamicResource SurfaceRaised}"
+                                    BorderBrush="{DynamicResource BorderDim}"
+                                    BorderThickness="1"
+                                    CornerRadius="3">
+                                <ScrollViewer SnapsToDevicePixels="True"
+                                              CanContentScroll="True"
+                                              VerticalScrollBarVisibility="Auto"
+                                              HorizontalScrollBarVisibility="Disabled">
+                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- ── Grouping container: small header label over a raised panel ──── -->
     <Style TargetType="GroupBox">
         <Setter Property="Foreground"      Value="{DynamicResource TextPrimary}"/>

--- a/Daqifi.Desktop/View/FirmwareDialog.xaml
+++ b/Daqifi.Desktop/View/FirmwareDialog.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=viewModels:FirmwareDialogViewModel}"
         dialogService:DialogService.IsRegisteredView="True"
-        Title="Firmware Settings" Height="300" Width="500" BorderThickness="0" Background="{StaticResource Surface}" GlowBrush="{DynamicResource AccentColorBrush}">
+        Title="Firmware Settings" Height="380" Width="500" BorderThickness="0" Background="{StaticResource Surface}" GlowBrush="{DynamicResource AccentColorBrush}">
 
     <controls:MetroWindow.Resources>
         <ResourceDictionary>
@@ -35,14 +35,26 @@
             </GroupBox>
 
             <GroupBox Grid.Row="1" Header="Update Firmware">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="85"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBox Grid.Column="0" Height="30" VerticalAlignment="Top" Margin="5" Text="{Binding FirmwareFilePath, Mode=OneWay}"/>
-                    <Button Grid.Column="1" Content="Browse" Width="75" Height="30" Margin="5" VerticalAlignment="Top" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal" Command="{Binding BrowseFirmwarePathCommand}"/>
-                </Grid>
+                <StackPanel>
+                    <!-- Latest DAQiFi firmware (default path): no need to locate a .hex file. -->
+                    <TextBlock Text="DAQiFi Firmware" Foreground="{StaticResource TextSecondary}" FontSize="11" Margin="2,0,2,4"/>
+                    <ComboBox Style="{StaticResource DarkComboBox}"
+                              AutomationProperties.AutomationId="BootloaderFirmwareSelector"
+                              ItemsSource="{Binding AvailableFirmwares}"
+                              DisplayMemberPath="Display"
+                              SelectedItem="{Binding SelectedFirmware, Mode=TwoWay}"/>
+
+                    <!-- Or browse for a specific .hex file -->
+                    <TextBlock Text="Or browse for a firmware file" Foreground="{StaticResource TextTertiary}" FontSize="11" Margin="2,12,2,4"/>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="85"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" Height="34" VerticalAlignment="Top" Margin="0,0,5,0" Text="{Binding FirmwareFilePath, Mode=OneWay}"/>
+                        <Button Grid.Column="1" Content="Browse" Width="75" Height="34" VerticalAlignment="Top" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal" Command="{Binding BrowseFirmwarePathCommand}"/>
+                    </Grid>
+                </StackPanel>
             </GroupBox>
 
             <Label Visibility="{Binding HasErrorOccured, Converter={StaticResource BoolToVis}}" Grid.Row="2" Content="Sorry, something went wrong uploading the firmware.  :(" HorizontalContentAlignment="Center" Foreground="{StaticResource StatusRed}"/>

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -118,19 +118,54 @@ public partial class ConnectionDialogViewModel : ObservableObject
     {
         Common.Loggers.AppLogger.Instance.AddBreadcrumb("discovery", "Device discovery started");
 
-        // WiFi Discovery
+        StartWiFiDiscovery();
+        StartSerialDiscovery();
+        StartHidDiscovery();
+    }
+
+    private void StartWiFiDiscovery()
+    {
+        // Idempotent while actually running; allow a restart once the prior loop has completed (e.g.
+        // it was drained around a firmware flash), otherwise a stale task reference blocks discovery.
+        if (_closed || _wifiDiscoveryTask is { IsCompleted: false }) { return; }
+
+        // Restart-after-drain: dispose the prior finder/CTS before replacing them so we never leak a
+        // subscribed finder or an undisposed CancellationTokenSource.
+        if (_wifiFinder != null) { _wifiFinder.DeviceDiscovered -= HandleCoreWifiDeviceDiscovered; _wifiFinder.Dispose(); }
+        _wifiDiscoveryCts?.Dispose();
+
         _wifiFinder = new WiFiDeviceFinder(30303);
         _wifiDiscoveryCts = new CancellationTokenSource();
         _wifiFinder.DeviceDiscovered += HandleCoreWifiDeviceDiscovered;
         _wifiDiscoveryTask = RunContinuousWiFiDiscoveryAsync(_wifiDiscoveryCts.Token);
+    }
 
-        // Serial Discovery
+    private void StartSerialDiscovery()
+    {
+        if (_closed || _serialDiscoveryTask is { IsCompleted: false }) { return; }
+
+        if (_serialFinder != null) { _serialFinder.DeviceDiscovered -= HandleCoreSerialDeviceDiscovered; _serialFinder.Dispose(); }
+        _serialDiscoveryCts?.Dispose();
+
         _serialFinder = new Daqifi.Core.Device.Discovery.SerialDeviceFinder();
         _serialDiscoveryCts = new CancellationTokenSource();
         _serialFinder.DeviceDiscovered += HandleCoreSerialDeviceDiscovered;
         _serialDiscoveryTask = RunContinuousSerialDiscoveryAsync(_serialDiscoveryCts.Token);
+    }
 
-        // HID Discovery
+    /// <summary>
+    /// Starts the continuous HID discovery loop. Extracted so it can be paused around a bootloader
+    /// flash: the loop opens every matching HID device each cycle (to read USB string descriptors),
+    /// which collides with the bootloader's in-progress HID I/O and corrupts the flash.
+    /// <see cref="ConnectHid"/> drains it before flashing and restarts it afterward.
+    /// </summary>
+    private void StartHidDiscovery()
+    {
+        if (_closed || _hidDiscoveryTask is { IsCompleted: false }) { return; }
+
+        if (_hidDeviceFinder != null) { _hidDeviceFinder.DeviceDiscovered -= HandleCoreHidDeviceDiscovered; _hidDeviceFinder.Dispose(); }
+        _hidDiscoveryCts?.Dispose();
+
         _hidDeviceFinder = new Daqifi.Core.Device.Discovery.HidDeviceFinder();
         _hidDiscoveryCts = new CancellationTokenSource();
         _hidDeviceFinder.DeviceDiscovered += HandleCoreHidDeviceDiscovered;
@@ -403,17 +438,35 @@ public partial class ConnectionDialogViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void ConnectHid(object selectedItems)
+    private async Task ConnectHid(object selectedItems)
     {
-        //_hidDeviceFinder.Stop();
+        if (selectedItems is not IEnumerable enumerable) { return; }
 
-        var selectedDevices = ((IEnumerable)selectedItems).Cast<CoreDeviceInfo>();
-        var hidDevice = selectedDevices.FirstOrDefault();
+        var hidDevice = enumerable.Cast<CoreDeviceInfo>().FirstOrDefault();
         if (hidDevice == null) { return; }
 
-        var firmwareDialogViewModel = new FirmwareDialogViewModel(hidDevice.Name);
-        _dialogService.ShowDialog<FirmwareDialog>(this, firmwareDialogViewModel);
-
+        // Pause ALL discovery for the duration of the flash, not just HID. Each loop probes the bus
+        // every cycle: HID discovery re-opens every matching HID device (reading USB string descriptors
+        // opens the handle) and serial discovery opens/probes every COM port waiting for an identify
+        // response. Either can collide with — or starve — the bootloader's HID I/O mid-flash, producing
+        // the intermittent "Connecting"-state HID write failure / read timeout. Awaiting the drains
+        // matters: cancel/dispose does NOT abort an in-flight DiscoverAsync cycle, so a still-running
+        // probe can hold a handle when the flasher fires.
+        await StopWiFiDiscoveryAsync();
+        await StopSerialDiscoveryAsync();
+        await StopHidDiscoveryAsync();
+        try
+        {
+            var firmwareDialogViewModel = new FirmwareDialogViewModel(hidDevice.Name);
+            _dialogService.ShowDialog<FirmwareDialog>(this, firmwareDialogViewModel);
+        }
+        finally
+        {
+            // Resume discovery once the flash dialog closes so the device list stays live.
+            StartWiFiDiscovery();
+            StartSerialDiscovery();
+            StartHidDiscovery();
+        }
     }
     #endregion
 
@@ -626,6 +679,86 @@ public partial class ConnectionDialogViewModel : ObservableObject
     private void StopHidDiscovery()
     {
         _hidDiscoveryCts?.Cancel();
+
+        if (_hidDeviceFinder != null)
+        {
+            _hidDeviceFinder.DeviceDiscovered -= HandleCoreHidDeviceDiscovered;
+            _hidDeviceFinder.Dispose();
+            _hidDeviceFinder = null;
+        }
+
+        _hidDiscoveryCts?.Dispose();
+        _hidDiscoveryCts = null;
+    }
+
+    /// <summary>
+    /// Stops WiFi discovery and waits for the in-flight discovery cycle to drain before returning —
+    /// the async counterpart to <see cref="StopWiFiDiscovery"/>, used before a bootloader flash so a
+    /// running UDP discovery cycle isn't still live when the flash begins. Mirrors
+    /// <see cref="StopSerialDiscoveryAsync"/>.
+    /// </summary>
+    private async Task StopWiFiDiscoveryAsync()
+    {
+        _wifiDiscoveryCts?.Cancel();
+
+        if (_wifiDiscoveryTask != null)
+        {
+            try
+            {
+                await _wifiDiscoveryTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                Common.Loggers.AppLogger.Instance.Warning("WiFi discovery task did not complete within timeout");
+            }
+            catch (OperationCanceledException) { }
+            catch (ObjectDisposedException) { }
+            catch (Exception ex)
+            {
+                Common.Loggers.AppLogger.Instance.Error(ex, "Unexpected error while stopping WiFi discovery");
+            }
+            _wifiDiscoveryTask = null;
+        }
+
+        if (_wifiFinder != null)
+        {
+            _wifiFinder.DeviceDiscovered -= HandleCoreWifiDeviceDiscovered;
+            _wifiFinder.Dispose();
+            _wifiFinder = null;
+        }
+
+        _wifiDiscoveryCts?.Dispose();
+        _wifiDiscoveryCts = null;
+    }
+
+    /// <summary>
+    /// Stops HID discovery and waits for the in-flight discovery cycle to finish before returning.
+    /// <see cref="StopHidDiscovery"/> alone only signals cancellation and disposes the finder, but a
+    /// running <c>DiscoverAsync</c> cycle keeps the bootloader's HID handle open until it returns;
+    /// draining the task first guarantees the flasher has exclusive access for its first write.
+    /// </summary>
+    private async Task StopHidDiscoveryAsync()
+    {
+        _hidDiscoveryCts?.Cancel();
+
+        if (_hidDiscoveryTask != null)
+        {
+            try
+            {
+                await _hidDiscoveryTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                Common.Loggers.AppLogger.Instance.Warning("HID discovery task did not complete within timeout");
+            }
+            catch (OperationCanceledException) { }
+            catch (ObjectDisposedException) { }
+            catch (Exception ex)
+            {
+                Common.Loggers.AppLogger.Instance.Error(ex, "Unexpected error while stopping HID discovery");
+            }
+            _hidDiscoveryTask = null;
+        }
 
         if (_hidDeviceFinder != null)
         {

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -1,11 +1,12 @@
 using Daqifi.Core.Firmware;
 using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device.Firmware;
+using Daqifi.Desktop.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using System.Net.Http;
+using System.Collections.ObjectModel;
+using System.IO;
 using File = System.IO.File;
 
 namespace Daqifi.Desktop.ViewModels;
@@ -13,6 +14,7 @@ namespace Daqifi.Desktop.ViewModels;
 public partial class FirmwareDialogViewModel : ObservableObject
 {
     private readonly IFirmwareUpdateService _firmwareUpdateService;
+    private readonly IFirmwareDownloadService _firmwareDownloadService;
     private readonly Daqifi.Core.Device.IStreamingDevice _coreDevice;
     private CancellationTokenSource? _updateCts;
 
@@ -20,10 +22,24 @@ public partial class FirmwareDialogViewModel : ObservableObject
     private string _version = "Bootloader mode";
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(UploadFirmwareCommand))]
     private string _firmwareFilePath = string.Empty;
+
+    /// <summary>
+    /// The latest published firmware the user can flash without browsing for a <c>.hex</c>. In
+    /// bootloader/recovery mode the device model isn't known, so this is typically a single
+    /// "DAQiFi — &lt;version&gt;" entry, loaded asynchronously after construction.
+    /// </summary>
+    public ObservableCollection<FirmwareOption> AvailableFirmwares { get; } = [];
+
+    /// <summary>The firmware option selected in the dropdown to flash when no .hex is browsed.</summary>
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(UploadFirmwareCommand))]
+    private FirmwareOption? _selectedFirmware;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(CancelUploadFirmwareCommand))]
+    [NotifyCanExecuteChangedFor(nameof(UploadFirmwareCommand))]
     private bool _isFirmwareUploading;
 
     [ObservableProperty]
@@ -38,15 +54,77 @@ public partial class FirmwareDialogViewModel : ObservableObject
 
     public string UploadFirmwareProgressText => $"Upload Progress: {UploadFirmwareProgress}%";
 
+    /// <summary>
+    /// Creates the bootloader firmware dialog view-model for a HID bootloader session and kicks off
+    /// loading the latest published firmware so the user can flash it without locating a .hex file.
+    /// </summary>
+    /// <param name="hidDeviceName">HID device name for the bootloader session (used by the flasher adapter).</param>
+    /// <param name="firmwareUpdateService">Optional override for tests; otherwise resolved from DI.</param>
+    /// <param name="firmwareDownloadService">Optional override for tests; otherwise resolved from DI.</param>
     public FirmwareDialogViewModel(
         string? hidDeviceName,
-        IFirmwareUpdateService? firmwareUpdateService = null)
+        IFirmwareUpdateService? firmwareUpdateService = null,
+        IFirmwareDownloadService? firmwareDownloadService = null)
     {
+        // Resolve from DI rather than newing up services/HttpClient here. Both are registered in
+        // App.ConfigureServices and the provider is always present at runtime; the throw is a
+        // fail-fast for a misconfigured container (tests pass mocks via the constructor args).
         _firmwareUpdateService = firmwareUpdateService
             ?? App.ServiceProvider?.GetService<IFirmwareUpdateService>()
-            ?? CreateFallbackFirmwareUpdateService();
+            ?? throw new InvalidOperationException("IFirmwareUpdateService is not registered.");
+
+        _firmwareDownloadService = firmwareDownloadService
+            ?? App.ServiceProvider?.GetService<IFirmwareDownloadService>()
+            ?? throw new InvalidOperationException("IFirmwareDownloadService is not registered.");
 
         _coreDevice = new BootloaderSessionStreamingDeviceAdapter(hidDeviceName ?? "DAQiFi Bootloader");
+
+        _ = LoadFirmwareOptionsAsync();
+    }
+
+    /// <summary>
+    /// Fetches the latest published firmware release and populates the dropdown so the user can flash
+    /// the latest DAQiFi firmware without browsing for a .hex file. Best-effort: a failure leaves the
+    /// dropdown empty and the user can still browse for a file.
+    /// </summary>
+    private async Task LoadFirmwareOptionsAsync()
+    {
+        try
+        {
+            var latestRelease = await _firmwareDownloadService.GetLatestReleaseAsync(includePreRelease: true);
+            if (latestRelease == null)
+            {
+                return;
+            }
+
+            var option = new FirmwareOption
+            {
+                DeviceModel = "DAQiFi",
+                Version = latestRelease.Version.ToString()
+            };
+
+            // GetLatestReleaseAsync may resume this continuation off the UI thread; AvailableFirmwares
+            // is bound to the dropdown, so marshal the mutation onto the dispatcher.
+            void AddOption()
+            {
+                AvailableFirmwares.Add(option);
+                SelectedFirmware ??= option;
+            }
+
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null && !dispatcher.CheckAccess())
+            {
+                await dispatcher.InvokeAsync(AddOption);
+            }
+            else
+            {
+                AddOption();
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Instance.Warning($"Failed to load latest firmware for bootloader dialog: {ex.Message}");
+        }
     }
 
     [RelayCommand]
@@ -68,7 +146,16 @@ public partial class FirmwareDialogViewModel : ObservableObject
         FirmwareFilePath = dialog.FileName;
     }
 
-    [RelayCommand]
+    /// <summary>
+    /// Upload is allowed once there's something to flash: a browsed .hex path, or a dropdown
+    /// selection (populated asynchronously). Gating the command prevents a click before
+    /// <see cref="LoadFirmwareOptionsAsync"/> finishes from showing a false "something went wrong".
+    /// </summary>
+    private bool CanUploadFirmware() =>
+        !IsFirmwareUploading
+        && (!string.IsNullOrWhiteSpace(FirmwareFilePath) || SelectedFirmware != null);
+
+    [RelayCommand(CanExecute = nameof(CanUploadFirmware))]
     private async Task UploadFirmware()
     {
         if (IsFirmwareUploading)
@@ -76,7 +163,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(FirmwareFilePath) || !File.Exists(FirmwareFilePath))
+        // A manually-browsed .hex takes precedence; otherwise flash the latest firmware selected
+        // from the dropdown (downloaded on demand).
+        var isManualUpload = !string.IsNullOrWhiteSpace(FirmwareFilePath);
+        if (!isManualUpload && SelectedFirmware == null)
         {
             HasErrorOccured = true;
             return;
@@ -92,6 +182,20 @@ public partial class FirmwareDialogViewModel : ObservableObject
             UploadFirmwareProgress = 0;
             IsFirmwareUploading = true;
             AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update started");
+
+            if (!isManualUpload)
+            {
+                FirmwareFilePath = await _firmwareDownloadService.DownloadLatestFirmwareAsync(
+                    GetFirmwareDownloadDirectory(),
+                    includePreRelease: true,
+                    cancellationToken: _updateCts.Token);
+            }
+
+            if (string.IsNullOrWhiteSpace(FirmwareFilePath) || !File.Exists(FirmwareFilePath))
+            {
+                HasErrorOccured = true;
+                return;
+            }
 
             var progress = new Progress<FirmwareUpdateProgress>(report =>
             {
@@ -143,14 +247,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
         return IsFirmwareUploading;
     }
 
-    private static IFirmwareUpdateService CreateFallbackFirmwareUpdateService()
+    private static string GetFirmwareDownloadDirectory()
     {
-        var downloadService = new GitHubFirmwareDownloadService(new HttpClient());
-        return new FirmwareUpdateService(
-            FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
-            downloadService,
-            new ProcessExternalProcessRunner(),
-            NullLogger<FirmwareUpdateService>.Instance,
-            options: FirmwareUpdateServiceConfig.CreateOptions());
+        var firmwareDirectory = Path.Combine(App.DaqifiDataDirectory, "Firmware", "PIC32");
+        Directory.CreateDirectory(firmwareDirectory);
+        return firmwareDirectory;
     }
 }


### PR DESCRIPTION
## Summary

Re-homes this PR onto current `main` (the post-#592/#601 architecture) and reframes the feature around a single user-facing idea: **"the firmware."** Users shouldn't need to know a Nyquist device carries both a PIC32 and a separately-flashable WINC1500 WiFi module — to them it's just firmware.

### Why this was reworked

The original branch was cut **before the #592 refactor wave**: before [#601](https://github.com/daqifi/daqifi-desktop/pull/601) extracted the firmware flow out of `DaqifiViewModel` into `FirmwareUpdateCoordinator` (behind `IFirmwareUpdateHost`), and before [#587](https://github.com/daqifi/daqifi-desktop/pull/587) delegated the WiFi version check to Core's `CheckWifiFirmwareStatusAsync`. As a result the original diff added ~900 lines back into `DaqifiViewModel`, re-implemented logic main already ships, and was `CONFLICTING`.

Critically, **main already updates the WiFi module as part of a single "Update Firmware" action** (the coordinator flashes PIC32 → then WiFi, using Core for the version decision). So the original PR's separate WiFi surface was largely redundant with what shipped to main while this branch was open. This rework keeps the genuinely-additive parts and drops the redundant ones.

### What's included

**Bootloader recovery dialog — "just flash the latest firmware":**
- A **DAQiFi Firmware dropdown** that downloads + flashes the latest published firmware, so recovery no longer requires hunting for a `.hex` (browse remains the fallback). Dark combobox styling; Upload is gated until there's something to flash.
- `IFirmwareUpdateService` / `IFirmwareDownloadService` resolved from DI (fail-fast) instead of newing up an `HttpClient`-backed service.

**Flash reliability (internal, no UX change):**
- **Never strand the device** on a failed WiFi flash: when the managed connection is already gone, `ResetLanAfterUpdate`'s transparent-mode exit silently no-ops, so we also send `SYSTem:USB:SetTransparentMode 0` over a raw serial write. Guarded on `!IsConnected` (no happy-path change) and run off the calling thread.
- **Pause + drain all device discovery** (WiFi + serial + HID) for the duration of a bootloader flash, restarting it when the dialog closes — a discovery probe re-opening the HID/serial handle mid-flash produced intermittent `Connecting`-state failures.

### Intentionally dropped (redundant with main)

The separate WiFi **badge / version line / notification / "Update WiFi" button** and the desktop-side hardcoded version check. Main's single "Update Firmware" already covers the WiFi module via the coordinator + Core, so these are unnecessary and contrary to the "just the firmware" model. The debug-only WiFi force-flash tooling for QA can come back as a small follow-up if still needed (it now lives most naturally on the coordinator).

## Testing

- New `FirmwareDialogViewModelTests` cover the dropdown load, upload gating, and download-latest vs browsed-`.hex` precedence.
- Fast unit gate green: **458/458** (`TestCategory!=Ui`).
- Not yet re-validated on the bench against hardware — the reliability changes (raw transparent-mode exit, discovery pause) should get a bench pass before merge.

> Note: this supersedes the original commits on the branch (which were built on a stale pre-#592 base). Original authorship preserved via co-author trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
