### PR TITLE
chore: call Core's WifiBridgeActivator instead of duplicating it

### DIFF
--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -612,24 +612,7 @@ public class FirmwareUpdateCoordinator
             _appLogger.Information($"Opening {portName} to send bridge activation commands.");
             try
             {
-                // USB CDC virtual ports ignore the baud rate; match the Core transport defaults.
-                using var port = new SerialPort(portName, 9600, Parity.None, 8, StopBits.One)
-                {
-                    DtrEnable = true,
-                    RtsEnable = false,
-                    WriteTimeout = 2000
-                };
-                port.Open();
-                // Brief pause to allow the DTR signal to be recognised by the firmware
-                // before we send commands (firmware checks isCdcHostConnected via DTR).
-                Thread.Sleep(200);
-                // Re-assert the FW-update-requested flag (idempotent; belt-and-suspenders).
-                port.Write("SYSTem:COMMUnicate:LAN:FWUpdate\n");
-                Thread.Sleep(100);
-                // Trigger the WiFi manager REINIT → bridge-mode state machine.
-                port.Write("SYSTem:COMMUnicate:LAN:APPLY\n");
-                // Give the firmware a moment to enqueue the APPLY before we close the port.
-                Thread.Sleep(300);
+                WifiBridgeActivator.Activate(portName);
                 _appLogger.Information("Bridge activation commands sent successfully.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

Follow-up to #614 / daqifi-core#243. While closing #614 (already resolved by #641), I found #641 added the `WifiBridgeActivationCallback` extensibility hook Core's `FirmwareUpdateService` needed, but the desktop callback that consumes it (`FirmwareUpdateCoordinator.CreateWifiFirmwareUpdateService`) still hand-rolled the same SCPI bridge-activation sequence with a raw `SerialPort` instead of calling `Daqifi.Core.Firmware.WifiBridgeActivator.Activate(portName)` — leaving Core's helper unused (the exact "unused helper" evidence daqifi-core#243 originally cited).

- Replaced the ~20-line raw `SerialPort` SCPI sequence (`DtrEnable`/`LAN:FWUpdate`/`LAN:APPLY` with the same 200ms/100ms/300ms delays) in `bridgeActivationAction` with a single call to `WifiBridgeActivator.Activate(portName)`.
- Verified byte-for-byte equivalence first: same port settings (9600/None/8/One/DTR/RTS defaults), same SCPI command text (`ScpiMessageProducer.SetLanFirmwareUpdateMode` / `ApplyNetworkLan`), same delays.
- Kept the existing try/catch + logging around the call (bridge activation stays best-effort; Core's output-based success verification is still the source of truth).

Closes daqifi/daqifi-core#243 (the callback-hook half of that issue already shipped in #641; this closes the remaining "call Core's helper instead of duplicating it" gap).

## Test plan
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 550 passed, 0 failed
- [x] `dotnet build` — 0 errors
- [x] Hardware-validated: forced a real WiFi (WINC1500) flash via the debug-mode "FLASH WIFI" button against the bench device (Nq1, COM3). Log confirms bridge activation → write → verify → `Operation completed successfully` → transparent-mode exit, and the app showed the success dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)