### PR TITLE
fix: subscribe to Core's StatusChanged so a lost connection updates the UI

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -779,6 +779,56 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
+    [DataRow(ConnectionStatus.Lost)]
+    [DataRow(ConnectionStatus.Failed)]
+    [DataRow(ConnectionStatus.Disconnected)]
+    public void OnCoreStatusChanged_UnexpectedDrop_NotifiesIsConnectedAndRaisesConnectionLost(ConnectionStatus status)
+    {
+        // Arrange — issue #638: the desktop never subscribed to Core's StatusChanged at all, so
+        // IsConnected never raised a change notification when Core detected a spontaneous drop.
+        var device = new CoreSynchronizationTestDevice();
+        var coreDevice = BuildCoreDeviceSnapshot(firmwareVersion: "1.0.0", calibrationM: 1.0f);
+        device.SimulateChannelsPopulated(coreDevice);
+
+        var raisedPropertyNames = new List<string?>();
+        device.PropertyChanged += (_, e) => raisedPropertyNames.Add(e.PropertyName);
+
+        ConnectionLostEventArgs? capturedArgs = null;
+        device.ConnectionLost += (_, e) => capturedArgs = e;
+
+        // Act
+        device.SimulateStatusChanged(coreDevice, status);
+
+        // Assert
+        Assert.IsTrue(
+            raisedPropertyNames.Contains(nameof(Daqifi.Desktop.Device.IStreamingDevice.IsConnected)),
+            "IsConnected must raise a PropertyChanged notification so bound UI (e.g. the device tile) refreshes.");
+        Assert.AreEqual(DeviceState.Disconnected, device.DeviceState);
+        Assert.IsNotNull(capturedArgs, "ConnectionLost should fire so ConnectionManager can tear down and notify the user.");
+    }
+
+    [TestMethod]
+    [DataRow(ConnectionStatus.Connecting)]
+    [DataRow(ConnectionStatus.Connected)]
+    [DataRow(ConnectionStatus.Retrying)]
+    public void OnCoreStatusChanged_NonDropStatus_DoesNotRaiseConnectionLost(ConnectionStatus status)
+    {
+        // Arrange
+        var device = new CoreSynchronizationTestDevice();
+        var coreDevice = BuildCoreDeviceSnapshot(firmwareVersion: "1.0.0", calibrationM: 1.0f);
+        device.SimulateChannelsPopulated(coreDevice);
+
+        var connectionLostRaised = false;
+        device.ConnectionLost += (_, _) => connectionLostRaised = true;
+
+        // Act
+        device.SimulateStatusChanged(coreDevice, status);
+
+        // Assert
+        Assert.IsFalse(connectionLostRaised, $"{status} is not an unexpected drop and must not raise ConnectionLost.");
+    }
+
+    [TestMethod]
     public void StartSdCardLogging_WhenSynchronizationContextIsBlocked_CompletesWithoutDeadlock()
     {
         // Arrange
@@ -1101,6 +1151,15 @@ public class AbstractStreamingDeviceTests
         public void SimulateChannelsPopulatedFromSender(object? sender, ChannelsPopulatedEventArgs args)
         {
             OnCoreChannelsPopulated(sender, args);
+        }
+
+        /// <summary>
+        /// Simulates Core's <see cref="Daqifi.Core.Device.IDevice.StatusChanged"/> event
+        /// (issue #638) without a real transport.
+        /// </summary>
+        public void SimulateStatusChanged(DaqifiDevice coreDevice, ConnectionStatus status)
+        {
+            OnCoreStatusChanged(coreDevice, new DeviceStatusEventArgs(status));
         }
 
         protected override void SendMessage(IOutboundMessage<string> message)

--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -802,9 +802,12 @@ public class AbstractStreamingDeviceTests
         // Assert
         Assert.IsTrue(
             raisedPropertyNames.Contains(nameof(Daqifi.Desktop.Device.IStreamingDevice.IsConnected)),
-            "IsConnected must raise a PropertyChanged notification so bound UI (e.g. the device tile) refreshes.");
+            "IsConnected must raise a PropertyChanged notification so bound UI " +
+            "(e.g. the device tile) refreshes.");
         Assert.AreEqual(DeviceState.Disconnected, device.DeviceState);
-        Assert.IsNotNull(capturedArgs, "ConnectionLost should fire so ConnectionManager can tear down and notify the user.");
+        Assert.IsNotNull(
+            capturedArgs,
+            "ConnectionLost should fire so ConnectionManager can tear down and notify the user.");
     }
 
     [TestMethod]
@@ -825,7 +828,9 @@ public class AbstractStreamingDeviceTests
         device.SimulateStatusChanged(coreDevice, status);
 
         // Assert
-        Assert.IsFalse(connectionLostRaised, $"{status} is not an unexpected drop and must not raise ConnectionLost.");
+        Assert.IsFalse(
+            connectionLostRaised,
+            $"{status} is not an unexpected drop and must not raise ConnectionLost.");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -28,6 +28,14 @@ public partial class ConnectionManager : ObservableObject
     [ObservableProperty]
     private bool _notifyConnection;
 
+    /// <summary>
+    /// Human-readable description of the most recent unexpected disconnect, set just before
+    /// <see cref="NotifyConnection"/> flips to <c>true</c> so subscribers can build a message
+    /// naming the device and the reason (issue #638).
+    /// </summary>
+    [ObservableProperty]
+    private string _lastDisconnectReason = string.Empty;
+
     public string ConnectionStatusString { get; set; } = "Disconnected";
 
     /// <summary>
@@ -129,6 +137,7 @@ public partial class ConnectionManager : ObservableObject
             }
             
             ConnectedDevices.Add(device);
+            device.ConnectionLost += OnDeviceConnectionLost;
             await Task.Delay(1000);
             OnPropertyChanged("ConnectedDevices");
             ConnectionStatus = DAQiFiConnectionStatus.Connected;
@@ -154,6 +163,7 @@ public partial class ConnectionManager : ObservableObject
         var connectionType = device.ConnectionType == ConnectionType.Usb ? "usb" : "wifi";
         try
         {
+            device.ConnectionLost -= OnDeviceConnectionLost;
             device.Disconnect();
             ConnectedDevices.Remove(device);
             OnPropertyChanged("ConnectedDevices");
@@ -187,6 +197,7 @@ public partial class ConnectionManager : ObservableObject
     {
         try
         {
+            device.ConnectionLost -= OnDeviceConnectionLost;
             device.Reboot();
             ConnectedDevices.Remove(device);
             OnPropertyChanged("ConnectedDevices");
@@ -208,6 +219,46 @@ public partial class ConnectionManager : ObservableObject
             DAQiFiConnectionStatus.AlreadyConnected => "AlreadyConnected",
             _ => "Error"
         };
+    }
+
+    /// <summary>
+    /// Handles a device's <see cref="IDevice.ConnectionLost"/> event — Core detected a
+    /// spontaneous transport drop (reboot, unplug, WiFi/TCP timeout, HID disconnect) that this
+    /// class would otherwise never learn about (issue #638). Mirrors the existing
+    /// <see cref="CheckIfSerialDeviceWasRemoved"/> teardown: unsubscribe the device's channels,
+    /// tear the connection down via <see cref="Disconnect(IStreamingDevice)"/> (which always
+    /// re-runs a fresh Core device + <c>InitializeAsync</c> on the next connect), and surface a
+    /// notification naming the device and the reason.
+    /// </summary>
+    private void OnDeviceConnectionLost(object? sender, ConnectionLostEventArgs e)
+    {
+        if (sender is not IStreamingDevice device)
+        {
+            return;
+        }
+
+        System.Windows.Application.Current.Dispatcher.Invoke(delegate
+        {
+            // Already torn down via another path (e.g. explicit user disconnect raced this event).
+            if (!ConnectedDevices.Contains(device))
+            {
+                return;
+            }
+
+            foreach (var channel in device.DataChannels)
+            {
+                LoggingManager.Instance.Unsubscribe(channel);
+            }
+
+            Disconnect(device);
+
+            // Only notify if this isn't an intentional disconnect during firmware update.
+            if (DeviceBeingUpdated == null || DeviceBeingUpdated.Name != device.Name)
+            {
+                LastDisconnectReason = $"{device.DeviceDisplayName} disconnected ({e.Reason}).";
+                NotifyConnection = true;
+            }
+        });
     }
 
     private void CheckIfSerialDeviceWasRemoved()

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -237,7 +237,7 @@ public partial class ConnectionManager : ObservableObject
             return;
         }
 
-        System.Windows.Application.Current.Dispatcher.Invoke(delegate
+        InvokeOnUiThread(() =>
         {
             // Already torn down via another path (e.g. explicit user disconnect raced this event).
             if (!ConnectedDevices.Contains(device))
@@ -259,6 +259,36 @@ public partial class ConnectionManager : ObservableObject
                 NotifyConnection = true;
             }
         });
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on the WPF UI thread — required here because
+    /// <see cref="IDevice.ConnectionLost"/> can fire from a background/transport thread and this
+    /// handler mutates the UI-bound <see cref="ConnectedDevices"/> collection. Runs inline when
+    /// there is no dispatcher (unit tests) or the caller is already on it; uses the non-blocking
+    /// <c>BeginInvoke</c> so teardown can never freeze the UI thread, and swallows failures during
+    /// app/dispatcher shutdown since there is nothing left to update.
+    /// </summary>
+    private static void InvokeOnUiThread(Action action)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        try
+        {
+            if (!dispatcher.HasShutdownStarted)
+            {
+                dispatcher.BeginInvoke(action);
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Instance.Warning(ex, "Dispatcher unavailable while handling ConnectionLost; UI update dropped.");
+        }
     }
 
     private void CheckIfSerialDeviceWasRemoved()
@@ -303,6 +333,9 @@ public partial class ConnectionManager : ObservableObject
                     if (!NotifyConnection &&
                         (DeviceBeingUpdated == null || DeviceBeingUpdated.Name != serialDevice.Name))
                     {
+                        // Scoped to this device so a later notification never shows a stale
+                        // reason string left over from a previous, unrelated disconnect.
+                        LastDisconnectReason = $"{serialDevice.DeviceDisplayName} disconnected (port removed).";
                         NotifyConnection = true;
                     }
                 });

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -494,9 +494,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return;
         }
 
-        DeviceState = DeviceState.Disconnected;
-        OnPropertyChanged(nameof(IsConnected));
-
         var reason = e.Status switch
         {
             ConnectionStatus.Lost => "connection lost",
@@ -504,7 +501,46 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             _ => "disconnected"
         };
         AppLogger.Warning($"DAQiFi device {DisplayIdentifier} {reason} unexpectedly.");
+
+        // Core can raise StatusChanged from a transport/background thread — DeviceState and
+        // IsConnected are WPF-bound, so the mutation and its change notification must be
+        // marshalled onto the UI thread (issue #638 code review).
+        InvokeOnUiThread(() =>
+        {
+            DeviceState = DeviceState.Disconnected;
+            OnPropertyChanged(nameof(IsConnected));
+        });
+
         ConnectionLost?.Invoke(this, new ConnectionLostEventArgs(reason));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on the WPF UI thread. Runs inline when there is no
+    /// dispatcher (unit tests — <c>Application.Current</c> is null) or the caller is already on
+    /// it. Uses the non-blocking <c>BeginInvoke</c> so a background-thread caller (e.g. Core's
+    /// <c>StatusChanged</c>) can never block on the UI thread; failures during app/dispatcher
+    /// shutdown are swallowed since there is nothing left to update.
+    /// </summary>
+    private static void InvokeOnUiThread(Action action)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        try
+        {
+            if (!dispatcher.HasShutdownStarted)
+            {
+                dispatcher.BeginInvoke(action);
+            }
+        }
+        catch (Exception)
+        {
+            // Dispatcher unavailable / shutting down — drop the UI update.
+        }
     }
     #endregion
 

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -287,6 +287,9 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     // Debug mode properties
     public bool IsDebugModeEnabled { get; private set; }
     public event Action<DebugDataModel>? DebugDataReceived;
+
+    /// <inheritdoc />
+    public event EventHandler<ConnectionLostEventArgs>? ConnectionLost;
     #endregion
 
     #region Abstract Methods
@@ -332,6 +335,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
             coreDevice.ChannelsPopulated += OnCoreChannelsPopulated;
             coreDevice.MessageReceived += OnCoreMessageReceived;
+            coreDevice.StatusChanged += OnCoreStatusChanged;
 
             InitializeDeviceState();
 
@@ -461,6 +465,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     {
         coreDevice.ChannelsPopulated -= OnCoreChannelsPopulated;
         coreDevice.MessageReceived -= OnCoreMessageReceived;
+        coreDevice.StatusChanged -= OnCoreStatusChanged;
     }
 
     /// <summary>
@@ -471,6 +476,35 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     private void OnCoreMessageReceived(object? sender, MessageReceivedEventArgs e)
     {
         HandleInboundMessage(e);
+    }
+
+    /// <summary>
+    /// Handles Core's <see cref="IDevice.StatusChanged"/> event (issue #638). Core is the only
+    /// party that observes a spontaneous transport drop (reboot, unplug, WiFi/TCP timeout, HID
+    /// disconnect) — before this, the desktop never subscribed at all, so <see cref="IsConnected"/>
+    /// (a plain <c>CoreDevice?.IsConnected</c> passthrough) never raised a change notification and
+    /// the UI kept showing a dead device as connected. A desktop-initiated <see cref="Disconnect"/>
+    /// always unsubscribes this handler (via <see cref="UnsubscribeCoreDeviceEvents"/>) before
+    /// touching the Core device, so only genuinely unexpected transitions reach here.
+    /// </summary>
+    protected virtual void OnCoreStatusChanged(object? sender, DeviceStatusEventArgs e)
+    {
+        if (e.Status is not (ConnectionStatus.Lost or ConnectionStatus.Failed or ConnectionStatus.Disconnected))
+        {
+            return;
+        }
+
+        DeviceState = DeviceState.Disconnected;
+        OnPropertyChanged(nameof(IsConnected));
+
+        var reason = e.Status switch
+        {
+            ConnectionStatus.Lost => "connection lost",
+            ConnectionStatus.Failed => "connection failed",
+            _ => "disconnected"
+        };
+        AppLogger.Warning($"DAQiFi device {DisplayIdentifier} {reason} unexpectedly.");
+        ConnectionLost?.Invoke(this, new ConnectionLostEventArgs(reason));
     }
     #endregion
 

--- a/Daqifi.Desktop/Device/ConnectionLostEventArgs.cs
+++ b/Daqifi.Desktop/Device/ConnectionLostEventArgs.cs
@@ -1,0 +1,12 @@
+namespace Daqifi.Desktop.Device;
+
+/// <summary>
+/// Raised when a streaming device's underlying Core connection drops unexpectedly (reboot,
+/// USB/CDC unplug, WiFi/TCP drop, firmware-flash re-enumeration, HID disconnect) rather than
+/// through an explicit, desktop-initiated <see cref="IDevice.Disconnect"/> call.
+/// </summary>
+public class ConnectionLostEventArgs(string reason) : EventArgs
+{
+    /// <summary>Short, human-readable description of why the connection was lost.</summary>
+    public string Reason { get; } = reason;
+}

--- a/Daqifi.Desktop/Device/IDevice.cs
+++ b/Daqifi.Desktop/Device/IDevice.cs
@@ -24,4 +24,13 @@ public interface IDevice : INotifyPropertyChanged
     /// Reboots the streamingDevice
     /// </summary>
     void Reboot();
+
+    /// <summary>
+    /// Raised when the device's connection drops unexpectedly (not via an explicit
+    /// <see cref="Disconnect"/> call) — e.g. reboot, unplug, WiFi/TCP drop, or
+    /// firmware-flash re-enumeration. Subscribers should tear down their reference to this
+    /// device and inform the user; the wrapper's own state is already updated by the time
+    /// this fires.
+    /// </summary>
+    event EventHandler<ConnectionLostEventArgs>? ConnectionLost;
 }

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1601,7 +1601,10 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
                 var deviceConnection = ConnectionManager.Instance.NotifyConnection;
                 if (deviceConnection)
                 {
-                    var errorDialogViewModel = new ErrorDialogViewModel("Device disconnected unexpectedly.");
+                    var message = string.IsNullOrWhiteSpace(ConnectionManager.Instance.LastDisconnectReason)
+                        ? "Device disconnected unexpectedly."
+                        : ConnectionManager.Instance.LastDisconnectReason;
+                    var errorDialogViewModel = new ErrorDialogViewModel(message);
                     _dialogService.ShowDialog<ErrorDialog>(this, errorDialogViewModel);
                     ConnectionManager.Instance.NotifyConnection = false;
                 }

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1607,6 +1607,9 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
                     var errorDialogViewModel = new ErrorDialogViewModel(message);
                     _dialogService.ShowDialog<ErrorDialog>(this, errorDialogViewModel);
                     ConnectionManager.Instance.NotifyConnection = false;
+                    // Clear so a later notification that doesn't set its own reason (if any)
+                    // never shows this one's stale device/reason text.
+                    ConnectionManager.Instance.LastDisconnectReason = string.Empty;
                 }
                 break;
         }


### PR DESCRIPTION
## Summary

Core already detects spontaneous disconnects (reboot, USB/CDC unplug, WiFi/TCP drop, firmware-flash re-enumeration) and sets its own `IsConnected`/`Status` accordingly — but the desktop never subscribed to Core's `StatusChanged` event at all, and `IsConnected` (a plain `CoreDevice?.IsConnected` passthrough) never raised a `PropertyChanged` notification. So a dead device kept showing as "connected" in the UI, and the next operation reused the stale connection instead of running a fresh `Connect()`/`InitializeAsync()` — which is why a rebooted device stayed in standby and firmware flashes failed with "device did not enter bootloader mode".

- `AbstractStreamingDevice` now subscribes to `coreDevice.StatusChanged` alongside its existing `ChannelsPopulated`/`MessageReceived` subscriptions (and unsubscribes in the same place those are torn down).
- On an unexpected `Lost`/`Failed`/`Disconnected` transition, it sets `DeviceState = Disconnected`, raises `IsConnected`'s change notification (the device tile view model was already wired to react to `nameof(IsConnected)` — it just never fired), and raises a new `ConnectionLost` event on `IDevice`.
- `ConnectionManager` subscribes to `ConnectionLost` for each connected device and mirrors its existing serial-port-removal teardown path: unsubscribe the device's channels from `LoggingManager`, tear the connection down via the existing `Disconnect(device)` (which removes it from `ConnectedDevices` and always rebuilds the Core device + reruns `InitializeAsync` on the next connect — no stale-connection reuse), and surface the existing "device disconnected unexpectedly" dialog, now naming the device and the reason.

### Note on the notification mechanism
The issue proposed routing the "why disconnected" message through the `NotificationsFlyout`/`Notifications` model. I instead extended the existing `NotifyConnection` → `ErrorDialogViewModel` path (already used for the serial-port-removal case) with a `LastDisconnectReason` string, so both disconnect-detection paths (physical port removal and Core's `StatusChanged`) funnel through one, already-working UX instead of introducing a second parallel notification mechanism.

### Out of scope (tracked as follow-ups in the issue)
- HID transport doesn't raise `StatusChanged` on disconnect at all — that's a Core-side gap.
- No WiFi/TCP heartbeat — a drop is only detected on the next I/O.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 537 passed, 0 failed
- [x] Added `AbstractStreamingDeviceTests`: simulated `Lost`/`Failed`/`Disconnected` raise `IsConnected` PropertyChanged + `DeviceState.Disconnected` + `ConnectionLost`; simulated `Connecting`/`Connected`/`Retrying` do not raise `ConnectionLost`.
- [ ] Hardware bench: reboot/unplug a connected device and confirm the UI flips to disconnected within ~1s and the dialog names the device.

Closes #638