### PR TITLE
chore: connect manual WiFi IPs without a synthetic IDeviceInfo (#620)

### DIFF
--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
@@ -112,8 +112,12 @@ public class DaqifiStreamingDeviceTests
     [TestMethod]
     public void Constructor_ManualEndpoint_ShouldSetPropertiesFromAddressAndPort()
     {
+        // Arrange
+        var ipAddress = IPAddress.Parse("10.0.0.42");
+        const int port = 9760;
+
         // Act
-        var device = new DaqifiStreamingDevice(IPAddress.Parse("10.0.0.42"), 9760, "Manual IP Device");
+        var device = new DaqifiStreamingDevice(ipAddress, port, "Manual IP Device");
 
         // Assert
         Assert.AreEqual("Manual IP Device", device.Name);
@@ -126,16 +130,36 @@ public class DaqifiStreamingDeviceTests
     [TestMethod]
     public void Constructor_ManualEndpoint_NullIpAddress_ShouldThrowArgumentNullException()
     {
+        // Arrange
+        IPAddress? ipAddress = null;
+
         // Act & Assert
         Assert.ThrowsExactly<ArgumentNullException>(() =>
-            new DaqifiStreamingDevice((IPAddress)null!, 9760, "Manual IP Device"));
+            new DaqifiStreamingDevice(ipAddress!, 9760, "Manual IP Device"));
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    [DataRow(70000)]
+    public void Constructor_ManualEndpoint_InvalidPort_ShouldThrowArgumentOutOfRangeException(int port)
+    {
+        // Arrange
+        var ipAddress = IPAddress.Parse("10.0.0.42");
+
+        // Act & Assert
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+            new DaqifiStreamingDevice(ipAddress, port, "Manual IP Device"));
     }
 
     [TestMethod]
     public void Constructor_ManualEndpoint_BlankName_ShouldFallBackToDefaultName()
     {
+        // Arrange
+        var ipAddress = IPAddress.Parse("10.0.0.42");
+
         // Act
-        var device = new DaqifiStreamingDevice(IPAddress.Parse("10.0.0.42"), 9760, "  ");
+        var device = new DaqifiStreamingDevice(ipAddress, 9760, "  ");
 
         // Assert
         Assert.AreEqual("DAQiFi Device", device.Name);

--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
@@ -109,6 +109,38 @@ public class DaqifiStreamingDeviceTests
         Assert.IsTrue(ex.Message.Contains("TCP port"), $"Expected TCP port error, got: {ex.Message}");
     }
 
+    [TestMethod]
+    public void Constructor_ManualEndpoint_ShouldSetPropertiesFromAddressAndPort()
+    {
+        // Act
+        var device = new DaqifiStreamingDevice(IPAddress.Parse("10.0.0.42"), 9760, "Manual IP Device");
+
+        // Assert
+        Assert.AreEqual("Manual IP Device", device.Name);
+        Assert.AreEqual("10.0.0.42", device.IpAddress);
+        Assert.AreEqual(9760, device.Port);
+        Assert.IsTrue(device.IsPowerOn);
+        Assert.IsFalse(device.IsStreaming);
+    }
+
+    [TestMethod]
+    public void Constructor_ManualEndpoint_NullIpAddress_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+            new DaqifiStreamingDevice((IPAddress)null!, 9760, "Manual IP Device"));
+    }
+
+    [TestMethod]
+    public void Constructor_ManualEndpoint_BlankName_ShouldFallBackToDefaultName()
+    {
+        // Act
+        var device = new DaqifiStreamingDevice(IPAddress.Parse("10.0.0.42"), 9760, "  ");
+
+        // Assert
+        Assert.AreEqual("DAQiFi Device", device.Name);
+    }
+
     #endregion
 
     #region Property Tests

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System.Net;
+using System.Net.Sockets;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Device;
@@ -52,6 +53,28 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
         Metadata.FirmwareVersion = deviceInfo.FirmwareVersion;
         Port = deviceInfo.Port.Value;
         IsPowerOn = deviceInfo.IsPowerOn;
+        IsStreaming = false;
+    }
+
+    /// <summary>
+    /// Creates a WiFi device wrapper for a manual (user-entered) IP connection, where no
+    /// discovery metadata exists — only the address, TCP data port, and a display name are known.
+    /// The shared <see cref="AbstractStreamingDevice.Connect"/> template drives the actual
+    /// connection through Core's <see cref="DaqifiDeviceFactory"/> (see <see cref="CreateCoreDevice"/>),
+    /// so there is no need to fabricate a discovery-shaped <c>IDeviceInfo</c> (issue #620).
+    /// </summary>
+    /// <param name="ipAddress">The device IP address.</param>
+    /// <param name="port">The TCP data port to connect to.</param>
+    /// <param name="name">Display name for the device.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ipAddress"/> is null.</exception>
+    public DaqifiStreamingDevice(IPAddress ipAddress, int port, string name)
+    {
+        ArgumentNullException.ThrowIfNull(ipAddress);
+
+        Name = string.IsNullOrWhiteSpace(name) ? "DAQiFi Device" : name;
+        Metadata.IpAddress = ipAddress.ToString();
+        Port = port;
+        IsPowerOn = true;
         IsStreaming = false;
     }
 

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -64,12 +64,17 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     /// so there is no need to fabricate a discovery-shaped <c>IDeviceInfo</c> (issue #620).
     /// </summary>
     /// <param name="ipAddress">The device IP address.</param>
-    /// <param name="port">The TCP data port to connect to.</param>
+    /// <param name="port">The TCP data port to connect to. Must be in the valid TCP range (1–65535).</param>
     /// <param name="name">Display name for the device.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ipAddress"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="port"/> is not a valid TCP port (1–65535).
+    /// </exception>
     public DaqifiStreamingDevice(IPAddress ipAddress, int port, string name)
     {
         ArgumentNullException.ThrowIfNull(ipAddress);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(port);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(port, 65535);
 
         Name = string.IsNullOrWhiteSpace(name) ? "DAQiFi Device" : name;
         Metadata.IpAddress = ipAddress.ToString();

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -13,8 +13,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Daqifi.Core.Device.Discovery;
-using CoreConcreteDeviceInfo = Daqifi.Core.Device.Discovery.DeviceInfo;
-using CoreConnectionType = Daqifi.Core.Device.Discovery.ConnectionType;
 using CoreDeviceInfo = Daqifi.Core.Device.Discovery.IDeviceInfo;
 
 namespace Daqifi.Desktop.ViewModels;
@@ -396,16 +394,11 @@ public partial class ConnectionDialogViewModel : ObservableObject
             return;
         }
 
-        var deviceInfo = new CoreConcreteDeviceInfo
-        {
-            Name = "Manual IP Device",
-            IPAddress = ipAddress,
-            Port = 9760, // Common DAQiFi TCP data port - TODO: make configurable or discover dynamically
-            IsPowerOn = true,
-            ConnectionType = CoreConnectionType.WiFi
-        };
-
-        var device = new DaqifiStreamingDevice(deviceInfo);
+        // Connect directly with the resolved endpoint instead of fabricating a discovery-shaped
+        // IDeviceInfo — the device wrapper drives the connection through Core's DaqifiDeviceFactory
+        // (issue #620). The hardcoded 9760 data port is tracked separately in issue #615.
+        const int manualWifiDataPort = 9760;
+        var device = new DaqifiStreamingDevice(ipAddress, manualWifiDataPort, "Manual IP Device");
         await ConnectionManager.Instance.Connect(device);
 
         // Post-connect status check mirrors the manual-serial path: an unreachable device
@@ -581,6 +574,11 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         InvokeOnUiThread(() =>
         {
+            // Dedup by MAC across discovery restarts: Core's WiFiDeviceFinder only dedups within a
+            // single DiscoverAsync session (its discoveredDevices set is per-call), but the dialog
+            // restarts the finder — e.g. the firmware-flash resume path — while AvailableWiFiDevices
+            // persists and is never cleared. Without this guard a rediscovered device is added twice.
+            // Mirrors the serial path's FindSerialDeviceByPortName dedup. (issue #621)
             if (AvailableWiFiDevices.Any(d => d.MacAddress == wifiDevice.MacAddress)) return;
             AvailableWiFiDevices.Add(wifiDevice);
             if (HasNoWiFiDevices) { HasNoWiFiDevices = false; }

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -397,8 +397,8 @@ public partial class ConnectionDialogViewModel : ObservableObject
         // Connect directly with the resolved endpoint instead of fabricating a discovery-shaped
         // IDeviceInfo — the device wrapper drives the connection through Core's DaqifiDeviceFactory
         // (issue #620). The hardcoded 9760 data port is tracked separately in issue #615.
-        const int manualWifiDataPort = 9760;
-        var device = new DaqifiStreamingDevice(ipAddress, manualWifiDataPort, "Manual IP Device");
+        const int MANUAL_WIFI_DATA_PORT = 9760;
+        var device = new DaqifiStreamingDevice(ipAddress, MANUAL_WIFI_DATA_PORT, "Manual IP Device");
         await ConnectionManager.Instance.Connect(device);
 
         // Post-connect status check mirrors the manual-serial path: an unreachable device


### PR DESCRIPTION
## Summary

Part of the cross-repo effort to make daqifi-desktop a thin wrapper over Daqifi.Core.

**Implements #620** — the manual-IP WiFi connect path fabricated a discovery-shaped `CoreConcreteDeviceInfo` purely to satisfy the `DaqifiStreamingDevice` constructor. But the wrapper only needs an address, TCP port, and name, and it already drives the actual connection through Core's `DaqifiDeviceFactory.ConnectTcp` in `CreateCoreDevice()`. This adds a direct `(IPAddress, port, name)` constructor and uses it, dropping the fake `IDeviceInfo` and its two now-unused `using` aliases (`CoreConcreteDeviceInfo`, `CoreConnectionType`).

The hardcoded `9760` data port is intentionally retained — removing it is tracked separately in #615 (blocked on daqifi-core#244).

## What changed
- `DaqifiStreamingDevice`: new `DaqifiStreamingDevice(IPAddress, int port, string name)` constructor for manual connections (no discovery metadata).
- `ConnectionDialogViewModel.ConnectManualWifiAsync`: uses the new constructor; removed the synthetic `DeviceInfo` block and unused aliases.
- Added 3 unit tests covering the new constructor (happy path, null-IP guard, blank-name fallback).

## Note on #621 (not included — ticket repurposed)
The sibling ticket #621 proposed deleting the WiFi MAC dedup guard in `HandleWifiDeviceFound` as "redundant since Core dedups by MAC." **Investigation showed this would introduce a regression**, so it is not done here:

- Core's dedup set (`discoveredDevices`) is a **local created per `DiscoverAsync` call** (`WiFiDeviceFinder.cs:132` @ v1.0.0) — it only dedups within one discovery session.
- The dialog **tears down and recreates the finder** on the firmware-flash resume path (`StartWiFiDiscovery` at the `finally` after the firmware dialog), giving a fresh empty dedup set, while `AvailableWiFiDevices` is **never cleared**.
- So a rediscovered device would be added twice after a firmware flash. The serial path keeps its equivalent guard (`FindSerialDeviceByPortName`), so removing only the WiFi one also breaks symmetry.

This PR instead **documents** why the guard is load-bearing. #621 is being repurposed to "clear `AvailableWiFiDevices` on discovery restart" (the real refactor that would let Core's dedup suffice).

## Testing
- `dotnet build` of `Daqifi.Desktop` and `Daqifi.Desktop.Test`: 0 errors (macOS).
- Unit tests run on Windows/CI (`net10.0-windows`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)