### PR TITLE
chore: remove redundant serial GetDeviceInfo poll loop

### DIFF
--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -11,14 +11,9 @@ namespace Daqifi.Desktop.Device.SerialDevice;
 
 public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvider
 {
-    private static readonly TimeSpan InitialStatusTimeout = TimeSpan.FromSeconds(8);
-    private static readonly TimeSpan InitialStatusPollInterval = TimeSpan.FromMilliseconds(100);
-    private static readonly TimeSpan InitialStatusRequestInterval = TimeSpan.FromSeconds(1);
-
     #region Properties
     private SerialPort? _port;
     private SerialStreamTransport? _transport;
-    private TaskCompletionSource<bool>? _initialStatusReceivedSource;
 
     public SerialPort? Port
     {
@@ -89,9 +84,6 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     /// </summary>
     protected override CoreStreamingDevice CreateCoreDevice()
     {
-        _initialStatusReceivedSource = new TaskCompletionSource<bool>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-
         // Use Core's transport for unified message handling (both send and receive).
         // The transport manages the actual SerialPort connection internally; DTR must stay
         // enabled or the device will not stream over USB.
@@ -122,73 +114,18 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
                 AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is in use by another process");
                 break;
             case TimeoutException:
-                // OnCoreDeviceInitialized throws this when the device never reports its initial
-                // status within InitialStatusTimeout. A newly-enumerated COM port whose driver/
-                // firmware hasn't settled yet, or a device that's unplugged/powered off/stuck in
-                // a non-responsive state, is a user/environmental condition, not an app bug — same
-                // classification as the WiFi connect-timeout case (issue #517, #632).
+                // Core's InitializeAsync throws this when the device never reports its channel
+                // configuration within its channel-population timeout. A newly-enumerated COM
+                // port whose driver/firmware hasn't settled yet, or a device that's unplugged/
+                // powered off/stuck in a non-responsive state, is a user/environmental condition,
+                // not an app bug — same classification as the WiFi connect-timeout case (issue
+                // #517, #632).
                 AppLogger.Warning(ex, $"Device on {PortName} did not respond within the connection timeout");
                 break;
             default:
                 AppLogger.Error(ex, $"Failed to connect on {PortName}");
                 break;
         }
-    }
-
-    /// <summary>
-    /// Signals the initial-status wait so <see cref="OnCoreDeviceInitialized"/> can return,
-    /// then runs the shared Core-to-desktop sync.
-    /// </summary>
-    protected override void OnCoreChannelsPopulated(object? sender, ChannelsPopulatedEventArgs e)
-    {
-        _initialStatusReceivedSource?.TrySetResult(true);
-        base.OnCoreChannelsPopulated(sender, e);
-    }
-
-    /// <summary>
-    /// Blocks until the device reports its initial status message, which gates
-    /// <see cref="AbstractStreamingDevice.Connect"/> returning for serial devices.
-    /// </summary>
-    protected override void OnCoreDeviceInitialized()
-    {
-        var coreDevice = CoreDevice;
-        if (coreDevice == null)
-        {
-            throw new InvalidOperationException("Core device was not initialized.");
-        }
-
-        var statusReceivedSource = _initialStatusReceivedSource
-            ?? throw new InvalidOperationException("Initial status wait source was not initialized.");
-
-        var deadline = DateTime.UtcNow + InitialStatusTimeout;
-        var nextDeviceInfoRequestAt = DateTime.UtcNow + InitialStatusRequestInterval;
-
-        while (DateTime.UtcNow < deadline)
-        {
-            if (statusReceivedSource.Task.Wait(InitialStatusPollInterval))
-            {
-                return;
-            }
-
-            if (DateTime.UtcNow < nextDeviceInfoRequestAt)
-            {
-                continue;
-            }
-
-            try
-            {
-                coreDevice.Send(ScpiMessageProducer.GetDeviceInfo);
-            }
-            catch (Exception ex)
-            {
-                AppLogger.Warning(ex, $"Failed to re-request device info on {PortName}");
-            }
-
-            nextDeviceInfoRequestAt = DateTime.UtcNow + InitialStatusRequestInterval;
-        }
-
-        throw new TimeoutException(
-            $"Device on {PortName} did not report status within {InitialStatusTimeout.TotalSeconds:F0} seconds of connect.");
     }
 
     /// <summary>
@@ -236,8 +173,6 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
 
     protected override void CleanupConnection()
     {
-        _initialStatusReceivedSource = null;
-
         // Unsubscribe Core device events and dispose the Core device first
         base.CleanupConnection();
 


### PR DESCRIPTION
## Summary
- `SerialStreamingDevice.OnCoreDeviceInitialized` re-implemented an 8s-timeout/1s-resend `GetDeviceInfo` poll loop to wait for the device to populate its channels.
- Since Core 1.0.0 (daqifi-core#247, consumed since #669), `AbstractStreamingDevice.Connect()` already blocks on `coreDevice.InitializeAsync()` before calling `OnCoreDeviceInitialized()` — and `InitializeAsync` internally does the exact same thing: sends `GetDeviceInfo`, waits for `ChannelsPopulated`, re-sends every 1s, and throws `TimeoutException` after 8s (identical defaults to the loop being removed).
- By the time `OnCoreDeviceInitialized` ran, initialization had already succeeded or `Connect()` had already failed via the exception path — the serial-specific loop was pure dead-weight duplication.
- Removed `OnCoreDeviceInitialized`, `OnCoreChannelsPopulated` overrides, the `_initialStatusReceivedSource` completion source, and the three timeout/interval constants. Serial now falls through to the base (no-op) `OnCoreDeviceInitialized`, matching the WiFi device's existing pattern.
- `LogConnectFailure`'s `TimeoutException` case is untouched — Core's `InitializeAsync` throws the same exception type with an equivalent message, so the existing warning-level classification (issue #517, #632) still applies correctly.

Closes #618

## Test plan
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 545 passed, 0 failed
- [x] `dotnet test Daqifi.Desktop.UITest --filter "FullyQualifiedName~ManualSerialConnectTests"` against a physically attached DAQiFi device on COM3 — all 3 tests passed, including `ManualSerial_RealDevicePort_Connects` which drives a real end-to-end serial connect through the new code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)