### PR TITLE
chore(test): add SD-card import-existing-file UI scenario

### DIFF
--- a/Daqifi.Desktop.UITest/SdCardImportExistingTests.cs
+++ b/Daqifi.Desktop.UITest/SdCardImportExistingTests.cs
@@ -1,0 +1,75 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Daqifi.Desktop.UITest;
+
+/// <summary>
+/// Focused end-to-end confirmation of the SD-card DOWNLOAD + IMPORT path alone, against a
+/// file already present on the card — deliberately decoupled from SD-card WRITE.
+///
+/// The full lifecycle test (<see cref="SdCardLoggingTests"/>) logs a fresh file and then
+/// imports it; when the device's SD WRITE side is wedged (no new file is finalized, the
+/// known intermittent bench state) that test fails at the write step and never exercises
+/// the download/import it shares with this one. This test connects over USB, lists the SD
+/// files already on the card, and imports the first one through the real DEVICE LOGS IMPORT
+/// button — driving the same production path the desktop uses
+/// (<c>SdCardSessionImporter.ImportFromDeviceAsync</c> -&gt; Core
+/// <c>DownloadSdCardFileAsync</c> -&gt; temp file -&gt; protobuf parse -&gt; SQLite bulk
+/// insert) — and asserts a non-empty session results. It is the GUI-level counterpart to the
+/// raw-serial proof that the device serves the file's bytes correctly.
+///
+/// Requires a DAQiFi device with an SD card that already holds at least one log file,
+/// connected via USB (SD operations are USB-only).
+/// </summary>
+[TestClass]
+public class SdCardImportExistingTests : DaqifiAppFixture
+{
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void SdCardImport_ExistingFileOnCard_ImportsToSession()
+    {
+        // Arrange — connect over USB (SD is USB-only).
+        ConnectFirstDevice(DeviceTransport.Serial);
+
+        var sessionsBefore = GetLoggedSessionCount();
+
+        // The card must already hold a file to import. GetSdCardFileCount marks the test
+        // inconclusive if no SD card is present; assert a file exists to import.
+        var fileCount = GetSdCardFileCount();
+        Assert.IsTrue(
+            fileCount > 0,
+            "Pre-condition failed: no files on the SD card to import. Stage at least one log file.");
+
+        // Act — import the first file on the card through the real DEVICE LOGS IMPORT button.
+        // This downloads it over USB (Core DownloadSdCardFileAsync) and imports it.
+        var importedFile = ImportSdCardFile();
+
+        // Assert (log) — the importer logged "Imported N samples ..." with N > 0, proving the
+        // downloaded file parsed into a non-empty session. This is the assertion that the
+        // original 0-byte defect would fail.
+        var importedSampleCount = WaitForImportedSampleCount(TimeSpan.FromSeconds(60));
+        Assert.IsTrue(
+            importedSampleCount > 0,
+            $"Expected importing existing SD file '{importedFile}' to yield a non-empty session, " +
+            $"but the importer reported {importedSampleCount} samples. A 0 here is the original " +
+            "download-returns-empty defect reproducing.");
+
+        // Assert (log) — the device import path completed successfully for the chosen file.
+        var successFragment = string.IsNullOrEmpty(importedFile)
+            ? "Successfully imported"
+            : $"Successfully imported '{importedFile}'";
+        Assert.IsTrue(
+            WaitForLogContains(successFragment, TimeSpan.FromSeconds(10)),
+            $"Expected a \"{successFragment} ... from device\" log line after the import, but none " +
+            "appeared. The download/parse failed.");
+
+        // Assert (UI) — a new row appears in the logged-session list.
+        WaitForLoggedSessionCount(sessionsBefore + 1, TimeSpan.FromSeconds(30));
+        var sessionsAfter = GetLoggedSessionCount();
+        Assert.IsTrue(
+            sessionsAfter > sessionsBefore,
+            $"Expected a new logged session after importing '{importedFile}' " +
+            $"(before={sessionsBefore}, after={sessionsAfter}).");
+    }
+}

--- a/Daqifi.Desktop.UITest/SdCardImportExistingTests.cs
+++ b/Daqifi.Desktop.UITest/SdCardImportExistingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Daqifi.Desktop.UITest;
@@ -24,6 +25,15 @@ namespace Daqifi.Desktop.UITest;
 [TestClass]
 public class SdCardImportExistingTests : DaqifiAppFixture
 {
+    /// <summary>
+    /// Connects over USB and imports a log file already present on the device's SD card
+    /// through the real DEVICE LOGS IMPORT button, asserting the importer reports a
+    /// non-empty session (samples &gt; 0), logs a success line, and adds a logged-session
+    /// row. This exercises the download + parse + insert path on its own, independently of
+    /// SD-card WRITE health. A deterministic target is chosen (newest <c>.bin</c> device log)
+    /// so the same file imports across runs. Marks the test inconclusive when the card holds
+    /// no files to import.
+    /// </summary>
     [TestMethod]
     [TestCategory("Ui")]
     [TestCategory("RequiresDevice")]
@@ -35,15 +45,32 @@ public class SdCardImportExistingTests : DaqifiAppFixture
         var sessionsBefore = GetLoggedSessionCount();
 
         // The card must already hold a file to import. GetSdCardFileCount marks the test
-        // inconclusive if no SD card is present; assert a file exists to import.
+        // inconclusive if no SD card is present. An empty-but-present card is an environment
+        // precondition, not a product failure, so treat it as inconclusive too (mirroring the
+        // fixture's "No SD card" handling) rather than a false-negative bench failure.
         var fileCount = GetSdCardFileCount();
-        Assert.IsTrue(
-            fileCount > 0,
-            "Pre-condition failed: no files on the SD card to import. Stage at least one log file.");
+        if (fileCount == 0)
+        {
+            Assert.Inconclusive(
+                "No files on the SD card to import. Stage at least one log file and re-run.");
+        }
 
-        // Act — import the first file on the card through the real DEVICE LOGS IMPORT button.
-        // This downloads it over USB (Core DownloadSdCardFileAsync) and imports it.
-        var importedFile = ImportSdCardFile();
+        // Pick a deterministic target: the device's file list applies no stable ordering and
+        // can mix .bin/.json/.csv, so "first row" varies across firmware responses. Prefer the
+        // newest .bin (the device-native log format), falling back to the newest importable
+        // file of any kind, then to first-file selection if names can't be read.
+        var fileNames = ReadSdCardFileNames();
+        var targetFileName =
+            fileNames.Where(n => n.EndsWith(".bin", StringComparison.OrdinalIgnoreCase))
+                     .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                     .LastOrDefault()
+            ?? fileNames.OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                        .LastOrDefault();
+
+        // Act — import the chosen file through the real DEVICE LOGS IMPORT button. This
+        // downloads it over USB (Core DownloadSdCardFileAsync) and imports it. A null/empty
+        // target falls back to the first file inside ImportSdCardFile.
+        var importedFile = ImportSdCardFile(targetFileName);
 
         // Assert (log) — the importer logged "Imported N samples ..." with N > 0, proving the
         // downloaded file parsed into a non-empty session. This is the assertion that the


### PR DESCRIPTION
## What

Adds `SdCardImportExistingTests.SdCardImport_ExistingFileOnCard_ImportsToSession` — a `[Ui]` + `[RequiresDevice]` FlaUI scenario that imports a log file **already present** on the device's SD card and asserts a non-empty `LoggingSession` results.

It drives the production import path through the real GUI: DEVICE LOGS → per-row **IMPORT** → `SdCardSessionImporter.ImportFromDeviceAsync` → Core `DownloadSdCardFileAsync` → protobuf parse → SQLite bulk insert, then asserts `Imported N samples` (N>0), `Successfully imported … from device`, and a +1 logged-session delta.

## Why

The existing `SdCardLoggingTests.SdCardLogging_LogsToSdCard_ThenImportsToSession` couples **SD write → import** in a single pass. When the device's SD **write** side is unhealthy it fails at the write/“new file appeared” step and never reaches the download/parse/import path the two tests share. This focused scenario exercises **download + import on its own**, against a file already on the card, so that path stays covered independently of SD-write health.

## Context

Added while root-causing a "SD download returns 0 bytes" defect. The bench investigation showed the failure is an **intermittent device-side SD-subsystem wedge** (firmware-side, tracked as daqifi-nyquist-firmware `#593`) — the same file/host code returns the full file when the device is healthy and a clean 0-byte (marker-only) transfer when wedged; a power-cycle recovers it. On a healthy device this test imports cleanly (verified locally: `ReportedSize=14668`, **18,745 samples**, `Passed!`).

The investigation also surfaced a Core gap — `DownloadSdCardFileAsync` reports an empty marker-only transfer as a *successful* 0-byte download instead of an error — filed as **daqifi/daqifi-core#264**. That fix lives in Core; this PR is test-only on the desktop side.

## Notes

- Test-only; no production code change.
- `[Ui]` + `[RequiresDevice]`, so it does **not** run in the unit gate or in CI without attached hardware (it compiles in the normal build).
- Requires a USB-connected device whose SD card already holds at least one log file (`GetSdCardFileCount` marks the test inconclusive otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
