### PR TITLE
fix: classify serial connect timeout as warning, not Sentry error

### DIFF
--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -112,6 +112,14 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
                 // already holds the port open. Same classification as above.
                 AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is in use by another process");
                 break;
+            case TimeoutException:
+                // OnCoreDeviceInitialized throws this when the device never reports its initial
+                // status within InitialStatusTimeout. A newly-enumerated COM port whose driver/
+                // firmware hasn't settled yet, or a device that's unplugged/powered off/stuck in
+                // a non-responsive state, is a user/environmental condition, not an app bug — same
+                // classification as the WiFi connect-timeout case (issue #517, #632).
+                AppLogger.Warning(ex, $"Device on {PortName} did not respond within the connection timeout");
+                break;
             default:
                 AppLogger.Error(ex, $"Failed to connect on {PortName}");
                 break;


### PR DESCRIPTION
## Summary
- `SerialStreamingDevice.OnCoreDeviceInitialized()` throws `TimeoutException` when a device doesn't report status within 8s of connect. This fell into `LogConnectFailure`'s `default` case (`AppLogger.Error`), which captures to Sentry, even though a slow-to-settle COM port or an unresponsive device is a user/environmental condition, not an app bug.
- Mirrors the WiFi connect-timeout classification already added in #595 for the same class of issue (#517): downgrade to `AppLogger.Warning` (keeps exception detail in the local log, stops Sentry capture).
- The dialog already surfaces a friendly inline error for any failed manual serial connect (`ConnectManualSerialAsync` checks `ConnectionStatus == Error`), so no UI changes were needed — only the Sentry classification.

Investigated Sentry issue DAQIFI-DESKTOP-15 (auto-filed as #632): single occurrence, one production user, ~3 weeks with zero repeats — consistent with rare hardware/driver timing variance, not a systemic bug. No defect found in the connect/retry/cleanup logic itself.

Fixes #632

## Test plan
- [x] `dotnet build` succeeds (no new errors/warnings)
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 516/516 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)