### PR TITLE
feat(firmware): grab and hold a detected HID bootloader until flash

### DIFF
--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <PackageReference Include="Daqifi.Core" Version="0.25.0" />
+        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.9" />
-        <PackageReference Include="Daqifi.Core" Version="0.25.0" />
+        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Device.Firmware;
+using Moq;
+
+namespace Daqifi.Desktop.Test.Device.Firmware;
+
+/// <summary>
+/// Verifies the bootloader hold service grabs a sitting HID bootloader, keeps an interrupt-IN read
+/// continuously pending (the keep-alive that prevents the #568 USB selective-suspend wedge), and hands
+/// the handle off to the flasher without disconnecting — versus releasing it outright on close.
+/// </summary>
+[TestClass]
+public class BootloaderHoldServiceTests
+{
+    private Mock<IHidTransport> _transport = null!;
+    private Mock<IAppLogger> _logger = null!;
+    private int _readCount;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _transport = new Mock<IHidTransport>();
+        _logger = new Mock<IAppLogger>();
+        _readCount = 0;
+
+        _transport
+            .Setup(t => t.ConnectAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _transport
+            .Setup(t => t.DisconnectAsync())
+            .Returns(Task.CompletedTask);
+        // A sitting bootloader sends nothing, so every keep-alive read times out. Delay a touch so the
+        // loop is observable (and so cancellation can interrupt an in-flight read for the hard-stop path).
+        _transport
+            .Setup(t => t.ReadAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Returns((TimeSpan? _, CancellationToken ct) => KeepAliveReadStub(ct));
+    }
+
+    private async Task<byte[]> KeepAliveReadStub(CancellationToken ct)
+    {
+        Interlocked.Increment(ref _readCount);
+        await Task.Delay(15, ct).ConfigureAwait(false);
+        throw new TimeoutException();
+    }
+
+    private BootloaderHoldService CreateService() =>
+        new(_transport.Object, _logger.Object, TimeSpan.FromMilliseconds(50));
+
+    [TestMethod]
+    public async Task BeginHoldAsync_OpensTransport_AndKeepsReadingPending()
+    {
+        using var service = CreateService();
+
+        await service.BeginHoldAsync();
+
+        Assert.IsTrue(service.IsHolding, "Service should report holding after a successful open.");
+        _transport.Verify(t => t.ConnectAsync(
+            0x04D8, 0x003C, It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // The keep-alive loop must keep re-issuing reads (a single pending read is what keeps the USB
+        // link out of selective-suspend).
+        var sawMultipleReads = await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 2, TimeSpan.FromSeconds(2));
+        Assert.IsTrue(sawMultipleReads, "Keep-alive loop should issue repeated reads while holding.");
+
+        await service.ReleaseAsync();
+    }
+
+    [TestMethod]
+    public async Task BeginHoldAsync_WhenNoBootloaderPresent_DoesNotThrow_AndDoesNotHold()
+    {
+        _transport
+            .Setup(t => t.ConnectAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("No HID device found."));
+
+        using var service = CreateService();
+
+        // A just-flashed device is in application mode — the open fails and the hold is a no-op.
+        await service.BeginHoldAsync();
+
+        Assert.IsFalse(service.IsHolding, "Service must not report holding when the open failed.");
+        _transport.Verify(t => t.ReadAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PauseForFlashAsync_StopsKeepAlive_ButLeavesHandleOpen()
+    {
+        using var service = CreateService();
+        await service.BeginHoldAsync();
+        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
+
+        await service.PauseForFlashAsync();
+
+        Assert.IsFalse(service.IsHolding, "Service should no longer report holding after a pause.");
+        // The whole point of pausing (vs releasing) is to hand the flasher a warm, still-open handle.
+        _transport.Verify(t => t.DisconnectAsync(), Times.Never);
+
+        // No further reads after the pause drains the loop.
+        var countAfterPause = Volatile.Read(ref _readCount);
+        await Task.Delay(100);
+        Assert.AreEqual(countAfterPause, Volatile.Read(ref _readCount),
+            "Keep-alive reads must stop once the hold is paused for flashing.");
+    }
+
+    [TestMethod]
+    public async Task ReleaseAsync_StopsKeepAlive_AndDisconnects()
+    {
+        using var service = CreateService();
+        await service.BeginHoldAsync();
+        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
+
+        await service.ReleaseAsync();
+
+        Assert.IsFalse(service.IsHolding, "Service should no longer report holding after release.");
+        _transport.Verify(t => t.DisconnectAsync(), Times.Once);
+
+        var countAfterRelease = Volatile.Read(ref _readCount);
+        await Task.Delay(100);
+        Assert.AreEqual(countAfterRelease, Volatile.Read(ref _readCount),
+            "Keep-alive reads must stop once the hold is released.");
+    }
+
+    [TestMethod]
+    public async Task BeginHoldAsync_WhenAlreadyHolding_DoesNotReopen()
+    {
+        using var service = CreateService();
+
+        await service.BeginHoldAsync();
+        await service.BeginHoldAsync();
+
+        _transport.Verify(t => t.ConnectAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        await service.ReleaseAsync();
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return condition();
+    }
+}

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -17,6 +17,7 @@ public class BootloaderHoldServiceTests
     private Mock<IHidTransport> _transport = null!;
     private Mock<IAppLogger> _logger = null!;
     private int _readCount;
+    private int _connectCount;
 
     [TestInitialize]
     public void Setup()
@@ -24,11 +25,12 @@ public class BootloaderHoldServiceTests
         _transport = new Mock<IHidTransport>();
         _logger = new Mock<IAppLogger>();
         _readCount = 0;
+        _connectCount = 0;
 
         _transport
             .Setup(t => t.ConnectAsync(
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .Returns(() => { Interlocked.Increment(ref _connectCount); return Task.CompletedTask; });
         _transport
             .Setup(t => t.DisconnectAsync())
             .Returns(Task.CompletedTask);
@@ -153,17 +155,20 @@ public class BootloaderHoldServiceTests
             .Returns((TimeSpan? _, CancellationToken ct) => KeepAliveReadThrows(ct));
 
         using var service = CreateService();
-        await service.BeginHoldAsync();
+        await service.BeginHoldAsync(); // open #1; the keep-alive immediately faults and the loop exits
 
-        // Wait for the keep-alive loop to fault and exit (read attempted, then the loop task completes).
-        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
-        await Task.Delay(50);
+        // Re-grab must re-establish once the faulted loop has exited. Retry on a bounded deadline rather
+        // than a fixed sleep so the test isn't timing-flaky: each BeginHoldAsync no-ops while the loop
+        // task is still running, then re-opens the transport once it has completed.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (Volatile.Read(ref _connectCount) < 2 && DateTime.UtcNow < deadline)
+        {
+            await service.BeginHoldAsync();
+            await Task.Delay(20);
+        }
 
-        // Re-grab must NOT no-op on the stale holding state — it must tear down and reconnect.
-        await service.BeginHoldAsync();
-
-        _transport.Verify(t => t.ConnectAsync(
-            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        Assert.IsTrue(Volatile.Read(ref _connectCount) >= 2,
+            "A faulted keep-alive must not leave a stale hold; BeginHoldAsync should re-open the transport.");
 
         await service.ReleaseAsync();
     }

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -46,6 +46,13 @@ public class BootloaderHoldServiceTests
         throw new TimeoutException();
     }
 
+    private async Task<byte[]> KeepAliveReadThrows(CancellationToken ct)
+    {
+        Interlocked.Increment(ref _readCount);
+        await Task.Yield();
+        throw new IOException("device gone");
+    }
+
     private BootloaderHoldService CreateService() =>
         new(_transport.Object, _logger.Object, TimeSpan.FromMilliseconds(50));
 
@@ -133,6 +140,30 @@ public class BootloaderHoldServiceTests
 
         _transport.Verify(t => t.ConnectAsync(
             It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        await service.ReleaseAsync();
+    }
+
+    [TestMethod]
+    public async Task BeginHoldAsync_AfterKeepAliveFaults_ReEstablishesHold()
+    {
+        // Keep-alive read throws a non-timeout error → the loop exits (device I/O error / surprise removal).
+        _transport
+            .Setup(t => t.ReadAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Returns((TimeSpan? _, CancellationToken ct) => KeepAliveReadThrows(ct));
+
+        using var service = CreateService();
+        await service.BeginHoldAsync();
+
+        // Wait for the keep-alive loop to fault and exit (read attempted, then the loop task completes).
+        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
+        await Task.Delay(50);
+
+        // Re-grab must NOT no-op on the stale holding state — it must tear down and reconnect.
+        await service.BeginHoldAsync();
+
+        _transport.Verify(t => t.ConnectAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
 
         await service.ReleaseAsync();
     }

--- a/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
@@ -33,6 +33,18 @@ public class FirmwareUpdateServiceConfigTests
     }
 
     [TestMethod]
+    public void CreateBootloaderHidTransport_RequestsExclusiveOpen()
+    {
+        // Act
+        var transport = FirmwareUpdateServiceConfig.CreateBootloaderHidTransport();
+
+        // Assert - the flash session must hold the bootloader's HID handle exclusively so no other
+        // user-mode opener (the discovery loop, a second app instance) can write a stray frame the
+        // CRC-disabled bootloader could mis-parse as an ERASE (A2 stray-write guard).
+        Assert.IsTrue(transport.ExclusiveAccess);
+    }
+
+    [TestMethod]
     public void CreateOptions_SetsBootloaderResponseTimeout()
     {
         // Act - the service passes BootloaderResponseTimeout to every bootloader read.

--- a/Daqifi.Desktop/App.xaml.cs
+++ b/Daqifi.Desktop/App.xaml.cs
@@ -103,6 +103,7 @@ public partial class App
                     && category.StartsWith("Daqifi", StringComparison.OrdinalIgnoreCase)
                     && level is >= LogLevel.Information and < LogLevel.None));
         });
+
         serviceCollection.AddHttpClient();
         serviceCollection.AddSingleton<IFirmwareDownloadService>(provider =>
         {
@@ -119,6 +120,13 @@ public partial class App
             provider.GetRequiredService<IExternalProcessRunner>(),
             provider.GetRequiredService<ILogger<FirmwareUpdateService>>(),
             options: FirmwareUpdateServiceConfig.CreateOptions()));
+        // Holds a sitting HID bootloader's handle open (over the SAME exclusive transport the flasher
+        // uses) with a keep-alive read pending, so Windows USB selective-suspend can't wedge it before
+        // the user flashes (daqifi-nyquist-firmware#568). The connection dialog grabs the hold on
+        // detection and hands the warm handle to the flasher.
+        serviceCollection.AddSingleton<IBootloaderHoldService>(provider => new BootloaderHoldService(
+            provider.GetRequiredService<IHidTransport>(),
+            Common.Loggers.AppLogger.Instance));
 
         serviceCollection.AddSingleton<LoggingManager>();
         ServiceLocator.RegisterSingleton<IDialogService, DialogService.DialogService>();

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <PackageReference Include="Daqifi.Core" Version="0.25.0" />
+        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -79,7 +79,27 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         {
             if (_holding)
             {
-                return;
+                // Already holding with a live keep-alive loop — nothing to do.
+                if (_keepAliveTask is { IsCompleted: false })
+                {
+                    return;
+                }
+
+                // The keep-alive loop exited early (device I/O error / surprise removal) but the hold
+                // state was never cleared. Tear the stale hold down here so we re-establish it below
+                // instead of no-opping and leaving the device unprotected from selective-suspend.
+                _logger.Information("HID bootloader keep-alive had stopped; re-establishing the hold.");
+                await StopKeepAliveAsync(hard: true).ConfigureAwait(false);
+                try
+                {
+                    await _transport.DisconnectAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning(ex, "Error disconnecting a stale HID bootloader hold before re-establishing.");
+                }
+
+                _holding = false;
             }
 
             try

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -244,9 +244,11 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
     private async Task StopKeepAliveAsync(bool hard)
     {
         _stopKeepAlive = true;
+
+        var cts = _keepAliveCts;
         if (hard)
         {
-            try { _keepAliveCts?.Cancel(); }
+            try { cts?.Cancel(); }
             catch (ObjectDisposedException) { /* already torn down */ }
         }
 
@@ -255,6 +257,23 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         {
             try
             {
+                if (!hard)
+                {
+                    // Graceful: let the in-flight read drain naturally so no orphaned read IRP collides
+                    // with the flasher. Bound the wait — if the read doesn't complete within its own
+                    // timeout (+ a small margin), escalate to cancellation so PauseForFlashAsync can never
+                    // hang the flash on a wedged/stuck read.
+                    var drained = await Task
+                        .WhenAny(task, Task.Delay(_keepAliveReadTimeout + TimeSpan.FromMilliseconds(250)))
+                        .ConfigureAwait(false);
+                    if (drained != task)
+                    {
+                        _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
+                        try { cts?.Cancel(); }
+                        catch (ObjectDisposedException) { /* already torn down */ }
+                    }
+                }
+
                 await task.ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -255,30 +255,31 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         var task = _keepAliveTask;
         if (task != null)
         {
-            try
-            {
-                if (!hard)
-                {
-                    // Graceful: let the in-flight read drain naturally so no orphaned read IRP collides
-                    // with the flasher. Bound the wait — if the read doesn't complete within its own
-                    // timeout (+ a small margin), escalate to cancellation so PauseForFlashAsync can never
-                    // hang the flash on a wedged/stuck read.
-                    var drained = await Task
-                        .WhenAny(task, Task.Delay(_keepAliveReadTimeout + TimeSpan.FromMilliseconds(250)))
-                        .ConfigureAwait(false);
-                    if (drained != task)
-                    {
-                        _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
-                        try { cts?.Cancel(); }
-                        catch (ObjectDisposedException) { /* already torn down */ }
-                    }
-                }
+            var settle = _keepAliveReadTimeout + TimeSpan.FromMilliseconds(250);
 
-                await task.ConfigureAwait(false);
-            }
-            catch (Exception ex)
+            // Graceful: let the in-flight read drain naturally first (so no orphaned read IRP collides
+            // with the flasher), bounded; on timeout, escalate to cancellation.
+            if (!hard)
             {
-                _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop.");
+                if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) != task)
+                {
+                    _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
+                    try { cts?.Cancel(); }
+                    catch (ObjectDisposedException) { /* already torn down */ }
+                }
+            }
+
+            // The FINAL wait is also bounded: a wedged/non-cancelable ReadAsync must never block the
+            // flash hand-off. If the loop still hasn't stopped, abandon the task (the cancelled read
+            // drains on its own later) rather than awaiting it indefinitely.
+            if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) == task)
+            {
+                try { await task.ConfigureAwait(false); }
+                catch (Exception ex) { _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop."); }
+            }
+            else
+            {
+                _logger.Warning("HID bootloader keep-alive loop did not stop after cancellation; abandoning it.");
             }
         }
 

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -1,0 +1,278 @@
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device.Discovery;
+using Daqifi.Desktop.Common.Loggers;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Default <see cref="IBootloaderHoldService"/> implementation. Holds the shared exclusive HID transport
+/// open with a continuously-pending interrupt-IN read to keep a sitting PIC32 bootloader out of USB
+/// selective-suspend (the cause of the #568 wedge). See <see cref="IBootloaderHoldService"/> for the
+/// full rationale.
+/// </summary>
+public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
+{
+    #region Constants
+    // VID/PID of the PIC32 HID bootloader. Single source of truth: Core's HID finder defaults
+    // (0x04D8 / 0x003C).
+    private const int BOOTLOADER_VENDOR_ID = HidDeviceFinder.DefaultVendorId;
+    private const int BOOTLOADER_PRODUCT_ID = HidDeviceFinder.DefaultProductId;
+
+    /// <summary>
+    /// Default per-read timeout for the keep-alive poll. Short enough that a read is pending
+    /// essentially continuously (so Windows never starts the USB selective-suspend idle timer), long
+    /// enough to avoid a tight busy-loop. A sitting bootloader sends nothing, so each read times out
+    /// and is immediately re-issued.
+    /// </summary>
+    public static readonly TimeSpan DefaultKeepAliveReadTimeout = TimeSpan.FromSeconds(1);
+    #endregion
+
+    #region Private Fields
+    private readonly IHidTransport _transport;
+    private readonly IAppLogger _logger;
+    private readonly TimeSpan _keepAliveReadTimeout;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private CancellationTokenSource? _keepAliveCts;
+    private Task? _keepAliveTask;
+    private volatile bool _stopKeepAlive;
+    private bool _holding;
+    private bool _disposed;
+    #endregion
+
+    #region Constructor
+    /// <summary>
+    /// Creates the hold service over the shared HID transport.
+    /// </summary>
+    /// <param name="transport">
+    /// The shared bootloader HID transport (the same DI singleton the flasher uses, configured for
+    /// exclusive access). Holding this transport open also locks every other user-mode opener out for
+    /// the duration of the hold (the A2 stray-write guard).
+    /// </param>
+    /// <param name="logger">Application logger for diagnostics.</param>
+    /// <param name="keepAliveReadTimeout">
+    /// Per-read keep-alive timeout. Null uses <see cref="DefaultKeepAliveReadTimeout"/>; tests pass a
+    /// small value to make the loop observable quickly.
+    /// </param>
+    public BootloaderHoldService(IHidTransport transport, IAppLogger logger, TimeSpan? keepAliveReadTimeout = null)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _keepAliveReadTimeout = keepAliveReadTimeout ?? DefaultKeepAliveReadTimeout;
+    }
+    #endregion
+
+    #region Public Methods
+    /// <inheritdoc />
+    public bool IsHolding => _holding;
+
+    /// <inheritdoc />
+    public async Task BeginHoldAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_holding)
+            {
+                return;
+            }
+
+            try
+            {
+                // Grab the bootloader's HID handle. ExclusiveAccess is set on the shared transport
+                // (FirmwareUpdateServiceConfig.CreateBootloaderHidTransport), so this also locks out
+                // every other user-mode opener for the duration of the hold. ConnectAsync returns
+                // immediately if the transport is already connected (e.g. the handle the flasher just
+                // left open), in which case we simply (re)start the keep-alive over it.
+                await _transport
+                    .ConnectAsync(BOOTLOADER_VENDOR_ID, BOOTLOADER_PRODUCT_ID, null, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // No bootloader present (a just-flashed device is now in application mode) or the open
+                // was refused. Holding is best-effort — stay un-held; the flash path's own connect +
+                // handshake retry still covers a device that shows up or recovers later.
+                _logger.Warning(ex, "Could not open the HID bootloader to hold it; continuing without a hold.");
+                return;
+            }
+
+            _stopKeepAlive = false;
+            _keepAliveCts = new CancellationTokenSource();
+            _keepAliveTask = Task.Run(() => KeepAliveLoopAsync(_keepAliveCts.Token));
+            _holding = true;
+
+            _logger.Information(
+                "Holding the HID bootloader handle (keep-alive read pending) so Windows USB selective-suspend " +
+                "cannot wedge it before flashing (daqifi-nyquist-firmware#568).");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task PauseForFlashAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!_holding)
+            {
+                return;
+            }
+
+            // Graceful stop: signal the loop and let its in-flight read complete naturally (within one
+            // keep-alive timeout) so no orphaned read IRP is left pending to swallow the flasher's first
+            // response. Deliberately do NOT disconnect — leave the handle OPEN and warm. The flasher's
+            // ConnectToBootloaderWithRetryAsync sees it connected, closes+reopens it back-to-back (no
+            // idle window, so no #568 wedge) and flashes. Handing it a warm handle is the point of the hold.
+            await StopKeepAliveAsync(hard: false).ConfigureAwait(false);
+            _holding = false;
+
+            _logger.Information("Paused the HID bootloader hold for flashing; handle left open for the flasher.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // Hard stop (no flash follows): cancel any in-flight read and close the handle so the device
+            // is never left held after the dialog goes away.
+            await StopKeepAliveAsync(hard: true).ConfigureAwait(false);
+
+            try
+            {
+                await _transport.DisconnectAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Error while releasing the HID bootloader handle.");
+            }
+
+            _holding = false;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+    #endregion
+
+    #region Private Methods
+    private async Task KeepAliveLoopAsync(CancellationToken cancellationToken)
+    {
+        // Keep an interrupt-IN read continuously pending. A pending read IRP keeps the USB link active so
+        // Windows never selective-suspends the device — the suspend whose reopen-without-SET_CONFIGURATION
+        // wedges the bootloader (#568). An *idle* open handle alone does NOT prevent suspend; the pending
+        // read does. Reads carry no payload TO the device, so unlike a write they can never be mis-parsed
+        // as a stray command — this is the one form of I/O that is safe to direct at a sitting bootloader.
+        while (!cancellationToken.IsCancellationRequested && !_stopKeepAlive)
+        {
+            try
+            {
+                // A sitting bootloader sends nothing unsolicited, so this normally times out; that is the
+                // expected, healthy case. Any bytes returned are discarded (no command is in flight).
+                await _transport.ReadAsync(_keepAliveReadTimeout, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                // Expected: idle bootloader, no data. Re-issue immediately to keep a read pending.
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // The handle went away (device detached / flashed / surprise-removed). Stop quietly; the
+                // flash path re-discovers and reconnects on its own.
+                _logger.Warning(ex, "HID bootloader keep-alive read failed; ending the hold.");
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stops the keep-alive loop and awaits its completion. When <paramref name="hard"/> is true the
+    /// in-flight read is cancelled immediately; when false it is allowed to drain naturally (so the
+    /// flasher inherits a quiescent handle with no orphaned read IRP). Must be called under <see cref="_gate"/>.
+    /// </summary>
+    private async Task StopKeepAliveAsync(bool hard)
+    {
+        _stopKeepAlive = true;
+        if (hard)
+        {
+            try { _keepAliveCts?.Cancel(); }
+            catch (ObjectDisposedException) { /* already torn down */ }
+        }
+
+        var task = _keepAliveTask;
+        if (task != null)
+        {
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop.");
+            }
+        }
+
+        _keepAliveTask = null;
+        _keepAliveCts?.Dispose();
+        _keepAliveCts = null;
+    }
+    #endregion
+
+    #region IDisposable
+    /// <summary>
+    /// Tears down the keep-alive loop. Does NOT dispose the transport — it is a shared DI singleton
+    /// owned by the container.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _stopKeepAlive = true;
+
+        try { _keepAliveCts?.Cancel(); }
+        catch (ObjectDisposedException) { /* already torn down */ }
+
+        try { _keepAliveTask?.Wait(TimeSpan.FromSeconds(2)); }
+        catch (Exception) { /* best-effort during shutdown */ }
+
+        _keepAliveCts?.Dispose();
+        _keepAliveCts = null;
+        _gate.Dispose();
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -243,6 +243,13 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
     /// </summary>
     private async Task StopKeepAliveAsync(bool hard)
     {
+        // Await the loop to completion — deliberately, not with an "abandon on timeout" fallback. The
+        // wait is already self-bounding: each keep-alive read is capped by the transport's own read
+        // timeout (_keepAliveReadTimeout, ~1s), so once _stopKeepAlive is set the in-flight read
+        // returns/throws and the loop exits within that window. Abandoning a still-running read would be
+        // worse than waiting: the orphaned read keeps the shared transport's I/O lock, so the flasher's
+        // reconnect would race/block on it anyway — the exact orphaned-read hand-off hazard this drain
+        // exists to prevent. The hard path additionally cancels so the in-flight read aborts at once.
         _stopKeepAlive = true;
 
         var cts = _keepAliveCts;
@@ -255,31 +262,13 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         var task = _keepAliveTask;
         if (task != null)
         {
-            var settle = _keepAliveReadTimeout + TimeSpan.FromMilliseconds(250);
-
-            // Graceful: let the in-flight read drain naturally first (so no orphaned read IRP collides
-            // with the flasher), bounded; on timeout, escalate to cancellation.
-            if (!hard)
+            try
             {
-                if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) != task)
-                {
-                    _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
-                    try { cts?.Cancel(); }
-                    catch (ObjectDisposedException) { /* already torn down */ }
-                }
+                await task.ConfigureAwait(false);
             }
-
-            // The FINAL wait is also bounded: a wedged/non-cancelable ReadAsync must never block the
-            // flash hand-off. If the loop still hasn't stopped, abandon the task (the cancelled read
-            // drains on its own later) rather than awaiting it indefinitely.
-            if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) == task)
+            catch (Exception ex)
             {
-                try { await task.ConfigureAwait(false); }
-                catch (Exception ex) { _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop."); }
-            }
-            else
-            {
-                _logger.Warning("HID bootloader keep-alive loop did not stop after cancellation; abandoning it.");
+                _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop.");
             }
         }
 

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -64,7 +64,7 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
 
     #region Public Methods
     /// <inheritdoc />
-    public bool IsHolding => _holding;
+    public bool IsHolding => Volatile.Read(ref _holding);
 
     /// <inheritdoc />
     public async Task BeginHoldAsync(CancellationToken cancellationToken = default)

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
@@ -43,7 +43,15 @@ public static class FirmwareUpdateServiceConfig
         return new HidLibraryTransport
         {
             ReadTimeout = BootloaderHidTimeout,
-            WriteTimeout = BootloaderHidTimeout
+            WriteTimeout = BootloaderHidTimeout,
+
+            // A2 (stray-write guard): open the bootloader's HID handle exclusively and hold it for
+            // the whole flash session so no other user-mode opener — the connection dialog's own HID
+            // discovery loop, a second app instance, anything — can open or write to the device
+            // mid-flash. The PIC32 bootloader's CRC check is disabled, so a stray frame from another
+            // opener can be mis-parsed as an ERASE; the exclusive handle is the guard. Best-effort in
+            // Core: a refused exclusive open falls back to shared so a working flash is not regressed.
+            ExclusiveAccess = true
         };
     }
 

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderHoldService.cs
@@ -1,0 +1,44 @@
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Grabs and holds a sitting PIC32 HID bootloader's USB handle so it cannot be wedged by Windows USB
+/// selective-suspend before the user flashes it (daqifi-nyquist-firmware#568).
+/// <para>
+/// The wedge happens when the host lets an idle bootloader go to selective-suspend and then reopens it:
+/// the reopen is a bus RESET with no follow-up SET_CONFIGURATION, so the device never reaches
+/// <c>USB_DEVICE_EVENT_CONFIGURED</c>, its data endpoints stay dark, and the version handshake times
+/// out. The cure is to never let it suspend in the first place: hold the handle open with an
+/// interrupt-IN read continuously pending (an <em>idle</em> open handle alone does not stop suspend — a
+/// pending read IRP does). Reads carry no payload to the device, so unlike a write they can never be
+/// mis-parsed as a stray command — they are the one form of I/O safe to direct at a sitting bootloader.
+/// </para>
+/// <para>
+/// The hold uses the same shared exclusive <c>IHidTransport</c> the flasher uses, so handing off to the
+/// flash is seamless: the flasher reopens the already-warm handle with no idle gap.
+/// </para>
+/// </summary>
+public interface IBootloaderHoldService
+{
+    /// <summary>Whether a hold is currently active (handle open, keep-alive read pending).</summary>
+    bool IsHolding { get; }
+
+    /// <summary>
+    /// Opens the bootloader's HID handle and starts the keep-alive read loop. Best-effort and
+    /// idempotent: if no bootloader is present (e.g. a just-flashed device now in application mode) the
+    /// open fails and the call returns without holding and without throwing. A no-op if already holding.
+    /// </summary>
+    Task BeginHoldAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops the keep-alive read so the flasher can own the device's HID I/O, but leaves the handle
+    /// OPEN and warm for the flasher to reopen with no idle gap. Lets the in-flight read drain fully so
+    /// no orphaned read IRP can swallow the flasher's first response. Call immediately before flashing.
+    /// </summary>
+    Task PauseForFlashAsync();
+
+    /// <summary>
+    /// Stops the keep-alive read and closes the handle. Call when the device is no longer being managed
+    /// (the connection dialog closes) so the bootloader is never left held.
+    /// </summary>
+    Task ReleaseAsync();
+}

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Device.Firmware;
 using Daqifi.Desktop.Device.SerialDevice;
 using Daqifi.Desktop.Device.WiFiDevice;
 using Daqifi.Desktop.DialogService;
@@ -10,6 +11,7 @@ using System.Net;
 using System.Net.Sockets;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Daqifi.Core.Device.Discovery;
 using CoreConcreteDeviceInfo = Daqifi.Core.Device.Discovery.DeviceInfo;
 using CoreConnectionType = Daqifi.Core.Device.Discovery.ConnectionType;
@@ -30,6 +32,13 @@ public partial class ConnectionDialogViewModel : ObservableObject
     private Task? _serialDiscoveryTask;
     private Task? _hidDiscoveryTask;
     private readonly IDialogService _dialogService;
+
+    /// <summary>
+    /// Holds a detected HID bootloader's handle open so Windows USB selective-suspend can't wedge it
+    /// before the user flashes (daqifi-nyquist-firmware#568). Null only in unit tests that construct the
+    /// view model without the DI container.
+    /// </summary>
+    private readonly IBootloaderHoldService? _bootloaderHoldService;
 
     [ObservableProperty]
     private bool _hasNoWiFiDevices = true;
@@ -100,11 +109,15 @@ public partial class ConnectionDialogViewModel : ObservableObject
     }
 
     #region Constructor
-    public ConnectionDialogViewModel() : this(ServiceLocator.Resolve<IDialogService>()) { }
+    public ConnectionDialogViewModel()
+        : this(ServiceLocator.Resolve<IDialogService>(), App.ServiceProvider?.GetService<IBootloaderHoldService>()) { }
 
-    public ConnectionDialogViewModel(IDialogService dialogService)
+    public ConnectionDialogViewModel(
+        IDialogService dialogService,
+        IBootloaderHoldService? bootloaderHoldService = null)
     {
         _dialogService = dialogService;
+        _bootloaderHoldService = bootloaderHoldService;
         ConnectCommand = new AsyncRelayCommand<object>(ConnectAsync);
         ConnectSerialCommand = new AsyncRelayCommand<object>(ConnectSerialAsync);
         ConnectManualSerialCommand = new AsyncRelayCommand(ConnectManualSerialAsync);
@@ -229,6 +242,21 @@ public partial class ConnectionDialogViewModel : ObservableObject
             while (!cancellationToken.IsCancellationRequested && _hidDeviceFinder != null)
             {
                 await _hidDeviceFinder.DiscoverAsync(cancellationToken);
+
+                // Stop repolling once a HID bootloader is in the list. Each DiscoverAsync cycle opens
+                // every matching HID device to read its USB string descriptors; for a bootloader that
+                // is just sitting here waiting to be flashed, that repeated ~2s open/close churn
+                // darkens its data endpoint (daqifi-nyquist-firmware#568) before the user ever clicks
+                // Upload. One enumeration is enough to list it — after that, leave it untouched until
+                // the flash itself opens it. Re-entering the dialog restarts discovery via
+                // StartHidDiscovery, so a hot-plugged bootloader is still picked up.
+                if (AvailableHidDevices.Count > 0)
+                {
+                    Common.Loggers.AppLogger.Instance.Information(
+                        "HID bootloader found — stopping HID discovery so the sitting device is not re-opened before flashing.");
+                    break;
+                }
+
                 // HID discovery is quick, pause longer between scans
                 await Task.Delay(2000, cancellationToken);
             }
@@ -466,6 +494,15 @@ public partial class ConnectionDialogViewModel : ObservableObject
         await StopWiFiDiscoveryAsync();
         await StopSerialDiscoveryAsync();
         await StopHidDiscoveryAsync();
+
+        // Hand the held handle to the flasher: stop the keep-alive read so the flash owns the device's
+        // HID I/O, but leave the handle OPEN and warm. The flasher closes+reopens it back-to-back (no
+        // idle gap, so no #568 wedge). No-op if we were never holding (the handle wasn't grabbed).
+        if (_bootloaderHoldService != null)
+        {
+            await _bootloaderHoldService.PauseForFlashAsync();
+        }
+
         try
         {
             var firmwareDialogViewModel = new FirmwareDialogViewModel(hidDevice.Name);
@@ -473,6 +510,15 @@ public partial class ConnectionDialogViewModel : ObservableObject
         }
         finally
         {
+            // Re-grab the hold if the device is still a sitting bootloader (the user cancelled, or the
+            // flash failed). A successful flash left it in application mode, so BeginHoldAsync finds no
+            // bootloader and no-ops. This keeps the device wedge-proof across a retry without reopening
+            // the dialog.
+            if (_bootloaderHoldService != null)
+            {
+                await _bootloaderHoldService.BeginHoldAsync();
+            }
+
             // Resume discovery once the flash dialog closes so the device list stays live.
             StartWiFiDiscovery();
             StartSerialDiscovery();
@@ -585,6 +631,12 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
                 AvailableHidDevices.Add(discoveredDevice);
                 HasNoHidDevices = AvailableHidDevices.Count == 0;
+
+                // A bootloader-VID/PID device just appeared. Immediately grab and hold its HID handle
+                // (exclusive, keep-alive read pending) so Windows USB selective-suspend can't wedge it
+                // into the #568 state while it sits here waiting to be flashed. Fire-and-forget: the
+                // open + keep-alive runs off the UI thread, and the hold is idempotent.
+                _ = _bootloaderHoldService?.BeginHoldAsync();
             });
         }
         catch (Exception ex)
@@ -628,6 +680,10 @@ public partial class ConnectionDialogViewModel : ObservableObject
         // Fire-and-forget: cancel discovery and clean up without waiting for task completion
         _ = StopSerialDiscoveryAsync();
         StopHidDiscovery();
+
+        // Release any held bootloader handle so the device is never left grabbed after the dialog
+        // closes. Fire-and-forget for the same reason as the serial drain above.
+        _ = _bootloaderHoldService?.ReleaseAsync();
     }
 
     private void StopWiFiDiscovery()

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -495,14 +495,11 @@ public partial class ConnectionDialogViewModel : ObservableObject
         await StopSerialDiscoveryAsync();
         await StopHidDiscoveryAsync();
 
-        // Hand the held handle to the flasher: stop the keep-alive read so the flash owns the device's
-        // HID I/O, but leave the handle OPEN and warm. The flasher closes+reopens it back-to-back (no
-        // idle gap, so no #568 wedge). No-op if we were never holding (the handle wasn't grabbed).
-        if (_bootloaderHoldService != null)
-        {
-            await _bootloaderHoldService.PauseForFlashAsync();
-        }
-
+        // Keep holding (keep-alive active) WHILE the dialog is open — the user may sit here for a while
+        // before clicking Upload, and an idle open handle alone does not stop USB selective-suspend, so
+        // pausing now would re-open the #568 wedge window. The flasher pauses the keep-alive itself at
+        // the moment the flash starts (FirmwareDialogViewModel.UploadFirmware), handing itself a warm
+        // handle with no idle gap.
         try
         {
             var firmwareDialogViewModel = new FirmwareDialogViewModel(hidDevice.Name);

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -16,6 +16,13 @@ public partial class FirmwareDialogViewModel : ObservableObject
     private readonly IFirmwareUpdateService _firmwareUpdateService;
     private readonly IFirmwareDownloadService _firmwareDownloadService;
     private readonly Daqifi.Core.Device.IStreamingDevice _coreDevice;
+
+    /// <summary>
+    /// The bootloader hold (keep-alive) that kept the device out of USB selective-suspend while the
+    /// user was deciding. Paused the instant the flash begins so the flasher owns the HID I/O. Null
+    /// only in unit tests that construct the view model without the DI container.
+    /// </summary>
+    private readonly IBootloaderHoldService? _bootloaderHoldService;
     private CancellationTokenSource? _updateCts;
 
     [ObservableProperty]
@@ -64,7 +71,8 @@ public partial class FirmwareDialogViewModel : ObservableObject
     public FirmwareDialogViewModel(
         string? hidDeviceName,
         IFirmwareUpdateService? firmwareUpdateService = null,
-        IFirmwareDownloadService? firmwareDownloadService = null)
+        IFirmwareDownloadService? firmwareDownloadService = null,
+        IBootloaderHoldService? bootloaderHoldService = null)
     {
         // Resolve from DI rather than newing up services/HttpClient here. Both are registered in
         // App.ConfigureServices and the provider is always present at runtime; the throw is a
@@ -76,6 +84,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
         _firmwareDownloadService = firmwareDownloadService
             ?? App.ServiceProvider?.GetService<IFirmwareDownloadService>()
             ?? throw new InvalidOperationException("IFirmwareDownloadService is not registered.");
+
+        // Optional: the connection dialog grabs the bootloader hold and this dialog pauses it at flash
+        // start. Resolved from DI in production; null is fine (no hold to pause) for tests/standalone use.
+        _bootloaderHoldService = bootloaderHoldService ?? App.ServiceProvider?.GetService<IBootloaderHoldService>();
 
         _coreDevice = new BootloaderSessionStreamingDeviceAdapter(hidDeviceName ?? "DAQiFi Bootloader");
 
@@ -201,6 +213,15 @@ public partial class FirmwareDialogViewModel : ObservableObject
             {
                 UploadFirmwareProgress = Math.Clamp((int)Math.Round(report.PercentComplete), 0, 100);
             });
+
+            // Stop the keep-alive hold right as the flash begins so the flasher owns the device's HID
+            // I/O. The hold stayed active across the user's time in this dialog (so the device couldn't
+            // selective-suspend/wedge while they decided); pausing here hands the flasher a warm,
+            // still-open handle it reopens with no idle gap.
+            if (_bootloaderHoldService != null)
+            {
+                await _bootloaderHoldService.PauseForFlashAsync();
+            }
 
             await _firmwareUpdateService.UpdateFirmwareAsync(
                 _coreDevice,

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -217,31 +217,18 @@ public partial class FirmwareDialogViewModel : ObservableObject
             // Stop the keep-alive hold right as the flash begins so the flasher owns the device's HID
             // I/O. The hold stayed active across the user's time in this dialog (so the device couldn't
             // selective-suspend/wedge while they decided); pausing here hands the flasher a warm,
-            // still-open handle it reopens with no idle gap.
+            // still-open handle it reopens with no idle gap. If the flash fails or is cancelled, the
+            // connection dialog re-grabs the hold when this dialog closes (ConnectHid's finally).
             if (_bootloaderHoldService != null)
             {
                 await _bootloaderHoldService.PauseForFlashAsync();
             }
 
-            try
-            {
-                await _firmwareUpdateService.UpdateFirmwareAsync(
-                    _coreDevice,
-                    FirmwareFilePath,
-                    progress,
-                    _updateCts.Token);
-            }
-            catch
-            {
-                // Flash failed or was cancelled — re-establish the hold so the device stays wedge-proof
-                // if the user retries from this still-open dialog (the keep-alive was paused above). On
-                // success we skip this: the device has rebooted into the application and is gone.
-                // Fire-and-forget: do NOT await, so the rethrow and the outer finally (which clears the
-                // "uploading" state) aren't delayed by a blocking HID open. BeginHoldAsync is best-effort
-                // and logs its own failures.
-                _ = _bootloaderHoldService?.BeginHoldAsync();
-                throw;
-            }
+            await _firmwareUpdateService.UpdateFirmwareAsync(
+                _coreDevice,
+                FirmwareFilePath,
+                progress,
+                _updateCts.Token);
 
             IsUploadComplete = true;
             AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update completed");

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -236,11 +236,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
                 // Flash failed or was cancelled — re-establish the hold so the device stays wedge-proof
                 // if the user retries from this still-open dialog (the keep-alive was paused above). On
                 // success we skip this: the device has rebooted into the application and is gone.
-                if (_bootloaderHoldService != null)
-                {
-                    await _bootloaderHoldService.BeginHoldAsync();
-                }
-
+                // Fire-and-forget: do NOT await, so the rethrow and the outer finally (which clears the
+                // "uploading" state) aren't delayed by a blocking HID open. BeginHoldAsync is best-effort
+                // and logs its own failures.
+                _ = _bootloaderHoldService?.BeginHoldAsync();
                 throw;
             }
 

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -223,11 +223,26 @@ public partial class FirmwareDialogViewModel : ObservableObject
                 await _bootloaderHoldService.PauseForFlashAsync();
             }
 
-            await _firmwareUpdateService.UpdateFirmwareAsync(
-                _coreDevice,
-                FirmwareFilePath,
-                progress,
-                _updateCts.Token);
+            try
+            {
+                await _firmwareUpdateService.UpdateFirmwareAsync(
+                    _coreDevice,
+                    FirmwareFilePath,
+                    progress,
+                    _updateCts.Token);
+            }
+            catch
+            {
+                // Flash failed or was cancelled — re-establish the hold so the device stays wedge-proof
+                // if the user retries from this still-open dialog (the keep-alive was paused above). On
+                // success we skip this: the device has rebooted into the application and is gone.
+                if (_bootloaderHoldService != null)
+                {
+                    await _bootloaderHoldService.BeginHoldAsync();
+                }
+
+                throw;
+            }
 
             IsUploadComplete = true;
             AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update completed");


### PR DESCRIPTION
## What

When a bootloader-VID/PID device (`0x04D8/0x003C`) appears in the connection dialog, the app now immediately **grabs and holds** its HID handle until the user flashes it:

- **`BootloaderHoldService`** (DI singleton over the shared exclusive `IHidTransport`): on detection, opens the handle and keeps an **interrupt-IN read continuously pending**. A pending read IRP keeps the USB link active so Windows can't selective-suspend the device — the suspend whose reopen-without-`SET_CONFIGURATION` wedges the bootloader (daqifi-nyquist-firmware#568). Reads carry no payload, so unlike a write they can't be mis-parsed as a stray command.
- **Hand-off**: `PauseForFlashAsync` stops the keep-alive but leaves the handle **open and warm** for the flasher; `ReleaseAsync` closes it on dialog close. Wired into `ConnectionDialogViewModel` (grab on detect, hand off before the flash dialog, re-grab after a cancelled flash, release on close).
- **Discovery** stops repolling once a bootloader is listed, so it isn't re-opened while held.
- **`FirmwareUpdateServiceConfig`** opens the bootloader transport **exclusively** (`ExclusiveAccess`), locking out other openers during the hold + flash (the bootloader's CRC gate is disabled, so a stray frame could be mis-parsed as an ERASE).

## Dependency

Requires **Daqifi.Core 0.26.0** (adds `HidLibraryTransport.ExclusiveAccess` — daqifi-core#274). Bumps `Daqifi.Core` 0.25.0 → 0.26.0.

## Testing

- 5 new `BootloaderHoldService` unit tests + an `ExclusiveAccess` config test. Full fast gate **469/469**.
- **Hardware-validated** on a sitting 1.4 bootloader: keep-alive hold across a 60s idle, then flash all 41,509 records + **4-region CRC verify + JMP** (~24s). The hold must be grabbed *before* the device suspends — it prevents the wedge, it can't revive an already-suspended one (that still needs a power-cycle or the 2.0 firmware re-enum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)