### PR TITLE
chore: delegate stream-frame decoding to Core's per-channel sample pipeline

### DIFF
--- a/Daqifi.Desktop.Test/Device/ChannelDataMappingTests.cs
+++ b/Daqifi.Desktop.Test/Device/ChannelDataMappingTests.cs
@@ -1,72 +1,60 @@
+using System.Linq;
 using Daqifi.Desktop.Channel;
-using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
 using ChannelType = Daqifi.Core.Channel.ChannelType;
 using Daqifi.Desktop.Device;
-using CoreAnalogChannel = Daqifi.Core.Channel.AnalogChannel;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
 
 namespace Daqifi.Desktop.Test.Device;
 
+/// <summary>
+/// Verifies analog stream decode maps device data to the correct channel regardless of which
+/// subset of channels is active (issue #663 predecessor coverage). Channel decoding itself is
+/// delegated to Core's <c>DaqifiStreamingDevice</c> (issue #613), so these tests route frames
+/// through both halves of the real production pipeline: the desktop's own gating/dispatch
+/// (<c>HandleInboundMessage</c>) and Core's decode step
+/// (<see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>) — in that synchronous order, exactly
+/// as Core's actual <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in
+/// production.
+/// </summary>
 [TestClass]
 public class ChannelDataMappingTests
 {
-    private TestableStreamingDevice _device;
+    // Large enough to cover every analog channel index exercised below.
+    private const int ANALOG_PORT_COUNT = 3;
+
+    private ChannelMappingTestDevice _device;
 
     [TestInitialize]
     public void Setup()
     {
-        _device = new TestableStreamingDevice();
-
-        // Create Core channels with calibration values, then wrap with Desktop channels
-        var coreChannel0 = new CoreAnalogChannel(0, 4096)
-        {
-            Name = "AI0",
-            Direction = ChannelDirection.Input,
-            CalibrationB = 0.0,
-            CalibrationM = 1.0,
-            InternalScaleM = 1.0,
-            PortRange = 5.0
-        };
-        var coreChannel1 = new CoreAnalogChannel(1, 4096)
-        {
-            Name = "AI1",
-            Direction = ChannelDirection.Input,
-            CalibrationB = 0.0,
-            CalibrationM = 1.0,
-            InternalScaleM = 1.0,
-            PortRange = 5.0
-        };
-        var coreChannel2 = new CoreAnalogChannel(2, 4096)
-        {
-            Name = "AI2",
-            Direction = ChannelDirection.Input,
-            CalibrationB = 0.0,
-            CalibrationM = 1.0,
-            InternalScaleM = 1.0,
-            PortRange = 5.0
-        };
-
-        _device.DataChannels.Add(new AnalogChannel(_device, coreChannel0));
-        _device.DataChannels.Add(new AnalogChannel(_device, coreChannel1));
-        _device.DataChannels.Add(new AnalogChannel(_device, coreChannel2));
+        _device = new ChannelMappingTestDevice(ANALOG_PORT_COUNT);
     }
+
+    private AnalogChannel ConfigureAnalogChannel(int index, bool isActive = true)
+    {
+        var channel = (AnalogChannel)_device.DataChannels.Single(
+            c => c.Type == ChannelType.Analog && c.Index == index);
+        channel.IsActive = isActive;
+        return channel;
+    }
+
+    private void RouteMessage(DaqifiOutMessage message) => _device.RouteStreamFrame(message);
 
     [TestMethod]
     public void SingleChannel_AI1_ShouldReceiveCorrectData()
     {
-        // This test demonstrates the current bug where AI1 alone doesn't receive data
-        
         // Arrange
-        var channel1 = _device.DataChannels[1] as AnalogChannel;
-        channel1.IsActive = true; // Only AI1 is active
-        
+        var channel1 = ConfigureAnalogChannel(1); // Only AI1 is active
+
         var message = CreateTestMessage();
-        message.AnalogInData.Add(5); // Device sends 5V for the single active channel
-        
+        message.AnalogInDataFloat.Add(5); // Device sends 5V for the single active channel
+
         // Act
-        _device.TestHandleStreamingMessage(message);
-        
+        RouteMessage(message);
+
         // Assert
-        // This test will FAIL with current implementation because the data mapping is incorrect
         Assert.IsNotNull(channel1.ActiveSample, "AI1 should receive data when it's the only active channel");
         Assert.AreEqual(5.0, channel1.ActiveSample.Value, 0.01, "AI1 should show 5V");
     }
@@ -74,20 +62,16 @@ public class ChannelDataMappingTests
     [TestMethod]
     public void SingleChannel_AI2_ShouldReceiveCorrectData()
     {
-        // This test demonstrates the current bug where AI2 alone doesn't receive data
-        
         // Arrange
-        var channel2 = _device.DataChannels[2] as AnalogChannel;
-        channel2.IsActive = true; // Only AI2 is active
-        
+        var channel2 = ConfigureAnalogChannel(2); // Only AI2 is active
+
         var message = CreateTestMessage();
-        message.AnalogInData.Add(5); // Device sends 5V for the single active channel
-        
+        message.AnalogInDataFloat.Add(5); // Device sends 5V for the single active channel
+
         // Act
-        _device.TestHandleStreamingMessage(message);
-        
+        RouteMessage(message);
+
         // Assert
-        // This test will FAIL with current implementation
         Assert.IsNotNull(channel2.ActiveSample, "AI2 should receive data when it's the only active channel");
         Assert.AreEqual(5.0, channel2.ActiveSample.Value, 0.01, "AI2 should show 5V");
     }
@@ -95,22 +79,17 @@ public class ChannelDataMappingTests
     [TestMethod]
     public void MultipleChannels_AI0AndAI1_ShouldReceiveCorrectData()
     {
-        // This test should pass with current implementation
-        
         // Arrange
-        var channel0 = _device.DataChannels[0] as AnalogChannel;
-        var channel1 = _device.DataChannels[1] as AnalogChannel;
-        
-        channel0.IsActive = true;
-        channel1.IsActive = true;
-        
+        var channel0 = ConfigureAnalogChannel(0);
+        var channel1 = ConfigureAnalogChannel(1);
+
         var message = CreateTestMessage();
-        message.AnalogInData.Add(5); // Data for first active channel (AI0)
-        message.AnalogInData.Add(3); // Data for second active channel (AI1)
-        
+        message.AnalogInDataFloat.Add(5); // Data for first active channel (AI0)
+        message.AnalogInDataFloat.Add(3); // Data for second active channel (AI1)
+
         // Act
-        _device.TestHandleStreamingMessage(message);
-        
+        RouteMessage(message);
+
         // Assert
         Assert.IsNotNull(channel0.ActiveSample, "AI0 should receive data");
         Assert.AreEqual(5.0, channel0.ActiveSample.Value, 0.01, "AI0 should show 5V");
@@ -122,27 +101,21 @@ public class ChannelDataMappingTests
     [TestMethod]
     public void MultipleChannels_AI0AndAI2_ShouldReceiveCorrectData()
     {
-        // This test demonstrates the issue where AI2 doesn't receive data when paired with AI0
-        
-        // Arrange
-        var channel0 = _device.DataChannels[0] as AnalogChannel;
-        var channel2 = _device.DataChannels[2] as AnalogChannel;
-        
-        channel0.IsActive = true;
-        channel2.IsActive = true;
-        
+        // Arrange — activating a non-consecutive subset (skipping AI1)
+        var channel0 = ConfigureAnalogChannel(0);
+        var channel2 = ConfigureAnalogChannel(2);
+
         var message = CreateTestMessage();
-        message.AnalogInData.Add(5); // Data for first active channel (AI0)
-        message.AnalogInData.Add(3); // Data for second active channel (AI2)
-        
+        message.AnalogInDataFloat.Add(5); // Data for first active channel (AI0)
+        message.AnalogInDataFloat.Add(3); // Data for second active channel (AI2)
+
         // Act
-        _device.TestHandleStreamingMessage(message);
-        
+        RouteMessage(message);
+
         // Assert
         Assert.IsNotNull(channel0.ActiveSample, "AI0 should receive data");
         Assert.AreEqual(5.0, channel0.ActiveSample.Value, 0.01, "AI0 should show 5V");
-        
-        // This assertion will FAIL with current implementation
+
         Assert.IsNotNull(channel2.ActiveSample, "AI2 should receive data");
         Assert.AreEqual(3.0, channel2.ActiveSample.Value, 0.01, "AI2 should show 3V");
     }
@@ -150,70 +123,48 @@ public class ChannelDataMappingTests
     [TestMethod]
     public void ChannelOrderingAssumption_ShouldMatchDeviceDataOrder()
     {
-        // This test verifies our assumption about how the device sends data
-        // The device should send data in channel index order, not in the order channels are activated
-        
         // Arrange - Activate channels in reverse order: AI2, AI1, AI0
-        var channel0 = _device.DataChannels[0] as AnalogChannel;
-        var channel1 = _device.DataChannels[1] as AnalogChannel;
-        var channel2 = _device.DataChannels[2] as AnalogChannel;
-        
-        // Activate in reverse order
-        channel2.IsActive = true;
-        channel1.IsActive = true;
-        channel0.IsActive = true;
-        
+        var channel2 = ConfigureAnalogChannel(2);
+        var channel1 = ConfigureAnalogChannel(1);
+        var channel0 = ConfigureAnalogChannel(0);
+
         var message = CreateTestMessage();
-        // If device sends data in channel index order (0, 1, 2), then:
-        message.AnalogInData.Add(1); // Should go to AI0 (index 0)
-        message.AnalogInData.Add(2); // Should go to AI1 (index 1)
-        message.AnalogInData.Add(3); // Should go to AI2 (index 2)
-        
+        // The device sends data in channel index order (0, 1, 2), not activation order
+        message.AnalogInDataFloat.Add(1); // Should go to AI0 (index 0)
+        message.AnalogInDataFloat.Add(2); // Should go to AI1 (index 1)
+        message.AnalogInDataFloat.Add(3); // Should go to AI2 (index 2)
+
         // Act
-        _device.TestHandleStreamingMessage(message);
-        
-        // Assert - If device sends in index order, each channel should get its expected value
+        RouteMessage(message);
+
+        // Assert
         Assert.IsNotNull(channel0.ActiveSample, "AI0 should receive data");
         Assert.AreEqual(1.0, channel0.ActiveSample.Value, 0.01, "AI0 should receive first data value (1.0V)");
-        
+
         Assert.IsNotNull(channel1.ActiveSample, "AI1 should receive data");
         Assert.AreEqual(2.0, channel1.ActiveSample.Value, 0.01, "AI1 should receive second data value (2.0V)");
-        
+
         Assert.IsNotNull(channel2.ActiveSample, "AI2 should receive data");
         Assert.AreEqual(3.0, channel2.ActiveSample.Value, 0.01, "AI2 should receive third data value (3.0V)");
     }
 
     [TestMethod]
-    public void CurrentImplementation_ShowsIncorrectMapping()
+    public void InactiveChannel_GetsNoSample()
     {
-        // This test demonstrates how the current implementation incorrectly maps data
-        
-        // Arrange - Activate AI1 and AI2 (skipping AI0)
-        var channel1 = _device.DataChannels[1] as AnalogChannel;
-        var channel2 = _device.DataChannels[2] as AnalogChannel;
-        
-        channel1.IsActive = true;
-        channel2.IsActive = true;
-        
+        // Arrange — activate AI1 and AI2 (skipping AI0), which stays inactive
+        var channel0 = ConfigureAnalogChannel(0, isActive: false);
+        ConfigureAnalogChannel(1);
+        ConfigureAnalogChannel(2);
+
         var message = CreateTestMessage();
-        // Device sends data for channels 1 and 2 in index order
-        message.AnalogInData.Add(2); // Data for AI1 (index 1)
-        message.AnalogInData.Add(3); // Data for AI2 (index 2)
-        
+        message.AnalogInDataFloat.Add(2); // AI1
+        message.AnalogInDataFloat.Add(3); // AI2
+
         // Act
-        _device.TestHandleStreamingMessage(message);
-        
-        // Current implementation will assign data based on active channel order:
-        // - First active channel (AI1) gets first data value (1.5) ✓ Correct
-        // - Second active channel (AI2) gets second data value (2.5) ✓ Correct
-        
-        // But if we had AI0 and AI2 active (skipping AI1):
-        // - Device would send data for indices 0 and 2
-        // - Current code would assign first data to AI0 ✓ and second data to AI2 ✓
-        // This works by coincidence when channels are consecutive
-        
-        Assert.IsNotNull(channel1.ActiveSample, "AI1 should receive data");
-        Assert.IsNotNull(channel2.ActiveSample, "AI2 should receive data");
+        RouteMessage(message);
+
+        // Assert
+        Assert.IsNull(channel0.ActiveSample, "An inactive channel must not receive a sample");
     }
 
     [TestMethod]
@@ -221,14 +172,13 @@ public class ChannelDataMappingTests
     {
         // USB firmware sends AnalogInDataFloat (pre-scaled volts) instead of AnalogInData (raw ADC counts)
         // Arrange
-        var channel0 = _device.DataChannels[0] as AnalogChannel;
-        channel0.IsActive = true;
+        var channel0 = ConfigureAnalogChannel(0);
 
         var message = CreateTestMessage();
         message.AnalogInDataFloat.Add(2.75f); // Pre-scaled: 2.75 V already
 
         // Act
-        _device.TestHandleStreamingMessage(message);
+        RouteMessage(message);
 
         // Assert
         Assert.IsNotNull(channel0.ActiveSample, "AI0 should receive data from AnalogInDataFloat");
@@ -239,18 +189,15 @@ public class ChannelDataMappingTests
     public void FloatData_MultipleChannels_ShouldReceivePreScaledValues()
     {
         // Arrange
-        var channel0 = _device.DataChannels[0] as AnalogChannel;
-        var channel1 = _device.DataChannels[1] as AnalogChannel;
-
-        channel0.IsActive = true;
-        channel1.IsActive = true;
+        var channel0 = ConfigureAnalogChannel(0);
+        var channel1 = ConfigureAnalogChannel(1);
 
         var message = CreateTestMessage();
         message.AnalogInDataFloat.Add(1.1f); // AI0
         message.AnalogInDataFloat.Add(3.3f); // AI1
 
         // Act
-        _device.TestHandleStreamingMessage(message);
+        RouteMessage(message);
 
         // Assert
         Assert.IsNotNull(channel0.ActiveSample, "AI0 should receive data");
@@ -260,7 +207,25 @@ public class ChannelDataMappingTests
         Assert.AreEqual(3.3, channel1.ActiveSample.Value, 0.001, "AI1 should show 3.3V");
     }
 
-    private DaqifiOutMessage CreateTestMessage()
+    [TestMethod]
+    public void RawData_AppliesChannelCalibration()
+    {
+        // Arrange — WiFi firmware sends raw ADC counts; Core applies each channel's calibration.
+        var channel0 = ConfigureAnalogChannel(0);
+
+        var message = CreateTestMessage();
+        message.AnalogInData.Add(2048); // Half of the 4095 resolution configured below
+
+        // Act
+        RouteMessage(message);
+
+        // Assert — resolution 4095, PortRange 5.0, CalibrationM/InternalScaleM 1.0, CalibrationB 0.0
+        // (see ChannelMappingTestDevice's status message), so 2048/4095*5.0 ≈ 2.5003V
+        Assert.IsNotNull(channel0.ActiveSample, "AI0 should receive calibrated data");
+        Assert.AreEqual(2.5, channel0.ActiveSample.Value, 0.01, "AI0 should apply channel calibration to the raw count");
+    }
+
+    private static DaqifiOutMessage CreateTestMessage()
     {
         return new DaqifiOutMessage
         {
@@ -269,61 +234,91 @@ public class ChannelDataMappingTests
             DeviceFwRev = "1.0.0"
         };
     }
-}
 
-// Test implementation of AbstractStreamingDevice to expose protected methods
-public class TestableStreamingDevice : AbstractStreamingDevice
-{
-    public override ConnectionType ConnectionType => ConnectionType.Usb;
-
-    public override bool Connect() => true;
-    public override bool Disconnect() => true;
-    public override bool Write(string command) => true;
-
-    protected override void SendMessage(Daqifi.Core.Communication.Messages.IOutboundMessage<string> message) { }
-
-    // Expose protected methods for testing
-    public void TestHandleStreamingMessage(DaqifiOutMessage message)
+    /// <summary>
+    /// Test device exposing the real inbound-message pipeline (protocol handler → stream
+    /// routing → Core decode → per-channel SampleReceived → desktop DataSample mapping).
+    /// </summary>
+    private sealed class ChannelMappingTestDevice : AbstractStreamingDevice
     {
-        // Set IsStreaming to true so the method processes the message
-        IsStreaming = true;
+        private readonly TestCoreStreamingDevice _coreDevice;
 
-        // Directly test the data mapping logic without going through the full message handling
-        TestDirectDataMapping(message);
+        public ChannelMappingTestDevice(int analogPortCount)
+        {
+            _coreDevice = new TestCoreStreamingDevice();
+            _coreDevice.Connect();
+
+            var statusMessage = new DaqifiOutMessage
+            {
+                DevicePn = "Nq1",
+                DeviceSn = 12345,
+                DeviceFwRev = "1.0.0",
+                AnalogInPortNum = (uint)analogPortCount,
+                AnalogInRes = 4095,
+            };
+            for (var i = 0; i < analogPortCount; i++)
+            {
+                statusMessage.AnalogInCalM.Add(1.0f);
+                statusMessage.AnalogInCalB.Add(0.0f);
+                statusMessage.AnalogInIntScaleM.Add(1.0f);
+                statusMessage.AnalogInPortRange.Add(5.0f);
+            }
+
+            _coreDevice.Metadata.UpdateFromProtobuf(statusMessage);
+            _coreDevice.PopulateChannelsFromStatus(statusMessage);
+
+            // Wires the desktop AnalogChannel wrappers around Core's actual channel instances
+            // (including the SampleReceived subscription installed by SyncChannelsFromCore).
+            SyncFromCoreDevice(_coreDevice);
+
+            InitializeDeviceState();
+
+            _coreDevice.StreamingFrequency = 1;
+            _coreDevice.StartStreaming();
+            IsStreaming = true;
+        }
+
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        protected override CoreStreamingDevice? CoreDeviceForStreaming => _coreDevice;
+
+        public override bool Connect() => true;
+
+        public override bool Disconnect() => true;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+
+        protected override void DispatchDeviceMessage(DeviceMessage deviceMessage)
+        {
+            // The logging pipeline needs the application service provider, which unit tests don't have.
+        }
+
+        /// <summary>
+        /// Routes a raw frame through both halves of the real production pipeline: the desktop's
+        /// own gating/dispatch (<c>HandleInboundMessage</c>) and Core's decode step
+        /// (<see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>) — in that order, exactly as
+        /// Core's actual <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in
+        /// production (base call raises <c>MessageReceived</c> before Core decodes).
+        /// </summary>
+        public void RouteStreamFrame(DaqifiOutMessage message)
+        {
+            HandleInboundMessage(
+                new MessageReceivedEventArgs(
+                    new GenericInboundMessage<object>(message)));
+            _coreDevice.SimulateStreamFrame(message);
+        }
     }
 
-    private void TestDirectDataMapping(DaqifiOutMessage message)
+    private sealed class TestCoreStreamingDevice() : CoreStreamingDevice("TestDevice")
     {
-        // Mirrors the logic in AbstractStreamingDevice.OnStreamMessageReceived
-        var messageTimestamp = DateTime.Now;
-        // USB firmware sends pre-scaled floats; WiFi sends raw ADC counts
-        var hasFloatData = message.AnalogInDataFloat.Count > 0;
-        var hasAnalogData = message.AnalogInData.Count > 0 || hasFloatData;
-
-        if (hasAnalogData)
+        public override void Send<T>(IOutboundMessage<T> message)
         {
-            var activeAnalogChannels = DataChannels.Where(c => c.IsActive && c.Type == ChannelType.Analog)
-                                                  .Cast<AnalogChannel>()
-                                                  .OrderBy(c => c.Index)
-                                                  .ToList();
-
-            var dataCount = hasFloatData ? message.AnalogInDataFloat.Count : message.AnalogInData.Count;
-
-            for (var dataIndex = 0; dataIndex < dataCount && dataIndex < activeAnalogChannels.Count; dataIndex++)
-            {
-                var channel = activeAnalogChannels[dataIndex];
-                double scaledValue;
-                if (hasFloatData)
-                {
-                    scaledValue = message.AnalogInDataFloat[dataIndex]; // already in volts
-                }
-                else
-                {
-                    scaledValue = Convert.ToDouble(message.AnalogInData[dataIndex]);
-                }
-                var sample = new DataSample(this, channel, messageTimestamp, scaledValue);
-                channel.ActiveSample = sample;
-            }
         }
+
+        public void SimulateStreamFrame(DaqifiOutMessage message) => OnStreamMessageReceived(message);
     }
 }

--- a/Daqifi.Desktop.Test/Device/DigitalChannelStreamDecodeTests.cs
+++ b/Daqifi.Desktop.Test/Device/DigitalChannelStreamDecodeTests.cs
@@ -1,10 +1,12 @@
+using System.Linq;
 using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Device;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
 using Google.Protobuf;
 using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
-using CoreDigitalChannel = Daqifi.Core.Channel.DigitalChannel;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
 
 namespace Daqifi.Desktop.Test.Device;
 
@@ -13,39 +15,38 @@ namespace Daqifi.Desktop.Test.Device;
 /// active-channel list (issue #663). The firmware streams the whole DIO port as a raw
 /// pin-state snapshot — bit N is pin N regardless of which channels are enabled — so
 /// enabling a subset of digital channels must still read the correct pins.
-/// These tests route messages through the real inbound pipeline, not a copy of the logic.
+/// Channel decoding itself is delegated to Core's <c>DaqifiStreamingDevice</c> (issue #613), so
+/// these tests route frames through both the real desktop gating pipeline
+/// (<see cref="DecodeTestDevice.RouteStreamFrame"/> calls <c>HandleInboundMessage</c>) and Core's
+/// real decode step (via <see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>), exactly
+/// mirroring the synchronous order Core's actual message pump uses in production.
 /// </summary>
 [TestClass]
 public class DigitalChannelStreamDecodeTests
 {
+    // Large enough to cover every digital channel index exercised below (up to DIO9).
+    private const int DIGITAL_PORT_COUNT = 16;
+
     private DecodeTestDevice _device;
 
     [TestInitialize]
     public void Setup()
     {
-        _device = new DecodeTestDevice();
-        _device.InitializeDeviceState();
-        _device.IsStreaming = true;
+        _device = new DecodeTestDevice(DIGITAL_PORT_COUNT);
     }
 
-    private DigitalChannel AddDigitalChannel(int index, ChannelDirection direction, bool isActive = true)
+    private DigitalChannel ConfigureDigitalChannel(int index, ChannelDirection direction, bool isActive = true)
     {
-        var coreChannel = new CoreDigitalChannel(index)
-        {
-            Name = $"DIO{index}",
-            Direction = direction
-        };
-        var channel = new DigitalChannel(_device, coreChannel)
-        {
-            IsActive = isActive
-        };
-        _device.DataChannels.Add(channel);
+        var channel = (DigitalChannel)_device.DataChannels.Single(
+            c => c.Type == ChannelType.Digital && c.Index == index);
+        channel.Direction = direction;
+        channel.IsActive = isActive;
         return channel;
     }
 
     private void RouteDigitalData(params byte[] portSnapshot)
     {
-        _device.RouteInboundMessage(new DaqifiOutMessage
+        _device.RouteStreamFrame(new DaqifiOutMessage
         {
             MsgTimeStamp = 1000,
             DeviceSn = 12345,
@@ -58,7 +59,7 @@ public class DigitalChannelStreamDecodeTests
     public void SubsetChannel_DIO4_ReadsItsOwnPinBit()
     {
         // Arrange — only DIO4 enabled. Positional mapping would read bit 0.
-        var dio4 = AddDigitalChannel(4, ChannelDirection.Input);
+        var dio4 = ConfigureDigitalChannel(4, ChannelDirection.Input);
 
         // Act — pin 4 high, pin 0 low
         RouteDigitalData(0b0001_0000);
@@ -72,7 +73,7 @@ public class DigitalChannelStreamDecodeTests
     public void SubsetChannel_DIO4_DoesNotReadPin0State()
     {
         // Arrange — only DIO4 enabled. The old positional decode read bit 0 here.
-        var dio4 = AddDigitalChannel(4, ChannelDirection.Input);
+        var dio4 = ConfigureDigitalChannel(4, ChannelDirection.Input);
 
         // Act — pin 0 high, pin 4 low
         RouteDigitalData(0b0000_0001);
@@ -86,8 +87,8 @@ public class DigitalChannelStreamDecodeTests
     public void NonConsecutiveSubset_EachChannelReadsItsOwnPin()
     {
         // Arrange
-        var dio1 = AddDigitalChannel(1, ChannelDirection.Input);
-        var dio3 = AddDigitalChannel(3, ChannelDirection.Input);
+        var dio1 = ConfigureDigitalChannel(1, ChannelDirection.Input);
+        var dio3 = ConfigureDigitalChannel(3, ChannelDirection.Input);
 
         // Act — pin 1 low, pin 3 high
         RouteDigitalData(0b0000_1000);
@@ -103,7 +104,7 @@ public class DigitalChannelStreamDecodeTests
     public void HighChannel_DIO9_ReadsSecondPayloadByte()
     {
         // Arrange — a channel above pin 7 alone; its bit lives in payload byte 1
-        var dio9 = AddDigitalChannel(9, ChannelDirection.Input);
+        var dio9 = ConfigureDigitalChannel(9, ChannelDirection.Input);
 
         // Act — pin 9 high (byte 1, bit 1)
         RouteDigitalData(0b0000_0000, 0b0000_0010);
@@ -117,7 +118,7 @@ public class DigitalChannelStreamDecodeTests
     public void ChannelBeyondPayload_GetsNoSample()
     {
         // Arrange — DIO9 needs payload byte 1, but the device only streamed one byte
-        var dio9 = AddDigitalChannel(9, ChannelDirection.Input);
+        var dio9 = ConfigureDigitalChannel(9, ChannelDirection.Input);
 
         // Act
         RouteDigitalData(0b1111_1111);
@@ -130,7 +131,7 @@ public class DigitalChannelStreamDecodeTests
     public void OutputDirectionChannel_GetsNoStreamedSample()
     {
         // Arrange — output channels display the commanded state, not streamed data
-        var dio0 = AddDigitalChannel(0, ChannelDirection.Output);
+        var dio0 = ConfigureDigitalChannel(0, ChannelDirection.Output);
 
         // Act
         RouteDigitalData(0b0000_0001);
@@ -143,7 +144,7 @@ public class DigitalChannelStreamDecodeTests
     public void InactiveChannel_GetsNoSample()
     {
         // Arrange
-        var dio2 = AddDigitalChannel(2, ChannelDirection.Input, isActive: false);
+        var dio2 = ConfigureDigitalChannel(2, ChannelDirection.Input, isActive: false);
 
         // Act — pin 2 high, but the channel is not enabled
         RouteDigitalData(0b0000_0100);
@@ -153,12 +154,42 @@ public class DigitalChannelStreamDecodeTests
     }
 
     /// <summary>
-    /// Test device exposing the real inbound-message pipeline
-    /// (protocol handler → stream routing → decode).
+    /// Test device exposing the real inbound-message pipeline (protocol handler → stream
+    /// routing → Core decode → per-channel SampleReceived → desktop DataSample mapping).
     /// </summary>
     private sealed class DecodeTestDevice : AbstractStreamingDevice
     {
+        private readonly TestCoreStreamingDevice _coreDevice;
+
+        public DecodeTestDevice(int digitalPortCount)
+        {
+            _coreDevice = new TestCoreStreamingDevice();
+            _coreDevice.Connect();
+
+            var statusMessage = new DaqifiOutMessage
+            {
+                DevicePn = "Nq1",
+                DeviceSn = 12345,
+                DeviceFwRev = "1.0.0",
+                DigitalPortNum = (uint)digitalPortCount
+            };
+            _coreDevice.Metadata.UpdateFromProtobuf(statusMessage);
+            _coreDevice.PopulateChannelsFromStatus(statusMessage);
+
+            // Wires the desktop DigitalChannel wrappers around Core's actual channel instances
+            // (including the SampleReceived subscription installed by SyncChannelsFromCore).
+            SyncFromCoreDevice(_coreDevice);
+
+            InitializeDeviceState();
+
+            _coreDevice.StreamingFrequency = 1;
+            _coreDevice.StartStreaming();
+            IsStreaming = true;
+        }
+
         public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        protected override CoreStreamingDevice? CoreDeviceForStreaming => _coreDevice;
 
         public override bool Connect() => true;
 
@@ -175,11 +206,28 @@ public class DigitalChannelStreamDecodeTests
             // The logging pipeline needs the application service provider, which unit tests don't have.
         }
 
-        public void RouteInboundMessage(DaqifiOutMessage message)
+        /// <summary>
+        /// Routes a raw frame through both halves of the real production pipeline: the desktop's
+        /// own gating/dispatch (<c>HandleInboundMessage</c>) and Core's decode step
+        /// (<see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>) — in that order, exactly as
+        /// Core's actual <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in
+        /// production (base call raises <c>MessageReceived</c> before Core decodes).
+        /// </summary>
+        public void RouteStreamFrame(DaqifiOutMessage message)
         {
             HandleInboundMessage(
                 new MessageReceivedEventArgs(
                     new GenericInboundMessage<object>(message)));
+            _coreDevice.SimulateStreamFrame(message);
         }
+    }
+
+    private sealed class TestCoreStreamingDevice() : CoreStreamingDevice("TestDevice")
+    {
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+
+        public void SimulateStreamFrame(DaqifiOutMessage message) => OnStreamMessageReceived(message);
     }
 }

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -114,6 +114,30 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     private IProtocolHandler? _protocolHandler;
 
     /// <summary>
+    /// Per-channel subscriptions onto Core's decode pipeline (issue #613). Core's
+    /// <c>DaqifiStreamingDevice</c> decodes every raw stream frame into per-channel samples and
+    /// raises <see cref="Daqifi.Core.Channel.IChannel.SampleReceived"/> automatically whenever its
+    /// own <c>IsStreaming</c> flag is set — independent of the leftover-frame/first-frame gating
+    /// below. Keyed by the desktop channel wrapper (stable across <c>ReplaceCoreChannel</c> calls)
+    /// so the handler on the previous Core channel instance can be found and removed.
+    /// </summary>
+    private readonly Dictionary<IChannel, EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs>> _channelSampleHandlers = new();
+
+    /// <summary>
+    /// Gate for <see cref="OnCoreChannelSampleReceived"/>: true only while the raw frame Core is
+    /// currently decoding is one <see cref="ProcessStreamMessage"/> just accepted. Core calls its
+    /// decode step synchronously, immediately after the <c>MessageReceived</c> event that reaches
+    /// <see cref="OnStreamMessageReceived"/> returns — so setting this at the end of
+    /// <see cref="ProcessStreamMessage"/> reliably covers Core's decode of that same frame.
+    /// Frames rejected by leftover-frame/first-frame validation never call
+    /// <see cref="ProcessStreamMessage"/>, so Core still decodes and broadcasts their samples, but
+    /// this gate keeps them from reaching the desktop's channels.
+    /// </summary>
+    private bool _acceptChannelSamples;
+    private DateTime _currentFrameTimestamp;
+    private double? _currentFrameFirmwareDeltaMs;
+
+    /// <summary>
     /// The Core streaming device created by the shared <see cref="Connect"/> template,
     /// or null while disconnected.
     /// </summary>
@@ -382,6 +406,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
             // Clear channels to prevent ghost channels on reconnect (Issue #29)
             AppLogger.Information($"Cleared {DataChannels.Count} channels for device {DeviceSerialNo}");
+            UnsubscribeAllChannelSamples();
             DataChannels.Clear();
 
             CleanupConnection();
@@ -620,6 +645,10 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     private void OnStreamMessageReceived(DaqifiOutMessage message)
     {
+        // Closed by default for every frame; only ProcessStreamMessage (reached below when this
+        // frame is accepted) opens it for Core's immediately-following decode of this same frame.
+        _acceptChannelSamples = false;
+
         // Belt-and-suspenders: firmware's fast streaming-frame encoder (Nanopb_EncodeStreamingFast)
         // hardcodes only msg_time_stamp/analog_in_data/digital_data/digital_port_dir — it never
         // includes friendly_device_name — so in practice this never fires from a real Stream
@@ -657,9 +686,17 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     }
 
     /// <summary>
-    /// Processes a validated streaming frame: computes its timestamp, updates channel samples,
-    /// and dispatches the device message to the logging pipeline.
+    /// Processes a validated streaming frame: computes its timestamp, opens the gate that lets
+    /// Core's per-channel decode of this same frame reach the desktop's channels (see
+    /// <see cref="_acceptChannelSamples"/>), and dispatches the device message to the logging
+    /// pipeline.
     /// </summary>
+    /// <remarks>
+    /// Channel decoding itself — active-channel ordering, the USB-float-vs-WiFi-raw branch, and
+    /// digital bit unpacking — is delegated to Core's <c>DaqifiStreamingDevice</c> (issue #613):
+    /// <see cref="OnCoreChannelSampleReceived"/> maps its decoded <c>IDataSample</c> into the
+    /// desktop's richer <see cref="DataSample"/> using this frame's timestamp/delta.
+    /// </remarks>
     /// <param name="message">The streaming protobuf message to process.</param>
     private void ProcessStreamMessage(DaqifiOutMessage message)
     {
@@ -679,105 +716,28 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             ? (double?)null
             : timestampResult.SecondsBetweenMessages * 1000.0;
 
-        var digitalCount = 0;
-        var analogCount = 0;
+        // Open the gate for Core's decode of this exact frame, which runs synchronously right
+        // after this method returns (see _acceptChannelSamples).
+        _currentFrameTimestamp = messageTimestamp;
+        _currentFrameFirmwareDeltaMs = firmwareDeltaMs;
+        _acceptChannelSamples = true;
 
-        var hasDigitalData = message.DigitalData.Length > 0;
-        // USB firmware sends pre-scaled floats (AnalogInDataFloat); WiFi sends raw ADC counts (AnalogInData).
-        var hasAnalogData = message.AnalogInData.Count > 0 || message.AnalogInDataFloat.Count > 0;
-
-        // Process analog channels - device sends data in channel index order, not activation order
-        if (hasAnalogData)
+        if (IsDebugModeEnabled && (message.AnalogInData.Count > 0 || message.AnalogInDataFloat.Count > 0))
         {
-            try
-            {
-                var activeAnalogChannels = DataChannels.Where(c => c.IsActive && c.Type == ChannelType.Analog)
-                                                      .Cast<AnalogChannel>()
-                                                      .OrderBy(c => c.Index)
-                                                      .ToList();
-
-                // USB firmware sends pre-scaled float values (already in volts); use them directly.
-                // WiFi firmware sends raw integer ADC counts; apply channel calibration scaling.
-                var hasFloatData = message.AnalogInDataFloat.Count > 0;
-                var dataCount = hasFloatData ? message.AnalogInDataFloat.Count : message.AnalogInData.Count;
-
-                for (var dataIndex = 0; dataIndex < dataCount && dataIndex < activeAnalogChannels.Count; dataIndex++)
-                {
-                    var channel = activeAnalogChannels[dataIndex];
-                    double scaledValue;
-                    if (hasFloatData)
-                    {
-                        // Float values are already voltage-scaled by the firmware — no calibration needed
-                        scaledValue = message.AnalogInDataFloat[dataIndex];
-                    }
-                    else
-                    {
-                        // Raw ADC count — apply channel calibration/scaling via Core
-                        scaledValue = channel.GetScaledValue((int)message.AnalogInData[dataIndex]);
-                    }
-
-                    var sample = new DataSample(this, channel, messageTimestamp, scaledValue, firmwareDeltaMs);
-                    channel.ActiveSample = sample;
-                }
-
-                if (dataCount != activeAnalogChannels.Count)
-                {
-                    AppLogger.Warning($"[CHANNEL_MAPPING] Analog data count mismatch: received {dataCount} data points for {activeAnalogChannels.Count} active channels");
-                }
-
-                // Send debug data if debug mode is enabled
-                SendDebugData(message, activeAnalogChannels, messageTimestamp);
-            }
-            catch (Exception ex)
-            {
-                AppLogger.Error($"[CHANNEL_MAPPING] Error processing analog channel data: {ex.Message}");
-            }
-        }
-
-        // Process digital channels. The firmware streams the whole DIO port as a raw pin-state
-        // snapshot — bit N is pin N regardless of which channels are enabled, because the
-        // wire-level DIO enable is port-global, not per pin — so bits are indexed by channel
-        // number, not by position in the active-channel list (issue #663).
-        if (hasDigitalData)
-        {
-            try
-            {
-                var activeDigitalChannels = DataChannels.Where(c => c.IsActive && c.Type == ChannelType.Digital)
-                                                       .OrderBy(c => c.Index)
-                                                       .ToList();
-
-                foreach (var channel in activeDigitalChannels)
-                {
-                    // Output-direction channels display the commanded state, not streamed data
-                    if (channel.Direction != ChannelDirection.Input)
-                    {
-                        continue;
-                    }
-
-                    var byteIndex = channel.Index / 8;
-                    if (channel.Index < 0 || byteIndex >= message.DigitalData.Length)
-                    {
-                        continue; // pin beyond the streamed payload: no sample
-                    }
-
-                    var bit = (message.DigitalData[byteIndex] & (1 << (channel.Index % 8))) != 0;
-                    channel.ActiveSample = new DataSample(
-                        this, channel, messageTimestamp, Convert.ToInt32(bit), firmwareDeltaMs);
-                }
-            }
-            catch (Exception ex)
-            {
-                AppLogger.Error($"Error processing digital channel data: {ex.Message}");
-            }
+            var activeAnalogChannels = DataChannels.Where(c => c.IsActive && c.Type == ChannelType.Analog)
+                                                    .Cast<AnalogChannel>()
+                                                    .OrderBy(c => c.Index)
+                                                    .ToList();
+            SendDebugData(message, activeAnalogChannels, messageTimestamp);
         }
 
         var deviceMessage = new DeviceMessage
         {
             DeviceName = Name,
-            AnalogChannelCount = analogCount,
+            AnalogChannelCount = 0,
             DeviceSerialNo = message.DeviceSn.ToString(CultureInfo.InvariantCulture),
             DeviceVersion = message.DeviceFwRev,
-            DigitalChannelCount = digitalCount,
+            DigitalChannelCount = 0,
             TimestampTicks = messageTimestamp.Ticks,
             AppTicks = DateTime.Now.Ticks,
             DeviceStatus = (int)message.DeviceStatus,
@@ -789,6 +749,54 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         };
 
         DispatchDeviceMessage(deviceMessage);
+    }
+
+    /// <summary>
+    /// Maps a sample Core's <c>DaqifiStreamingDevice</c> decoded from the current stream frame
+    /// into the desktop's richer <see cref="DataSample"/> (issue #613). Fires synchronously,
+    /// immediately after <see cref="ProcessStreamMessage"/> returns, for every enabled channel —
+    /// gated by <see cref="_acceptChannelSamples"/> so leftover/held frames (which Core still
+    /// decodes, since Core has no notion of the desktop's leftover-frame heuristics) never reach
+    /// desktop channels.
+    /// </summary>
+    private void OnCoreChannelSampleReceived(IChannel desktopChannel, Daqifi.Core.Channel.IDataSample coreSample)
+    {
+        if (!_acceptChannelSamples)
+        {
+            return;
+        }
+
+        desktopChannel.ActiveSample = new DataSample(
+            this, desktopChannel, _currentFrameTimestamp, coreSample.Value, _currentFrameFirmwareDeltaMs);
+    }
+
+    /// <summary>
+    /// Subscribes to a Core channel's <see cref="Daqifi.Core.Channel.IChannel.SampleReceived"/>,
+    /// routing decoded samples through <see cref="OnCoreChannelSampleReceived"/> for the given
+    /// desktop channel wrapper. Tracks the handler by desktop channel so
+    /// <see cref="UnsubscribeChannelSamples"/> can remove it later even after
+    /// <c>ReplaceCoreChannel</c> has swapped in a different Core channel instance.
+    /// </summary>
+    private void SubscribeChannelSamples(IChannel desktopChannel, Daqifi.Core.Channel.IChannel coreChannel)
+    {
+        EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs> handler =
+            (_, e) => OnCoreChannelSampleReceived(desktopChannel, e.Sample);
+        coreChannel.SampleReceived += handler;
+        _channelSampleHandlers[desktopChannel] = handler;
+    }
+
+    /// <summary>
+    /// Removes the subscription <see cref="SubscribeChannelSamples"/> installed for
+    /// <paramref name="desktopChannel"/> from <paramref name="coreChannel"/>. Must be called with
+    /// the same Core channel instance that was subscribed — callers replacing a channel's Core
+    /// backing must unsubscribe the old instance before rewiring the new one.
+    /// </summary>
+    private void UnsubscribeChannelSamples(IChannel desktopChannel, Daqifi.Core.Channel.IChannel coreChannel)
+    {
+        if (_channelSampleHandlers.Remove(desktopChannel, out var handler))
+        {
+            coreChannel.SampleReceived -= handler;
+        }
     }
 
     /// <summary>
@@ -1541,6 +1549,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     {
         var existingChannels = DataChannels.ToDictionary(GetChannelKey);
         var updatedChannels = new List<IChannel>(coreChannels.Count);
+        var handledExistingKeys = new HashSet<string>();
 
         foreach (var coreChannel in coreChannels)
         {
@@ -1548,21 +1557,26 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
             if (existingChannels.TryGetValue(channelKey, out var existingChannel))
             {
+                handledExistingKeys.Add(channelKey);
                 switch (existingChannel)
                 {
                     case AnalogChannel desktopAnalogChannel
                         when coreChannel is Daqifi.Core.Channel.IAnalogChannel coreAnalogChannel:
+                        UnsubscribeChannelSamples(desktopAnalogChannel, desktopAnalogChannel.CoreChannel);
                         desktopAnalogChannel.ReplaceCoreChannel(coreAnalogChannel);
                         desktopAnalogChannel.DeviceName = DevicePartNumber;
                         desktopAnalogChannel.DeviceSerialNo = DeviceSerialNo;
+                        SubscribeChannelSamples(desktopAnalogChannel, coreAnalogChannel);
                         updatedChannels.Add(desktopAnalogChannel);
                         continue;
 
                     case DigitalChannel desktopDigitalChannel
                         when coreChannel is Daqifi.Core.Channel.IDigitalChannel coreDigitalChannel:
+                        UnsubscribeChannelSamples(desktopDigitalChannel, desktopDigitalChannel.CoreChannel);
                         desktopDigitalChannel.ReplaceCoreChannel(coreDigitalChannel);
                         desktopDigitalChannel.DeviceName = DevicePartNumber;
                         desktopDigitalChannel.DeviceSerialNo = DeviceSerialNo;
+                        SubscribeChannelSamples(desktopDigitalChannel, coreDigitalChannel);
                         updatedChannels.Add(desktopDigitalChannel);
                         continue;
                 }
@@ -1571,12 +1585,47 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             var desktopChannel = CreateDesktopChannel(coreChannel);
             if (desktopChannel != null)
             {
+                SubscribeChannelSamples(desktopChannel, coreChannel);
                 updatedChannels.Add(desktopChannel);
+            }
+        }
+
+        // A channel present before this sync but absent from the new Core snapshot (e.g. a
+        // reconfigured channel count) still holds a subscription onto its old Core channel —
+        // remove it so a stale handler can't fire against a channel no longer in DataChannels.
+        foreach (var (key, oldChannel) in existingChannels)
+        {
+            if (handledExistingKeys.Contains(key))
+            {
+                continue;
+            }
+
+            var oldCoreChannel = GetCoreChannel(oldChannel);
+            if (oldCoreChannel != null)
+            {
+                UnsubscribeChannelSamples(oldChannel, oldCoreChannel);
             }
         }
 
         DataChannels.Clear();
         DataChannels.AddRange(updatedChannels);
+    }
+
+    /// <summary>
+    /// Unsubscribes every channel's Core-sample handler installed by
+    /// <see cref="SubscribeChannelSamples"/>. Called before <see cref="DataChannels"/> is cleared
+    /// so no stale handler outlives the channel it was wired to.
+    /// </summary>
+    private void UnsubscribeAllChannelSamples()
+    {
+        foreach (var channel in DataChannels)
+        {
+            var coreChannel = GetCoreChannel(channel);
+            if (coreChannel != null)
+            {
+                UnsubscribeChannelSamples(channel, coreChannel);
+            }
+        }
     }
 
     private IChannel? CreateDesktopChannel(Daqifi.Core.Channel.IChannel coreChannel)

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -121,7 +121,8 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// below. Keyed by the desktop channel wrapper (stable across <c>ReplaceCoreChannel</c> calls)
     /// so the handler on the previous Core channel instance can be found and removed.
     /// </summary>
-    private readonly Dictionary<IChannel, EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs>> _channelSampleHandlers = new();
+    private readonly Dictionary<IChannel, EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs>>
+        _channelSampleHandlers = new();
 
     /// <summary>
     /// Gate for <see cref="OnCoreChannelSampleReceived"/>: true only while the raw frame Core is


### PR DESCRIPTION
## Summary
Implements #613: removes the hand-rolled stream-frame demux in `ProcessStreamMessage` (`Daqifi.Desktop/Device/AbstractStreamingDevice.cs`) — active-channel ordering, the USB-float-vs-WiFi-raw branch, and digital bit unpacking — and delegates it to Core's per-channel sample pipeline (shipped in Core 1.0.0 / consumed since #669, unblocked by daqifi-core#242).

- Core's `DaqifiStreamingDevice` decodes every streamed frame into per-channel samples and raises `IChannel.SampleReceived` automatically while streaming.
- `AbstractStreamingDevice` now subscribes to each wrapped channel's `SampleReceived` (via `SubscribeChannelSamples`/`UnsubscribeChannelSamples`, wired through `SyncChannelsFromCore` and `Disconnect`) and maps Core's `IDataSample` into the desktop's richer `DataSample` (`DeviceName`/`SerialNo`/`Color`/`FirmwareDeltaMs`) in `OnCoreChannelSampleReceived`.
- A per-frame gate (`_acceptChannelSamples`) keeps the existing leftover-frame/first-frame-validation heuristics (issue #573) working correctly: Core decodes every raw frame unconditionally once its own `IsStreaming` flag is set, with no notion of the desktop's leftover-frame detection, so the gate is only open while the frame Core is decoding is one the desktop's own gating just accepted. This relies on the two steps running synchronously back-to-back for the same frame (Core's `OnStreamMessageReceived` calls `base.OnStreamMessageReceived` — which raises the `MessageReceived` event the desktop's gating logic runs on — immediately before its own decode step).
  - One known, narrow trade-off: the very first frame of the very first stream session after connect is *held* by the first-frame-validation heuristic and only released once its successor arrives — by then Core has already decoded (and the gate had discarded) that first frame's channel samples, so that one frame's live channel update is silently skipped rather than delayed by one period as before. This happens at most once per device connection and does not affect the dispatched `DeviceMessage`/logging pipeline.

## Tests
- `ChannelDataMappingTests.cs` and `DigitalChannelStreamDecodeTests.cs` were rewritten to route frames through the real production pipeline (the desktop's own gating + a real Core decode step via a small test-only `OnStreamMessageReceived` wrapper) instead of a local reimplementation of the old decode logic, so they now actually protect the new code path.
- Fast gate: `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — **550 passed, 0 failed**.

## Hardware verification
Bench Nyquist device connected over USB (COM3), built from this branch:
- Enabled a non-consecutive analog subset (AI0 + AI2, skipping AI1) — both streamed correctly with the right values, confirming device-order-not-activation-order mapping still works.
- Added a digital channel (DIO2) alongside the analog channels — streamed correctly.
- Stopped and restarted streaming — resumed cleanly with no leftover-frame glitch (issue #573 heuristics unaffected).

Closes #613
