### PR TITLE
fix: seed Live Graph RATE chip from device on connect

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelStreamingFrequencyTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelStreamingFrequencyTests.cs
@@ -1,0 +1,46 @@
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.DialogService;
+using Daqifi.Desktop.ViewModels;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+[TestClass]
+public class DaqifiViewModelStreamingFrequencyTests
+{
+    [TestMethod]
+    public void SelectedStreamingFrequency_SeededFromDevice_WhenDeviceConnects()
+    {
+        var viewModel = CreateViewModel();
+        var device = new Mock<IStreamingDevice>();
+        device.SetupGet(d => d.StreamingFrequency).Returns(1);
+
+        viewModel.ConnectedDevices.Add(device.Object);
+
+        Assert.AreEqual(1, viewModel.SelectedStreamingFrequency,
+            "RATE chip should reflect the device's actual streaming frequency as soon as it connects, " +
+            "not stay at 0 until the FREQUENCY slider is touched (issue #686).");
+    }
+
+    [TestMethod]
+    public void SelectedStreamingFrequency_NotOverwritten_ByLaterConnectingDevice()
+    {
+        var viewModel = CreateViewModel();
+        var firstDevice = new Mock<IStreamingDevice>();
+        firstDevice.SetupGet(d => d.StreamingFrequency).Returns(2);
+        viewModel.ConnectedDevices.Add(firstDevice.Object);
+
+        var secondDevice = new Mock<IStreamingDevice>();
+        secondDevice.SetupGet(d => d.StreamingFrequency).Returns(5);
+        viewModel.ConnectedDevices.Add(secondDevice.Object);
+
+        Assert.AreEqual(2, viewModel.SelectedStreamingFrequency,
+            "Once seeded, a second connecting device should not clobber the already-established value.");
+    }
+
+    private static DaqifiViewModel CreateViewModel()
+    {
+        var dialogService = new Mock<IDialogService>();
+        return new DaqifiViewModel(dialogService.Object);
+    }
+}

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelStreamingFrequencyTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelStreamingFrequencyTests.cs
@@ -23,6 +23,20 @@ public class DaqifiViewModelStreamingFrequencyTests
     }
 
     [TestMethod]
+    public void SelectedStreamingFrequency_ClampedToOne_WhenDeviceReportsZero()
+    {
+        var viewModel = CreateViewModel();
+        var device = new Mock<IStreamingDevice>();
+        device.SetupGet(d => d.StreamingFrequency).Returns(0);
+
+        viewModel.ConnectedDevices.Add(device.Object);
+
+        Assert.AreEqual(1, viewModel.SelectedStreamingFrequency,
+            "Seeding must apply the same >=1 floor as the public setter, so an uninitialized/invalid " +
+            "device value can't surface as 0 Hz on the chip.");
+    }
+
+    [TestMethod]
     public void SelectedStreamingFrequency_NotOverwritten_ByLaterConnectingDevice()
     {
         var viewModel = CreateViewModel();

--- a/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
+++ b/Daqifi.Desktop.UITest/DaqifiAppFixture.cs
@@ -118,6 +118,12 @@ public abstract class DaqifiAppFixture
     // rendering — to assert the plot shows believable data while streaming (issue #560).
     private const string PLOT_STATS_TEXT_ID = "PlotStatsText";
 
+    // The Live Graph header's RATE chip value (stream mode only — collapsed while SD-card
+    // logging is active). Reads DaqifiViewModel.SelectedStreamingFrequency; the chip itself is
+    // only in the UIA tree while IsLogging is true (it lives in the status-chips StackPanel
+    // gated on that binding), so a caller must be actively streaming before reading it.
+    private const string STREAM_RATE_TEXT_ID = "StreamRateText";
+
     // Per-row DELETE button (one per session row, like ExportSessionButton — it is in the item
     // template, so a row-scoped search targets that one row) and the affirmative button of the
     // app's in-pane confirm overlay. That overlay is the dark, in-window card the app shows for
@@ -981,6 +987,20 @@ public abstract class DaqifiAppFixture
     {
         var slider = OpenDeviceSettingsFrequencySlider();
         return slider.Patterns.RangeValue.Pattern.Value.Value;
+    }
+
+    /// <summary>
+    /// Reads the Live Graph header's RATE chip text (e.g. "1 Hz") via the invisible-until-logging
+    /// <c>StreamRateText</c> element's UIA Name (issue #686 — verifies the chip is seeded from the
+    /// device's real streaming frequency, not stuck at "0 Hz", the moment streaming starts).
+    /// Navigates to the Live Graph tab first. Only meaningful while <c>IsLogging</c> is true — the
+    /// chip's containing StackPanel is absent from the UIA tree otherwise.
+    /// </summary>
+    protected string GetStreamRateText()
+    {
+        NavigateToTab(LIVE_GRAPH_TAB_TEXT);
+        var rate = FindByAutomationId(STREAM_RATE_TEXT_ID);
+        return rate.Name;
     }
 
     /// <summary>

--- a/Daqifi.Desktop.UITest/RateChipTests.cs
+++ b/Daqifi.Desktop.UITest/RateChipTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Daqifi.Desktop.UITest;
+
+/// <summary>
+/// Live Graph RATE chip seeding (issue #686). Connects to the attached device and starts
+/// streaming <b>without ever touching the FREQUENCY slider</b>, then reads the RATE chip
+/// straight from the UI. Before the fix, <c>SelectedStreamingFrequency</c>'s backing field
+/// only changed via the slider's write-through, so the chip stayed at "0 Hz" even though the
+/// device was already streaming at its real (device-reported) rate. Drives the real GUI
+/// out-of-process; asserts only through visible UI. Requires a DAQiFi device.
+/// </summary>
+[TestClass]
+public class RateChipTests : DaqifiAppFixture
+{
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void SelectedStreamingFrequency_ShowsDeviceRate_WithoutTouchingFrequencySlider()
+    {
+        // Arrange — connect to the attached device. Deliberately skip SetSamplingFrequency:
+        // the whole point of issue #686 is that the chip must be correct even when the user
+        // never opens the frequency flyout.
+        var transport = ResolveTransport();
+        ConnectFirstDevice(transport);
+
+        var activeChannels = EnableAllAnalogChannels();
+        Assert.IsTrue(
+            activeChannels > 0,
+            "Pre-condition failed: no analog channels became active.");
+
+        // Act — start streaming, then read the RATE chip.
+        StartLogging();
+        var rateText = GetStreamRateText();
+
+        // Assert — the chip must not read "0 Hz". Parse the numeric prefix (format is
+        // "<N> Hz", see LiveGraphPane.xaml's two Runs) and assert it's a positive rate.
+        var parts = rateText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        Assert.IsTrue(
+            parts.Length >= 1 && double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var rateHz),
+            $"RATE chip text '{rateText}' did not parse as '<number> Hz'.");
+
+        double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedRateHz);
+        Assert.IsTrue(
+            parsedRateHz >= 1,
+            $"RATE chip showed {rateText} immediately after connecting/streaming, without the " +
+            "FREQUENCY slider ever being touched. Expected it to be seeded from the device's " +
+            "actual streaming frequency (>= 1 Hz), not stuck at 0 Hz (issue #686).");
+
+        // Cross-check against the per-device settings flyout, which reads the same underlying
+        // device property through a different binding path — they should agree.
+        StopLogging();
+        var sliderFrequency = GetSamplingFrequency();
+        Assert.AreEqual(
+            sliderFrequency,
+            parsedRateHz,
+            0.5,
+            $"RATE chip ({parsedRateHz} Hz) should match the device's actual sampling " +
+            $"frequency as read from the settings flyout ({sliderFrequency} Hz).");
+
+        // Per-test independence: the base fixture's [TestCleanup] closes the app,
+        // which disconnects the device. A fresh app instance is launched per test.
+    }
+}

--- a/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
+++ b/Daqifi.Desktop/View/Prototype/LiveGraphPane.xaml
@@ -201,7 +201,8 @@
                         <TextBlock FontFamily="Consolas"
                                    FontSize="11"
                                    Foreground="{StaticResource TextSecondary}"
-                                   VerticalAlignment="Center">
+                                   VerticalAlignment="Center"
+                                   AutomationProperties.AutomationId="StreamRateText">
                             <Run Text="{Binding SelectedStreamingFrequency}"/><Run Text=" Hz"/>
                         </TextBlock>
                     </StackPanel>

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1259,6 +1259,18 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         {
             streamingDevice.DebugDataReceived += OnDebugDataReceived;
         }
+
+        // Seed the RATE chip from the device's actual streaming frequency the first time a
+        // device connects. SelectedStreamingFrequency's setter is only ever driven by the
+        // Devices pane FREQUENCY slider, so without this the chip shows a stale "0 Hz" until
+        // the user touches the slider even though the device is already streaming at its
+        // default rate (issue #686). This is a read-back, not a user-initiated change, so it
+        // intentionally bypasses the setter's logging-lock guard and device write-through.
+        if (_selectedStreamingFrequency < 1)
+        {
+            _selectedStreamingFrequency = device.StreamingFrequency;
+            OnPropertyChanged(nameof(SelectedStreamingFrequency));
+        }
     }
 
     /// <summary>

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1268,7 +1268,9 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         // intentionally bypasses the setter's logging-lock guard and device write-through.
         if (_selectedStreamingFrequency < 1)
         {
-            _selectedStreamingFrequency = device.StreamingFrequency;
+            // Clamp to the same >=1 floor the public setter enforces, so an out-of-range device
+            // value (e.g. an uninitialized 0) can't surface as "0 Hz" on the chip.
+            _selectedStreamingFrequency = Math.Max(1, device.StreamingFrequency);
             OnPropertyChanged(nameof(SelectedStreamingFrequency));
         }
     }


### PR DESCRIPTION
## Summary
- The Live Graph toolbar's RATE chip binds `DaqifiViewModel.SelectedStreamingFrequency`, whose backing field started at `0` and was only ever assigned inside its own setter, which is only invoked from the Devices pane drawer's FREQUENCY slider write-through.
- Result: connect a device and start streaming without touching the slider → the device streams at its real rate (default `AbstractStreamingDevice.StreamingFrequency = 1` Hz) while the chip claimed **RATE 0 Hz**.
- Fix: in `SubscribeDeviceEvents` (invoked once per newly-connected device from `OnConnectedDevicesCollectionChanged`), seed `_selectedStreamingFrequency` from the device's actual `StreamingFrequency` when it's still unset (`< 1`), then raise `OnPropertyChanged(nameof(SelectedStreamingFrequency))`. This is a read-back, so it intentionally bypasses the setter's logging-lock guard and device write-through — matching the fix already applied on the Avalonia port (daqifi-avalonia).

## Test plan
- [x] Added `Daqifi.Desktop.Test/ViewModels/DaqifiViewModelStreamingFrequencyTests.cs`: verifies the chip is seeded from the connecting device's `StreamingFrequency`, and that a later-connecting device does not clobber an already-seeded value.
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 515 passed, 0 failed.
- [x] `dotnet build` — 0 errors.

Fixes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)