### PR TITLE
chore: clear AvailableWiFiDevices on discovery restart so Core dedup suffices

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelWifiDiscoveryTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelWifiDiscoveryTests.cs
@@ -3,6 +3,7 @@ using Daqifi.Desktop.DialogService;
 using Daqifi.Desktop.ViewModels;
 using Moq;
 using System.Net;
+using System.Reflection;
 
 namespace Daqifi.Desktop.Test.ViewModels;
 
@@ -59,9 +60,64 @@ public class ConnectionDialogViewModelWifiDiscoveryTests
         Assert.IsTrue(wifiDevice.IsPowerOn);
     }
 
+    [TestMethod]
+    public void StartWiFiDiscovery_ClearsAvailableWiFiDevicesFromPriorSession()
+    {
+        // Arrange: populate the list as if a device was found before a discovery restart
+        // (e.g. the firmware-flash resume path recreates the finder).
+        var viewModel = CreateViewModel();
+        var deviceInfo = new DeviceInfo
+        {
+            Name = "NQ1-WiFi",
+            MacAddress = "00:11:22:33:44:55",
+            IPAddress = IPAddress.Parse("192.168.1.100"),
+            Port = 9760,
+            ConnectionType = ConnectionType.WiFi
+        };
+        viewModel.HandleCoreWifiDeviceDiscovered(null, new DeviceDiscoveredEventArgs(deviceInfo));
+        Assert.HasCount(1, viewModel.AvailableWiFiDevices);
+        Assert.IsFalse(viewModel.HasNoWiFiDevices);
+
+        try
+        {
+            // Act: restart discovery (simulates the firmware-flash resume path recreating the finder)
+            InvokeStartWiFiDiscovery(viewModel);
+
+            // Assert: the list is reset synchronously so a rediscovery under the new finder's own
+            // per-session MAC dedup can't be re-added as a duplicate.
+            Assert.IsEmpty(viewModel.AvailableWiFiDevices);
+            Assert.IsTrue(viewModel.HasNoWiFiDevices);
+        }
+        finally
+        {
+            // Stop the discovery loop kicked off above before the test ends.
+            InvokeStopWiFiDiscovery(viewModel);
+        }
+    }
+
     private static ConnectionDialogViewModel CreateViewModel()
     {
         var dialogService = new Mock<IDialogService>();
         return new ConnectionDialogViewModel(dialogService.Object);
+    }
+
+    private static void InvokeStartWiFiDiscovery(ConnectionDialogViewModel viewModel)
+    {
+        var method = typeof(ConnectionDialogViewModel).GetMethod(
+            "StartWiFiDiscovery",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.IsNotNull(method);
+        method.Invoke(viewModel, null);
+    }
+
+    private static void InvokeStopWiFiDiscovery(ConnectionDialogViewModel viewModel)
+    {
+        var method = typeof(ConnectionDialogViewModel).GetMethod(
+            "StopWiFiDiscovery",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.IsNotNull(method);
+        method.Invoke(viewModel, null);
     }
 }

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelWifiDiscoveryTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelWifiDiscoveryTests.cs
@@ -61,7 +61,7 @@ public class ConnectionDialogViewModelWifiDiscoveryTests
     }
 
     [TestMethod]
-    public void StartWiFiDiscovery_ClearsAvailableWiFiDevicesFromPriorSession()
+    public async Task StartWiFiDiscovery_ClearsAvailableWiFiDevicesFromPriorSession()
     {
         // Arrange: populate the list as if a device was found before a discovery restart
         // (e.g. the firmware-flash resume path recreates the finder).
@@ -90,8 +90,10 @@ public class ConnectionDialogViewModelWifiDiscoveryTests
         }
         finally
         {
-            // Stop the discovery loop kicked off above before the test ends.
-            InvokeStopWiFiDiscovery(viewModel);
+            // Drain the discovery loop kicked off above (rather than the non-async stop, which
+            // cancels/disposes without awaiting the running task) so no background discovery work
+            // is still in flight once the test completes.
+            await InvokeStopWiFiDiscoveryAsync(viewModel);
         }
     }
 
@@ -111,13 +113,13 @@ public class ConnectionDialogViewModelWifiDiscoveryTests
         method.Invoke(viewModel, null);
     }
 
-    private static void InvokeStopWiFiDiscovery(ConnectionDialogViewModel viewModel)
+    private static Task InvokeStopWiFiDiscoveryAsync(ConnectionDialogViewModel viewModel)
     {
         var method = typeof(ConnectionDialogViewModel).GetMethod(
-            "StopWiFiDiscovery",
+            "StopWiFiDiscoveryAsync",
             BindingFlags.Instance | BindingFlags.NonPublic);
 
         Assert.IsNotNull(method);
-        method.Invoke(viewModel, null);
+        return (Task)method.Invoke(viewModel, null)!;
     }
 }

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -173,6 +173,14 @@ public partial class ConnectionDialogViewModel : ObservableObject
         if (_wifiFinder != null) { _wifiFinder.DeviceDiscovered -= HandleCoreWifiDeviceDiscovered; _wifiFinder.Dispose(); }
         _wifiDiscoveryCts?.Dispose();
 
+        // Reset the bound list to match the new finder's dedup set: WiFiDeviceFinder's MAC dedup is
+        // per-DiscoverAsync-call (a fresh finder means a fresh, empty dedup set), so a list that
+        // outlives the finder it was populated from (e.g. the firmware-flash resume path, which tears
+        // down and recreates the finder) would let a rediscovered device be re-added as a duplicate.
+        // Clearing here keeps Core's per-session dedup sufficient on its own. (issue #621)
+        AvailableWiFiDevices.Clear();
+        HasNoWiFiDevices = true;
+
         _wifiFinder = new WiFiDeviceFinder(30303);
         _wifiDiscoveryCts = new CancellationTokenSource();
         _wifiFinder.DeviceDiscovered += HandleCoreWifiDeviceDiscovered;
@@ -612,12 +620,10 @@ public partial class ConnectionDialogViewModel : ObservableObject
 
         InvokeOnUiThread(() =>
         {
-            // Dedup by MAC across discovery restarts: Core's WiFiDeviceFinder only dedups within a
-            // single DiscoverAsync session (its discoveredDevices set is per-call), but the dialog
-            // restarts the finder — e.g. the firmware-flash resume path — while AvailableWiFiDevices
-            // persists and is never cleared. Without this guard a rediscovered device is added twice.
-            // Mirrors the serial path's FindSerialDeviceByPortName dedup. (issue #621)
-            if (AvailableWiFiDevices.Any(d => d.MacAddress == wifiDevice.MacAddress)) return;
+            // No MAC dedup guard here: StartWiFiDiscovery clears AvailableWiFiDevices whenever the
+            // finder is (re)created, so the list never outlives the finder's own per-session dedup
+            // set — Core's WiFiDeviceFinder dedup (by MAC, within a DiscoverAsync session) is
+            // sufficient on its own. (issue #621)
             AvailableWiFiDevices.Add(wifiDevice);
             if (HasNoWiFiDevices) { HasNoWiFiDevices = false; }
         });

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -178,8 +178,14 @@ public partial class ConnectionDialogViewModel : ObservableObject
         // outlives the finder it was populated from (e.g. the firmware-flash resume path, which tears
         // down and recreates the finder) would let a rediscovered device be re-added as a duplicate.
         // Clearing here keeps Core's per-session dedup sufficient on its own. (issue #621)
-        AvailableWiFiDevices.Clear();
-        HasNoWiFiDevices = true;
+        // Routed through InvokeOnUiThread like every other AvailableWiFiDevices mutation (see
+        // HandleWifiDeviceFound) so this stays safe even if a future caller invokes
+        // StartWiFiDiscovery off the UI thread.
+        InvokeOnUiThread(() =>
+        {
+            AvailableWiFiDevices.Clear();
+            HasNoWiFiDevices = true;
+        });
 
         _wifiFinder = new WiFiDeviceFinder(30303);
         _wifiDiscoveryCts = new CancellationTokenSource();


### PR DESCRIPTION
## Summary
- `StartWiFiDiscovery` now clears `AvailableWiFiDevices` (and resets `HasNoWiFiDevices`) synchronously whenever it (re)creates the `WiFiDeviceFinder` — most notably on the firmware-flash resume path, which tears down and recreates the finder.
- Since the bound list can no longer outlive the finder's own per-`DiscoverAsync`-call MAC dedup set, the desktop-side `AvailableWiFiDevices.Any(d => d.MacAddress == ...)` guard in `HandleWifiDeviceFound` is redundant and removed — Core's dedup is sufficient on its own.
- The equivalent serial-path dedup (`FindSerialDeviceByPortName`) is left untouched — issue #621's investigation flagged that as a separate, optional follow-up, not in scope here.

Closes #621

## Context
This issue was originally scoped as "just delete the guard," but the issue's own investigation (see its comment) found that would regress: without clearing the list first, the guard is load-bearing across finder restarts. This PR implements the repurposed scope from that investigation — clear-on-restart instead of a live dedup guard.

## Test plan
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 545 passed, 0 failed
- [x] Added `StartWiFiDiscovery_ClearsAvailableWiFiDevicesFromPriorSession` exercising the private `StartWiFiDiscovery`/`StopWiFiDiscovery` methods via reflection to verify the list is cleared synchronously on restart
- [ ] Hardware bench: not exercised — this repro requires a WiFi-connected device plus a full firmware-flash resume cycle to hit the restart path; the bench available in this environment is USB/serial-connected. Verified via the targeted unit test and code inspection instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)