### PR TITLE
chore(release): bump version to 3.3.0

### DIFF
--- a/Daqifi.Desktop.Setup/DAQifiDesktopSetup/Product.wxs
+++ b/Daqifi.Desktop.Setup/DAQifiDesktopSetup/Product.wxs
@@ -3,7 +3,7 @@
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
   <Package Name="DAQiFi"
            Manufacturer="DAQiFi"
-           Version="3.2.0.0"
+           Version="3.3.0.0"
            UpgradeCode="ACA4F4E1-6DBB-47C0-A829-84AA1536C147"
            Language="1033">
 

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -7,7 +7,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>
 		<UseWindowsForms>true</UseWindowsForms>
-		<Version>3.2.0</Version>
+		<Version>3.3.0</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<InternalsVisibleTo>Daqifi.Desktop.Test</InternalsVisibleTo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Minor version bump for the **3.3.0** release (3.2.0 is already published as `v3.2.0`).

- `Daqifi.Desktop.csproj`: 3.2.0 → 3.3.0
- `Product.wxs` (MSI): 3.2.0.0 → 3.3.0.0

**What 3.3.0 ships** (already on `main`):
- App-global **HID bootloader watcher** — discovers and holds every sitting PIC32 bootloader (keep-alive, wedge-proof per #568) and flashes any one by device path; multi-device safe (#656).
- Built on **Daqifi.Core 0.27.0** (HID device-path addressing).
- Pairs with the firmware-side #568 fix (bootloader 2.0).

After merge, push tag `3.3.0` to trigger the release workflow (builds the MSI + creates a draft GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)