### PR TITLE
feat(firmware): app-global watcher holds & flashes all detected HID bootloaders

### DIFF
--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <PackageReference Include="Daqifi.Core" Version="0.25.0" />
+        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -8,7 +8,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
+        <!-- DEV: local Core 0.27.0 until 0.27.0 ships to NuGet (revert to PackageReference 0.27.0 for the PR). -->
+        <ProjectReference Include="..\..\daqifi-core\src\Daqifi.Core\Daqifi.Core.csproj" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
+++ b/Daqifi.Desktop.DataModel/Daqifi.Desktop.DataModel.csproj
@@ -8,8 +8,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <!-- DEV: local Core 0.27.0 until 0.27.0 ships to NuGet (revert to PackageReference 0.27.0 for the PR). -->
-        <ProjectReference Include="..\..\daqifi-core\src\Daqifi.Core\Daqifi.Core.csproj" />
+	  <PackageReference Include="Daqifi.Core" Version="0.27.0" />
 	  <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -7,8 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.9" />
-        <!-- DEV: local Core 0.27.0 until 0.27.0 ships to NuGet (revert to PackageReference 0.27.0 for the PR). -->
-        <ProjectReference Include="..\..\daqifi-core\src\Daqifi.Core\Daqifi.Core.csproj" />
+		<PackageReference Include="Daqifi.Core" Version="0.27.0" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.9" />
-        <PackageReference Include="Daqifi.Core" Version="0.25.0" />
+        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
+++ b/Daqifi.Desktop.IO/Daqifi.Desktop.IO.csproj
@@ -7,7 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.IO.Ports" Version="10.0.9" />
-        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
+        <!-- DEV: local Core 0.27.0 until 0.27.0 ships to NuGet (revert to PackageReference 0.27.0 for the PR). -->
+        <ProjectReference Include="..\..\daqifi-core\src\Daqifi.Core\Daqifi.Core.csproj" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Device.Firmware;
+using Moq;
+
+namespace Daqifi.Desktop.Test.Device.Firmware;
+
+/// <summary>
+/// Verifies the bootloader hold service grabs a sitting HID bootloader, keeps an interrupt-IN read
+/// continuously pending (the keep-alive that prevents the #568 USB selective-suspend wedge), and hands
+/// the handle off to the flasher without disconnecting — versus releasing it outright on close.
+/// </summary>
+[TestClass]
+public class BootloaderHoldServiceTests
+{
+    private Mock<IHidTransport> _transport = null!;
+    private Mock<IAppLogger> _logger = null!;
+    private int _readCount;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _transport = new Mock<IHidTransport>();
+        _logger = new Mock<IAppLogger>();
+        _readCount = 0;
+
+        _transport
+            .Setup(t => t.ConnectAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _transport
+            .Setup(t => t.DisconnectAsync())
+            .Returns(Task.CompletedTask);
+        // A sitting bootloader sends nothing, so every keep-alive read times out. Delay a touch so the
+        // loop is observable (and so cancellation can interrupt an in-flight read for the hard-stop path).
+        _transport
+            .Setup(t => t.ReadAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Returns((TimeSpan? _, CancellationToken ct) => KeepAliveReadStub(ct));
+    }
+
+    private async Task<byte[]> KeepAliveReadStub(CancellationToken ct)
+    {
+        Interlocked.Increment(ref _readCount);
+        await Task.Delay(15, ct).ConfigureAwait(false);
+        throw new TimeoutException();
+    }
+
+    private BootloaderHoldService CreateService() =>
+        new(_transport.Object, _logger.Object, TimeSpan.FromMilliseconds(50));
+
+    [TestMethod]
+    public async Task BeginHoldAsync_OpensTransport_AndKeepsReadingPending()
+    {
+        using var service = CreateService();
+
+        await service.BeginHoldAsync();
+
+        Assert.IsTrue(service.IsHolding, "Service should report holding after a successful open.");
+        _transport.Verify(t => t.ConnectAsync(
+            0x04D8, 0x003C, It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // The keep-alive loop must keep re-issuing reads (a single pending read is what keeps the USB
+        // link out of selective-suspend).
+        var sawMultipleReads = await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 2, TimeSpan.FromSeconds(2));
+        Assert.IsTrue(sawMultipleReads, "Keep-alive loop should issue repeated reads while holding.");
+
+        await service.ReleaseAsync();
+    }
+
+    [TestMethod]
+    public async Task BeginHoldAsync_WhenNoBootloaderPresent_DoesNotThrow_AndDoesNotHold()
+    {
+        _transport
+            .Setup(t => t.ConnectAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("No HID device found."));
+
+        using var service = CreateService();
+
+        // A just-flashed device is in application mode — the open fails and the hold is a no-op.
+        await service.BeginHoldAsync();
+
+        Assert.IsFalse(service.IsHolding, "Service must not report holding when the open failed.");
+        _transport.Verify(t => t.ReadAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PauseForFlashAsync_StopsKeepAlive_ButLeavesHandleOpen()
+    {
+        using var service = CreateService();
+        await service.BeginHoldAsync();
+        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
+
+        await service.PauseForFlashAsync();
+
+        Assert.IsFalse(service.IsHolding, "Service should no longer report holding after a pause.");
+        // The whole point of pausing (vs releasing) is to hand the flasher a warm, still-open handle.
+        _transport.Verify(t => t.DisconnectAsync(), Times.Never);
+
+        // No further reads after the pause drains the loop.
+        var countAfterPause = Volatile.Read(ref _readCount);
+        await Task.Delay(100);
+        Assert.AreEqual(countAfterPause, Volatile.Read(ref _readCount),
+            "Keep-alive reads must stop once the hold is paused for flashing.");
+    }
+
+    [TestMethod]
+    public async Task ReleaseAsync_StopsKeepAlive_AndDisconnects()
+    {
+        using var service = CreateService();
+        await service.BeginHoldAsync();
+        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
+
+        await service.ReleaseAsync();
+
+        Assert.IsFalse(service.IsHolding, "Service should no longer report holding after release.");
+        _transport.Verify(t => t.DisconnectAsync(), Times.Once);
+
+        var countAfterRelease = Volatile.Read(ref _readCount);
+        await Task.Delay(100);
+        Assert.AreEqual(countAfterRelease, Volatile.Read(ref _readCount),
+            "Keep-alive reads must stop once the hold is released.");
+    }
+
+    [TestMethod]
+    public async Task BeginHoldAsync_WhenAlreadyHolding_DoesNotReopen()
+    {
+        using var service = CreateService();
+
+        await service.BeginHoldAsync();
+        await service.BeginHoldAsync();
+
+        _transport.Verify(t => t.ConnectAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        await service.ReleaseAsync();
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return condition();
+    }
+}

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -133,6 +133,66 @@ public class BootloaderHoldServiceTests
     }
 
     [TestMethod]
+    public async Task BeginHoldAsync_WithDevicePath_ConnectsByThatExactPath_NotFirstMatch()
+    {
+        const string path = @"\\?\hid#vid_04d8&pid_003c#6&abc&0&0000#{4d1e55b2}";
+        _transport
+            .Setup(t => t.ConnectByPathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(() => { Interlocked.Increment(ref _connectCount); return Task.CompletedTask; });
+
+        using var service = new BootloaderHoldService(
+            _transport.Object, _logger.Object, TimeSpan.FromMilliseconds(50), devicePath: path, deviceName: "DAQiFi Bootloader");
+
+        await service.BeginHoldAsync();
+
+        Assert.IsTrue(service.IsHolding, "Service should report holding after a successful path-based open.");
+        Assert.AreEqual(path, service.DevicePath);
+        Assert.AreEqual("DAQiFi Bootloader", service.DeviceName);
+        _transport.Verify(t => t.ConnectByPathAsync(path, It.IsAny<CancellationToken>()), Times.Once);
+        // A path-targeted hold must address that exact device — never fall back to VID/PID first-match
+        // (which could grab the wrong one of several identical bootloaders).
+        _transport.Verify(t => t.ConnectAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        await service.ReleaseAsync();
+    }
+
+    [TestMethod]
+    public async Task KeepAliveFault_RaisesHoldDropped()
+    {
+        // A non-timeout read error means the device went away under us → the watcher must be told.
+        _transport
+            .Setup(t => t.ReadAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Returns((TimeSpan? _, CancellationToken ct) => KeepAliveReadThrows(ct));
+
+        using var service = CreateService();
+        var dropped = new TaskCompletionSource();
+        service.HoldDropped += (_, _) => dropped.TrySetResult();
+
+        await service.BeginHoldAsync();
+
+        var fired = await Task.WhenAny(dropped.Task, Task.Delay(TimeSpan.FromSeconds(2))) == dropped.Task;
+        Assert.IsTrue(fired, "HoldDropped must fire when the keep-alive read faults (device removed).");
+    }
+
+    [TestMethod]
+    public async Task ReleaseAsync_DoesNotRaiseHoldDropped()
+    {
+        using var service = CreateService();
+        var droppedCount = 0;
+        service.HoldDropped += (_, _) => Interlocked.Increment(ref droppedCount);
+
+        await service.BeginHoldAsync();
+        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
+
+        await service.ReleaseAsync();
+
+        await Task.Delay(100);
+        Assert.AreEqual(0, Volatile.Read(ref droppedCount),
+            "A graceful release (not a device drop) must not raise HoldDropped.");
+    }
+
+    [TestMethod]
     public async Task BeginHoldAsync_WhenAlreadyHolding_DoesNotReopen()
     {
         using var service = CreateService();

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -17,6 +17,7 @@ public class BootloaderHoldServiceTests
     private Mock<IHidTransport> _transport = null!;
     private Mock<IAppLogger> _logger = null!;
     private int _readCount;
+    private int _connectCount;
 
     [TestInitialize]
     public void Setup()
@@ -24,11 +25,12 @@ public class BootloaderHoldServiceTests
         _transport = new Mock<IHidTransport>();
         _logger = new Mock<IAppLogger>();
         _readCount = 0;
+        _connectCount = 0;
 
         _transport
             .Setup(t => t.ConnectAsync(
                 It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .Returns(() => { Interlocked.Increment(ref _connectCount); return Task.CompletedTask; });
         _transport
             .Setup(t => t.DisconnectAsync())
             .Returns(Task.CompletedTask);
@@ -153,17 +155,20 @@ public class BootloaderHoldServiceTests
             .Returns((TimeSpan? _, CancellationToken ct) => KeepAliveReadThrows(ct));
 
         using var service = CreateService();
-        await service.BeginHoldAsync();
+        await service.BeginHoldAsync(); // open #1; the keep-alive immediately faults and the loop exits
 
-        // Wait for the keep-alive loop to fault and exit (read attempted, then the loop task completes).
-        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
-        await Task.Delay(50);
+        // Re-grab must re-establish once the faulted loop has exited. Retry on a bounded deadline rather
+        // than a fixed sleep so the test isn't timing-flaky: each BeginHoldAsync no-ops while the loop
+        // task is still running, then re-opens the transport once it has completed.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (Volatile.Read(ref _connectCount) < 2 && DateTime.UtcNow < deadline)
+        {
+            await service.BeginHoldAsync();
+            await Task.Delay(20);
+        }
 
-        // Re-grab must NOT no-op on the stale holding state — it must tear down and reconnect.
-        await service.BeginHoldAsync();
-
-        _transport.Verify(t => t.ConnectAsync(
-            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        Assert.IsTrue(Volatile.Read(ref _connectCount) >= 2,
+            "A faulted keep-alive must not leave a stale hold; BeginHoldAsync should re-open the transport.");
 
         await service.ReleaseAsync();
     }

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -176,6 +176,20 @@ public class BootloaderHoldServiceTests
     }
 
     [TestMethod]
+    public async Task Dispose_DisposesOwnedTransport()
+    {
+        var service = CreateService();
+        await service.BeginHoldAsync();
+
+        service.Dispose();
+
+        // The hold now owns a fresh per-device transport (the watcher news one up per device), so it must
+        // dispose it to close the exclusive HID handle — otherwise a re-appearing bootloader at the same
+        // path can be locked out until GC finalization.
+        _transport.Verify(t => t.Dispose(), Times.AtLeastOnce);
+    }
+
+    [TestMethod]
     public async Task ReleaseAsync_DoesNotRaiseHoldDropped()
     {
         using var service = CreateService();

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderHoldServiceTests.cs
@@ -46,6 +46,13 @@ public class BootloaderHoldServiceTests
         throw new TimeoutException();
     }
 
+    private async Task<byte[]> KeepAliveReadThrows(CancellationToken ct)
+    {
+        Interlocked.Increment(ref _readCount);
+        await Task.Yield();
+        throw new IOException("device gone");
+    }
+
     private BootloaderHoldService CreateService() =>
         new(_transport.Object, _logger.Object, TimeSpan.FromMilliseconds(50));
 
@@ -133,6 +140,30 @@ public class BootloaderHoldServiceTests
 
         _transport.Verify(t => t.ConnectAsync(
             It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        await service.ReleaseAsync();
+    }
+
+    [TestMethod]
+    public async Task BeginHoldAsync_AfterKeepAliveFaults_ReEstablishesHold()
+    {
+        // Keep-alive read throws a non-timeout error → the loop exits (device I/O error / surprise removal).
+        _transport
+            .Setup(t => t.ReadAsync(It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Returns((TimeSpan? _, CancellationToken ct) => KeepAliveReadThrows(ct));
+
+        using var service = CreateService();
+        await service.BeginHoldAsync();
+
+        // Wait for the keep-alive loop to fault and exit (read attempted, then the loop task completes).
+        await WaitUntilAsync(() => Volatile.Read(ref _readCount) >= 1, TimeSpan.FromSeconds(2));
+        await Task.Delay(50);
+
+        // Re-grab must NOT no-op on the stale holding state — it must tear down and reconnect.
+        await service.BeginHoldAsync();
+
+        _transport.Verify(t => t.ConnectAsync(
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
 
         await service.ReleaseAsync();
     }

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
@@ -1,0 +1,252 @@
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Device.Firmware;
+using Moq;
+
+namespace Daqifi.Desktop.Test.Device.Firmware;
+
+/// <summary>
+/// Verifies the app-global bootloader watcher discovers and holds EVERY sitting HID bootloader, drops one
+/// when its device goes away, and coordinates a flash by releasing only the target while every other
+/// bootloader stays held — the multi-device "grab and hold all" behavior.
+/// </summary>
+[TestClass]
+public class BootloaderWatcherTests
+{
+    private FakeDiscovery _discovery = null!;
+    private Dictionary<string, FakeHold> _createdHolds = null!;
+    private HashSet<string> _failOpenPaths = null!;
+    private Mock<IAppLogger> _logger = null!;
+
+    private const string PathA = @"\\?\hid#vid_04d8&pid_003c#a";
+    private const string PathB = @"\\?\hid#vid_04d8&pid_003c#b";
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _discovery = new FakeDiscovery();
+        _createdHolds = new Dictionary<string, FakeHold>(StringComparer.Ordinal);
+        _failOpenPaths = new HashSet<string>(StringComparer.Ordinal);
+        _logger = new Mock<IAppLogger>();
+    }
+
+    private BootloaderWatcher CreateWatcher() =>
+        new(_discovery, HoldFactory, _logger.Object);
+
+    private IBootloaderHoldService HoldFactory(string devicePath, string? deviceName)
+    {
+        var hold = new FakeHold(devicePath, deviceName) { WillHold = !_failOpenPaths.Contains(devicePath) };
+        _createdHolds[devicePath] = hold;
+        return hold;
+    }
+
+    [TestMethod]
+    public async Task Start_HoldsEveryDiscoveredBootloader()
+    {
+        using var watcher = CreateWatcher();
+        watcher.Start();
+
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        _discovery.Raise(PathB, "DAQiFi Bootloader");
+
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 2);
+
+        Assert.AreEqual(2, watcher.Bootloaders.Count);
+        Assert.IsTrue(_createdHolds[PathA].IsHolding);
+        Assert.IsTrue(_createdHolds[PathB].IsHolding);
+        Assert.IsTrue(_discovery.IsRunning, "Discovery should be running after Start.");
+    }
+
+    [TestMethod]
+    public async Task Discover_SamePathTwice_HoldsOnce()
+    {
+        using var watcher = CreateWatcher();
+        watcher.Start();
+
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await Task.Delay(50);
+
+        Assert.AreEqual(1, watcher.Bootloaders.Count, "A duplicate discovery for the same path must not double-hold.");
+        Assert.AreEqual(1, _createdHolds.Count);
+    }
+
+    [TestMethod]
+    public async Task Discover_WhenOpenFails_NotListed()
+    {
+        // A just-flashed device in application mode: its open fails, so it must not appear in the list.
+        _failOpenPaths.Add(PathA);
+        using var watcher = CreateWatcher();
+        watcher.Start();
+
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await Task.Delay(50);
+
+        Assert.IsFalse(watcher.Bootloaders.Any(b => b.DevicePath == PathA),
+            "A bootloader whose hold could not be opened must not be listed.");
+        Assert.IsTrue(_createdHolds[PathA].Disposed, "An unheld hold must be disposed, not leaked.");
+    }
+
+    [TestMethod]
+    public async Task HoldDropped_RemovesFromList_AndRaisesWatcherEvent()
+    {
+        using var watcher = CreateWatcher();
+        string? droppedPath = null;
+        watcher.HoldDropped += (_, e) => droppedPath = e.DevicePath;
+        watcher.Start();
+
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+
+        _createdHolds[PathA].RaiseDropped();
+
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 0);
+        Assert.AreEqual(0, watcher.Bootloaders.Count);
+        Assert.AreEqual(PathA, droppedPath, "The watcher must surface a HoldDropped for the removed device.");
+        Assert.IsTrue(_createdHolds[PathA].Disposed, "A dropped hold must be disposed.");
+    }
+
+    [TestMethod]
+    public async Task PrepareFlash_ReleasesOnlyTarget_PausesDiscovery_OthersStayHeld()
+    {
+        using var watcher = CreateWatcher();
+        watcher.Start();
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        _discovery.Raise(PathB, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 2);
+
+        var lease = await watcher.PrepareFlashAsync(PathA);
+
+        Assert.AreEqual(1, _createdHolds[PathA].ReleaseCount, "The flash target's hold must be released.");
+        Assert.AreEqual(0, _createdHolds[PathB].ReleaseCount, "Other bootloaders must stay held during the flash.");
+        Assert.IsTrue(_createdHolds[PathB].IsHolding, "Other bootloaders must remain wedge-proof during the flash.");
+        Assert.IsFalse(_discovery.IsRunning, "Discovery must be paused during a flash.");
+        Assert.AreEqual(2, watcher.Bootloaders.Count, "The target stays listed (as the device being flashed).");
+
+        // Failed/cancelled flash: device is still a bootloader → re-grabbed, discovery resumes.
+        await lease.DisposeAsync();
+
+        Assert.AreEqual(2, _createdHolds[PathA].BeginHoldCount, "Disposing the lease must re-grab the target.");
+        Assert.IsTrue(_createdHolds[PathA].IsHolding);
+        Assert.IsTrue(_discovery.IsRunning, "Discovery must resume after the flash lease is disposed.");
+        Assert.AreEqual(2, watcher.Bootloaders.Count);
+    }
+
+    [TestMethod]
+    public async Task PrepareFlash_AfterSuccessfulFlash_DropsTargetFromList()
+    {
+        using var watcher = CreateWatcher();
+        watcher.Start();
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+
+        var lease = await watcher.PrepareFlashAsync(PathA);
+
+        // A successful flash leaves the device in application mode: the re-grab open fails.
+        _createdHolds[PathA].WillHold = false;
+        await lease.DisposeAsync();
+
+        Assert.AreEqual(0, watcher.Bootloaders.Count,
+            "A successfully-flashed device is no longer a bootloader and must drop off the list.");
+        Assert.IsTrue(_createdHolds[PathA].Disposed);
+    }
+
+    [TestMethod]
+    public async Task SuspendDiscovery_PausesDiscovery_KeepsHolds_SuppressesNewGrabs()
+    {
+        using var watcher = CreateWatcher();
+        watcher.Start();
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+
+        var lease = await watcher.SuspendDiscoveryAsync();
+
+        Assert.IsFalse(_discovery.IsRunning, "Discovery must be paused while suspended.");
+        Assert.IsTrue(_createdHolds[PathA].IsHolding, "Existing holds must stay alive during an auto-update suspend.");
+        Assert.AreEqual(1, watcher.Bootloaders.Count);
+
+        // A device appearing while suspended (e.g. the coordinator's own device) must NOT be grabbed.
+        _discovery.Raise(PathB, "DAQiFi Bootloader");
+        await Task.Delay(50);
+        Assert.IsFalse(watcher.Bootloaders.Any(b => b.DevicePath == PathB),
+            "New bootloaders must not be grabbed while discovery is suspended.");
+
+        await lease.DisposeAsync();
+        Assert.IsTrue(_discovery.IsRunning, "Discovery must resume after the suspend lease is disposed.");
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+    }
+
+    #region Fakes
+    private sealed class FakeDiscovery : IBootloaderDiscovery
+    {
+        public event EventHandler<BootloaderDiscoveredEventArgs>? BootloaderDiscovered;
+        public bool IsRunning { get; private set; }
+
+        public void Start() => IsRunning = true;
+        public void Stop() => IsRunning = false;
+
+        // Simulate a discovery cycle surfacing a device — fired regardless of running state so tests can
+        // also exercise the "suppressed while paused" guard.
+        public void Raise(string devicePath, string? deviceName) =>
+            BootloaderDiscovered?.Invoke(this, new BootloaderDiscoveredEventArgs(devicePath, deviceName));
+    }
+
+    private sealed class FakeHold : IBootloaderHoldService
+    {
+        public FakeHold(string devicePath, string? deviceName)
+        {
+            DevicePath = devicePath;
+            DeviceName = deviceName;
+        }
+
+        public bool IsHolding { get; private set; }
+        public string? DevicePath { get; }
+        public string? DeviceName { get; }
+
+        /// <summary>Result the next <see cref="BeginHoldAsync"/> sets <see cref="IsHolding"/> to.</summary>
+        public bool WillHold { get; set; }
+        public int BeginHoldCount { get; private set; }
+        public int ReleaseCount { get; private set; }
+        public bool Disposed { get; private set; }
+
+        public event EventHandler? HoldDropped;
+
+        public Task BeginHoldAsync(CancellationToken cancellationToken = default)
+        {
+            BeginHoldCount++;
+            IsHolding = WillHold;
+            return Task.CompletedTask;
+        }
+
+        public Task PauseForFlashAsync()
+        {
+            IsHolding = false;
+            return Task.CompletedTask;
+        }
+
+        public Task ReleaseAsync()
+        {
+            ReleaseCount++;
+            IsHolding = false;
+            return Task.CompletedTask;
+        }
+
+        public void RaiseDropped() => HoldDropped?.Invoke(this, EventArgs.Empty);
+
+        public void Dispose() => Disposed = true;
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
@@ -175,6 +175,30 @@ public class BootloaderWatcherTests
         Assert.IsTrue(_discovery.IsRunning, "Discovery must resume after the suspend lease is disposed.");
     }
 
+    [TestMethod]
+    public async Task OverlappingFlashAndSuspend_DiscoveryStaysPausedUntilBothComplete()
+    {
+        using var watcher = CreateWatcher();
+        watcher.Start();
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+
+        // A manual flash (PrepareFlashAsync → _flashingPath) and an auto-update (SuspendDiscoveryAsync →
+        // _grabSuppressed) overlap on a multi-device bench.
+        var flashLease = await watcher.PrepareFlashAsync(PathA);
+        var suspendLease = await watcher.SuspendDiscoveryAsync();
+        Assert.IsFalse(_discovery.IsRunning, "Discovery paused once either operation starts.");
+
+        // The auto-update finishes first — discovery must NOT resume while the manual flash is still live.
+        await suspendLease.DisposeAsync();
+        Assert.IsFalse(_discovery.IsRunning,
+            "Discovery must stay paused while the manual flash is still in progress.");
+
+        // The manual flash finishes — now it is safe to resume.
+        await flashLease.DisposeAsync();
+        Assert.IsTrue(_discovery.IsRunning, "Discovery must resume only once both operations complete.");
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
     {
         var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeoutMs);

--- a/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
@@ -33,6 +33,18 @@ public class FirmwareUpdateServiceConfigTests
     }
 
     [TestMethod]
+    public void CreateBootloaderHidTransport_RequestsExclusiveOpen()
+    {
+        // Act
+        var transport = FirmwareUpdateServiceConfig.CreateBootloaderHidTransport();
+
+        // Assert - the flash session must hold the bootloader's HID handle exclusively so no other
+        // user-mode opener (the discovery loop, a second app instance) can write a stray frame the
+        // CRC-disabled bootloader could mis-parse as an ERASE (A2 stray-write guard).
+        Assert.IsTrue(transport.ExclusiveAccess);
+    }
+
+    [TestMethod]
     public void CreateOptions_SetsBootloaderResponseTimeout()
     {
         // Act - the service passes BootloaderResponseTimeout to every bootloader read.

--- a/Daqifi.Desktop.Test/ViewModels/FirmwareDialogViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/FirmwareDialogViewModelTests.cs
@@ -63,7 +63,7 @@ public class FirmwareDialogViewModelTests
         var update = new Mock<IFirmwareUpdateService>();
         var download = DownloadServiceReturning(Release(3, 6, 1, "v3.6.1"));
 
-        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+        var vm = new FirmwareDialogViewModel("TestHid", firmwareUpdateService: update.Object, firmwareDownloadService: download.Object);
 
         WaitUntil(() => vm.AvailableFirmwares.Count > 0);
         Assert.AreEqual(1, vm.AvailableFirmwares.Count);
@@ -78,7 +78,7 @@ public class FirmwareDialogViewModelTests
         var update = new Mock<IFirmwareUpdateService>();
         var download = DownloadServiceReturning(null);
 
-        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+        var vm = new FirmwareDialogViewModel("TestHid", firmwareUpdateService: update.Object, firmwareDownloadService: download.Object);
 
         // Nothing to select; the upload command must be disabled until the user browses a file.
         Assert.AreEqual(0, vm.AvailableFirmwares.Count);
@@ -91,7 +91,7 @@ public class FirmwareDialogViewModelTests
     {
         var update = new Mock<IFirmwareUpdateService>();
         var download = DownloadServiceReturning(null);
-        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+        var vm = new FirmwareDialogViewModel("TestHid", firmwareUpdateService: update.Object, firmwareDownloadService: download.Object);
 
         Assert.IsFalse(vm.UploadFirmwareCommand.CanExecute(null), "Disabled with no file and no dropdown selection.");
 
@@ -118,7 +118,7 @@ public class FirmwareDialogViewModelTests
                 It.IsAny<string>(), true, It.IsAny<IProgress<int>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_tempHexPath);
 
-        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object);
+        var vm = new FirmwareDialogViewModel("TestHid", firmwareUpdateService: update.Object, firmwareDownloadService: download.Object);
         // Stand in for the async dropdown load so we exercise the no-file path deterministically.
         vm.SelectedFirmware = new Models.FirmwareOption { DeviceModel = "DAQiFi", Version = "3.6.1" };
 
@@ -147,7 +147,7 @@ public class FirmwareDialogViewModelTests
 
         var download = DownloadServiceReturning(Release(3, 6, 1, "v3.6.1"));
 
-        var vm = new FirmwareDialogViewModel("TestHid", update.Object, download.Object)
+        var vm = new FirmwareDialogViewModel("TestHid", firmwareUpdateService: update.Object, firmwareDownloadService: download.Object)
         {
             FirmwareFilePath = _tempHexPath
         };

--- a/Daqifi.Desktop/App.xaml.cs
+++ b/Daqifi.Desktop/App.xaml.cs
@@ -120,12 +120,20 @@ public partial class App
             provider.GetRequiredService<IExternalProcessRunner>(),
             provider.GetRequiredService<ILogger<FirmwareUpdateService>>(),
             options: FirmwareUpdateServiceConfig.CreateOptions()));
-        // Holds a sitting HID bootloader's handle open (over the SAME exclusive transport the flasher
-        // uses) with a keep-alive read pending, so Windows USB selective-suspend can't wedge it before
-        // the user flashes (daqifi-nyquist-firmware#568). The connection dialog grabs the hold on
-        // detection and hands the warm handle to the flasher.
-        serviceCollection.AddSingleton<IBootloaderHoldService>(provider => new BootloaderHoldService(
-            provider.GetRequiredService<IHidTransport>(),
+        // App-global bootloader watcher: discovers EVERY sitting HID bootloader and holds each one's
+        // handle open (its own exclusive transport, keyed by device path) with a keep-alive read so
+        // Windows USB selective-suspend can't wedge it before flashing (daqifi-nyquist-firmware#568).
+        // The connection dialog binds to its list; the firmware dialog flashes a chosen one by path while
+        // the others stay held. Each hold gets a FRESH transport (not the flasher's DI singleton) so
+        // holding N devices never contends with the flasher or with each other.
+        serviceCollection.AddSingleton<IBootloaderWatcher>(_ => new BootloaderWatcher(
+            new HidBootloaderDiscovery(Common.Loggers.AppLogger.Instance),
+            (devicePath, deviceName) => new BootloaderHoldService(
+                FirmwareUpdateServiceConfig.CreateBootloaderHidTransport(),
+                Common.Loggers.AppLogger.Instance,
+                keepAliveReadTimeout: null,
+                devicePath: devicePath,
+                deviceName: deviceName),
             Common.Loggers.AppLogger.Instance));
 
         serviceCollection.AddSingleton<LoggingManager>();
@@ -133,6 +141,11 @@ public partial class App
         ServiceLocator.RegisterSingleton<IWindowViewModelMappings, WindowViewModelMappings>();
 
         ServiceProvider = serviceCollection.BuildServiceProvider();
+
+        // Start holding any sitting HID bootloaders app-wide, right away — before the user opens the
+        // connection dialog — so a device left in bootloader mode can't selective-suspend/wedge (#568)
+        // while it waits. The watcher runs for the app's lifetime.
+        ServiceProvider.GetRequiredService<IBootloaderWatcher>().Start();
 
         // Apply database migrations before any DB access.
         // Temporarily switch to OnExplicitShutdown so closing the migration

--- a/Daqifi.Desktop/App.xaml.cs
+++ b/Daqifi.Desktop/App.xaml.cs
@@ -103,6 +103,7 @@ public partial class App
                     && category.StartsWith("Daqifi", StringComparison.OrdinalIgnoreCase)
                     && level is >= LogLevel.Information and < LogLevel.None));
         });
+
         serviceCollection.AddHttpClient();
         serviceCollection.AddSingleton<IFirmwareDownloadService>(provider =>
         {
@@ -119,6 +120,13 @@ public partial class App
             provider.GetRequiredService<IExternalProcessRunner>(),
             provider.GetRequiredService<ILogger<FirmwareUpdateService>>(),
             options: FirmwareUpdateServiceConfig.CreateOptions()));
+        // Holds a sitting HID bootloader's handle open (over the SAME exclusive transport the flasher
+        // uses) with a keep-alive read pending, so Windows USB selective-suspend can't wedge it before
+        // the user flashes (daqifi-nyquist-firmware#568). The connection dialog grabs the hold on
+        // detection and hands the warm handle to the flasher.
+        serviceCollection.AddSingleton<IBootloaderHoldService>(provider => new BootloaderHoldService(
+            provider.GetRequiredService<IHidTransport>(),
+            Common.Loggers.AppLogger.Instance));
 
         serviceCollection.AddSingleton<LoggingManager>();
         ServiceLocator.RegisterSingleton<IDialogService, DialogService.DialogService>();

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -54,7 +54,9 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
+        <!-- DEV: local Core 0.27.0 (device-path addressing) until 0.27.0 ships to NuGet.
+             Revert to <PackageReference Include="Daqifi.Core" Version="0.27.0" /> before the PR. -->
+        <ProjectReference Include="..\..\daqifi-core\src\Daqifi.Core\Daqifi.Core.csproj" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -54,7 +54,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <PackageReference Include="Daqifi.Core" Version="0.25.0" />
+        <PackageReference Include="Daqifi.Core" Version="0.26.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -54,9 +54,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <!-- DEV: local Core 0.27.0 (device-path addressing) until 0.27.0 ships to NuGet.
-             Revert to <PackageReference Include="Daqifi.Core" Version="0.27.0" /> before the PR. -->
-        <ProjectReference Include="..\..\daqifi-core\src\Daqifi.Core\Daqifi.Core.csproj" />
+		<PackageReference Include="Daqifi.Core" Version="0.27.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />

--- a/Daqifi.Desktop/Device/Firmware/BootloaderDiscoveredEventArgs.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderDiscoveredEventArgs.cs
@@ -1,0 +1,20 @@
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Identifies a HID bootloader that discovery surfaced.
+/// </summary>
+public sealed class BootloaderDiscoveredEventArgs : EventArgs
+{
+    /// <summary>Creates the event args.</summary>
+    public BootloaderDiscoveredEventArgs(string devicePath, string? deviceName)
+    {
+        DevicePath = devicePath;
+        DeviceName = deviceName;
+    }
+
+    /// <summary>OS HID device path of the discovered bootloader.</summary>
+    public string DevicePath { get; }
+
+    /// <summary>Friendly device name, when discovery could read it; otherwise null.</summary>
+    public string? DeviceName { get; }
+}

--- a/Daqifi.Desktop/Device/Firmware/BootloaderDiscoveredEventArgs.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderDiscoveredEventArgs.cs
@@ -8,7 +8,9 @@ public sealed class BootloaderDiscoveredEventArgs : EventArgs
     /// <summary>Creates the event args.</summary>
     public BootloaderDiscoveredEventArgs(string devicePath, string? deviceName)
     {
-        DevicePath = devicePath;
+        DevicePath = string.IsNullOrWhiteSpace(devicePath)
+            ? throw new ArgumentException("Device path cannot be empty.", nameof(devicePath))
+            : devicePath;
         DeviceName = deviceName;
     }
 

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldDroppedEventArgs.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldDroppedEventArgs.cs
@@ -6,7 +6,9 @@ public sealed class BootloaderHoldDroppedEventArgs : EventArgs
     /// <summary>Creates the event args.</summary>
     public BootloaderHoldDroppedEventArgs(string devicePath)
     {
-        DevicePath = devicePath;
+        DevicePath = string.IsNullOrWhiteSpace(devicePath)
+            ? throw new ArgumentException("Device path cannot be empty.", nameof(devicePath))
+            : devicePath;
     }
 
     /// <summary>OS HID device path of the bootloader whose hold was dropped.</summary>

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldDroppedEventArgs.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldDroppedEventArgs.cs
@@ -1,0 +1,14 @@
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>Identifies a held bootloader that dropped out of the watcher's list.</summary>
+public sealed class BootloaderHoldDroppedEventArgs : EventArgs
+{
+    /// <summary>Creates the event args.</summary>
+    public BootloaderHoldDroppedEventArgs(string devicePath)
+    {
+        DevicePath = devicePath;
+    }
+
+    /// <summary>OS HID device path of the bootloader whose hold was dropped.</summary>
+    public string DevicePath { get; }
+}

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -330,8 +330,11 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
 
     #region IDisposable
     /// <summary>
-    /// Tears down the keep-alive loop. Does NOT dispose the transport — it is a shared DI singleton
-    /// owned by the container.
+    /// Tears down the keep-alive loop and disposes the owned transport. Each hold owns a fresh transport
+    /// (the watcher's factory news one up per device), so disposing it here is what deterministically
+    /// closes the exclusive HID handle — without it, a surprise-removal drop would leave the handle open
+    /// until GC finalization, transiently locking out a bootloader that re-appears at the same path and
+    /// defeating the very wedge protection (#568) this hold provides.
     /// </summary>
     public void Dispose()
     {
@@ -348,6 +351,11 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
 
         try { _keepAliveTask?.Wait(TimeSpan.FromSeconds(2)); }
         catch (Exception) { /* best-effort during shutdown */ }
+
+        // Dispose the owned transport (closes its exclusive HID handle) once the keep-alive read is no
+        // longer in flight against it.
+        try { _transport.Dispose(); }
+        catch (Exception ex) { _logger.Warning(ex, "Error disposing the HID bootloader transport."); }
 
         _keepAliveCts?.Dispose();
         _keepAliveCts = null;

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -79,7 +79,27 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         {
             if (_holding)
             {
-                return;
+                // Already holding with a live keep-alive loop — nothing to do.
+                if (_keepAliveTask is { IsCompleted: false })
+                {
+                    return;
+                }
+
+                // The keep-alive loop exited early (device I/O error / surprise removal) but the hold
+                // state was never cleared. Tear the stale hold down here so we re-establish it below
+                // instead of no-opping and leaving the device unprotected from selective-suspend.
+                _logger.Information("HID bootloader keep-alive had stopped; re-establishing the hold.");
+                await StopKeepAliveAsync(hard: true).ConfigureAwait(false);
+                try
+                {
+                    await _transport.DisconnectAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning(ex, "Error disconnecting a stale HID bootloader hold before re-establishing.");
+                }
+
+                _holding = false;
             }
 
             try

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -244,9 +244,11 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
     private async Task StopKeepAliveAsync(bool hard)
     {
         _stopKeepAlive = true;
+
+        var cts = _keepAliveCts;
         if (hard)
         {
-            try { _keepAliveCts?.Cancel(); }
+            try { cts?.Cancel(); }
             catch (ObjectDisposedException) { /* already torn down */ }
         }
 
@@ -255,6 +257,23 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         {
             try
             {
+                if (!hard)
+                {
+                    // Graceful: let the in-flight read drain naturally so no orphaned read IRP collides
+                    // with the flasher. Bound the wait — if the read doesn't complete within its own
+                    // timeout (+ a small margin), escalate to cancellation so PauseForFlashAsync can never
+                    // hang the flash on a wedged/stuck read.
+                    var drained = await Task
+                        .WhenAny(task, Task.Delay(_keepAliveReadTimeout + TimeSpan.FromMilliseconds(250)))
+                        .ConfigureAwait(false);
+                    if (drained != task)
+                    {
+                        _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
+                        try { cts?.Cancel(); }
+                        catch (ObjectDisposedException) { /* already torn down */ }
+                    }
+                }
+
                 await task.ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -255,30 +255,31 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         var task = _keepAliveTask;
         if (task != null)
         {
-            try
-            {
-                if (!hard)
-                {
-                    // Graceful: let the in-flight read drain naturally so no orphaned read IRP collides
-                    // with the flasher. Bound the wait — if the read doesn't complete within its own
-                    // timeout (+ a small margin), escalate to cancellation so PauseForFlashAsync can never
-                    // hang the flash on a wedged/stuck read.
-                    var drained = await Task
-                        .WhenAny(task, Task.Delay(_keepAliveReadTimeout + TimeSpan.FromMilliseconds(250)))
-                        .ConfigureAwait(false);
-                    if (drained != task)
-                    {
-                        _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
-                        try { cts?.Cancel(); }
-                        catch (ObjectDisposedException) { /* already torn down */ }
-                    }
-                }
+            var settle = _keepAliveReadTimeout + TimeSpan.FromMilliseconds(250);
 
-                await task.ConfigureAwait(false);
-            }
-            catch (Exception ex)
+            // Graceful: let the in-flight read drain naturally first (so no orphaned read IRP collides
+            // with the flasher), bounded; on timeout, escalate to cancellation.
+            if (!hard)
             {
-                _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop.");
+                if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) != task)
+                {
+                    _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
+                    try { cts?.Cancel(); }
+                    catch (ObjectDisposedException) { /* already torn down */ }
+                }
+            }
+
+            // The FINAL wait is also bounded: a wedged/non-cancelable ReadAsync must never block the
+            // flash hand-off. If the loop still hasn't stopped, abandon the task (the cancelled read
+            // drains on its own later) rather than awaiting it indefinitely.
+            if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) == task)
+            {
+                try { await task.ConfigureAwait(false); }
+                catch (Exception ex) { _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop."); }
+            }
+            else
+            {
+                _logger.Warning("HID bootloader keep-alive loop did not stop after cancellation; abandoning it.");
             }
         }
 

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -1,0 +1,278 @@
+using Daqifi.Core.Communication.Transport;
+using Daqifi.Core.Device.Discovery;
+using Daqifi.Desktop.Common.Loggers;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Default <see cref="IBootloaderHoldService"/> implementation. Holds the shared exclusive HID transport
+/// open with a continuously-pending interrupt-IN read to keep a sitting PIC32 bootloader out of USB
+/// selective-suspend (the cause of the #568 wedge). See <see cref="IBootloaderHoldService"/> for the
+/// full rationale.
+/// </summary>
+public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
+{
+    #region Constants
+    // VID/PID of the PIC32 HID bootloader. Single source of truth: Core's HID finder defaults
+    // (0x04D8 / 0x003C).
+    private const int BOOTLOADER_VENDOR_ID = HidDeviceFinder.DefaultVendorId;
+    private const int BOOTLOADER_PRODUCT_ID = HidDeviceFinder.DefaultProductId;
+
+    /// <summary>
+    /// Default per-read timeout for the keep-alive poll. Short enough that a read is pending
+    /// essentially continuously (so Windows never starts the USB selective-suspend idle timer), long
+    /// enough to avoid a tight busy-loop. A sitting bootloader sends nothing, so each read times out
+    /// and is immediately re-issued.
+    /// </summary>
+    public static readonly TimeSpan DefaultKeepAliveReadTimeout = TimeSpan.FromSeconds(1);
+    #endregion
+
+    #region Private Fields
+    private readonly IHidTransport _transport;
+    private readonly IAppLogger _logger;
+    private readonly TimeSpan _keepAliveReadTimeout;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private CancellationTokenSource? _keepAliveCts;
+    private Task? _keepAliveTask;
+    private volatile bool _stopKeepAlive;
+    private bool _holding;
+    private bool _disposed;
+    #endregion
+
+    #region Constructor
+    /// <summary>
+    /// Creates the hold service over the shared HID transport.
+    /// </summary>
+    /// <param name="transport">
+    /// The shared bootloader HID transport (the same DI singleton the flasher uses, configured for
+    /// exclusive access). Holding this transport open also locks every other user-mode opener out for
+    /// the duration of the hold (the A2 stray-write guard).
+    /// </param>
+    /// <param name="logger">Application logger for diagnostics.</param>
+    /// <param name="keepAliveReadTimeout">
+    /// Per-read keep-alive timeout. Null uses <see cref="DefaultKeepAliveReadTimeout"/>; tests pass a
+    /// small value to make the loop observable quickly.
+    /// </param>
+    public BootloaderHoldService(IHidTransport transport, IAppLogger logger, TimeSpan? keepAliveReadTimeout = null)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _keepAliveReadTimeout = keepAliveReadTimeout ?? DefaultKeepAliveReadTimeout;
+    }
+    #endregion
+
+    #region Public Methods
+    /// <inheritdoc />
+    public bool IsHolding => _holding;
+
+    /// <inheritdoc />
+    public async Task BeginHoldAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_holding)
+            {
+                return;
+            }
+
+            try
+            {
+                // Grab the bootloader's HID handle. ExclusiveAccess is set on the shared transport
+                // (FirmwareUpdateServiceConfig.CreateBootloaderHidTransport), so this also locks out
+                // every other user-mode opener for the duration of the hold. ConnectAsync returns
+                // immediately if the transport is already connected (e.g. the handle the flasher just
+                // left open), in which case we simply (re)start the keep-alive over it.
+                await _transport
+                    .ConnectAsync(BOOTLOADER_VENDOR_ID, BOOTLOADER_PRODUCT_ID, null, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // No bootloader present (a just-flashed device is now in application mode) or the open
+                // was refused. Holding is best-effort — stay un-held; the flash path's own connect +
+                // handshake retry still covers a device that shows up or recovers later.
+                _logger.Warning(ex, "Could not open the HID bootloader to hold it; continuing without a hold.");
+                return;
+            }
+
+            _stopKeepAlive = false;
+            _keepAliveCts = new CancellationTokenSource();
+            _keepAliveTask = Task.Run(() => KeepAliveLoopAsync(_keepAliveCts.Token));
+            _holding = true;
+
+            _logger.Information(
+                "Holding the HID bootloader handle (keep-alive read pending) so Windows USB selective-suspend " +
+                "cannot wedge it before flashing (daqifi-nyquist-firmware#568).");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task PauseForFlashAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!_holding)
+            {
+                return;
+            }
+
+            // Graceful stop: signal the loop and let its in-flight read complete naturally (within one
+            // keep-alive timeout) so no orphaned read IRP is left pending to swallow the flasher's first
+            // response. Deliberately do NOT disconnect — leave the handle OPEN and warm. The flasher's
+            // ConnectToBootloaderWithRetryAsync sees it connected, closes+reopens it back-to-back (no
+            // idle window, so no #568 wedge) and flashes. Handing it a warm handle is the point of the hold.
+            await StopKeepAliveAsync(hard: false).ConfigureAwait(false);
+            _holding = false;
+
+            _logger.Information("Paused the HID bootloader hold for flashing; handle left open for the flasher.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // Hard stop (no flash follows): cancel any in-flight read and close the handle so the device
+            // is never left held after the dialog goes away.
+            await StopKeepAliveAsync(hard: true).ConfigureAwait(false);
+
+            try
+            {
+                await _transport.DisconnectAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Error while releasing the HID bootloader handle.");
+            }
+
+            _holding = false;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+    #endregion
+
+    #region Private Methods
+    private async Task KeepAliveLoopAsync(CancellationToken cancellationToken)
+    {
+        // Keep an interrupt-IN read continuously pending. A pending read IRP keeps the USB link active so
+        // Windows never selective-suspends the device — the suspend whose reopen-without-SET_CONFIGURATION
+        // wedges the bootloader (#568). An *idle* open handle alone does NOT prevent suspend; the pending
+        // read does. Reads carry no payload TO the device, so unlike a write they can never be mis-parsed
+        // as a stray command — this is the one form of I/O that is safe to direct at a sitting bootloader.
+        while (!cancellationToken.IsCancellationRequested && !_stopKeepAlive)
+        {
+            try
+            {
+                // A sitting bootloader sends nothing unsolicited, so this normally times out; that is the
+                // expected, healthy case. Any bytes returned are discarded (no command is in flight).
+                await _transport.ReadAsync(_keepAliveReadTimeout, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                // Expected: idle bootloader, no data. Re-issue immediately to keep a read pending.
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // The handle went away (device detached / flashed / surprise-removed). Stop quietly; the
+                // flash path re-discovers and reconnects on its own.
+                _logger.Warning(ex, "HID bootloader keep-alive read failed; ending the hold.");
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stops the keep-alive loop and awaits its completion. When <paramref name="hard"/> is true the
+    /// in-flight read is cancelled immediately; when false it is allowed to drain naturally (so the
+    /// flasher inherits a quiescent handle with no orphaned read IRP). Must be called under <see cref="_gate"/>.
+    /// </summary>
+    private async Task StopKeepAliveAsync(bool hard)
+    {
+        _stopKeepAlive = true;
+        if (hard)
+        {
+            try { _keepAliveCts?.Cancel(); }
+            catch (ObjectDisposedException) { /* already torn down */ }
+        }
+
+        var task = _keepAliveTask;
+        if (task != null)
+        {
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop.");
+            }
+        }
+
+        _keepAliveTask = null;
+        _keepAliveCts?.Dispose();
+        _keepAliveCts = null;
+    }
+    #endregion
+
+    #region IDisposable
+    /// <summary>
+    /// Tears down the keep-alive loop. Does NOT dispose the transport — it is a shared DI singleton
+    /// owned by the container.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _stopKeepAlive = true;
+
+        try { _keepAliveCts?.Cancel(); }
+        catch (ObjectDisposedException) { /* already torn down */ }
+
+        try { _keepAliveTask?.Wait(TimeSpan.FromSeconds(2)); }
+        catch (Exception) { /* best-effort during shutdown */ }
+
+        _keepAliveCts?.Dispose();
+        _keepAliveCts = null;
+        _gate.Dispose();
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -31,6 +31,8 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
     private readonly IHidTransport _transport;
     private readonly IAppLogger _logger;
     private readonly TimeSpan _keepAliveReadTimeout;
+    private readonly string? _devicePath;
+    private readonly string? _deviceName;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
     private CancellationTokenSource? _keepAliveCts;
@@ -54,17 +56,40 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
     /// Per-read keep-alive timeout. Null uses <see cref="DefaultKeepAliveReadTimeout"/>; tests pass a
     /// small value to make the loop observable quickly.
     /// </param>
-    public BootloaderHoldService(IHidTransport transport, IAppLogger logger, TimeSpan? keepAliveReadTimeout = null)
+    /// <param name="devicePath">
+    /// OS HID device path to target. When non-null the hold opens this exact device via
+    /// <see cref="IHidTransport.ConnectByPathAsync"/> — the watcher uses this to hold one specific
+    /// bootloader among several identical ones. When null the hold opens the first VID/PID match
+    /// (the single-device behavior).
+    /// </param>
+    /// <param name="deviceName">Friendly device name surfaced in the UI; null when unknown.</param>
+    public BootloaderHoldService(
+        IHidTransport transport,
+        IAppLogger logger,
+        TimeSpan? keepAliveReadTimeout = null,
+        string? devicePath = null,
+        string? deviceName = null)
     {
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _keepAliveReadTimeout = keepAliveReadTimeout ?? DefaultKeepAliveReadTimeout;
+        _devicePath = devicePath;
+        _deviceName = deviceName;
     }
     #endregion
 
     #region Public Methods
     /// <inheritdoc />
     public bool IsHolding => Volatile.Read(ref _holding);
+
+    /// <inheritdoc />
+    public string? DevicePath => _devicePath;
+
+    /// <inheritdoc />
+    public string? DeviceName => _deviceName;
+
+    /// <inheritdoc />
+    public event EventHandler? HoldDropped;
 
     /// <inheritdoc />
     public async Task BeginHoldAsync(CancellationToken cancellationToken = default)
@@ -104,14 +129,25 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
 
             try
             {
-                // Grab the bootloader's HID handle. ExclusiveAccess is set on the shared transport
+                // Grab the bootloader's HID handle. ExclusiveAccess is set on the transport
                 // (FirmwareUpdateServiceConfig.CreateBootloaderHidTransport), so this also locks out
-                // every other user-mode opener for the duration of the hold. ConnectAsync returns
-                // immediately if the transport is already connected (e.g. the handle the flasher just
-                // left open), in which case we simply (re)start the keep-alive over it.
-                await _transport
-                    .ConnectAsync(BOOTLOADER_VENDOR_ID, BOOTLOADER_PRODUCT_ID, null, cancellationToken)
-                    .ConfigureAwait(false);
+                // every other user-mode opener for the duration of the hold. A connect over an
+                // already-connected transport (e.g. the handle the flasher just left open) returns
+                // immediately, in which case we simply (re)start the keep-alive over it.
+                if (_devicePath != null)
+                {
+                    // Multi-device: target this exact bootloader by path. Identical bootloaders share
+                    // VID/PID and have no serial, so the path is the only discriminator.
+                    await _transport
+                        .ConnectByPathAsync(_devicePath, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await _transport
+                        .ConnectAsync(BOOTLOADER_VENDOR_ID, BOOTLOADER_PRODUCT_ID, null, cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {
@@ -210,6 +246,7 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         // wedges the bootloader (#568). An *idle* open handle alone does NOT prevent suspend; the pending
         // read does. Reads carry no payload TO the device, so unlike a write they can never be mis-parsed
         // as a stray command — this is the one form of I/O that is safe to direct at a sitting bootloader.
+        var droppedByError = false;
         while (!cancellationToken.IsCancellationRequested && !_stopKeepAlive)
         {
             try
@@ -231,7 +268,20 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
                 // The handle went away (device detached / flashed / surprise-removed). Stop quietly; the
                 // flash path re-discovers and reconnects on its own.
                 _logger.Warning(ex, "HID bootloader keep-alive read failed; ending the hold.");
+                droppedByError = true;
                 break;
+            }
+        }
+
+        // Notify the watcher only when the device dropped out from under us — never on a requested stop
+        // (PauseForFlash/Release set _stopKeepAlive). Raise off this task's thread so a HoldDropped handler
+        // that disposes this hold (Dispose awaits this very task) cannot deadlock on itself.
+        if (droppedByError && !_stopKeepAlive)
+        {
+            var handler = HoldDropped;
+            if (handler != null)
+            {
+                _ = Task.Run(() => handler(this, EventArgs.Empty));
             }
         }
     }

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -243,6 +243,13 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
     /// </summary>
     private async Task StopKeepAliveAsync(bool hard)
     {
+        // Await the loop to completion — deliberately, not with an "abandon on timeout" fallback. The
+        // wait is already self-bounding: each keep-alive read is capped by the transport's own read
+        // timeout (_keepAliveReadTimeout, ~1s), so once _stopKeepAlive is set the in-flight read
+        // returns/throws and the loop exits within that window. Abandoning a still-running read would be
+        // worse than waiting: the orphaned read keeps the shared transport's I/O lock, so the flasher's
+        // reconnect would race/block on it anyway — the exact orphaned-read hand-off hazard this drain
+        // exists to prevent. The hard path additionally cancels so the in-flight read aborts at once.
         _stopKeepAlive = true;
 
         var cts = _keepAliveCts;
@@ -255,31 +262,13 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         var task = _keepAliveTask;
         if (task != null)
         {
-            var settle = _keepAliveReadTimeout + TimeSpan.FromMilliseconds(250);
-
-            // Graceful: let the in-flight read drain naturally first (so no orphaned read IRP collides
-            // with the flasher), bounded; on timeout, escalate to cancellation.
-            if (!hard)
+            try
             {
-                if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) != task)
-                {
-                    _logger.Warning("HID bootloader keep-alive did not drain in time; cancelling to unblock flashing.");
-                    try { cts?.Cancel(); }
-                    catch (ObjectDisposedException) { /* already torn down */ }
-                }
+                await task.ConfigureAwait(false);
             }
-
-            // The FINAL wait is also bounded: a wedged/non-cancelable ReadAsync must never block the
-            // flash hand-off. If the loop still hasn't stopped, abandon the task (the cancelled read
-            // drains on its own later) rather than awaiting it indefinitely.
-            if (await Task.WhenAny(task, Task.Delay(settle)).ConfigureAwait(false) == task)
+            catch (Exception ex)
             {
-                try { await task.ConfigureAwait(false); }
-                catch (Exception ex) { _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop."); }
-            }
-            else
-            {
-                _logger.Warning("HID bootloader keep-alive loop did not stop after cancellation; abandoning it.");
+                _logger.Warning(ex, "Error while stopping the HID bootloader keep-alive loop.");
             }
         }
 

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -64,7 +64,7 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
 
     #region Public Methods
     /// <inheritdoc />
-    public bool IsHolding => _holding;
+    public bool IsHolding => Volatile.Read(ref _holding);
 
     /// <inheritdoc />
     public async Task BeginHoldAsync(CancellationToken cancellationToken = default)

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -121,7 +121,8 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warning(ex, "Error disconnecting a stale HID bootloader hold before re-establishing.");
+                    _logger.Warning(
+                        ex, "Error disconnecting a stale HID bootloader hold before re-establishing.");
                 }
 
                 _holding = false;

--- a/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderHoldService.cs
@@ -248,6 +248,7 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         // read does. Reads carry no payload TO the device, so unlike a write they can never be mis-parsed
         // as a stray command — this is the one form of I/O that is safe to direct at a sitting bootloader.
         var droppedByError = false;
+        var stopWasRequested = false;
         while (!cancellationToken.IsCancellationRequested && !_stopKeepAlive)
         {
             try
@@ -270,6 +271,9 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
                 // flash path re-discovers and reconnects on its own.
                 _logger.Warning(ex, "HID bootloader keep-alive read failed; ending the hold.");
                 droppedByError = true;
+                // Snapshot at failure time: a concurrent PauseForFlash/Release could flip _stopKeepAlive
+                // between here and the post-loop check, which would otherwise swallow a genuine drop.
+                stopWasRequested = _stopKeepAlive;
                 break;
             }
         }
@@ -277,7 +281,7 @@ public sealed class BootloaderHoldService : IBootloaderHoldService, IDisposable
         // Notify the watcher only when the device dropped out from under us — never on a requested stop
         // (PauseForFlash/Release set _stopKeepAlive). Raise off this task's thread so a HoldDropped handler
         // that disposes this hold (Dispose awaits this very task) cannot deadlock on itself.
-        if (droppedByError && !_stopKeepAlive)
+        if (droppedByError && !stopWasRequested)
         {
             var handler = HoldDropped;
             if (handler != null)

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -49,12 +49,17 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         _discovery = discovery ?? throw new ArgumentNullException(nameof(discovery));
         _holdFactory = holdFactory ?? throw new ArgumentNullException(nameof(holdFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        Bootloaders = new ReadOnlyObservableCollection<HeldBootloader>(_bootloaders);
     }
     #endregion
 
     #region IBootloaderWatcher
+    // Internal mutable backing; the public surface is a read-only view so external code (the bound
+    // dialog) can observe the list but cannot mutate the watcher's state.
+    private readonly ObservableCollection<HeldBootloader> _bootloaders = [];
+
     /// <inheritdoc />
-    public ObservableCollection<HeldBootloader> Bootloaders { get; } = [];
+    public ReadOnlyObservableCollection<HeldBootloader> Bootloaders { get; }
 
     /// <inheritdoc />
     public event EventHandler<BootloaderHoldDroppedEventArgs>? HoldDropped;
@@ -212,9 +217,10 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
             }
 
             _holds[devicePath] = created;
+            created = null; // ownership transferred to _holds BEFORE the UI marshal, so a marshal failure
+                            // can never make the finally dispose a now-tracked hold (stale-entry bug).
             var displayName = string.IsNullOrWhiteSpace(deviceName) ? "DAQiFi Bootloader" : deviceName!;
-            InvokeOnUiThread(() => Bootloaders.Add(new HeldBootloader(devicePath, displayName)));
-            created = null; // ownership transferred to _holds
+            InvokeOnUiThread(() => _bootloaders.Add(new HeldBootloader(devicePath, displayName)));
             _logger.Information($"Holding HID bootloader {devicePath} ({displayName}).");
         }
         catch (Exception ex)
@@ -269,10 +275,10 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         hold.Dispose();
         InvokeOnUiThread(() =>
         {
-            var row = Bootloaders.FirstOrDefault(b => string.Equals(b.DevicePath, devicePath, StringComparison.Ordinal));
+            var row = _bootloaders.FirstOrDefault(b => string.Equals(b.DevicePath, devicePath, StringComparison.Ordinal));
             if (row != null)
             {
-                Bootloaders.Remove(row);
+                _bootloaders.Remove(row);
             }
         });
     }
@@ -307,7 +313,20 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
             return;
         }
 
-        dispatcher.BeginInvoke(action);
+        // Non-throwing: during app/dispatcher shutdown BeginInvoke can throw, and these calls run inside
+        // the gate-protected handlers — a marshal failure must never propagate (it would strand watcher
+        // state). If the dispatcher is gone the bound list simply won't update, which is fine at shutdown.
+        try
+        {
+            if (!dispatcher.HasShutdownStarted)
+            {
+                dispatcher.BeginInvoke(action);
+            }
+        }
+        catch (Exception)
+        {
+            // Dispatcher unavailable / shutting down — drop the UI update.
+        }
     }
     #endregion
 
@@ -322,6 +341,7 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
 
         _disposed = true;
         _discovery.BootloaderDiscovered -= OnBootloaderDiscovered;
+        _discovery.Stop();
         (_discovery as IDisposable)?.Dispose();
 
         _gate.Wait();
@@ -333,7 +353,7 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
                 hold.Dispose();
             }
             _holds.Clear();
-            InvokeOnUiThread(Bootloaders.Clear);
+            InvokeOnUiThread(_bootloaders.Clear);
         }
         finally
         {

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -141,10 +141,7 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
                 }
             }
 
-            if (!_disposed)
-            {
-                _discovery.Start();
-            }
+            ResumeDiscoveryIfIdle();
         }
         finally
         {
@@ -158,15 +155,27 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         try
         {
             _grabSuppressed = false;
-            if (!_disposed)
-            {
-                _discovery.Start();
-            }
+            ResumeDiscoveryIfIdle();
             _logger.Information("Bootloader watcher discovery resumed after auto-update.");
         }
         finally
         {
             _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Restarts discovery only when no operation still needs it paused. A manual flash
+    /// (<see cref="_flashingPath"/>) and an auto-update (<see cref="_grabSuppressed"/>) can overlap on a
+    /// multi-device bench; whichever lease disposes first must NOT resume discovery while the other is
+    /// still flashing — a live finder cycle could re-open the in-flight device during the flasher's
+    /// reconnect window. Must be called under <see cref="_gate"/>.
+    /// </summary>
+    private void ResumeDiscoveryIfIdle()
+    {
+        if (!_disposed && _flashingPath == null && !_grabSuppressed)
+        {
+            _discovery.Start();
         }
     }
     #endregion

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -282,7 +282,10 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     private static void InvokeOnUiThread(Action action)
     {
         // No WPF dispatcher in unit tests (Application.Current is null) — run inline. In the app, marshal
-        // the bound-collection mutation onto the UI thread.
+        // the bound-collection mutation onto the UI thread. Use the NON-blocking BeginInvoke: these calls
+        // happen while _gate is held, and a blocking Dispatcher.Invoke could lock-invert with Dispose()'s
+        // synchronous _gate.Wait() (UI thread waits on the gate while a gate-holder waits on the UI
+        // thread). BeginInvoke queues the mutation in order without blocking, so no inversion is possible.
         var dispatcher = System.Windows.Application.Current?.Dispatcher;
         if (dispatcher == null || dispatcher.CheckAccess())
         {
@@ -290,7 +293,7 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
             return;
         }
 
-        dispatcher.Invoke(action);
+        dispatcher.BeginInvoke(action);
     }
     #endregion
 

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -1,0 +1,338 @@
+using System.Collections.ObjectModel;
+using Daqifi.Desktop.Common.Loggers;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Default <see cref="IBootloaderWatcher"/> implementation. Runs continuous HID-bootloader discovery and,
+/// for every bootloader it finds, opens an exclusive per-device hold (its own transport, keyed by device
+/// path) with a keep-alive read so Windows USB selective-suspend can't wedge it before flashing
+/// (daqifi-nyquist-firmware#568). All mutating operations are serialized through <see cref="_gate"/>; the
+/// bound <see cref="Bootloaders"/> collection is mutated on the UI thread.
+/// </summary>
+public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
+{
+    #region Private Fields
+    private readonly IBootloaderDiscovery _discovery;
+    private readonly Func<string, string?, IBootloaderHoldService> _holdFactory;
+    private readonly IAppLogger _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    // Source of truth, keyed by device path. Mirrored into Bootloaders for the UI.
+    private readonly Dictionary<string, IBootloaderHoldService> _holds = new(StringComparer.Ordinal);
+
+    private bool _started;
+    private bool _disposed;
+
+    // The single device currently being flashed (its hold is released so the flasher can open it); new
+    // grabs for this path are suppressed until the flash lease is disposed.
+    private string? _flashingPath;
+
+    // Set while an auto-update is in progress: discovery is paused and new grabs are suppressed, but
+    // existing holds stay alive so other sitting bootloaders remain wedge-proof.
+    private bool _grabSuppressed;
+    #endregion
+
+    #region Constructor
+    /// <summary>Creates the watcher.</summary>
+    /// <param name="discovery">Continuous HID-bootloader discovery source.</param>
+    /// <param name="holdFactory">
+    /// Creates a per-device hold (device path, friendly name) → hold service. Each hold owns its own
+    /// exclusive HID transport so holding/flashing one device never disturbs the others.
+    /// </param>
+    /// <param name="logger">Application logger for diagnostics.</param>
+    public BootloaderWatcher(
+        IBootloaderDiscovery discovery,
+        Func<string, string?, IBootloaderHoldService> holdFactory,
+        IAppLogger logger)
+    {
+        _discovery = discovery ?? throw new ArgumentNullException(nameof(discovery));
+        _holdFactory = holdFactory ?? throw new ArgumentNullException(nameof(holdFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+    #endregion
+
+    #region IBootloaderWatcher
+    /// <inheritdoc />
+    public ObservableCollection<HeldBootloader> Bootloaders { get; } = [];
+
+    /// <inheritdoc />
+    public event EventHandler<BootloaderHoldDroppedEventArgs>? HoldDropped;
+
+    /// <inheritdoc />
+    public void Start()
+    {
+        if (_disposed || _started)
+        {
+            return;
+        }
+
+        _started = true;
+        _discovery.BootloaderDiscovered += OnBootloaderDiscovered;
+        _discovery.Start();
+        _logger.Information("Bootloader watcher started; holding every detected HID bootloader app-wide.");
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable> PrepareFlashAsync(string devicePath)
+    {
+        ArgumentNullException.ThrowIfNull(devicePath);
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // Pause discovery and mark this device as the flash target so it isn't re-grabbed while the
+            // flasher owns it. Other holds are left untouched (they stay wedge-proof).
+            _discovery.Stop();
+            _flashingPath = devicePath;
+
+            if (_holds.TryGetValue(devicePath, out var hold))
+            {
+                // Release ONLY the target so the flasher's transport can open it by path. Graceful release
+                // (no HoldDropped); the hold object is kept so the lease can re-grab the same device after.
+                await hold.ReleaseAsync().ConfigureAwait(false);
+                _logger.Information($"Released hold on {devicePath} for flashing; other bootloaders stay held.");
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        return new WatcherLease(() => ResumeAfterFlashAsync(devicePath));
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable> SuspendDiscoveryAsync()
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _discovery.Stop();
+            _grabSuppressed = true;
+            _logger.Information("Bootloader watcher discovery suspended for an auto-update; existing holds kept.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        return new WatcherLease(ResumeDiscoveryAsync);
+    }
+    #endregion
+
+    #region Resume (lease disposal)
+    private async Task ResumeAfterFlashAsync(string devicePath)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _flashingPath = null;
+
+            if (_holds.TryGetValue(devicePath, out var hold))
+            {
+                // Re-grab the exact device by path. A failed/cancelled flash leaves it a bootloader →
+                // re-held. A successful flash left it in application mode → the open fails and we drop it.
+                await hold.BeginHoldAsync().ConfigureAwait(false);
+                if (!hold.IsHolding)
+                {
+                    RemoveHold(devicePath, hold);
+                    _logger.Information($"{devicePath} is no longer a bootloader after flashing; dropped from the held list.");
+                }
+            }
+
+            if (!_disposed)
+            {
+                _discovery.Start();
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task ResumeDiscoveryAsync()
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _grabSuppressed = false;
+            if (!_disposed)
+            {
+                _discovery.Start();
+            }
+            _logger.Information("Bootloader watcher discovery resumed after auto-update.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+    #endregion
+
+    #region Discovery / drop handling
+    private void OnBootloaderDiscovered(object? sender, BootloaderDiscoveredEventArgs e)
+    {
+        // The discovery loop is synchronous; grabbing the hold is async, so dispatch without blocking it.
+        _ = HandleDiscoveredAsync(e.DevicePath, e.DeviceName);
+    }
+
+    private async Task HandleDiscoveredAsync(string devicePath, string? deviceName)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        IBootloaderHoldService? created = null;
+        try
+        {
+            if (_disposed || _grabSuppressed || devicePath == _flashingPath || _holds.ContainsKey(devicePath))
+            {
+                return;
+            }
+
+            created = _holdFactory(devicePath, deviceName);
+            created.HoldDropped += OnHoldDropped;
+            await created.BeginHoldAsync().ConfigureAwait(false);
+
+            if (!created.IsHolding)
+            {
+                // Could not open it (already gone, or transitioned to application mode). Don't list it.
+                created.HoldDropped -= OnHoldDropped;
+                created.Dispose();
+                created = null;
+                return;
+            }
+
+            _holds[devicePath] = created;
+            var displayName = string.IsNullOrWhiteSpace(deviceName) ? "DAQiFi Bootloader" : deviceName!;
+            InvokeOnUiThread(() => Bootloaders.Add(new HeldBootloader(devicePath, displayName)));
+            created = null; // ownership transferred to _holds
+            _logger.Information($"Holding HID bootloader {devicePath} ({displayName}).");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, $"Failed to hold discovered bootloader {devicePath}.");
+        }
+        finally
+        {
+            // If we created a hold but didn't transfer ownership, tear it down so we don't leak it.
+            if (created != null)
+            {
+                created.HoldDropped -= OnHoldDropped;
+                created.Dispose();
+            }
+            _gate.Release();
+        }
+    }
+
+    private void OnHoldDropped(object? sender, EventArgs e)
+    {
+        if (sender is IBootloaderHoldService hold && hold.DevicePath != null)
+        {
+            _ = HandleHoldDroppedAsync(hold.DevicePath, hold);
+        }
+    }
+
+    private async Task HandleHoldDroppedAsync(string devicePath, IBootloaderHoldService hold)
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            // Only act if this is still the live hold for the path (ignore a late event from a replaced one).
+            if (_holds.TryGetValue(devicePath, out var current) && ReferenceEquals(current, hold))
+            {
+                RemoveHold(devicePath, hold);
+                _logger.Information($"Held bootloader {devicePath} dropped (device removed).");
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        HoldDropped?.Invoke(this, new BootloaderHoldDroppedEventArgs(devicePath));
+    }
+
+    /// <summary>Removes and disposes a hold and its UI row. Must be called under <see cref="_gate"/>.</summary>
+    private void RemoveHold(string devicePath, IBootloaderHoldService hold)
+    {
+        hold.HoldDropped -= OnHoldDropped;
+        _holds.Remove(devicePath);
+        hold.Dispose();
+        InvokeOnUiThread(() =>
+        {
+            var row = Bootloaders.FirstOrDefault(b => string.Equals(b.DevicePath, devicePath, StringComparison.Ordinal));
+            if (row != null)
+            {
+                Bootloaders.Remove(row);
+            }
+        });
+    }
+    #endregion
+
+    #region Helpers
+    private static void InvokeOnUiThread(Action action)
+    {
+        // No WPF dispatcher in unit tests (Application.Current is null) — run inline. In the app, marshal
+        // the bound-collection mutation onto the UI thread.
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        dispatcher.Invoke(action);
+    }
+    #endregion
+
+    #region IDisposable
+    /// <summary>Stops discovery and releases every held bootloader.</summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _discovery.BootloaderDiscovered -= OnBootloaderDiscovered;
+        (_discovery as IDisposable)?.Dispose();
+
+        _gate.Wait();
+        try
+        {
+            foreach (var hold in _holds.Values)
+            {
+                hold.HoldDropped -= OnHoldDropped;
+                hold.Dispose();
+            }
+            _holds.Clear();
+            InvokeOnUiThread(Bootloaders.Clear);
+        }
+        finally
+        {
+            _gate.Release();
+            _gate.Dispose();
+        }
+    }
+    #endregion
+
+    #region Lease
+    /// <summary>An <see cref="IAsyncDisposable"/> that runs a resume action exactly once on disposal.</summary>
+    private sealed class WatcherLease : IAsyncDisposable
+    {
+        private Func<Task>? _onDispose;
+
+        public WatcherLease(Func<Task> onDispose) => _onDispose = onDispose;
+
+        public async ValueTask DisposeAsync()
+        {
+            var action = Interlocked.Exchange(ref _onDispose, null);
+            if (action != null)
+            {
+                await action().ConfigureAwait(false);
+            }
+        }
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -184,7 +184,7 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     private void OnBootloaderDiscovered(object? sender, BootloaderDiscoveredEventArgs e)
     {
         // The discovery loop is synchronous; grabbing the hold is async, so dispatch without blocking it.
-        _ = HandleDiscoveredAsync(e.DevicePath, e.DeviceName);
+        RunDetached(HandleDiscoveredAsync(e.DevicePath, e.DeviceName), "handling a discovered bootloader");
     }
 
     private async Task HandleDiscoveredAsync(string devicePath, string? deviceName)
@@ -237,7 +237,7 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     {
         if (sender is IBootloaderHoldService hold && hold.DevicePath != null)
         {
-            _ = HandleHoldDroppedAsync(hold.DevicePath, hold);
+            RunDetached(HandleHoldDroppedAsync(hold.DevicePath, hold), "handling a dropped bootloader hold");
         }
     }
 
@@ -279,6 +279,20 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     #endregion
 
     #region Helpers
+    /// <summary>
+    /// Observes a fire-and-forget task's faults. The handlers carry their own try/catch for expected
+    /// failures; this is a backstop so an unexpected fault outside that scope (e.g. the gate already
+    /// disposed during shutdown) is logged rather than going unobserved.
+    /// </summary>
+    private void RunDetached(Task task, string context)
+    {
+        _ = task.ContinueWith(
+            t => _logger.Error(t.Exception!, $"Unhandled exception while {context}."),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+    }
+
     private static void InvokeOnUiThread(Action action)
     {
         // No WPF dispatcher in unit tests (Application.Current is null) — run inline. In the app, marshal

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -344,7 +344,15 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         _discovery.Stop();
         (_discovery as IDisposable)?.Dispose();
 
-        _gate.Wait();
+        // Bounded wait: never hang app shutdown if a handler is stuck holding the gate. On timeout we
+        // skip the gated teardown and dispose the gate best-effort (the process is exiting anyway).
+        if (!_gate.Wait(TimeSpan.FromSeconds(2)))
+        {
+            _logger.Warning("Timed out acquiring the gate during bootloader watcher dispose; releasing best-effort.");
+            _gate.Dispose();
+            return;
+        }
+
         try
         {
             foreach (var hold in _holds.Values)

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -357,18 +357,19 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         _discovery.Stop();
         (_discovery as IDisposable)?.Dispose();
 
-        // Bounded wait: never hang app shutdown if a handler is stuck holding the gate. On timeout we
-        // skip the gated teardown and dispose the gate best-effort (the process is exiting anyway).
-        if (!_gate.Wait(TimeSpan.FromSeconds(2)))
+        // Bounded wait so a stuck gate-holder can't hang app shutdown. Whether or not the gate is
+        // acquired we STILL dispose the holds (best-effort) — skipping that on timeout would leak their
+        // exclusive HID handles. Snapshot the holds first so a racing in-flight handler can't trip the
+        // enumeration; release the gate only if we actually took it.
+        var gateAcquired = _gate.Wait(TimeSpan.FromSeconds(2));
+        if (!gateAcquired)
         {
-            _logger.Warning("Timed out acquiring the gate during bootloader watcher dispose; releasing best-effort.");
-            _gate.Dispose();
-            return;
+            _logger.Warning("Timed out acquiring the gate during bootloader watcher dispose; disposing holds best-effort.");
         }
 
         try
         {
-            foreach (var hold in _holds.Values)
+            foreach (var hold in _holds.Values.ToList())
             {
                 hold.HoldDropped -= OnHoldDropped;
                 hold.Dispose();
@@ -378,7 +379,10 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         }
         finally
         {
-            _gate.Release();
+            if (gateAcquired)
+            {
+                _gate.Release();
+            }
             _gate.Dispose();
         }
     }

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -220,7 +220,14 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
             created = null; // ownership transferred to _holds BEFORE the UI marshal, so a marshal failure
                             // can never make the finally dispose a now-tracked hold (stale-entry bug).
             var displayName = string.IsNullOrWhiteSpace(deviceName) ? "DAQiFi Bootloader" : deviceName!;
-            InvokeOnUiThread(() => _bootloaders.Add(new HeldBootloader(devicePath, displayName)));
+            InvokeOnUiThread(() =>
+            {
+                // Guard: a callback queued just before Dispose must not re-add a row after teardown.
+                if (!_disposed)
+                {
+                    _bootloaders.Add(new HeldBootloader(devicePath, displayName));
+                }
+            });
             _logger.Information($"Holding HID bootloader {devicePath} ({displayName}).");
         }
         catch (Exception ex)
@@ -275,6 +282,12 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         hold.Dispose();
         InvokeOnUiThread(() =>
         {
+            // Guard: a callback queued just before Dispose must not mutate the list after teardown.
+            if (_disposed)
+            {
+                return;
+            }
+
             var row = _bootloaders.FirstOrDefault(b => string.Equals(b.DevicePath, devicePath, StringComparison.Ordinal));
             if (row != null)
             {

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -364,7 +364,8 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         var gateAcquired = _gate.Wait(TimeSpan.FromSeconds(2));
         if (!gateAcquired)
         {
-            _logger.Warning("Timed out acquiring the gate during bootloader watcher dispose; disposing holds best-effort.");
+            _logger.Warning(
+                "Timed out acquiring the gate during bootloader watcher dispose; disposing holds best-effort.");
         }
 
         try

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -30,6 +30,14 @@ public class FirmwareUpdateCoordinator
     private readonly IAppLogger _appLogger;
     private readonly string _firmwareDataDirectory;
     private readonly Func<string, string, IFirmwareUpdateService> _wifiFirmwareUpdateServiceFactory;
+
+    /// <summary>
+    /// App-global bootloader watcher. During an auto-update the connected device reboots into the HID
+    /// bootloader; the watcher would otherwise discover and exclusively grab it, starving the
+    /// coordinator's own flasher. The coordinator suspends the watcher's discovery for the PIC32 flash so
+    /// its flasher keeps exclusive access. Null is tolerated (tests / no watcher).
+    /// </summary>
+    private readonly IBootloaderWatcher? _watcher;
     private CancellationTokenSource? _firmwareUploadCts;
     private string _latestFirmwareVersion = string.Empty;
 
@@ -73,6 +81,10 @@ public class FirmwareUpdateCoordinator
     /// Overrides the WiFi-update-mode settle delay. Null uses
     /// <see cref="DefaultWifiUpdateModeSettleDelay"/>; tests pass <see cref="TimeSpan.Zero"/> to skip the wait.
     /// </param>
+    /// <param name="watcher">
+    /// App-global bootloader watcher whose discovery is suspended around the PIC32 flash so it doesn't
+    /// grab the rebooting device. Null is tolerated (tests / no watcher).
+    /// </param>
     public FirmwareUpdateCoordinator(
         IFirmwareUpdateHost host,
         IFirmwareUpdateService firmwareUpdateService,
@@ -81,7 +93,8 @@ public class FirmwareUpdateCoordinator
         IAppLogger appLogger,
         string firmwareDataDirectory,
         Func<string, string, IFirmwareUpdateService>? wifiFirmwareUpdateServiceFactory = null,
-        TimeSpan? wifiUpdateModeSettleDelay = null)
+        TimeSpan? wifiUpdateModeSettleDelay = null,
+        IBootloaderWatcher? watcher = null)
     {
         _host = host ?? throw new ArgumentNullException(nameof(host));
         _firmwareUpdateService = firmwareUpdateService ?? throw new ArgumentNullException(nameof(firmwareUpdateService));
@@ -91,6 +104,7 @@ public class FirmwareUpdateCoordinator
         _firmwareDataDirectory = firmwareDataDirectory ?? throw new ArgumentNullException(nameof(firmwareDataDirectory));
         _wifiFirmwareUpdateServiceFactory = wifiFirmwareUpdateServiceFactory ?? CreateWifiFirmwareUpdateService;
         _wifiUpdateModeSettleDelay = wifiUpdateModeSettleDelay ?? DefaultWifiUpdateModeSettleDelay;
+        _watcher = watcher;
     }
     #endregion
 
@@ -195,11 +209,20 @@ public class FirmwareUpdateCoordinator
                 }
             });
 
-            await _firmwareUpdateService.UpdateFirmwareAsync(
-                coreDevice,
-                effectiveFirmwarePath,
-                pic32Progress,
-                _firmwareUploadCts.Token);
+            // Suspend the watcher's HID discovery for just the PIC32 flash: the connected device reboots
+            // into the bootloader here, and the watcher must not grab it out from under this flasher.
+            // Existing holds on OTHER sitting bootloaders stay alive. (Known limitation: if another
+            // bootloader is held while this runs, Core's first-match enumeration could land on the held
+            // one — auto-update is fundamentally a single-device operation, so this is acceptable.)
+            var watcherLease = _watcher != null ? await _watcher.SuspendDiscoveryAsync() : null;
+            await using (watcherLease)
+            {
+                await _firmwareUpdateService.UpdateFirmwareAsync(
+                    coreDevice,
+                    effectiveFirmwarePath,
+                    pic32Progress,
+                    _firmwareUploadCts.Token);
+            }
 
             if (!isManualUpload)
             {

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
@@ -43,7 +43,15 @@ public static class FirmwareUpdateServiceConfig
         return new HidLibraryTransport
         {
             ReadTimeout = BootloaderHidTimeout,
-            WriteTimeout = BootloaderHidTimeout
+            WriteTimeout = BootloaderHidTimeout,
+
+            // A2 (stray-write guard): open the bootloader's HID handle exclusively and hold it for
+            // the whole flash session so no other user-mode opener — the connection dialog's own HID
+            // discovery loop, a second app instance, anything — can open or write to the device
+            // mid-flash. The PIC32 bootloader's CRC check is disabled, so a stray frame from another
+            // opener can be mis-parsed as an ERASE; the exclusive handle is the guard. Best-effort in
+            // Core: a refused exclusive open falls back to shared so a working flash is not regressed.
+            ExclusiveAccess = true
         };
     }
 

--- a/Daqifi.Desktop/Device/Firmware/HeldBootloader.cs
+++ b/Daqifi.Desktop/Device/Firmware/HeldBootloader.cs
@@ -14,7 +14,9 @@ public sealed class HeldBootloader
     public HeldBootloader(string devicePath, string displayName)
     {
         DevicePath = devicePath ?? throw new ArgumentNullException(nameof(devicePath));
-        DisplayName = displayName;
+        DisplayName = string.IsNullOrWhiteSpace(displayName)
+            ? throw new ArgumentException("Display name cannot be empty.", nameof(displayName))
+            : displayName;
     }
 
     /// <summary>OS HID device path; the stable identity passed to the path-targeted flash.</summary>

--- a/Daqifi.Desktop/Device/Firmware/HeldBootloader.cs
+++ b/Daqifi.Desktop/Device/Firmware/HeldBootloader.cs
@@ -13,7 +13,9 @@ public sealed class HeldBootloader
     /// <param name="displayName">Friendly name shown in the UI.</param>
     public HeldBootloader(string devicePath, string displayName)
     {
-        DevicePath = devicePath ?? throw new ArgumentNullException(nameof(devicePath));
+        DevicePath = string.IsNullOrWhiteSpace(devicePath)
+            ? throw new ArgumentException("Device path cannot be empty.", nameof(devicePath))
+            : devicePath;
         DisplayName = string.IsNullOrWhiteSpace(displayName)
             ? throw new ArgumentException("Display name cannot be empty.", nameof(displayName))
             : displayName;

--- a/Daqifi.Desktop/Device/Firmware/HeldBootloader.cs
+++ b/Daqifi.Desktop/Device/Firmware/HeldBootloader.cs
@@ -1,0 +1,25 @@
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// A sitting HID bootloader the <see cref="IBootloaderWatcher"/> is holding (handle open, keep-alive
+/// read pending) so Windows USB selective-suspend can't wedge it (daqifi-nyquist-firmware#568). Bound to
+/// the connection dialog's firmware list; the user picks one to flash. Identified by its OS HID device
+/// path — identical bootloaders share VID/PID and have no serial, so the path is the only discriminator.
+/// </summary>
+public sealed class HeldBootloader
+{
+    /// <summary>Creates a held-bootloader list item.</summary>
+    /// <param name="devicePath">OS HID device path — the stable identity used to target the flash.</param>
+    /// <param name="displayName">Friendly name shown in the UI.</param>
+    public HeldBootloader(string devicePath, string displayName)
+    {
+        DevicePath = devicePath ?? throw new ArgumentNullException(nameof(devicePath));
+        DisplayName = displayName;
+    }
+
+    /// <summary>OS HID device path; the stable identity passed to the path-targeted flash.</summary>
+    public string DevicePath { get; }
+
+    /// <summary>Friendly name shown in the connection dialog's firmware list.</summary>
+    public string DisplayName { get; }
+}

--- a/Daqifi.Desktop/Device/Firmware/HidBootloaderDiscovery.cs
+++ b/Daqifi.Desktop/Device/Firmware/HidBootloaderDiscovery.cs
@@ -21,6 +21,7 @@ public sealed class HidBootloaderDiscovery : IBootloaderDiscovery, IDisposable
     #region Private Fields
     private readonly IAppLogger _logger;
     private readonly TimeSpan _pollInterval;
+    private readonly Func<HidDeviceFinder> _finderFactory;
     private readonly object _sync = new();
 
     private HidDeviceFinder? _finder;
@@ -35,10 +36,18 @@ public sealed class HidBootloaderDiscovery : IBootloaderDiscovery, IDisposable
     /// <summary>Creates the discovery source.</summary>
     /// <param name="logger">Application logger for diagnostics.</param>
     /// <param name="pollInterval">Pause between discovery cycles; null uses <see cref="DefaultPollInterval"/>.</param>
-    public HidBootloaderDiscovery(IAppLogger logger, TimeSpan? pollInterval = null)
+    /// <param name="finderFactory">
+    /// Factory for the underlying Core HID finder; a fresh one is created per Start/Stop cycle (the finder
+    /// is disposed on Stop). Null uses the production <c>HidDeviceFinder</c>; tests inject a fake.
+    /// </param>
+    public HidBootloaderDiscovery(
+        IAppLogger logger,
+        TimeSpan? pollInterval = null,
+        Func<HidDeviceFinder>? finderFactory = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _pollInterval = pollInterval ?? DefaultPollInterval;
+        _finderFactory = finderFactory ?? (() => new HidDeviceFinder());
     }
 
     /// <inheritdoc />
@@ -60,7 +69,7 @@ public sealed class HidBootloaderDiscovery : IBootloaderDiscovery, IDisposable
             }
             _cts?.Dispose();
 
-            _finder = new HidDeviceFinder();
+            _finder = _finderFactory();
             _cts = new CancellationTokenSource();
             _finder.DeviceDiscovered += OnDeviceDiscovered;
             _loopTask = RunAsync(_finder, _cts.Token);
@@ -83,8 +92,12 @@ public sealed class HidBootloaderDiscovery : IBootloaderDiscovery, IDisposable
 
             _cts?.Dispose();
             _cts = null;
-            // Do not block on the loop task — Stop() may run on the UI thread. The loop drains on
-            // cancellation; Start() tolerates a still-completing prior task via the IsCompleted check.
+
+            // Clear the task reference (without blocking on it — Stop() may run on the UI thread) so a
+            // subsequent Start() restarts discovery immediately. The abandoned loop owns its own
+            // (now-cancelled, now-disposed) finder via a parameter, so it drains and exits on its own; a
+            // fresh Start() spins up a new finder/CTS and is not gated on the old loop completing.
+            _loopTask = null;
         }
     }
 

--- a/Daqifi.Desktop/Device/Firmware/HidBootloaderDiscovery.cs
+++ b/Daqifi.Desktop/Device/Firmware/HidBootloaderDiscovery.cs
@@ -1,0 +1,139 @@
+using Daqifi.Core.Device.Discovery;
+using Daqifi.Desktop.Common.Loggers;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Default <see cref="IBootloaderDiscovery"/> implementation: a continuous loop over Core's
+/// <see cref="HidDeviceFinder"/> that forwards every matching HID bootloader as a
+/// <see cref="BootloaderDiscoveredEventArgs"/>. Unlike the connection dialog's old one-shot discovery,
+/// this keeps polling so additional hot-plugged bootloaders are surfaced too; the watcher holds each one
+/// exclusively the moment it appears, so the finder's per-cycle open attempts on an already-held device
+/// fail harmlessly (a refused exclusive open sends no I/O to the device).
+/// </summary>
+public sealed class HidBootloaderDiscovery : IBootloaderDiscovery, IDisposable
+{
+    #region Constants
+    /// <summary>Default pause between discovery cycles.</summary>
+    public static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(2);
+    #endregion
+
+    #region Private Fields
+    private readonly IAppLogger _logger;
+    private readonly TimeSpan _pollInterval;
+    private readonly object _sync = new();
+
+    private HidDeviceFinder? _finder;
+    private CancellationTokenSource? _cts;
+    private Task? _loopTask;
+    private bool _disposed;
+    #endregion
+
+    /// <inheritdoc />
+    public event EventHandler<BootloaderDiscoveredEventArgs>? BootloaderDiscovered;
+
+    /// <summary>Creates the discovery source.</summary>
+    /// <param name="logger">Application logger for diagnostics.</param>
+    /// <param name="pollInterval">Pause between discovery cycles; null uses <see cref="DefaultPollInterval"/>.</param>
+    public HidBootloaderDiscovery(IAppLogger logger, TimeSpan? pollInterval = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _pollInterval = pollInterval ?? DefaultPollInterval;
+    }
+
+    /// <inheritdoc />
+    public void Start()
+    {
+        lock (_sync)
+        {
+            if (_disposed || _loopTask is { IsCompleted: false })
+            {
+                return;
+            }
+
+            // Restart-after-stop: dispose the prior finder/CTS before replacing them so we never leak a
+            // subscribed finder or an undisposed CancellationTokenSource.
+            if (_finder != null)
+            {
+                _finder.DeviceDiscovered -= OnDeviceDiscovered;
+                _finder.Dispose();
+            }
+            _cts?.Dispose();
+
+            _finder = new HidDeviceFinder();
+            _cts = new CancellationTokenSource();
+            _finder.DeviceDiscovered += OnDeviceDiscovered;
+            _loopTask = RunAsync(_finder, _cts.Token);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Stop()
+    {
+        lock (_sync)
+        {
+            _cts?.Cancel();
+
+            if (_finder != null)
+            {
+                _finder.DeviceDiscovered -= OnDeviceDiscovered;
+                _finder.Dispose();
+                _finder = null;
+            }
+
+            _cts?.Dispose();
+            _cts = null;
+            // Do not block on the loop task — Stop() may run on the UI thread. The loop drains on
+            // cancellation; Start() tolerates a still-completing prior task via the IsCompleted check.
+        }
+    }
+
+    private async Task RunAsync(HidDeviceFinder finder, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await finder.DiscoverAsync(cancellationToken).ConfigureAwait(false);
+                await Task.Delay(_pollInterval, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when stopped.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Expected when the finder is disposed during a discovery cycle.
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Error in bootloader discovery loop");
+        }
+    }
+
+    private void OnDeviceDiscovered(object? sender, DeviceDiscoveredEventArgs e)
+    {
+        try
+        {
+            var info = e.DeviceInfo;
+            if (string.IsNullOrWhiteSpace(info.DevicePath))
+            {
+                return;
+            }
+
+            BootloaderDiscovered?.Invoke(this, new BootloaderDiscoveredEventArgs(info.DevicePath, info.Name));
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Error handling bootloader discovery");
+        }
+    }
+
+    /// <summary>Stops discovery and releases the finder.</summary>
+    public void Dispose()
+    {
+        Stop();
+        _disposed = true;
+    }
+}

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderDiscovery.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderDiscovery.cs
@@ -1,0 +1,40 @@
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Identifies a HID bootloader that discovery surfaced.
+/// </summary>
+public sealed class BootloaderDiscoveredEventArgs : EventArgs
+{
+    /// <summary>Creates the event args.</summary>
+    public BootloaderDiscoveredEventArgs(string devicePath, string? deviceName)
+    {
+        DevicePath = devicePath;
+        DeviceName = deviceName;
+    }
+
+    /// <summary>OS HID device path of the discovered bootloader.</summary>
+    public string DevicePath { get; }
+
+    /// <summary>Friendly device name, when discovery could read it; otherwise null.</summary>
+    public string? DeviceName { get; }
+}
+
+/// <summary>
+/// Continuous HID-bootloader discovery source for the <see cref="IBootloaderWatcher"/>. Abstracted from
+/// Core's <c>HidDeviceFinder</c> so the watcher can be unit-tested without hardware (tests raise
+/// <see cref="BootloaderDiscovered"/> directly) and so discovery can be paused around a flash.
+/// </summary>
+public interface IBootloaderDiscovery
+{
+    /// <summary>Raised once per discovery cycle for every matching HID bootloader currently present.</summary>
+    event EventHandler<BootloaderDiscoveredEventArgs>? BootloaderDiscovered;
+
+    /// <summary>Starts (or resumes) the continuous discovery loop. Idempotent while running.</summary>
+    void Start();
+
+    /// <summary>
+    /// Stops the discovery loop. Used to pause discovery for the duration of a flash so it does not
+    /// re-open or fight the bootloader's HID I/O. <see cref="Start"/> resumes afterward.
+    /// </summary>
+    void Stop();
+}

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderDiscovery.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderDiscovery.cs
@@ -1,25 +1,6 @@
 namespace Daqifi.Desktop.Device.Firmware;
 
 /// <summary>
-/// Identifies a HID bootloader that discovery surfaced.
-/// </summary>
-public sealed class BootloaderDiscoveredEventArgs : EventArgs
-{
-    /// <summary>Creates the event args.</summary>
-    public BootloaderDiscoveredEventArgs(string devicePath, string? deviceName)
-    {
-        DevicePath = devicePath;
-        DeviceName = deviceName;
-    }
-
-    /// <summary>OS HID device path of the discovered bootloader.</summary>
-    public string DevicePath { get; }
-
-    /// <summary>Friendly device name, when discovery could read it; otherwise null.</summary>
-    public string? DeviceName { get; }
-}
-
-/// <summary>
 /// Continuous HID-bootloader discovery source for the <see cref="IBootloaderWatcher"/>. Abstracted from
 /// Core's <c>HidDeviceFinder</c> so the watcher can be unit-tested without hardware (tests raise
 /// <see cref="BootloaderDiscovered"/> directly) and so discovery can be paused around a flash.

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderHoldService.cs
@@ -17,10 +17,28 @@ namespace Daqifi.Desktop.Device.Firmware;
 /// flash is seamless: the flasher reopens the already-warm handle with no idle gap.
 /// </para>
 /// </summary>
-public interface IBootloaderHoldService
+public interface IBootloaderHoldService : IDisposable
 {
     /// <summary>Whether a hold is currently active (handle open, keep-alive read pending).</summary>
     bool IsHolding { get; }
+
+    /// <summary>
+    /// The OS HID device path this hold targets, or null when the hold connects by VID/PID first-match
+    /// (the single-device case). The watcher uses the path to address one specific bootloader among
+    /// several identical ones (same VID/PID, no serial), and to re-grab the exact device after a flash.
+    /// </summary>
+    string? DevicePath { get; }
+
+    /// <summary>Friendly name for the held device, surfaced in the UI. Null when unknown.</summary>
+    string? DeviceName { get; }
+
+    /// <summary>
+    /// Raised when the keep-alive loop ends because the device went away (I/O error / surprise removal),
+    /// not because of a requested <see cref="PauseForFlashAsync"/>/<see cref="ReleaseAsync"/>. The watcher
+    /// subscribes to drop the device from its held-bootloader list. Raised off the keep-alive task thread
+    /// so a handler may safely dispose this hold.
+    /// </summary>
+    event EventHandler? HoldDropped;
 
     /// <summary>
     /// Opens the bootloader's HID handle and starts the keep-alive read loop. Best-effort and

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderHoldService.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderHoldService.cs
@@ -1,0 +1,44 @@
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Grabs and holds a sitting PIC32 HID bootloader's USB handle so it cannot be wedged by Windows USB
+/// selective-suspend before the user flashes it (daqifi-nyquist-firmware#568).
+/// <para>
+/// The wedge happens when the host lets an idle bootloader go to selective-suspend and then reopens it:
+/// the reopen is a bus RESET with no follow-up SET_CONFIGURATION, so the device never reaches
+/// <c>USB_DEVICE_EVENT_CONFIGURED</c>, its data endpoints stay dark, and the version handshake times
+/// out. The cure is to never let it suspend in the first place: hold the handle open with an
+/// interrupt-IN read continuously pending (an <em>idle</em> open handle alone does not stop suspend — a
+/// pending read IRP does). Reads carry no payload to the device, so unlike a write they can never be
+/// mis-parsed as a stray command — they are the one form of I/O safe to direct at a sitting bootloader.
+/// </para>
+/// <para>
+/// The hold uses the same shared exclusive <c>IHidTransport</c> the flasher uses, so handing off to the
+/// flash is seamless: the flasher reopens the already-warm handle with no idle gap.
+/// </para>
+/// </summary>
+public interface IBootloaderHoldService
+{
+    /// <summary>Whether a hold is currently active (handle open, keep-alive read pending).</summary>
+    bool IsHolding { get; }
+
+    /// <summary>
+    /// Opens the bootloader's HID handle and starts the keep-alive read loop. Best-effort and
+    /// idempotent: if no bootloader is present (e.g. a just-flashed device now in application mode) the
+    /// open fails and the call returns without holding and without throwing. A no-op if already holding.
+    /// </summary>
+    Task BeginHoldAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops the keep-alive read so the flasher can own the device's HID I/O, but leaves the handle
+    /// OPEN and warm for the flasher to reopen with no idle gap. Lets the in-flight read drain fully so
+    /// no orphaned read IRP can swallow the flasher's first response. Call immediately before flashing.
+    /// </summary>
+    Task PauseForFlashAsync();
+
+    /// <summary>
+    /// Stops the keep-alive read and closes the handle. Call when the device is no longer being managed
+    /// (the connection dialog closes) so the bootloader is never left held.
+    /// </summary>
+    Task ReleaseAsync();
+}

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
@@ -1,0 +1,63 @@
+using System.Collections.ObjectModel;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>Identifies a held bootloader that dropped out of the watcher's list.</summary>
+public sealed class BootloaderHoldDroppedEventArgs : EventArgs
+{
+    /// <summary>Creates the event args.</summary>
+    public BootloaderHoldDroppedEventArgs(string devicePath)
+    {
+        DevicePath = devicePath;
+    }
+
+    /// <summary>OS HID device path of the bootloader whose hold was dropped.</summary>
+    public string DevicePath { get; }
+}
+
+/// <summary>
+/// App-global service that discovers <em>every</em> sitting PIC32 HID bootloader and holds each one's USB
+/// handle open with a keep-alive read so Windows USB selective-suspend can't wedge it before the user
+/// flashes (daqifi-nyquist-firmware#568). Each bootloader is held over its own exclusive transport,
+/// addressed by device path (identical bootloaders share VID/PID and have no serial), so holding or
+/// flashing one never disturbs the others.
+/// <para>
+/// Holds persist for the app's lifetime regardless of whether the connection dialog is open — that is the
+/// point of an app-global watcher. The dialog binds to <see cref="Bootloaders"/> to list them and calls
+/// <see cref="PrepareFlashAsync"/> to flash one; the auto-update coordinator calls
+/// <see cref="SuspendDiscoveryAsync"/> so the watcher doesn't grab the device it is mid-flashing.
+/// </para>
+/// </summary>
+public interface IBootloaderWatcher
+{
+    /// <summary>
+    /// The bootloaders currently held, bound to the connection dialog's firmware list. Mutated on the UI
+    /// thread so it can be data-bound directly.
+    /// </summary>
+    ObservableCollection<HeldBootloader> Bootloaders { get; }
+
+    /// <summary>Raised when a held bootloader drops off the list (device removed / surprise-detached).</summary>
+    event EventHandler<BootloaderHoldDroppedEventArgs>? HoldDropped;
+
+    /// <summary>Begins discovery and holding. Idempotent; call once at app startup.</summary>
+    void Start();
+
+    /// <summary>
+    /// Prepares to flash one specific held bootloader: pauses discovery and releases <em>only</em> that
+    /// device's hold (so the flasher can open it by path), while every other bootloader stays held and
+    /// wedge-proof. Disposing the returned lease re-grabs the target (if it is still a bootloader — a
+    /// successful flash leaves it in application mode, so it drops off the list) and resumes discovery.
+    /// </summary>
+    /// <param name="devicePath">OS HID device path of the bootloader to flash.</param>
+    /// <returns>A lease whose disposal restores the hold and resumes discovery.</returns>
+    Task<IAsyncDisposable> PrepareFlashAsync(string devicePath);
+
+    /// <summary>
+    /// Suspends discovery (and suppresses new grabs) for the duration of an auto-update, while keeping
+    /// existing holds alive. Used by the firmware coordinator: when a connected device reboots into the
+    /// bootloader mid-update, the watcher must not grab it out from under the coordinator's flasher.
+    /// Disposing the returned lease resumes discovery.
+    /// </summary>
+    /// <returns>A lease whose disposal resumes discovery.</returns>
+    Task<IAsyncDisposable> SuspendDiscoveryAsync();
+}

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
@@ -2,19 +2,6 @@ using System.Collections.ObjectModel;
 
 namespace Daqifi.Desktop.Device.Firmware;
 
-/// <summary>Identifies a held bootloader that dropped out of the watcher's list.</summary>
-public sealed class BootloaderHoldDroppedEventArgs : EventArgs
-{
-    /// <summary>Creates the event args.</summary>
-    public BootloaderHoldDroppedEventArgs(string devicePath)
-    {
-        DevicePath = devicePath;
-    }
-
-    /// <summary>OS HID device path of the bootloader whose hold was dropped.</summary>
-    public string DevicePath { get; }
-}
-
 /// <summary>
 /// App-global service that discovers <em>every</em> sitting PIC32 HID bootloader and holds each one's USB
 /// handle open with a keep-alive read so Windows USB selective-suspend can't wedge it before the user

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
@@ -18,10 +18,11 @@ namespace Daqifi.Desktop.Device.Firmware;
 public interface IBootloaderWatcher
 {
     /// <summary>
-    /// The bootloaders currently held, bound to the connection dialog's firmware list. Mutated on the UI
-    /// thread so it can be data-bound directly.
+    /// The bootloaders currently held, bound to the connection dialog's firmware list. A read-only view
+    /// over the watcher's internal collection (mutated on the UI thread) so callers can observe but not
+    /// mutate the watcher's state.
     /// </summary>
-    ObservableCollection<HeldBootloader> Bootloaders { get; }
+    ReadOnlyObservableCollection<HeldBootloader> Bootloaders { get; }
 
     /// <summary>Raised when a held bootloader drops off the list (device removed / surprise-detached).</summary>
     event EventHandler<BootloaderHoldDroppedEventArgs>? HoldDropped;

--- a/Daqifi.Desktop/View/ConnectionDialog.xaml
+++ b/Daqifi.Desktop/View/ConnectionDialog.xaml
@@ -475,7 +475,7 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                 </Grid.ColumnDefinitions>
                                                 <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                                                    <TextBlock Text="DAQiFi Device"
+                                                    <TextBlock Text="{Binding DisplayName}"
                                                                FontFamily="Consolas" FontSize="15" FontWeight="Medium"
                                                                Foreground="{StaticResource TextPrimary}"/>
                                                     <TextBlock Text="Firmware mode"

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -24,21 +24,20 @@ public partial class ConnectionDialogViewModel : ObservableObject
     #region Private Variables
     private WiFiDeviceFinder? _wifiFinder;
     private Daqifi.Core.Device.Discovery.SerialDeviceFinder? _serialFinder;
-    private Daqifi.Core.Device.Discovery.HidDeviceFinder? _hidDeviceFinder;
     private CancellationTokenSource? _wifiDiscoveryCts;
     private CancellationTokenSource? _serialDiscoveryCts;
-    private CancellationTokenSource? _hidDiscoveryCts;
     private Task? _wifiDiscoveryTask;
     private Task? _serialDiscoveryTask;
-    private Task? _hidDiscoveryTask;
     private readonly IDialogService _dialogService;
 
     /// <summary>
-    /// Holds a detected HID bootloader's handle open so Windows USB selective-suspend can't wedge it
-    /// before the user flashes (daqifi-nyquist-firmware#568). Null only in unit tests that construct the
-    /// view model without the DI container.
+    /// App-global watcher that discovers and holds every sitting HID bootloader (keep-alive read pending)
+    /// so Windows USB selective-suspend can't wedge one before the user flashes (daqifi-nyquist-firmware#568).
+    /// The dialog binds its firmware list to <see cref="IBootloaderWatcher.Bootloaders"/> and opens the
+    /// firmware dialog for the chosen device. Null only in unit tests that construct the view model
+    /// without the DI container.
     /// </summary>
-    private readonly IBootloaderHoldService? _bootloaderHoldService;
+    private readonly IBootloaderWatcher? _watcher;
 
     [ObservableProperty]
     private bool _hasNoWiFiDevices = true;
@@ -63,7 +62,14 @@ public partial class ConnectionDialogViewModel : ObservableObject
     #region Properties
     public ObservableCollection<DaqifiStreamingDevice> AvailableWiFiDevices { get; } = [];
     public ObservableCollection<SerialStreamingDevice> AvailableSerialDevices { get; } = [];
-    public ObservableCollection<CoreDeviceInfo> AvailableHidDevices { get; } = [];
+
+    /// <summary>
+    /// The sitting HID bootloaders the app-global watcher is holding, bound to the Firmware tab. The user
+    /// picks one to flash. Falls back to an empty collection when no watcher is present (unit tests).
+    /// </summary>
+    public ObservableCollection<HeldBootloader> AvailableHidDevices => _watcher?.Bootloaders ?? _emptyHidDevices;
+
+    private readonly ObservableCollection<HeldBootloader> _emptyHidDevices = [];
 
     [ObservableProperty]
     private string? _manualPortName;
@@ -110,21 +116,34 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     #region Constructor
     public ConnectionDialogViewModel()
-        : this(ServiceLocator.Resolve<IDialogService>(), App.ServiceProvider?.GetService<IBootloaderHoldService>()) { }
+        : this(ServiceLocator.Resolve<IDialogService>(), App.ServiceProvider?.GetService<IBootloaderWatcher>()) { }
 
     public ConnectionDialogViewModel(
         IDialogService dialogService,
-        IBootloaderHoldService? bootloaderHoldService = null)
+        IBootloaderWatcher? watcher = null)
     {
         _dialogService = dialogService;
-        _bootloaderHoldService = bootloaderHoldService;
+        _watcher = watcher;
         ConnectCommand = new AsyncRelayCommand<object>(ConnectAsync);
         ConnectSerialCommand = new AsyncRelayCommand<object>(ConnectSerialAsync);
         ConnectManualSerialCommand = new AsyncRelayCommand(ConnectManualSerialAsync);
         ConnectManualWifiCommand = new AsyncRelayCommand(ConnectManualWifiAsync);
-        
+
+        // The watcher holds bootloaders app-wide, so its list may already be populated before the dialog
+        // opens. Reflect its current count and track changes so the "scanning…" overlay is accurate.
+        if (_watcher != null)
+        {
+            HasNoHidDevices = _watcher.Bootloaders.Count == 0;
+            _watcher.Bootloaders.CollectionChanged += OnHidDevicesChanged;
+        }
+
         // Set up the duplicate device handler
         ConnectionManager.Instance.DuplicateDeviceHandler = HandleDuplicateDevice;
+    }
+
+    private void OnHidDevicesChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        HasNoHidDevices = AvailableHidDevices.Count == 0;
     }
 
     public void StartConnectionFinders()
@@ -133,7 +152,8 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         StartWiFiDiscovery();
         StartSerialDiscovery();
-        StartHidDiscovery();
+        // HID bootloader discovery + holding is the app-global watcher's job (started at app startup),
+        // not the dialog's — the dialog only binds to AvailableHidDevices.
     }
 
     private void StartWiFiDiscovery()
@@ -164,25 +184,6 @@ public partial class ConnectionDialogViewModel : ObservableObject
         _serialDiscoveryCts = new CancellationTokenSource();
         _serialFinder.DeviceDiscovered += HandleCoreSerialDeviceDiscovered;
         _serialDiscoveryTask = RunContinuousSerialDiscoveryAsync(_serialDiscoveryCts.Token);
-    }
-
-    /// <summary>
-    /// Starts the continuous HID discovery loop. Extracted so it can be paused around a bootloader
-    /// flash: the loop opens every matching HID device each cycle (to read USB string descriptors),
-    /// which collides with the bootloader's in-progress HID I/O and corrupts the flash.
-    /// <see cref="ConnectHid"/> drains it before flashing and restarts it afterward.
-    /// </summary>
-    private void StartHidDiscovery()
-    {
-        if (_closed || _hidDiscoveryTask is { IsCompleted: false }) { return; }
-
-        if (_hidDeviceFinder != null) { _hidDeviceFinder.DeviceDiscovered -= HandleCoreHidDeviceDiscovered; _hidDeviceFinder.Dispose(); }
-        _hidDiscoveryCts?.Dispose();
-
-        _hidDeviceFinder = new Daqifi.Core.Device.Discovery.HidDeviceFinder();
-        _hidDiscoveryCts = new CancellationTokenSource();
-        _hidDeviceFinder.DeviceDiscovered += HandleCoreHidDeviceDiscovered;
-        _hidDiscoveryTask = RunContinuousHidDiscoveryAsync(_hidDiscoveryCts.Token);
     }
 
     private async Task RunContinuousWiFiDiscoveryAsync(CancellationToken cancellationToken)
@@ -235,45 +236,6 @@ public partial class ConnectionDialogViewModel : ObservableObject
         }
     }
 
-    private async Task RunContinuousHidDiscoveryAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            while (!cancellationToken.IsCancellationRequested && _hidDeviceFinder != null)
-            {
-                await _hidDeviceFinder.DiscoverAsync(cancellationToken);
-
-                // Stop repolling once a HID bootloader is in the list. Each DiscoverAsync cycle opens
-                // every matching HID device to read its USB string descriptors; for a bootloader that
-                // is just sitting here waiting to be flashed, that repeated ~2s open/close churn
-                // darkens its data endpoint (daqifi-nyquist-firmware#568) before the user ever clicks
-                // Upload. One enumeration is enough to list it — after that, leave it untouched until
-                // the flash itself opens it. Re-entering the dialog restarts discovery via
-                // StartHidDiscovery, so a hot-plugged bootloader is still picked up.
-                if (AvailableHidDevices.Count > 0)
-                {
-                    Common.Loggers.AppLogger.Instance.Information(
-                        "HID bootloader found — stopping HID discovery so the sitting device is not re-opened before flashing.");
-                    break;
-                }
-
-                // HID discovery is quick, pause longer between scans
-                await Task.Delay(2000, cancellationToken);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected when cancelled
-        }
-        catch (ObjectDisposedException)
-        {
-            // Expected when finder is disposed during discovery
-        }
-        catch (Exception ex)
-        {
-            Common.Loggers.AppLogger.Instance.Error(ex, "Error in HID discovery loop");
-        }
-    }
     #endregion
 
     #region Commands
@@ -481,45 +443,31 @@ public partial class ConnectionDialogViewModel : ObservableObject
     {
         if (selectedItems is not IEnumerable enumerable) { return; }
 
-        var hidDevice = enumerable.Cast<CoreDeviceInfo>().FirstOrDefault();
-        if (hidDevice == null) { return; }
+        var bootloader = enumerable.Cast<HeldBootloader>().FirstOrDefault();
+        if (bootloader == null) { return; }
 
-        // Pause ALL discovery for the duration of the flash, not just HID. Each loop probes the bus
-        // every cycle: HID discovery re-opens every matching HID device (reading USB string descriptors
-        // opens the handle) and serial discovery opens/probes every COM port waiting for an identify
-        // response. Either can collide with — or starve — the bootloader's HID I/O mid-flash, producing
-        // the intermittent "Connecting"-state HID write failure / read timeout. Awaiting the drains
-        // matters: cancel/dispose does NOT abort an in-flight DiscoverAsync cycle, so a still-running
-        // probe can hold a handle when the flasher fires.
+        // Pause WiFi + serial discovery while the firmware dialog is open: their per-cycle bus probing
+        // (serial opens/probes every COM port; WiFi UDP-broadcasts) can starve the bootloader's HID I/O
+        // mid-flash. HID discovery and the per-device holds belong to the app-global watcher — it pauses
+        // HID discovery and releases the target's hold itself when the flash starts
+        // (FirmwareDialogViewModel → BootloaderWatcher.PrepareFlashAsync), while every OTHER held
+        // bootloader stays wedge-proof. Awaiting the drains matters: cancel/dispose does NOT abort an
+        // in-flight DiscoverAsync cycle, so a still-running probe could otherwise hold a handle when the
+        // flasher fires.
         await StopWiFiDiscoveryAsync();
         await StopSerialDiscoveryAsync();
-        await StopHidDiscoveryAsync();
 
-        // Keep holding (keep-alive active) WHILE the dialog is open — the user may sit here for a while
-        // before clicking Upload, and an idle open handle alone does not stop USB selective-suspend, so
-        // pausing now would re-open the #568 wedge window. The flasher pauses the keep-alive itself at
-        // the moment the flash starts (FirmwareDialogViewModel.UploadFirmware), handing itself a warm
-        // handle with no idle gap.
         try
         {
-            var firmwareDialogViewModel = new FirmwareDialogViewModel(hidDevice.Name);
+            var firmwareDialogViewModel = new FirmwareDialogViewModel(bootloader.DisplayName, bootloader.DevicePath);
             _dialogService.ShowDialog<FirmwareDialog>(this, firmwareDialogViewModel);
         }
         finally
         {
-            // Re-grab the hold if the device is still a sitting bootloader (the user cancelled, or the
-            // flash failed). A successful flash left it in application mode, so BeginHoldAsync finds no
-            // bootloader and no-ops. This keeps the device wedge-proof across a retry without reopening
-            // the dialog.
-            if (_bootloaderHoldService != null)
-            {
-                await _bootloaderHoldService.BeginHoldAsync();
-            }
-
-            // Resume discovery once the flash dialog closes so the device list stays live.
+            // Resume discovery once the flash dialog closes so the device list stays live. The watcher
+            // keeps holding the bootloader (or drops it if the flash succeeded) on its own.
             StartWiFiDiscovery();
             StartSerialDiscovery();
-            StartHidDiscovery();
         }
     }
     #endregion
@@ -612,41 +560,6 @@ public partial class ConnectionDialogViewModel : ObservableObject
         dispatcher.Invoke(action);
     }
 
-    private void HandleCoreHidDeviceDiscovered(object? sender, DeviceDiscoveredEventArgs e)
-    {
-        try
-        {
-            System.Windows.Application.Current.Dispatcher.Invoke(() =>
-            {
-                var discoveredDevice = e.DeviceInfo;
-                var discoveredKey = BuildHidDeviceKey(discoveredDevice);
-                var alreadyTracked = AvailableHidDevices.Any(device => BuildHidDeviceKey(device) == discoveredKey);
-                if (alreadyTracked)
-                {
-                    return;
-                }
-
-                AvailableHidDevices.Add(discoveredDevice);
-                HasNoHidDevices = AvailableHidDevices.Count == 0;
-
-                // A bootloader-VID/PID device just appeared. Immediately grab and hold its HID handle
-                // (exclusive, keep-alive read pending) so Windows USB selective-suspend can't wedge it
-                // into the #568 state while it sits here waiting to be flashed. Fire-and-forget: the
-                // open + keep-alive runs off the UI thread, and the hold is idempotent.
-                _ = _bootloaderHoldService?.BeginHoldAsync();
-            });
-        }
-        catch (Exception ex)
-        {
-            Common.Loggers.AppLogger.Instance.Error(ex, "Error handling HID device discovery");
-        }
-    }
-
-    private static string BuildHidDeviceKey(CoreDeviceInfo deviceInfo)
-    {
-        return $"{deviceInfo.DevicePath}|{deviceInfo.SerialNumber}|{deviceInfo.Name}";
-    }
-
     #endregion
 
     #region Desktop Device Event Handlers
@@ -676,11 +589,14 @@ public partial class ConnectionDialogViewModel : ObservableObject
         StopWiFiDiscovery();
         // Fire-and-forget: cancel discovery and clean up without waiting for task completion
         _ = StopSerialDiscoveryAsync();
-        StopHidDiscovery();
 
-        // Release any held bootloader handle so the device is never left grabbed after the dialog
-        // closes. Fire-and-forget for the same reason as the serial drain above.
-        _ = _bootloaderHoldService?.ReleaseAsync();
+        // HID bootloader holds are owned by the app-global watcher and intentionally persist after the
+        // dialog closes (so a sitting bootloader stays wedge-proof). Only stop unsubscribing this dialog
+        // from the watcher's list.
+        if (_watcher != null)
+        {
+            _watcher.Bootloaders.CollectionChanged -= OnHidDevicesChanged;
+        }
     }
 
     private void StopWiFiDiscovery()
@@ -740,21 +656,6 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
     }
 
-    private void StopHidDiscovery()
-    {
-        _hidDiscoveryCts?.Cancel();
-
-        if (_hidDeviceFinder != null)
-        {
-            _hidDeviceFinder.DeviceDiscovered -= HandleCoreHidDeviceDiscovered;
-            _hidDeviceFinder.Dispose();
-            _hidDeviceFinder = null;
-        }
-
-        _hidDiscoveryCts?.Dispose();
-        _hidDiscoveryCts = null;
-    }
-
     /// <summary>
     /// Stops WiFi discovery and waits for the in-flight discovery cycle to drain before returning —
     /// the async counterpart to <see cref="StopWiFiDiscovery"/>, used before a bootloader flash so a
@@ -793,46 +694,6 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         _wifiDiscoveryCts?.Dispose();
         _wifiDiscoveryCts = null;
-    }
-
-    /// <summary>
-    /// Stops HID discovery and waits for the in-flight discovery cycle to finish before returning.
-    /// <see cref="StopHidDiscovery"/> alone only signals cancellation and disposes the finder, but a
-    /// running <c>DiscoverAsync</c> cycle keeps the bootloader's HID handle open until it returns;
-    /// draining the task first guarantees the flasher has exclusive access for its first write.
-    /// </summary>
-    private async Task StopHidDiscoveryAsync()
-    {
-        _hidDiscoveryCts?.Cancel();
-
-        if (_hidDiscoveryTask != null)
-        {
-            try
-            {
-                await _hidDiscoveryTask.WaitAsync(TimeSpan.FromSeconds(5));
-            }
-            catch (TimeoutException)
-            {
-                Common.Loggers.AppLogger.Instance.Warning("HID discovery task did not complete within timeout");
-            }
-            catch (OperationCanceledException) { }
-            catch (ObjectDisposedException) { }
-            catch (Exception ex)
-            {
-                Common.Loggers.AppLogger.Instance.Error(ex, "Unexpected error while stopping HID discovery");
-            }
-            _hidDiscoveryTask = null;
-        }
-
-        if (_hidDeviceFinder != null)
-        {
-            _hidDeviceFinder.DeviceDiscovered -= HandleCoreHidDeviceDiscovered;
-            _hidDeviceFinder.Dispose();
-            _hidDeviceFinder = null;
-        }
-
-        _hidDiscoveryCts?.Dispose();
-        _hidDiscoveryCts = null;
     }
 
     /// <summary>

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Device.Firmware;
 using Daqifi.Desktop.Device.SerialDevice;
 using Daqifi.Desktop.Device.WiFiDevice;
 using Daqifi.Desktop.DialogService;
@@ -10,6 +11,7 @@ using System.Net;
 using System.Net.Sockets;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Daqifi.Core.Device.Discovery;
 using CoreConcreteDeviceInfo = Daqifi.Core.Device.Discovery.DeviceInfo;
 using CoreConnectionType = Daqifi.Core.Device.Discovery.ConnectionType;
@@ -30,6 +32,13 @@ public partial class ConnectionDialogViewModel : ObservableObject
     private Task? _serialDiscoveryTask;
     private Task? _hidDiscoveryTask;
     private readonly IDialogService _dialogService;
+
+    /// <summary>
+    /// Holds a detected HID bootloader's handle open so Windows USB selective-suspend can't wedge it
+    /// before the user flashes (daqifi-nyquist-firmware#568). Null only in unit tests that construct the
+    /// view model without the DI container.
+    /// </summary>
+    private readonly IBootloaderHoldService? _bootloaderHoldService;
 
     [ObservableProperty]
     private bool _hasNoWiFiDevices = true;
@@ -100,11 +109,15 @@ public partial class ConnectionDialogViewModel : ObservableObject
     }
 
     #region Constructor
-    public ConnectionDialogViewModel() : this(ServiceLocator.Resolve<IDialogService>()) { }
+    public ConnectionDialogViewModel()
+        : this(ServiceLocator.Resolve<IDialogService>(), App.ServiceProvider?.GetService<IBootloaderHoldService>()) { }
 
-    public ConnectionDialogViewModel(IDialogService dialogService)
+    public ConnectionDialogViewModel(
+        IDialogService dialogService,
+        IBootloaderHoldService? bootloaderHoldService = null)
     {
         _dialogService = dialogService;
+        _bootloaderHoldService = bootloaderHoldService;
         ConnectCommand = new AsyncRelayCommand<object>(ConnectAsync);
         ConnectSerialCommand = new AsyncRelayCommand<object>(ConnectSerialAsync);
         ConnectManualSerialCommand = new AsyncRelayCommand(ConnectManualSerialAsync);
@@ -229,6 +242,21 @@ public partial class ConnectionDialogViewModel : ObservableObject
             while (!cancellationToken.IsCancellationRequested && _hidDeviceFinder != null)
             {
                 await _hidDeviceFinder.DiscoverAsync(cancellationToken);
+
+                // Stop repolling once a HID bootloader is in the list. Each DiscoverAsync cycle opens
+                // every matching HID device to read its USB string descriptors; for a bootloader that
+                // is just sitting here waiting to be flashed, that repeated ~2s open/close churn
+                // darkens its data endpoint (daqifi-nyquist-firmware#568) before the user ever clicks
+                // Upload. One enumeration is enough to list it — after that, leave it untouched until
+                // the flash itself opens it. Re-entering the dialog restarts discovery via
+                // StartHidDiscovery, so a hot-plugged bootloader is still picked up.
+                if (AvailableHidDevices.Count > 0)
+                {
+                    Common.Loggers.AppLogger.Instance.Information(
+                        "HID bootloader found — stopping HID discovery so the sitting device is not re-opened before flashing.");
+                    break;
+                }
+
                 // HID discovery is quick, pause longer between scans
                 await Task.Delay(2000, cancellationToken);
             }
@@ -466,6 +494,15 @@ public partial class ConnectionDialogViewModel : ObservableObject
         await StopWiFiDiscoveryAsync();
         await StopSerialDiscoveryAsync();
         await StopHidDiscoveryAsync();
+
+        // Hand the held handle to the flasher: stop the keep-alive read so the flash owns the device's
+        // HID I/O, but leave the handle OPEN and warm. The flasher closes+reopens it back-to-back (no
+        // idle gap, so no #568 wedge). No-op if we were never holding (the handle wasn't grabbed).
+        if (_bootloaderHoldService != null)
+        {
+            await _bootloaderHoldService.PauseForFlashAsync();
+        }
+
         try
         {
             var firmwareDialogViewModel = new FirmwareDialogViewModel(hidDevice.Name);
@@ -473,6 +510,15 @@ public partial class ConnectionDialogViewModel : ObservableObject
         }
         finally
         {
+            // Re-grab the hold if the device is still a sitting bootloader (the user cancelled, or the
+            // flash failed). A successful flash left it in application mode, so BeginHoldAsync finds no
+            // bootloader and no-ops. This keeps the device wedge-proof across a retry without reopening
+            // the dialog.
+            if (_bootloaderHoldService != null)
+            {
+                await _bootloaderHoldService.BeginHoldAsync();
+            }
+
             // Resume discovery once the flash dialog closes so the device list stays live.
             StartWiFiDiscovery();
             StartSerialDiscovery();
@@ -585,6 +631,12 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
                 AvailableHidDevices.Add(discoveredDevice);
                 HasNoHidDevices = AvailableHidDevices.Count == 0;
+
+                // A bootloader-VID/PID device just appeared. Immediately grab and hold its HID handle
+                // (exclusive, keep-alive read pending) so Windows USB selective-suspend can't wedge it
+                // into the #568 state while it sits here waiting to be flashed. Fire-and-forget: the
+                // open + keep-alive runs off the UI thread, and the hold is idempotent.
+                _ = _bootloaderHoldService?.BeginHoldAsync();
             });
         }
         catch (Exception ex)
@@ -628,6 +680,10 @@ public partial class ConnectionDialogViewModel : ObservableObject
         // Fire-and-forget: cancel discovery and clean up without waiting for task completion
         _ = StopSerialDiscoveryAsync();
         StopHidDiscovery();
+
+        // Release any held bootloader handle so the device is never left grabbed after the dialog
+        // closes. Fire-and-forget for the same reason as the serial drain above.
+        _ = _bootloaderHoldService?.ReleaseAsync();
     }
 
     private void StopWiFiDiscovery()

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -67,9 +67,10 @@ public partial class ConnectionDialogViewModel : ObservableObject
     /// The sitting HID bootloaders the app-global watcher is holding, bound to the Firmware tab. The user
     /// picks one to flash. Falls back to an empty collection when no watcher is present (unit tests).
     /// </summary>
-    public ObservableCollection<HeldBootloader> AvailableHidDevices => _watcher?.Bootloaders ?? _emptyHidDevices;
+    public ReadOnlyObservableCollection<HeldBootloader> AvailableHidDevices => _watcher?.Bootloaders ?? _emptyHidDevices;
 
-    private readonly ObservableCollection<HeldBootloader> _emptyHidDevices = [];
+    private readonly ReadOnlyObservableCollection<HeldBootloader> _emptyHidDevices =
+        new(new ObservableCollection<HeldBootloader>());
 
     [ObservableProperty]
     private string? _manualPortName;
@@ -115,9 +116,13 @@ public partial class ConnectionDialogViewModel : ObservableObject
     }
 
     #region Constructor
+    /// <summary>Creates the connection dialog view model using services resolved from the app container.</summary>
     public ConnectionDialogViewModel()
         : this(ServiceLocator.Resolve<IDialogService>(), App.ServiceProvider?.GetService<IBootloaderWatcher>()) { }
 
+    /// <summary>Creates the connection dialog view model.</summary>
+    /// <param name="dialogService">Dialog service used to display modal dialogs.</param>
+    /// <param name="watcher">Optional app-global bootloader watcher (null in unit tests without the DI container).</param>
     public ConnectionDialogViewModel(
         IDialogService dialogService,
         IBootloaderWatcher? watcher = null)
@@ -131,10 +136,13 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         // The watcher holds bootloaders app-wide, so its list may already be populated before the dialog
         // opens. Reflect its current count and track changes so the "scanning…" overlay is accurate.
+        // (Bootloaders is a ReadOnlyObservableCollection — its CollectionChanged is an explicit interface
+        // member, so reach it via INotifyCollectionChanged.)
         if (_watcher != null)
         {
             HasNoHidDevices = _watcher.Bootloaders.Count == 0;
-            _watcher.Bootloaders.CollectionChanged += OnHidDevicesChanged;
+            ((System.Collections.Specialized.INotifyCollectionChanged)_watcher.Bootloaders).CollectionChanged
+                += OnHidDevicesChanged;
         }
 
         // Set up the duplicate device handler
@@ -591,11 +599,12 @@ public partial class ConnectionDialogViewModel : ObservableObject
         _ = StopSerialDiscoveryAsync();
 
         // HID bootloader holds are owned by the app-global watcher and intentionally persist after the
-        // dialog closes (so a sitting bootloader stays wedge-proof). Only stop unsubscribing this dialog
-        // from the watcher's list.
+        // dialog closes (so a sitting bootloader stays wedge-proof). Only unsubscribe this dialog from
+        // the watcher's list.
         if (_watcher != null)
         {
-            _watcher.Bootloaders.CollectionChanged -= OnHidDevicesChanged;
+            ((System.Collections.Specialized.INotifyCollectionChanged)_watcher.Bootloaders).CollectionChanged
+                -= OnHidDevicesChanged;
         }
     }
 

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -495,14 +495,11 @@ public partial class ConnectionDialogViewModel : ObservableObject
         await StopSerialDiscoveryAsync();
         await StopHidDiscoveryAsync();
 
-        // Hand the held handle to the flasher: stop the keep-alive read so the flash owns the device's
-        // HID I/O, but leave the handle OPEN and warm. The flasher closes+reopens it back-to-back (no
-        // idle gap, so no #568 wedge). No-op if we were never holding (the handle wasn't grabbed).
-        if (_bootloaderHoldService != null)
-        {
-            await _bootloaderHoldService.PauseForFlashAsync();
-        }
-
+        // Keep holding (keep-alive active) WHILE the dialog is open — the user may sit here for a while
+        // before clicking Upload, and an idle open handle alone does not stop USB selective-suspend, so
+        // pausing now would re-open the #568 wedge window. The flasher pauses the keep-alive itself at
+        // the moment the flash starts (FirmwareDialogViewModel.UploadFirmware), handing itself a warm
+        // handle with no idle gap.
         try
         {
             var firmwareDialogViewModel = new FirmwareDialogViewModel(hidDevice.Name);

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -749,30 +749,29 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     [RelayCommand]
     private void ShowConnectionDialog()
     {
-        _connectionDialogViewModel = new ConnectionDialogViewModel();
+        var dialogVm = new ConnectionDialogViewModel();
+        _connectionDialogViewModel = dialogVm;
         try
         {
-            _connectionDialogViewModel.StartConnectionFinders();
-            _dialogService.ShowDialog<ConnectionDialog>(this, _connectionDialogViewModel);
+            dialogVm.StartConnectionFinders();
+            _dialogService.ShowDialog<ConnectionDialog>(this, dialogVm);
         }
         finally
         {
-            // Guarantee the dialog unsubscribes from the app-global watcher's collection even if the
-            // dialog throws before its window opens — otherwise the lifetime singleton would permanently
-            // root this VM. Close() is idempotent, so the normal window-Closing path that already called
-            // it is unaffected. Best-effort so it can't mask an exception from the show attempt.
+            // Release the field reference before closing so the closed VM can be collected and a Close()
+            // side effect can't re-enter through the field. Guarantee the dialog unsubscribes from the
+            // app-global watcher's collection even if the dialog threw before its window opened (otherwise
+            // the lifetime singleton would permanently root the VM). Close() is idempotent, so the normal
+            // window-Closing path that already called it is unaffected; best-effort so it can't mask an
+            // exception from the show attempt.
+            _connectionDialogViewModel = null;
             try
             {
-                _connectionDialogViewModel.Close();
+                dialogVm.Close();
             }
             catch (Exception ex)
             {
                 _appLogger.Error(ex, "Failed to close connection dialog view model after dialog attempt.");
-            }
-            finally
-            {
-                // Release the reference so the closed dialog VM can be collected before the next open.
-                _connectionDialogViewModel = null;
             }
         }
     }

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -175,7 +175,7 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     // Owns the WiFi-only flash lifecycle (the PIC32 path's CTS lives in the coordinator).
     private CancellationTokenSource? _firmwareUploadCts;
     private readonly LoggingSessionListViewModel _loggingSessionList;
-    private ConnectionDialogViewModel _connectionDialogViewModel;
+    private ConnectionDialogViewModel? _connectionDialogViewModel;
     private string _selectedLoggingMode = "Stream to App";
     private bool _isLogToDeviceMode;
     private SdCardLogFormat _selectedSdCardLogFormat = SdCardLogFormat.Protobuf;
@@ -768,6 +768,11 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             catch (Exception ex)
             {
                 _appLogger.Error(ex, "Failed to close connection dialog view model after dialog attempt.");
+            }
+            finally
+            {
+                // Release the reference so the closed dialog VM can be collected before the next open.
+                _connectionDialogViewModel = null;
             }
         }
     }

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -551,7 +551,10 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             resolvedFirmwareLogger,
             _appLogger,
             App.DaqifiDataDirectory,
-            wifiFirmwareUpdateServiceFactory);
+            wifiFirmwareUpdateServiceFactory,
+            // Suspend the app-global bootloader watcher's discovery during the PIC32 flash so it doesn't
+            // grab the connected device when it reboots into the bootloader mid-update.
+            watcher: App.ServiceProvider?.GetService<IBootloaderWatcher>());
 
         // Logged-data session-list actions (display/export/delete + collection plumbing) live in the
         // list view model (issue #592). The view model keeps the bound properties + thin command

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -760,8 +760,15 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             // Guarantee the dialog unsubscribes from the app-global watcher's collection even if the
             // dialog throws before its window opens — otherwise the lifetime singleton would permanently
             // root this VM. Close() is idempotent, so the normal window-Closing path that already called
-            // it is unaffected.
-            _connectionDialogViewModel.Close();
+            // it is unaffected. Best-effort so it can't mask an exception from the show attempt.
+            try
+            {
+                _connectionDialogViewModel.Close();
+            }
+            catch (Exception ex)
+            {
+                _appLogger.Error(ex, "Failed to close connection dialog view model after dialog attempt.");
+            }
         }
     }
 

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -750,8 +750,19 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     private void ShowConnectionDialog()
     {
         _connectionDialogViewModel = new ConnectionDialogViewModel();
-        _connectionDialogViewModel.StartConnectionFinders();
-        _dialogService.ShowDialog<ConnectionDialog>(this, _connectionDialogViewModel);
+        try
+        {
+            _connectionDialogViewModel.StartConnectionFinders();
+            _dialogService.ShowDialog<ConnectionDialog>(this, _connectionDialogViewModel);
+        }
+        finally
+        {
+            // Guarantee the dialog unsubscribes from the app-global watcher's collection even if the
+            // dialog throws before its window opens — otherwise the lifetime singleton would permanently
+            // root this VM. Close() is idempotent, so the normal window-Closing path that already called
+            // it is unaffected.
+            _connectionDialogViewModel.Close();
+        }
     }
 
     [RelayCommand]

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -16,6 +16,13 @@ public partial class FirmwareDialogViewModel : ObservableObject
     private readonly IFirmwareUpdateService _firmwareUpdateService;
     private readonly IFirmwareDownloadService _firmwareDownloadService;
     private readonly Daqifi.Core.Device.IStreamingDevice _coreDevice;
+
+    /// <summary>
+    /// The bootloader hold (keep-alive) that kept the device out of USB selective-suspend while the
+    /// user was deciding. Paused the instant the flash begins so the flasher owns the HID I/O. Null
+    /// only in unit tests that construct the view model without the DI container.
+    /// </summary>
+    private readonly IBootloaderHoldService? _bootloaderHoldService;
     private CancellationTokenSource? _updateCts;
 
     [ObservableProperty]
@@ -64,7 +71,8 @@ public partial class FirmwareDialogViewModel : ObservableObject
     public FirmwareDialogViewModel(
         string? hidDeviceName,
         IFirmwareUpdateService? firmwareUpdateService = null,
-        IFirmwareDownloadService? firmwareDownloadService = null)
+        IFirmwareDownloadService? firmwareDownloadService = null,
+        IBootloaderHoldService? bootloaderHoldService = null)
     {
         // Resolve from DI rather than newing up services/HttpClient here. Both are registered in
         // App.ConfigureServices and the provider is always present at runtime; the throw is a
@@ -76,6 +84,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
         _firmwareDownloadService = firmwareDownloadService
             ?? App.ServiceProvider?.GetService<IFirmwareDownloadService>()
             ?? throw new InvalidOperationException("IFirmwareDownloadService is not registered.");
+
+        // Optional: the connection dialog grabs the bootloader hold and this dialog pauses it at flash
+        // start. Resolved from DI in production; null is fine (no hold to pause) for tests/standalone use.
+        _bootloaderHoldService = bootloaderHoldService ?? App.ServiceProvider?.GetService<IBootloaderHoldService>();
 
         _coreDevice = new BootloaderSessionStreamingDeviceAdapter(hidDeviceName ?? "DAQiFi Bootloader");
 
@@ -201,6 +213,15 @@ public partial class FirmwareDialogViewModel : ObservableObject
             {
                 UploadFirmwareProgress = Math.Clamp((int)Math.Round(report.PercentComplete), 0, 100);
             });
+
+            // Stop the keep-alive hold right as the flash begins so the flasher owns the device's HID
+            // I/O. The hold stayed active across the user's time in this dialog (so the device couldn't
+            // selective-suspend/wedge while they decided); pausing here hands the flasher a warm,
+            // still-open handle it reopens with no idle gap.
+            if (_bootloaderHoldService != null)
+            {
+                await _bootloaderHoldService.PauseForFlashAsync();
+            }
 
             await _firmwareUpdateService.UpdateFirmwareAsync(
                 _coreDevice,

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -217,31 +217,18 @@ public partial class FirmwareDialogViewModel : ObservableObject
             // Stop the keep-alive hold right as the flash begins so the flasher owns the device's HID
             // I/O. The hold stayed active across the user's time in this dialog (so the device couldn't
             // selective-suspend/wedge while they decided); pausing here hands the flasher a warm,
-            // still-open handle it reopens with no idle gap.
+            // still-open handle it reopens with no idle gap. If the flash fails or is cancelled, the
+            // connection dialog re-grabs the hold when this dialog closes (ConnectHid's finally).
             if (_bootloaderHoldService != null)
             {
                 await _bootloaderHoldService.PauseForFlashAsync();
             }
 
-            try
-            {
-                await _firmwareUpdateService.UpdateFirmwareAsync(
-                    _coreDevice,
-                    FirmwareFilePath,
-                    progress,
-                    _updateCts.Token);
-            }
-            catch
-            {
-                // Flash failed or was cancelled — re-establish the hold so the device stays wedge-proof
-                // if the user retries from this still-open dialog (the keep-alive was paused above). On
-                // success we skip this: the device has rebooted into the application and is gone.
-                // Fire-and-forget: do NOT await, so the rethrow and the outer finally (which clears the
-                // "uploading" state) aren't delayed by a blocking HID open. BeginHoldAsync is best-effort
-                // and logs its own failures.
-                _ = _bootloaderHoldService?.BeginHoldAsync();
-                throw;
-            }
+            await _firmwareUpdateService.UpdateFirmwareAsync(
+                _coreDevice,
+                FirmwareFilePath,
+                progress,
+                _updateCts.Token);
 
             IsUploadComplete = true;
             AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update completed");

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -236,11 +236,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
                 // Flash failed or was cancelled — re-establish the hold so the device stays wedge-proof
                 // if the user retries from this still-open dialog (the keep-alive was paused above). On
                 // success we skip this: the device has rebooted into the application and is gone.
-                if (_bootloaderHoldService != null)
-                {
-                    await _bootloaderHoldService.BeginHoldAsync();
-                }
-
+                // Fire-and-forget: do NOT await, so the rethrow and the outer finally (which clears the
+                // "uploading" state) aren't delayed by a blocking HID open. BeginHoldAsync is best-effort
+                // and logs its own failures.
+                _ = _bootloaderHoldService?.BeginHoldAsync();
                 throw;
             }
 

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -18,11 +18,20 @@ public partial class FirmwareDialogViewModel : ObservableObject
     private readonly Daqifi.Core.Device.IStreamingDevice _coreDevice;
 
     /// <summary>
-    /// The bootloader hold (keep-alive) that kept the device out of USB selective-suspend while the
-    /// user was deciding. Paused the instant the flash begins so the flasher owns the HID I/O. Null
-    /// only in unit tests that construct the view model without the DI container.
+    /// The app-global watcher holding the sitting bootloaders. When the flash starts, the dialog asks it
+    /// to release THIS device's hold (so the flasher can open it by path) while every other held
+    /// bootloader stays wedge-proof; disposing the flash lease re-grabs/drops it and resumes discovery.
+    /// Null only in unit tests that construct the view model without the DI container.
     /// </summary>
-    private readonly IBootloaderHoldService? _bootloaderHoldService;
+    private readonly IBootloaderWatcher? _watcher;
+
+    /// <summary>
+    /// OS HID device path of the bootloader to flash. Passed to the path-targeted
+    /// <see cref="IFirmwareUpdateService.UpdateFirmwareAsync(Daqifi.Core.Device.IStreamingDevice,string,IProgress{FirmwareUpdateProgress}?,string?,CancellationToken)"/>
+    /// overload so the right device is flashed when several identical bootloaders are present. Null in
+    /// tests / standalone use (falls back to first-match flashing).
+    /// </summary>
+    private readonly string? _targetDevicePath;
     private CancellationTokenSource? _updateCts;
 
     [ObservableProperty]
@@ -66,13 +75,16 @@ public partial class FirmwareDialogViewModel : ObservableObject
     /// loading the latest published firmware so the user can flash it without locating a .hex file.
     /// </summary>
     /// <param name="hidDeviceName">HID device name for the bootloader session (used by the flasher adapter).</param>
+    /// <param name="targetDevicePath">OS HID device path of the bootloader to flash; null falls back to first-match.</param>
     /// <param name="firmwareUpdateService">Optional override for tests; otherwise resolved from DI.</param>
     /// <param name="firmwareDownloadService">Optional override for tests; otherwise resolved from DI.</param>
+    /// <param name="watcher">Optional override for tests; otherwise resolved from DI.</param>
     public FirmwareDialogViewModel(
         string? hidDeviceName,
+        string? targetDevicePath = null,
         IFirmwareUpdateService? firmwareUpdateService = null,
         IFirmwareDownloadService? firmwareDownloadService = null,
-        IBootloaderHoldService? bootloaderHoldService = null)
+        IBootloaderWatcher? watcher = null)
     {
         // Resolve from DI rather than newing up services/HttpClient here. Both are registered in
         // App.ConfigureServices and the provider is always present at runtime; the throw is a
@@ -85,9 +97,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
             ?? App.ServiceProvider?.GetService<IFirmwareDownloadService>()
             ?? throw new InvalidOperationException("IFirmwareDownloadService is not registered.");
 
-        // Optional: the connection dialog grabs the bootloader hold and this dialog pauses it at flash
-        // start. Resolved from DI in production; null is fine (no hold to pause) for tests/standalone use.
-        _bootloaderHoldService = bootloaderHoldService ?? App.ServiceProvider?.GetService<IBootloaderHoldService>();
+        // Optional: the app-global watcher holds the bootloaders; this dialog asks it to release the
+        // target's hold at flash start. Resolved from DI in production; null is fine for tests/standalone.
+        _watcher = watcher ?? App.ServiceProvider?.GetService<IBootloaderWatcher>();
+        _targetDevicePath = targetDevicePath;
 
         _coreDevice = new BootloaderSessionStreamingDeviceAdapter(hidDeviceName ?? "DAQiFi Bootloader");
 
@@ -187,6 +200,10 @@ public partial class FirmwareDialogViewModel : ObservableObject
         _updateCts?.Dispose();
         _updateCts = new CancellationTokenSource();
 
+        // Lease the device from the watcher for the duration of the flash. Acquired just before the flash
+        // (after any download) and released in the finally so discovery/holds always recover.
+        IAsyncDisposable? flashLease = null;
+
         try
         {
             HasErrorOccured = false;
@@ -214,21 +231,36 @@ public partial class FirmwareDialogViewModel : ObservableObject
                 UploadFirmwareProgress = Math.Clamp((int)Math.Round(report.PercentComplete), 0, 100);
             });
 
-            // Stop the keep-alive hold right as the flash begins so the flasher owns the device's HID
-            // I/O. The hold stayed active across the user's time in this dialog (so the device couldn't
-            // selective-suspend/wedge while they decided); pausing here hands the flasher a warm,
-            // still-open handle it reopens with no idle gap. If the flash fails or is cancelled, the
-            // connection dialog re-grabs the hold when this dialog closes (ConnectHid's finally).
-            if (_bootloaderHoldService != null)
+            // Hand this device off to the flasher right as the flash begins: the watcher pauses HID
+            // discovery and releases THIS bootloader's hold (so the flasher can open it by path) while
+            // every other held bootloader stays wedge-proof. The hold stayed active across the user's
+            // time in this dialog (so the device couldn't selective-suspend/wedge while they decided).
+            // Disposing the lease (in the finally) re-grabs the device on a failed/cancelled flash, or
+            // drops it once a successful flash leaves it in application mode — and resumes discovery.
+            if (_targetDevicePath != null)
             {
-                await _bootloaderHoldService.PauseForFlashAsync();
-            }
+                if (_watcher != null)
+                {
+                    flashLease = await _watcher.PrepareFlashAsync(_targetDevicePath);
+                }
 
-            await _firmwareUpdateService.UpdateFirmwareAsync(
-                _coreDevice,
-                FirmwareFilePath,
-                progress,
-                _updateCts.Token);
+                // Several identical bootloaders may be present — target this exact one by path.
+                await _firmwareUpdateService.UpdateFirmwareAsync(
+                    _coreDevice,
+                    FirmwareFilePath,
+                    progress,
+                    _targetDevicePath,
+                    _updateCts.Token);
+            }
+            else
+            {
+                // No specific target (tests / standalone) — first-match flash.
+                await _firmwareUpdateService.UpdateFirmwareAsync(
+                    _coreDevice,
+                    FirmwareFilePath,
+                    progress,
+                    _updateCts.Token);
+            }
 
             IsUploadComplete = true;
             AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update completed");
@@ -252,6 +284,13 @@ public partial class FirmwareDialogViewModel : ObservableObject
         }
         finally
         {
+            // Release the device back to the watcher (re-grab on failure / drop on success) and resume
+            // discovery, regardless of how the flash ended.
+            if (flashLease != null)
+            {
+                await flashLease.DisposeAsync();
+            }
+
             IsFirmwareUploading = false;
             _updateCts?.Dispose();
             _updateCts = null;

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -285,10 +285,18 @@ public partial class FirmwareDialogViewModel : ObservableObject
         finally
         {
             // Release the device back to the watcher (re-grab on failure / drop on success) and resume
-            // discovery, regardless of how the flash ended.
+            // discovery, regardless of how the flash ended. Best-effort: a failure resuming the watcher
+            // must not crash the command or mask the flash's own outcome (already recorded above).
             if (flashLease != null)
             {
-                await flashLease.DisposeAsync();
+                try
+                {
+                    await flashLease.DisposeAsync();
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Instance.Warning(ex, "Error releasing the bootloader flash lease back to the watcher.");
+                }
             }
 
             IsFirmwareUploading = false;

--- a/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/FirmwareDialogViewModel.cs
@@ -223,11 +223,26 @@ public partial class FirmwareDialogViewModel : ObservableObject
                 await _bootloaderHoldService.PauseForFlashAsync();
             }
 
-            await _firmwareUpdateService.UpdateFirmwareAsync(
-                _coreDevice,
-                FirmwareFilePath,
-                progress,
-                _updateCts.Token);
+            try
+            {
+                await _firmwareUpdateService.UpdateFirmwareAsync(
+                    _coreDevice,
+                    FirmwareFilePath,
+                    progress,
+                    _updateCts.Token);
+            }
+            catch
+            {
+                // Flash failed or was cancelled — re-establish the hold so the device stays wedge-proof
+                // if the user retries from this still-open dialog (the keep-alive was paused above). On
+                // success we skip this: the device has rebooted into the application and is gone.
+                if (_bootloaderHoldService != null)
+                {
+                    await _bootloaderHoldService.BeginHoldAsync();
+                }
+
+                throw;
+            }
 
             IsUploadComplete = true;
             AppLogger.Instance.AddBreadcrumb("firmware", "Firmware update completed");


### PR DESCRIPTION
## What

Replaces the dialog-scoped, single-device bootloader hold with an **app-global `BootloaderWatcher`** that discovers **every** sitting PIC32 HID bootloader and holds each one's USB handle open (its own exclusive transport, keyed by device path) with a continuously-pending keep-alive read — so none can be wedged by Windows USB selective-suspend (daqifi-nyquist-firmware#568) before the user flashes, **regardless of whether the Connection dialog is open**. The user can then flash any one of several connected bootloaders by path while the others stay held and wedge-proof.

> Supersedes #654 (single-device grab-and-hold). The watcher generalizes and replaces that approach — the dialog-scoped trigger was insufficient in the field — so this PR carries the full grab-and-hold → multi-device story and #654 is closed as superseded.

## Why

Multiple PIC32 bootloaders are **identical**: same `VID 0x04D8 / PID 0x003C`, and **no serial number** (`GetSerialNumber` throws). The only discriminator is the **USB device path**. Holding/flashing a specific one therefore requires path-based addressing, added in **`Daqifi.Core 0.27.0`** (`IHidTransport.ConnectByPathAsync` + a path-targeted `UpdateFirmwareAsync` overload; daqifi-core#275).

## How

- **`BootloaderWatcher`** (app-startup singleton): holds all detected bootloaders; `PrepareFlashAsync(path)` releases **only** the target (so the shared flasher reopens it by path) while every other bootloader stays held, then re-grabs it on a failed flash or drops it once a successful flash leaves it in application mode; `SuspendDiscoveryAsync()` lets the auto-update coordinator flash a device that reboots into the bootloader without the watcher stealing it.
- **`HidBootloaderDiscovery`**: continuous Core `HidDeviceFinder` loop (the exclusive holds make its per-cycle opens on already-held devices fail harmlessly).
- **`BootloaderHoldService`**: generalized to path addressing (`ConnectByPathAsync`) + a `HoldDropped` event on device removal; now owns and disposes its per-device transport.
- **Connection dialog** binds the Firmware tab to the watcher's list and flashes the chosen device by path; **firmware dialog** brackets the flash in the watcher lease; **`FirmwareUpdateCoordinator`** suspends discovery around the PIC32 flash.

## Code review

Ran a multi-agent review (4 dimensions × adversarial verification) of the watcher change before this PR: 5 confirmed findings (3 distinct), all fixed — per-device transport disposal, guarded discovery-resume across overlapping flash + auto-update, and a dialog `CollectionChanged` unsubscribe on a missed `Close()`. Four lower-confidence findings were verified and refuted.

## Tests

- New: 8 `BootloaderWatcher` tests + 5 `BootloaderHoldService` tests (path connect, `HoldDropped`, graceful release, transport disposal, overlapping flash/suspend resume coordination).
- **482 desktop unit tests green** (`TestCategory!=Ui`).

## Known limitation / follow-up

During a connected-device auto-update, if **another** bootloader is separately held, Core's first-match enumeration could land on the held one — auto-update is fundamentally a single-device operation, so this is documented and accepted. Tracked by #655 (track each device by physical USB location so identity survives serial ⇄ bootloader ⇄ post-flash and disambiguates identical bootloaders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
