### PR TITLE
chore: replace hand-built SCPI channel bitmask loops with Core channel API

### DIFF
--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1211,69 +1211,40 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return;
         }
 
-        switch (channel.Type)
+        var coreChannel = GetCoreChannel(channel);
+        if (coreChannel == null)
         {
-            case ChannelType.Analog:
-                var activeAnalogChannels = GetActiveAnalogChannels();
-                var channelSetByte = 0u; // Use unsigned int to handle higher channel numbers
-
-                // Get Exsiting Channel Set Byte
-                foreach (var activeChannel in activeAnalogChannels)
-                {
-                    channelSetByte = channelSetByte | (1u << activeChannel.Index);
-                }
-
-                // Add Channel Bit to the Channel Set Byte
-                channelSetByte = channelSetByte | (1u << channel.Index);
-
-                // Convert to a string
-                var channelSetString = Convert.ToString(channelSetByte);
-
-                // Send the command to add the channel
-                SendMessage(ScpiMessageProducer.EnableAdcChannels(channelSetString));
-                break;
-            case ChannelType.Digital:
-                SendMessage(ScpiMessageProducer.EnableDioPorts());
-                break;
+            AppLogger.Warning($"Ignored add channel for {channel.Name}: not a Core-backed channel wrapper.");
+            return;
         }
 
+        // Set locally first so the desktop wrapper's change-notification fires — Core's
+        // EnableChannel mutates the same underlying IsEnabled directly and would otherwise
+        // leave this a no-op transition (true -> true) that never notifies bound UI.
         channel.IsActive = true;
+        ExecuteDeviceCommand("enable channel", $"channel {channel.Name}",
+            coreDevice => coreDevice.EnableChannel(coreChannel));
     }
 
     public void RemoveChannel(IChannel channelToRemove)
     {
-        switch (channelToRemove.Type)
-        {
-            case ChannelType.Analog:
-                var activeAnalogChannels = GetActiveAnalogChannels();
-                var channelSetByte = 0u; // Use unsigned int to handle higher channel numbers
-
-                //Get Exsiting Channel Set Byte
-                foreach (var activeChannel in activeAnalogChannels)
-                {
-                    channelSetByte = channelSetByte | (1u << activeChannel.Index);
-                }
-
-                //Remove Channel Bit from the Channel Set Byte
-                channelSetByte = channelSetByte & ~(1u << channelToRemove.Index);
-
-                //Convert to a string
-                var channelSetString = Convert.ToString(channelSetByte);
-
-                //Send the command to remove the channel
-                SendMessage(ScpiMessageProducer.EnableAdcChannels(channelSetString));
-                break;
-        }
-
         var channel = DataChannels.FirstOrDefault(c => Equals(c, channelToRemove));
         if (channel == null)
         {
             AppLogger.Error($"There was a problem removing channel: {channelToRemove.Name}");
+            return;
         }
-        else
+
+        var coreChannel = GetCoreChannel(channel);
+        if (coreChannel == null)
         {
-            channel.IsActive = false;
+            AppLogger.Warning($"Ignored remove channel for {channel.Name}: not a Core-backed channel wrapper.");
+            return;
         }
+
+        channel.IsActive = false;
+        ExecuteDeviceCommand("disable channel", $"channel {channel.Name}",
+            coreDevice => coreDevice.DisableChannel(coreChannel));
     }
 
     /// <summary>
@@ -1281,37 +1252,31 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     public void AddChannels(IEnumerable<IChannel> channelsToAdd)
     {
-        var channelSetByte = 0u;
-        var hasAnalog = false;
-        var hasDigital = false;
+        var coreChannels = new List<Daqifi.Core.Channel.IChannel>();
 
         foreach (var channelToAdd in channelsToAdd)
         {
             var channel = DataChannels.FirstOrDefault(c => Equals(c, channelToAdd));
             if (channel == null) continue;
 
-            switch (channel.Type)
+            var coreChannel = GetCoreChannel(channel);
+            if (coreChannel == null)
             {
-                case ChannelType.Analog:
-                    channelSetByte |= (1u << channel.Index);
-                    channel.IsActive = true;
-                    hasAnalog = true;
-                    break;
-                case ChannelType.Digital:
-                    channel.IsActive = true;
-                    hasDigital = true;
-                    break;
+                AppLogger.Warning($"Ignored add channel for {channel.Name}: not a Core-backed channel wrapper.");
+                continue;
             }
+
+            channel.IsActive = true;
+            coreChannels.Add(coreChannel);
         }
 
-        if (hasAnalog)
+        if (coreChannels.Count == 0)
         {
-            SendMessage(ScpiMessageProducer.EnableAdcChannels(Convert.ToString(channelSetByte)));
+            return;
         }
-        if (hasDigital)
-        {
-            SendMessage(ScpiMessageProducer.EnableDioPorts());
-        }
+
+        ExecuteDeviceCommand("enable channels", $"{coreChannels.Count} channel(s)",
+            coreDevice => coreDevice.EnableChannels(coreChannels));
     }
 
     /// <summary>
@@ -1319,17 +1284,26 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     public void RemoveAllChannels()
     {
-        SendMessage(ScpiMessageProducer.EnableAdcChannels("0"));
-        SendMessage(ScpiMessageProducer.DisableDioPorts());
         foreach (var channel in DataChannels)
         {
             channel.IsActive = false;
         }
+
+        ExecuteDeviceCommand("disable all channels", coreDevice => coreDevice.DisableAllChannels());
     }
 
-    private IEnumerable<IChannel> GetActiveAnalogChannels()
+    /// <summary>
+    /// Resolves the Core channel wrapped by a desktop <see cref="IChannel"/>, or <c>null</c>
+    /// if it isn't one of the known Core-backed wrapper types.
+    /// </summary>
+    private static Daqifi.Core.Channel.IChannel? GetCoreChannel(IChannel channel)
     {
-        return DataChannels.Where(channel => channel.Type == ChannelType.Analog && channel.IsActive).ToList();
+        return channel switch
+        {
+            AnalogChannel analogChannel => analogChannel.CoreChannel,
+            DigitalChannel digitalChannel => digitalChannel.CoreChannel,
+            _ => null
+        };
     }
 
     /// <inheritdoc />

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1201,6 +1201,10 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     #endregion
 
     #region Channel Methods
+    /// <summary>
+    /// Enables a single channel on the device.
+    /// </summary>
+    /// <param name="channelToAdd">The channel to enable. Must belong to this device's <see cref="DataChannels"/>.</param>
     public void AddChannel(IChannel channelToAdd)
     {
         var channel = DataChannels.FirstOrDefault(c => Equals(c, channelToAdd));
@@ -1220,12 +1224,23 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         // Set locally first so the desktop wrapper's change-notification fires — Core's
         // EnableChannel mutates the same underlying IsEnabled directly and would otherwise
-        // leave this a no-op transition (true -> true) that never notifies bound UI.
+        // leave this a no-op transition (true -> true) that never notifies bound UI. Rolled
+        // back below if the device command didn't actually run, so IsActive never lies about
+        // what the device is doing.
+        var wasActive = channel.IsActive;
         channel.IsActive = true;
-        ExecuteDeviceCommand("enable channel", $"channel {channel.Name}",
+        var succeeded = ExecuteDeviceCommand("enable channel", $"channel {channel.Name}",
             coreDevice => coreDevice.EnableChannel(coreChannel));
+        if (!succeeded)
+        {
+            channel.IsActive = wasActive;
+        }
     }
 
+    /// <summary>
+    /// Disables a single channel on the device.
+    /// </summary>
+    /// <param name="channelToRemove">The channel to disable. Must belong to this device's <see cref="DataChannels"/>.</param>
     public void RemoveChannel(IChannel channelToRemove)
     {
         var channel = DataChannels.FirstOrDefault(c => Equals(c, channelToRemove));
@@ -1242,17 +1257,23 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return;
         }
 
+        var wasActive = channel.IsActive;
         channel.IsActive = false;
-        ExecuteDeviceCommand("disable channel", $"channel {channel.Name}",
+        var succeeded = ExecuteDeviceCommand("disable channel", $"channel {channel.Name}",
             coreDevice => coreDevice.DisableChannel(coreChannel));
+        if (!succeeded)
+        {
+            channel.IsActive = wasActive;
+        }
     }
 
     /// <summary>
-    /// Enables multiple channels on the device with a single SCPI command per channel type.
+    /// Enables multiple channels on the device with a single Core command per affected channel type.
     /// </summary>
     public void AddChannels(IEnumerable<IChannel> channelsToAdd)
     {
         var coreChannels = new List<Daqifi.Core.Channel.IChannel>();
+        var affectedChannels = new List<(IChannel Channel, bool WasActive)>();
 
         foreach (var channelToAdd in channelsToAdd)
         {
@@ -1266,6 +1287,14 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
                 continue;
             }
 
+            // Skip channels already queued this call (e.g. duplicate entries from a profile)
+            // so the device command and its logged count reflect distinct channels only.
+            if (coreChannels.Contains(coreChannel))
+            {
+                continue;
+            }
+
+            affectedChannels.Add((channel, channel.IsActive));
             channel.IsActive = true;
             coreChannels.Add(coreChannel);
         }
@@ -1275,8 +1304,15 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return;
         }
 
-        ExecuteDeviceCommand("enable channels", $"{coreChannels.Count} channel(s)",
+        var succeeded = ExecuteDeviceCommand("enable channels", $"{coreChannels.Count} channel(s)",
             coreDevice => coreDevice.EnableChannels(coreChannels));
+        if (!succeeded)
+        {
+            foreach (var (channel, wasActive) in affectedChannels)
+            {
+                channel.IsActive = wasActive;
+            }
+        }
     }
 
     /// <summary>
@@ -1284,12 +1320,20 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     public void RemoveAllChannels()
     {
+        var affectedChannels = DataChannels.Select(c => (Channel: c, WasActive: c.IsActive)).ToList();
         foreach (var channel in DataChannels)
         {
             channel.IsActive = false;
         }
 
-        ExecuteDeviceCommand("disable all channels", coreDevice => coreDevice.DisableAllChannels());
+        var succeeded = ExecuteDeviceCommand("disable all channels", coreDevice => coreDevice.DisableAllChannels());
+        if (!succeeded)
+        {
+            foreach (var (channel, wasActive) in affectedChannels)
+            {
+                channel.IsActive = wasActive;
+            }
+        }
     }
 
     /// <summary>
@@ -1417,22 +1461,25 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// unavailability is logged and swallowed to preserve the pre-delegation no-op
     /// semantics instead of surfacing an exception through a WPF binding.
     /// </summary>
-    private void ExecuteDeviceCommand(string operation, string target, Action<CoreStreamingDevice> command)
+    /// <returns><c>true</c> if the command ran without being skipped or throwing.</returns>
+    private bool ExecuteDeviceCommand(string operation, string target, Action<CoreStreamingDevice> command)
     {
         var coreDevice = CoreDevice;
         if (coreDevice == null || !coreDevice.IsConnected)
         {
             AppLogger.Warning($"Ignored {operation} for {target}: device is not connected.");
-            return;
+            return false;
         }
 
         try
         {
             command(coreDevice);
+            return true;
         }
         catch (Exception ex)
         {
             AppLogger.Error(ex, $"Failed to {operation} for {target}");
+            return false;
         }
     }
 
@@ -1440,9 +1487,10 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// Runs a device-level Core command (no channel involved), logging against this
     /// device's display name.
     /// </summary>
-    private void ExecuteDeviceCommand(string operation, Action<CoreStreamingDevice> command)
+    /// <returns><c>true</c> if the command ran without being skipped or throwing.</returns>
+    private bool ExecuteDeviceCommand(string operation, Action<CoreStreamingDevice> command)
     {
-        ExecuteDeviceCommand(operation, $"device {DeviceDisplayName}", command);
+        return ExecuteDeviceCommand(operation, $"device {DeviceDisplayName}", command);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Replaces the hand-built ADC enable-bitmask loops in `AddChannel`, `RemoveChannel`, `AddChannels`, and `RemoveAllChannels` with calls to Core's device-level channel API (`EnableChannel`/`EnableChannels`/`DisableChannel`/`DisableAllChannels`), now available since Core 1.0.0 (daqifi-core#241, consumed here at 1.1.1).
- Fixes an existing asymmetry along the way: `RemoveChannel` previously only sent a device command for analog channels — removing a digital channel silently no-opped on the wire. It's now symmetric with `AddChannel` for both channel types.
- Preserves WPF change notification for `IChannel.IsActive`: the desktop wrapper's flag is set *before* invoking Core's API, since Core mutates the same underlying `IsEnabled` directly and would otherwise leave a silent no-op transition that never notifies bound UI (channel tiles, live graph legend, etc.).
- `SetChannelOutputValue`/`SetChannelDirection` were already delegating to Core from earlier work; this closes the loop on the remaining channel-enable methods named in #612.

`StartSdCardLogging`'s manual analog-mask building was left as-is — a dedicated test (`StartSdCardLogging_UsesCombinedAnalogMaskAndConfiguresDigitalPortsOnce`) locks in its current design (Core handles the mask via the `channelMask` param; desktop still owns the DIO enable for that flow), and folding it into this refactor risked more churn than the issue's stated scope warranted.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 545/545 passed
- [x] Verified on bench hardware (USB-connected Nq1) via the Debug build:
  - `AddChannel`: individually activating AI0, AI2, AI4, AI8 correctly enables each and Live Graph streams real data for them
  - `RemoveChannel`: deactivating AI2 stops just that channel, others keep streaming
  - `RemoveAllChannels` ("Clear All"): zeroes all 16 channels
  - `AddChannels` ("Select All"): activates all 16 channels in one call, including AI8–AI15 (the historically bug-prone high-bit range past the old `int`/`uint` overflow boundary), all verified streaming live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
