### PR TITLE
fix(build): stamp AssemblyVersion/FileVersion 3.3.0.0

### DIFF
--- a/Daqifi.Desktop/app.Debug.manifest
+++ b/Daqifi.Desktop/app.Debug.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="3.2.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="3.3.0.0" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/Daqifi.Desktop/app.manifest
+++ b/Daqifi.Desktop/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="3.2.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="3.3.0.0" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>3.2.0.0</AssemblyVersion>
-    <FileVersion>3.2.0.0</FileVersion>
+    <AssemblyVersion>3.3.0.0</AssemblyVersion>
+    <FileVersion>3.3.0.0</FileVersion>
 
     <!-- Enable .NET code analysis -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
## What & why

`Directory.Build.props` hardcoded `AssemblyVersion`/`FileVersion` at `3.2.0.0` solution-wide. The 3.3.0 release bump (#657) updated only the csproj `<Version>` (→ informational `3.3.0+sha`) and the WiX `Product.wxs` (→ MSI ProductVersion `3.3.0.0`), but missed this file — so the shipped **3.3.0 build self-reported `3.2.0.0`**:

- The app **title bar reads "DAQiFi v3.2.0"** on the 3.3.0 build (confirmed on the bench).
- The exe `FileVersion` is `3.2.0.0`.
- **Sentry tags every 3.3.0 crash as `release: 3.2.0.0`** — `AppLogger` sets `options.Release = Assembly.GetName().Version`, so the stale assembly version corrupts the release tag we rely on to monitor post-release issues (notably the firmware-flash telemetry).

## Change

Bump `AssemblyVersion`/`FileVersion` to `3.3.0.0` to match the release. One line each.

After the fix, the built `DAQiFi.dll` reports:

```
AssemblyVersion = 3.3.0.0
FileVersion     = 3.3.0.0
ProductVersion  = 3.3.0+<sha>
```

The MSI `ProductVersion` (from `Product.wxs`) was already correct, so **install/upgrade behavior is unchanged** — this only corrects the exe's self-reported version + crash telemetry.

> Note: the existing 3.3.0 **draft** release MSI predates this commit and still self-reports 3.2.0.0. After merging, re-generate the release so the MSI carries 3.3.0.0.

## Verification

- `dotnet build -c Release` — succeeds, assembly version confirmed `3.3.0.0`.
- Full unit suite (483 tests) and the FlaUI hardware UI suite were green on this code prior to the change; this change is build-metadata only.

## Follow-up (optional, not in this PR)

Consider driving `AssemblyVersion`/`FileVersion` from the csproj `<Version>` (single source of truth) so future release bumps only touch one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
