### PR TITLE
chore: establish a control-level style guide and consolidate the UI onto it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ When working on:
   [daqifi-core](https://github.com/daqifi/daqifi-core) SDK (consumed as the `Daqifi.Core` NuGet package). Prefer
   using or extending Core implementations over re-implementing protocol logic here; remaining gaps are tracked as
   GitHub issues in the two repos
-- **UI changes**: Update both View and ViewModel following MVVM. For new or redesigned surfaces, read [docs/design-philosophy.md](docs/design-philosophy.md) first — the Channels pane is the current exemplar
+- **UI changes**: Update both View and ViewModel following MVVM. For new or redesigned surfaces, read [docs/design-philosophy.md](docs/design-philosophy.md) (principles) and [docs/style-guide.md](docs/style-guide.md) (concrete control specs) first — the Channels pane is the current exemplar. Shared button/field/dropdown styles live in `Daqifi.Desktop/Resources/Controls.xaml`; never redeclare them in a view
 - **Data persistence**: Use Entity Framework patterns
 - **Protocol changes**: Update `.proto` files and regenerate
 - **Firewall/Network**: Ensure admin privileges handled properly, verify ports match

--- a/Daqifi.Desktop/App.xaml
+++ b/Daqifi.Desktop/App.xaml
@@ -12,6 +12,9 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Blue.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.FlatSlider.xaml" />
                 <ResourceDictionary Source="/Resources/DesignTokens.xaml" />
+                <!-- Canonical control specs (buttons/fields/dropdowns). Must follow
+                     DesignTokens: Controls.xaml resolves tokens via DynamicResource. -->
+                <ResourceDictionary Source="/Resources/Controls.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <Style x:Key="FadeButton" TargetType="{x:Type Button}">

--- a/Daqifi.Desktop/Resources/Controls.xaml
+++ b/Daqifi.Desktop/Resources/Controls.xaml
@@ -1,0 +1,285 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Canonical control styles for the dark visual system — the single home for the
+        button, field and dropdown specs shared by every pane and dialog.
+
+        This dictionary is merged into App.xaml (after DesignTokens.xaml), so every key here
+        resolves from any view via {StaticResource}. Before this existed, PillButton and
+        friends were copy-pasted into five views and had drifted apart (DAQiFi#627); add new
+        shared control specs here rather than re-declaring them in a view.
+
+        Rules for this file:
+        - Keyed styles only. An implicit (unkeyed) style here would apply to every control in
+          the app; window-scoped implicit skins belong in /Resources/DarkDialog.xaml.
+        - Tokens are referenced via DynamicResource. DesignTokens.xaml is a sibling merged
+          dictionary, so its keys are not in this file's static lookup scope.
+        - No layout properties (Margin, Width, Height on buttons). Spacing between controls is
+          the call site's business — see docs/style-guide.md.
+
+        Concrete values and usage rules: docs/style-guide.md
+        Principles behind them:       docs/design-philosophy.md
+    -->
+
+    <!-- ══════════════════════════════ Buttons ══════════════════════════════
+         One family, three intents (neutral / primary / destructive) and two sizes
+         (compact for pane toolbars and drawers, dialog for dialog action rows).
+         Geometry is shared: 14px corner radius, 1px border, SemiBold. -->
+
+    <!-- Neutral action. The default: use it unless the action is THE primary one. -->
+    <Style x:Key="PillButton" TargetType="Button">
+        <Setter Property="Background"      Value="Transparent"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource BorderDim}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground"      Value="{DynamicResource TextSecondary}"/>
+        <Setter Property="Padding"         Value="12,4"/>
+        <Setter Property="FontSize"        Value="10"/>
+        <Setter Property="FontWeight"      Value="SemiBold"/>
+        <Setter Property="Cursor"          Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="14"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource BorderBright}"/>
+                <Setter Property="Background"  Value="#141821"/>
+                <Setter Property="Foreground"  Value="{DynamicResource TextPrimary}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.35"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- Primary action. At most one per surface — it is the emphasis, so two accents
+         side by side means neither reads as the default. Slightly roomier than neutral. -->
+    <Style x:Key="AccentPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
+        <Setter Property="Background"  Value="{DynamicResource Accent}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
+        <Setter Property="Foreground"  Value="White"/>
+        <Setter Property="Padding"     Value="16,6"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background"  Value="#1EB3F0"/>
+                <Setter Property="BorderBrush" Value="#1EB3F0"/>
+                <Setter Property="Foreground"  Value="White"/>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.35"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- Destructive action (delete, disconnect). Outline-only at rest: the red is a warning,
+         not an invitation, so it never competes with the accent for the eye. -->
+    <Style x:Key="DangerPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
+        <Setter Property="BorderBrush" Value="#4A1F28"/>
+        <Setter Property="Foreground"  Value="{DynamicResource StatusRed}"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background"  Value="#2A0F14"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource StatusRed}"/>
+                <Setter Property="Foreground"  Value="{DynamicResource StatusRed}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- ── Dialog-scale variants ────────────────────────────────────────────
+         A dialog's action row carries more weight than a pane toolbar: bigger hit target,
+         readable label casing, and a MinWidth so "OK" and "Cancel" match width. -->
+    <Style x:Key="DialogPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Padding"  Value="24,8"/>
+        <Setter Property="MinWidth" Value="96"/>
+    </Style>
+
+    <Style x:Key="DialogAccentPillButton" TargetType="Button" BasedOn="{StaticResource AccentPillButton}">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Padding"  Value="24,8"/>
+        <Setter Property="MinWidth" Value="96"/>
+    </Style>
+
+    <!-- No DialogDangerPillButton: no dialog currently has a destructive action (the
+         destructive confirms are in-pane overlays, which use the compact DangerPillButton).
+         Add it here, BasedOn DangerPillButton with the sizing above, when one needs it. -->
+
+    <!-- ══════════════════════════════ Fields ══════════════════════════════
+         The standard bordered input. 32px tall: 30 clipped descenders (DAQiFi#627). -->
+    <Style x:Key="DarkTextBox" TargetType="TextBox">
+        <Setter Property="Foreground"               Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="CaretBrush"               Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="Background"               Value="{DynamicResource Surface}"/>
+        <Setter Property="BorderBrush"              Value="{DynamicResource BorderDim}"/>
+        <Setter Property="BorderThickness"          Value="1"/>
+        <Setter Property="Padding"                  Value="10,0"/>
+        <Setter Property="MinHeight"                Value="32"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border x:Name="Bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="3">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource BorderBright}"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ════════════════════════════ Dropdown ════════════════════════════
+         Self-contained dark template. The app runs on the MahApps Light.Blue theme, whose
+         combo brings a white toggle and popup that swallow light text, so we own the whole
+         visual rather than re-skinning parts of theirs. -->
+    <Style x:Key="DarkComboBoxItem" TargetType="ComboBoxItem">
+        <Setter Property="Background"          Value="Transparent"/>
+        <Setter Property="Foreground"          Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="Padding"             Value="10,6"/>
+        <Setter Property="FontSize"            Value="12"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="Bg"
+                            Background="{TemplateBinding Background}"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="Bg" Property="Background" Value="{DynamicResource SurfaceActive}"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="Bg" Property="Background" Value="{DynamicResource SurfaceActive}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="DarkComboBox" TargetType="ComboBox">
+        <Setter Property="Background"          Value="{DynamicResource Surface}"/>
+        <Setter Property="Foreground"          Value="{DynamicResource TextPrimary}"/>
+        <Setter Property="BorderBrush"         Value="{DynamicResource BorderDim}"/>
+        <Setter Property="BorderThickness"     Value="1"/>
+        <Setter Property="MinHeight"           Value="32"/>
+        <Setter Property="FontSize"            Value="12"/>
+        <Setter Property="Padding"             Value="10,0"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <!-- This template has no editable text part, so keep the control non-editable. -->
+        <Setter Property="IsEditable"          Value="False"/>
+        <Setter Property="ItemContainerStyle"  Value="{StaticResource DarkComboBoxItem}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="28"/>
+                        </Grid.ColumnDefinitions>
+
+                        <Border x:Name="Bg"
+                                Grid.ColumnSpan="2"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3"/>
+
+                        <ContentPresenter Grid.Column="0"
+                                          Margin="{TemplateBinding Padding}"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Left"
+                                          IsHitTestVisible="False"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"/>
+
+                        <ToggleButton Grid.Column="1"
+                                      Background="Transparent"
+                                      BorderThickness="0"
+                                      Focusable="False"
+                                      ClickMode="Press"
+                                      IsChecked="{Binding Path=IsDropDownOpen,
+                                                  Mode=TwoWay,
+                                                  RelativeSource={RelativeSource TemplatedParent}}">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border Background="Transparent">
+                                        <Path HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              Data="M 0 0 L 4 4 L 8 0 Z"
+                                              Fill="{DynamicResource TextSecondary}"/>
+                                    </Border>
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+
+                        <Popup x:Name="PART_Popup"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               AllowsTransparency="True"
+                               Focusable="False"
+                               PopupAnimation="Slide"
+                               Placement="Bottom">
+                            <Border Background="{DynamicResource SurfaceRaised}"
+                                    BorderBrush="{DynamicResource BorderDim}"
+                                    BorderThickness="1"
+                                    CornerRadius="3"
+                                    Margin="0,2,0,0"
+                                    MinWidth="{TemplateBinding ActualWidth}"
+                                    MaxHeight="{TemplateBinding MaxDropDownHeight}">
+                                <ScrollViewer SnapsToDevicePixels="True"
+                                              CanContentScroll="True"
+                                              VerticalScrollBarVisibility="Auto"
+                                              HorizontalScrollBarVisibility="Disabled">
+                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bg" Property="BorderBrush" Value="{DynamicResource BorderBright}"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter TargetName="Bg" Property="BorderBrush" Value="{DynamicResource Accent}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/Daqifi.Desktop/Resources/Controls.xaml
+++ b/Daqifi.Desktop/Resources/Controls.xaml
@@ -244,12 +244,17 @@
                             </ToggleButton.Template>
                         </ToggleButton>
 
+                        <!-- PlacementTarget is explicit: without it the popup anchors to whatever
+                             ends up as its placement context, which is not guaranteed to be the
+                             ComboBox. This template is app-wide, so an unanchored dropdown would
+                             be a systemic bug. -->
                         <Popup x:Name="PART_Popup"
                                IsOpen="{TemplateBinding IsDropDownOpen}"
                                AllowsTransparency="True"
                                Focusable="False"
                                PopupAnimation="Slide"
-                               Placement="Bottom">
+                               Placement="Bottom"
+                               PlacementTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}">
                             <Border Background="{DynamicResource SurfaceRaised}"
                                     BorderBrush="{DynamicResource BorderDim}"
                                     BorderThickness="1"

--- a/Daqifi.Desktop/Resources/DarkDialog.xaml
+++ b/Daqifi.Desktop/Resources/DarkDialog.xaml
@@ -2,23 +2,36 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--
-        Dark-mode control skins for the app's legacy MahApps dialogs (Export, Firmware,
-        DuplicateDevice). The application runs on the MahApps "Light.Blue" theme, so a plain
-        MetroWindow and its standard controls render light; these styles re-skin GroupBox,
-        TextBox, Label and a secondary Button onto the dark design tokens so older dialogs
-        match the rest of the app (see /Resources/DesignTokens.xaml and
-        docs/design-philosophy.md §2 dark by default, §9 one visual system).
+        Window-scoped dark skins for the app's MahApps dialogs (Export, Firmware,
+        DuplicateDevice, Debug). The application runs on the MahApps "Light.Blue" theme, so a plain
+        MetroWindow and its standard controls render light; the styles here re-skin the
+        controls a dialog gets by default — GroupBox, TextBox, Label, RadioButton — onto the
+        dark design tokens (see docs/design-philosophy.md §2 dark by default, §9 one visual
+        system).
+
+        This file holds ONLY implicit (unkeyed) styles. They must stay window-scoped, because
+        an implicit style in App.xaml would restyle every control in the app. Anything keyed
+        and shared — the button family, the canonical field, the dropdown — lives in
+        /Resources/Controls.xaml, which is merged below so these implicit styles can inherit
+        from it via BasedOn.
 
         Usage: merge this dictionary into a dialog's Window.Resources and set the root
-        container Background to {StaticResource Surface}. The GroupBox/TextBox/Label styles
-        are implicit (no x:Key) so they apply automatically within that window only.
+        container Background to {StaticResource Surface}.
 
         Tokens are referenced via DynamicResource so they resolve against the
         application-scope DesignTokens dictionary at runtime — this file is merged into a
         window, not into App.xaml, so the tokens are not in its own static scope. The
         templates intentionally reference only DesignTokens keys (never MahApps-internal
         brush/style keys) so there are no load-time resolution surprises.
+
+        Concrete values and usage rules: docs/style-guide.md
     -->
+
+    <ResourceDictionary.MergedDictionaries>
+        <!-- Brings the canonical control specs into this dictionary's static scope so the
+             implicit styles below can BasedOn them (BasedOn cannot use DynamicResource). -->
+        <ResourceDictionary Source="/Resources/Controls.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
 
     <!-- ── Content labels ──────────────────────────────────────────────── -->
     <Style TargetType="Label">
@@ -74,161 +87,13 @@
         </Setter>
     </Style>
 
-    <!-- ── Dark input field ────────────────────────────────────────────── -->
-    <Style TargetType="TextBox">
-        <Setter Property="Foreground"               Value="{DynamicResource TextPrimary}"/>
-        <Setter Property="CaretBrush"               Value="{DynamicResource TextPrimary}"/>
-        <Setter Property="Background"               Value="{DynamicResource Surface}"/>
-        <Setter Property="BorderBrush"              Value="{DynamicResource BorderDim}"/>
-        <Setter Property="BorderThickness"          Value="1"/>
-        <Setter Property="Padding"                  Value="8,4"/>
-        <Setter Property="MinHeight"                Value="28"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="TextBox">
-                    <Border Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="3">
-                        <ScrollViewer x:Name="PART_ContentHost"
-                                      Margin="{TemplateBinding Padding}"
-                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter Property="BorderBrush" Value="{DynamicResource Accent}"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.5"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+    <!-- ── Dark input field ──────────────────────────────────────────────
+         A dialog's TextBoxes default to the canonical field spec; no local overrides. -->
+    <Style TargetType="TextBox" BasedOn="{StaticResource DarkTextBox}"/>
 
-    <!-- ── Dark dropdown ────────────────────────────────────────────────────
-         Self-contained dark template. The MahApps light-theme combo brings a white
-         toggle/popup background that swallows light text, so we own the whole visual:
-         a bordered field with a chevron, over a dark popup of dark items. Keyed (opt-in)
-         and wired together via ItemContainerStyle so it never implicitly overrides other
-         ComboBoxes in dialogs that merge this dictionary. -->
-    <Style x:Key="DarkComboBoxItem" TargetType="ComboBoxItem">
-        <Setter Property="Foreground"          Value="{DynamicResource TextPrimary}"/>
-        <Setter Property="Background"           Value="Transparent"/>
-        <Setter Property="Padding"              Value="8,5"/>
-        <Setter Property="SnapsToDevicePixels"  Value="True"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="ComboBoxItem">
-                    <Border x:Name="Bd"
-                            Background="{TemplateBinding Background}"
-                            Padding="{TemplateBinding Padding}"
-                            SnapsToDevicePixels="True">
-                        <ContentPresenter TextElement.Foreground="{TemplateBinding Foreground}"/>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsHighlighted" Value="True">
-                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SurfaceActive}"/>
-                        </Trigger>
-                        <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SurfaceActive}"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style x:Key="DarkComboBox" TargetType="ComboBox">
-        <Setter Property="Foreground"               Value="{DynamicResource TextPrimary}"/>
-        <Setter Property="Background"               Value="{DynamicResource Surface}"/>
-        <Setter Property="BorderBrush"              Value="{DynamicResource BorderDim}"/>
-        <Setter Property="BorderThickness"          Value="1"/>
-        <Setter Property="Padding"                  Value="8,4"/>
-        <Setter Property="MinHeight"                Value="28"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <!-- This template has no editable text part, so keep the control non-editable. -->
-        <Setter Property="IsEditable"               Value="False"/>
-        <Setter Property="ItemContainerStyle"       Value="{StaticResource DarkComboBoxItem}"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="ComboBox">
-                    <Grid>
-                        <ToggleButton x:Name="ToggleButton"
-                                      Focusable="False"
-                                      ClickMode="Press"
-                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
-                            <ToggleButton.Template>
-                                <ControlTemplate TargetType="ToggleButton">
-                                    <Border x:Name="Bd"
-                                            Background="{DynamicResource Surface}"
-                                            BorderBrush="{DynamicResource BorderDim}"
-                                            BorderThickness="1"
-                                            CornerRadius="3">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="22"/>
-                                            </Grid.ColumnDefinitions>
-                                            <Path Grid.Column="1"
-                                                  HorizontalAlignment="Center"
-                                                  VerticalAlignment="Center"
-                                                  Data="M 0 0 L 4 4 L 8 0 Z"
-                                                  Fill="{DynamicResource TextSecondary}"/>
-                                        </Grid>
-                                    </Border>
-                                    <ControlTemplate.Triggers>
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Accent}"/>
-                                        </Trigger>
-                                    </ControlTemplate.Triggers>
-                                </ControlTemplate>
-                            </ToggleButton.Template>
-                        </ToggleButton>
-                        <ContentPresenter x:Name="ContentSite"
-                                          IsHitTestVisible="False"
-                                          Content="{TemplateBinding SelectionBoxItem}"
-                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                          ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
-                                          Margin="{TemplateBinding Padding}"
-                                          VerticalAlignment="Center"
-                                          HorizontalAlignment="Left"
-                                          TextElement.Foreground="{DynamicResource TextPrimary}"/>
-                        <Popup x:Name="PART_Popup"
-                               Placement="Bottom"
-                               PlacementTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}"
-                               IsOpen="{TemplateBinding IsDropDownOpen}"
-                               AllowsTransparency="True"
-                               Focusable="False"
-                               PopupAnimation="Slide">
-                            <Border x:Name="DropDownBorder"
-                                    MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
-                                    MaxHeight="200"
-                                    Margin="0,2,0,0"
-                                    Background="{DynamicResource SurfaceRaised}"
-                                    BorderBrush="{DynamicResource BorderDim}"
-                                    BorderThickness="1"
-                                    CornerRadius="3">
-                                <ScrollViewer SnapsToDevicePixels="True"
-                                              CanContentScroll="True"
-                                              VerticalScrollBarVisibility="Auto"
-                                              HorizontalScrollBarVisibility="Disabled">
-                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                </ScrollViewer>
-                            </Border>
-                        </Popup>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.5"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+    <!-- The dark dropdown (DarkComboBox / DarkComboBoxItem) is keyed and lives in
+         /Resources/Controls.xaml, merged above. It stays opt-in rather than implicit so it
+         never silently overrides other ComboBoxes in a dialog that merges this dictionary. -->
 
     <!-- ── Grouping container: small header label over a raised panel ──── -->
     <Style TargetType="GroupBox">
@@ -259,41 +124,6 @@
                             <ContentPresenter/>
                         </Border>
                     </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <!-- ── Secondary (non-accent) button ───────────────────────────────────
-         SurfaceActive (the lightest surface token) so the button reads as a control
-         on both the root Surface and the raised SurfaceRaised GroupBox panels. -->
-    <Style x:Key="DarkSecondaryButton" TargetType="Button">
-        <Setter Property="Background"      Value="{DynamicResource SurfaceActive}"/>
-        <Setter Property="BorderBrush"     Value="{DynamicResource BorderBright}"/>
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Foreground"      Value="{DynamicResource TextPrimary}"/>
-        <Setter Property="Padding"         Value="16,6"/>
-        <Setter Property="FontSize"        Value="12"/>
-        <Setter Property="Cursor"          Value="Hand"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="Button">
-                    <Border x:Name="Bg"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="3">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Bg" Property="Background"  Value="#283143"/>
-                            <Setter TargetName="Bg" Property="BorderBrush" Value="{DynamicResource Accent}"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.4"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/Daqifi.Desktop/View/ConnectionDialog.xaml
+++ b/Daqifi.Desktop/View/ConnectionDialog.xaml
@@ -138,39 +138,8 @@
             </Setter>
         </Style>
 
-        <!-- ── Accent pill button ─────────────────────────────────────── -->
-        <Style x:Key="AccentPillButton" TargetType="Button">
-            <Setter Property="Background"       Value="{StaticResource Accent}"/>
-            <Setter Property="BorderBrush"      Value="{StaticResource Accent}"/>
-            <Setter Property="BorderThickness"  Value="1"/>
-            <Setter Property="Foreground"       Value="White"/>
-            <Setter Property="Padding"          Value="24,8"/>
-            <Setter Property="FontSize"         Value="11"/>
-            <Setter Property="FontWeight"       Value="SemiBold"/>
-            <Setter Property="Cursor"           Value="Hand"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="14"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background"  Value="#1EB3F0"/>
-                    <Setter Property="BorderBrush" Value="#1EB3F0"/>
-                </Trigger>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Opacity" Value="0.4"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
+        <!-- This dialog's action buttons use DialogAccentPillButton from
+             /Resources/Controls.xaml (it was the source for that spec). See docs/style-guide.md. -->
 
         <!-- ── Field label ────────────────────────────────────────────── -->
         <Style x:Key="FieldLabel" TargetType="TextBlock">
@@ -180,7 +149,11 @@
             <Setter Property="Margin"       Value="0,0,0,6"/>
         </Style>
 
-        <!-- ── Dark text field ────────────────────────────────────────── -->
+        <!-- ── Dark text field ──────────────────────────────────────────
+             A two-part composite: this Border carries the field's border/background/padding,
+             and DarkTextFieldInput below is the borderless TextBox that sits inside it. The
+             pair adds up to the canonical field in /Resources/Controls.xaml — it is NOT that
+             style, so it must not reuse the DarkTextBox key (see docs/style-guide.md). -->
         <Style x:Key="DarkTextField" TargetType="Border">
             <Setter Property="Background"       Value="{StaticResource Surface}"/>
             <Setter Property="BorderBrush"      Value="{StaticResource BorderDim}"/>
@@ -189,7 +162,7 @@
             <Setter Property="Padding"          Value="10,0"/>
         </Style>
 
-        <Style x:Key="DarkTextBox" TargetType="TextBox">
+        <Style x:Key="DarkTextFieldInput" TargetType="TextBox">
             <Setter Property="Background"               Value="Transparent"/>
             <Setter Property="BorderThickness"          Value="0"/>
             <Setter Property="Foreground"               Value="{StaticResource TextPrimary}"/>
@@ -281,7 +254,7 @@
                             Padding="0,12,0,0" Margin="0,12,0,0">
                         <Button HorizontalAlignment="Right"
                                 AutomationProperties.AutomationId="ConnectButton_Wifi"
-                                Style="{StaticResource AccentPillButton}"
+                                Style="{StaticResource DialogAccentPillButton}"
                                 CommandParameter="{Binding ElementName=DeviceList, Path=SelectedItems}"
                                 Command="{Binding ConnectCommand}"
                                 Content="Connect"/>
@@ -303,7 +276,7 @@
                         <Border Style="{StaticResource DarkTextField}">
                             <TextBox Text="{Binding ManualIpAddress, UpdateSourceTrigger=PropertyChanged}"
                                      AutomationProperties.AutomationId="ManualIpInput"
-                                     Style="{StaticResource DarkTextBox}"/>
+                                     Style="{StaticResource DarkTextFieldInput}"/>
                         </Border>
                         <TextBlock Text="Enter the IP address or hostname of the DAQiFi device."
                                    FontSize="10" Foreground="{StaticResource TextTertiary}"
@@ -320,7 +293,7 @@
                             Padding="0,12,0,0" Margin="0,12,0,0">
                         <Button HorizontalAlignment="Right"
                                 AutomationProperties.AutomationId="ConnectButton_Manual"
-                                Style="{StaticResource AccentPillButton}"
+                                Style="{StaticResource DialogAccentPillButton}"
                                 Command="{Binding ConnectManualWifiCommand}"
                                 Content="Connect"/>
                     </Border>
@@ -401,7 +374,7 @@
                             Padding="0,12,0,0" Margin="0,12,0,0">
                         <Button HorizontalAlignment="Right"
                                 AutomationProperties.AutomationId="ConnectButton_Serial"
-                                Style="{StaticResource AccentPillButton}"
+                                Style="{StaticResource DialogAccentPillButton}"
                                 CommandParameter="{Binding ElementName=SerialList, Path=SelectedItems}"
                                 Command="{Binding ConnectSerialCommand}"
                                 Content="Connect"/>
@@ -423,7 +396,7 @@
                         <Border Style="{StaticResource DarkTextField}">
                             <TextBox Text="{Binding ManualPortName, UpdateSourceTrigger=PropertyChanged}"
                                      AutomationProperties.AutomationId="ManualPortInput"
-                                     Style="{StaticResource DarkTextBox}"/>
+                                     Style="{StaticResource DarkTextFieldInput}"/>
                         </Border>
                         <TextBlock Text="Enter the COM port name of the DAQiFi device (e.g. COM3)."
                                    FontSize="10" Foreground="{StaticResource TextTertiary}"
@@ -440,7 +413,7 @@
                             Padding="0,12,0,0" Margin="0,12,0,0">
                         <Button HorizontalAlignment="Right"
                                 AutomationProperties.AutomationId="ConnectButton_ManualSerial"
-                                Style="{StaticResource AccentPillButton}"
+                                Style="{StaticResource DialogAccentPillButton}"
                                 Command="{Binding ConnectManualSerialCommand}"
                                 Content="Connect"/>
                     </Border>
@@ -513,7 +486,7 @@
                             BorderBrush="{StaticResource BorderDim}" BorderThickness="0,1,0,0"
                             Padding="0,12,0,0" Margin="0,12,0,0">
                         <Button HorizontalAlignment="Right"
-                                Style="{StaticResource AccentPillButton}"
+                                Style="{StaticResource DialogAccentPillButton}"
                                 CommandParameter="{Binding ElementName=HidList, Path=SelectedItems}"
                                 Command="{Binding ConnectHidCommand}"
                                 Content="Open Firmware"/>

--- a/Daqifi.Desktop/View/DebugWindow.xaml
+++ b/Daqifi.Desktop/View/DebugWindow.xaml
@@ -3,53 +3,130 @@
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
                   xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-                  Title="DAQiFi Debug Console" 
-                  Height="600" 
+                  Title="DAQiFi Debug Console"
+                  Height="600"
                   Width="1000"
                   WindowStartupLocation="CenterOwner"
                   ShowInTaskbar="False"
-                  ResizeMode="CanResize">
+                  ResizeMode="CanResize"
+                  BorderThickness="0"
+                  Background="{StaticResource Surface}"
+                  GlowBrush="{DynamicResource AccentColorBrush}">
 
-    <Grid>
+    <mah:MetroWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Resources/DarkDialog.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- Dark DataGrid. The app runs on the MahApps Light.Blue theme, whose DataGrid
+                 renders white-on-white against our dark surface, so the grid, its rows, cells
+                 and headers are re-skinned onto the design tokens here. View-scoped because
+                 this is the only DataGrid in the app. -->
+            <Style TargetType="DataGrid">
+                <Setter Property="Background"           Value="{StaticResource Surface}"/>
+                <Setter Property="Foreground"           Value="{StaticResource TextPrimary}"/>
+                <Setter Property="BorderThickness"      Value="0"/>
+                <Setter Property="RowBackground"        Value="Transparent"/>
+                <Setter Property="AlternatingRowBackground" Value="Transparent"/>
+                <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource BorderDim}"/>
+                <Setter Property="VerticalGridLinesBrush"   Value="Transparent"/>
+                <Setter Property="RowHeaderWidth"       Value="0"/>
+                <Setter Property="FontFamily"           Value="Consolas"/>
+                <Setter Property="FontSize"             Value="11"/>
+            </Style>
+
+            <Style TargetType="DataGridColumnHeader">
+                <Setter Property="Background"      Value="{StaticResource SurfaceRaised}"/>
+                <Setter Property="Foreground"      Value="{StaticResource TextTertiary}"/>
+                <Setter Property="BorderBrush"     Value="{StaticResource BorderDim}"/>
+                <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                <Setter Property="Padding"         Value="8,8"/>
+                <Setter Property="FontFamily"      Value="Segoe UI"/>
+                <Setter Property="FontSize"        Value="10"/>
+                <Setter Property="FontWeight"      Value="Bold"/>
+                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            </Style>
+
+            <Style TargetType="DataGridCell">
+                <Setter Property="Background"      Value="Transparent"/>
+                <Setter Property="Foreground"      Value="{StaticResource TextPrimary}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Padding"         Value="8,4"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="DataGridCell">
+                            <Border Background="{TemplateBinding Background}"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter VerticalAlignment="Center"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter Property="Background" Value="{StaticResource SurfaceActive}"/>
+                        <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="DataGridRow">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="{StaticResource SurfaceHover}"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </mah:MetroWindow.Resources>
+
+    <Grid Background="{StaticResource Surface}" TextElement.Foreground="{StaticResource TextPrimary}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- Header -->
-        <Border Grid.Row="0" Background="{DynamicResource MahApps.Brushes.Accent}" Padding="10">
+        <!-- Header. A raised strip rather than the old full-width accent banner: accent is
+             reserved for the primary action, not decoration (design-philosophy §1, §3). -->
+        <Border Grid.Row="0"
+                Background="{StaticResource SurfaceRaised}"
+                BorderBrush="{StaticResource BorderDim}"
+                BorderThickness="0,0,0,1"
+                Padding="16,10">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                
+
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
-                    <iconPacks:PackIconMaterial Kind="Bug" 
-                                              Foreground="White" 
-                                              Width="24" 
-                                              Height="24" 
+                    <iconPacks:PackIconMaterial Kind="Bug"
+                                              Foreground="{StaticResource TextSecondary}"
+                                              Width="16"
+                                              Height="16"
                                               VerticalAlignment="Center"/>
-                    <TextBlock Text="Real-time Device Data Flow Debug Console" 
-                             Foreground="White" 
-                             FontSize="16" 
-                             FontWeight="Bold" 
+                    <TextBlock Text="Real-time Device Data Flow Debug Console"
+                             Foreground="{StaticResource TextPrimary}"
+                             FontSize="13"
                              Margin="10,0,0,0"
                              VerticalAlignment="Center"/>
                 </StackPanel>
 
-                <Button Grid.Column="1" 
-                        Content="Clear" 
+                <Button Grid.Column="1"
+                        Content="CLEAR"
                         Command="{Binding ClearDebugDataCommand}"
-                        Style="{DynamicResource MahApps.Styles.Button.Dialogs.Accent}"
-                        Margin="0,0,10,0"/>
-                
-                <Button Grid.Column="2" 
-                        Content="Close" 
+                        Style="{StaticResource PillButton}"
+                        Margin="0,0,8,0"/>
+
+                <Button Grid.Column="2"
+                        Content="CLOSE"
                         Click="CloseButton_Click"
-                        Style="{DynamicResource MahApps.Styles.Button.Dialogs.Accent}"/>
+                        Style="{StaticResource PillButton}"/>
             </Grid>
         </Border>
 
@@ -62,14 +139,14 @@
             </Grid.ColumnDefinitions>
 
             <!-- Left Panel - Latest Data -->
-            <Border Grid.Column="0" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" BorderThickness="1">
+            <Border Grid.Column="0" BorderBrush="{StaticResource BorderDim}" BorderThickness="1">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
-                    <Border Grid.Row="0" Background="{DynamicResource MahApps.Brushes.Gray10}" Padding="10">
+                    <Border Grid.Row="0" Background="{StaticResource SurfaceRaised}" Padding="10">
                         <TextBlock Text="Latest Data Packet" FontWeight="Bold" FontSize="14"/>
                     </Border>
 
@@ -104,7 +181,7 @@
                                 </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border Background="{DynamicResource MahApps.Brushes.Gray9}" 
+                                        <Border Background="{StaticResource SurfaceActive}" 
                                               Padding="5" Margin="2">
                                             <TextBlock Text="{Binding}" FontFamily="Consolas"/>
                                         </Border>
@@ -115,7 +192,7 @@
                             <TextBlock Text="Data Flow Visualization:" FontWeight="Bold" Margin="0,10,0,5"/>
                             <TextBlock Text="{Binding DataFlowVisualization}" 
                                      FontFamily="Consolas" 
-                                     Background="{DynamicResource MahApps.Brushes.Gray9}"
+                                     Background="{StaticResource SurfaceActive}"
                                      Padding="10"
                                      TextWrapping="Wrap"/>
                         </StackPanel>
@@ -125,17 +202,17 @@
 
             <GridSplitter Grid.Column="1" 
                         HorizontalAlignment="Stretch" 
-                        Background="{DynamicResource MahApps.Brushes.Gray7}"/>
+                        Background="{StaticResource BorderDim}"/>
 
             <!-- Right Panel - History -->
-            <Border Grid.Column="2" BorderBrush="{DynamicResource MahApps.Brushes.Accent}" BorderThickness="1">
+            <Border Grid.Column="2" BorderBrush="{StaticResource BorderDim}" BorderThickness="1">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
-                    <Border Grid.Row="0" Background="{DynamicResource MahApps.Brushes.Gray10}" Padding="10">
+                    <Border Grid.Row="0" Background="{StaticResource SurfaceRaised}" Padding="10">
                         <TextBlock Text="Debug History (Last 100 packets)" FontWeight="Bold" FontSize="14"/>
                     </Border>
 
@@ -174,7 +251,7 @@
         </Grid>
 
         <!-- Status Bar -->
-        <Border Grid.Row="2" Background="{DynamicResource MahApps.Brushes.Gray10}" Padding="10">
+        <Border Grid.Row="2" Background="{StaticResource SurfaceRaised}" Padding="10">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>

--- a/Daqifi.Desktop/View/DeviceLogsView.xaml
+++ b/Daqifi.Desktop/View/DeviceLogsView.xaml
@@ -15,167 +15,8 @@
         <converters:NotNullToVisibilityConverter x:Key="NotNullToVisibilityConverter"/>
         <converters:InvertedBoolToVisibilityConverter x:Key="InvertedBoolToVis"/>
 
-        <!-- Pill button (matches LoggedDataPanePrototype / DevicesPanePrototype) -->
-        <Style x:Key="PillButton" TargetType="Button">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="BorderBrush" Value="{StaticResource BorderDim}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
-            <Setter Property="Padding" Value="12,4"/>
-            <Setter Property="Margin" Value="0,0,6,0"/>
-            <Setter Property="FontSize" Value="10"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="14"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="BorderBrush" Value="{StaticResource BorderBright}"/>
-                    <Setter Property="Background" Value="#141821"/>
-                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-                </Trigger>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Opacity" Value="0.35"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="AccentPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
-            <Setter Property="Background" Value="{StaticResource Accent}"/>
-            <Setter Property="BorderBrush" Value="{StaticResource Accent}"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="Padding" Value="16,6"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#1EB3F0"/>
-                    <Setter Property="BorderBrush" Value="#1EB3F0"/>
-                    <Setter Property="Foreground" Value="White"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <!-- Dark ComboBox (MahApps Light.Blue forces a white toggle, so replace the template) -->
-        <Style x:Key="DarkComboBoxItem" TargetType="ComboBoxItem">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-            <Setter Property="Padding" Value="10,6"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ComboBoxItem">
-                        <Border x:Name="Bg"
-                                Background="{TemplateBinding Background}"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter VerticalAlignment="Center"/>
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsHighlighted" Value="True">
-                                <Setter TargetName="Bg" Property="Background" Value="{StaticResource SurfaceActive}"/>
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <Style x:Key="DarkComboBox" TargetType="ComboBox">
-            <Setter Property="Background" Value="{StaticResource Surface}"/>
-            <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-            <Setter Property="BorderBrush" Value="{StaticResource BorderDim}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Height" Value="32"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
-            <Setter Property="Padding" Value="10,0"/>
-            <Setter Property="SnapsToDevicePixels" Value="True"/>
-            <Setter Property="ItemContainerStyle" Value="{StaticResource DarkComboBoxItem}"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ComboBox">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="28"/>
-                            </Grid.ColumnDefinitions>
-
-                            <Border x:Name="Bg"
-                                    Grid.ColumnSpan="2"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="3"/>
-
-                            <ContentPresenter Grid.Column="0"
-                                              Margin="{TemplateBinding Padding}"
-                                              VerticalAlignment="Center"
-                                              HorizontalAlignment="Left"
-                                              IsHitTestVisible="False"
-                                              Content="{TemplateBinding SelectionBoxItem}"
-                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                              ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
-                                              TextElement.Foreground="{TemplateBinding Foreground}"/>
-
-                            <ToggleButton Grid.Column="1"
-                                          Background="Transparent"
-                                          BorderThickness="0"
-                                          Focusable="False"
-                                          ClickMode="Press"
-                                          IsChecked="{Binding Path=IsDropDownOpen,
-                                                      Mode=TwoWay,
-                                                      RelativeSource={RelativeSource TemplatedParent}}">
-                                <ToggleButton.Template>
-                                    <ControlTemplate TargetType="ToggleButton">
-                                        <Border Background="Transparent">
-                                            <Path HorizontalAlignment="Center"
-                                                  VerticalAlignment="Center"
-                                                  Data="M 0 0 L 4 4 L 8 0 Z"
-                                                  Fill="{StaticResource TextSecondary}"/>
-                                        </Border>
-                                    </ControlTemplate>
-                                </ToggleButton.Template>
-                            </ToggleButton>
-
-                            <Popup x:Name="Popup"
-                                   IsOpen="{TemplateBinding IsDropDownOpen}"
-                                   AllowsTransparency="True"
-                                   Focusable="False"
-                                   PopupAnimation="Slide"
-                                   Placement="Bottom">
-                                <Border Background="{StaticResource SurfaceRaised}"
-                                        BorderBrush="{StaticResource BorderDim}"
-                                        BorderThickness="1"
-                                        CornerRadius="3"
-                                        MinWidth="{TemplateBinding ActualWidth}"
-                                        MaxHeight="{TemplateBinding MaxDropDownHeight}">
-                                    <ScrollViewer>
-                                        <ItemsPresenter/>
-                                    </ScrollViewer>
-                                </Border>
-                            </Popup>
-                        </Grid>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bg" Property="BorderBrush" Value="{StaticResource BorderBright}"/>
-                            </Trigger>
-                            <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                                <Setter TargetName="Bg" Property="BorderBrush" Value="{StaticResource Accent}"/>
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
+        <!-- The PillButton / AccentPillButton family and the DarkComboBox / DarkComboBoxItem
+             styles come from /Resources/Controls.xaml via App.xaml. See docs/style-guide.md. -->
 
         <!-- Dark list row -->
         <Style x:Key="DarkListViewItem" TargetType="ListViewItem">
@@ -256,8 +97,11 @@
                        VerticalAlignment="Center"
                        Margin="0,0,12,0"/>
 
+            <!-- Monospace here is deliberate: device display names read as identifiers
+                 alongside the serial/firmware readouts below. -->
             <ComboBox Grid.Column="1"
                       Style="{StaticResource DarkComboBox}"
+                      FontFamily="Consolas"
                       ItemsSource="{Binding ConnectedDevices}"
                       SelectedItem="{Binding SelectedDevice}"
                       DisplayMemberPath="DeviceDisplayName"
@@ -267,6 +111,7 @@
                     Style="{StaticResource PillButton}"
                     AutomationProperties.AutomationId="RefreshSdCardFilesButton"
                     Command="{Binding RefreshFilesCommand}"
+                    Margin="0,0,8,0"
                     ToolTip="{Binding ConnectionTypeMessage}"
                     IsEnabled="{Binding CanAccessSdCard}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -416,8 +261,7 @@
                            Margin="0,0,0,16"/>
                 <Button Style="{StaticResource PillButton}"
                         Command="{Binding CopyDiagnosticInfoCommand}"
-                        HorizontalAlignment="Center"
-                        Margin="0">
+                        HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal">
                         <iconPacks:PackIconMaterial Kind="ContentCopy"
                                                    Width="10" Height="10"
@@ -476,8 +320,7 @@
                            Margin="0,0,0,16"/>
                 <Button Style="{StaticResource PillButton}"
                         Command="{Binding CopyDiagnosticInfoCommand}"
-                        HorizontalAlignment="Center"
-                        Margin="0">
+                        HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal">
                         <iconPacks:PackIconMaterial Kind="ContentCopy"
                                                    Width="10" Height="10"

--- a/Daqifi.Desktop/View/DuplicateDeviceDialog.xaml
+++ b/Daqifi.Desktop/View/DuplicateDeviceDialog.xaml
@@ -52,11 +52,13 @@
         <!-- Buttons -->
         <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" 
                    Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Content="OK" Click="BtnOk_Click" Width="80" Height="30" Margin="0,0,10,0"
-                   Style="{StaticResource MahApps.Styles.Button.Square.Accent}" 
+            <!-- Cancel first, then the primary action last: the accent sits closest to the
+                 window's bottom-right corner, matching every other dialog's action row. -->
+            <Button Content="Cancel" Click="BtnCancel_Click" Margin="0,0,8,0"
+                   Style="{StaticResource DialogPillButton}"
                    controls:ControlsHelper.ContentCharacterCasing="Normal"/>
-            <Button Content="Cancel" Click="BtnCancel_Click" Width="80" Height="30"
-                   Style="{StaticResource DarkSecondaryButton}"
+            <Button Content="OK" Click="BtnOk_Click"
+                   Style="{StaticResource DialogAccentPillButton}"
                    controls:ControlsHelper.ContentCharacterCasing="Normal"/>
         </StackPanel>
     </Grid>

--- a/Daqifi.Desktop/View/ErrorDialog.xaml
+++ b/Daqifi.Desktop/View/ErrorDialog.xaml
@@ -36,8 +36,8 @@
                  FontSize="14" VerticalAlignment="Center" Foreground="{StaticResource TextPrimary}"/>
 
         <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Content="Ok" Click="btnOk_Click"
-                IsDefault="True" Width="80" Height="30" Margin="0,20,0,0"
-                HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent}"
+                IsDefault="True" Margin="0,20,0,0"
+                HorizontalAlignment="Right" Style="{StaticResource DialogAccentPillButton}"
                 controls:ControlsHelper.ContentCharacterCasing="Normal"/>
     </Grid>
 </controls:MetroWindow>

--- a/Daqifi.Desktop/View/ExportDialog.xaml
+++ b/Daqifi.Desktop/View/ExportDialog.xaml
@@ -38,7 +38,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <TextBox Grid.Column="0" HorizontalAlignment="Stretch" Text="{Binding ExportFilePath, Mode=OneWay}" IsEnabled="False"/>
-                    <Button Grid.Column="1" Content="Browse" Command="{Binding BrowseCommand}" Margin="8,0,0,0" Style="{StaticResource DarkSecondaryButton}"/>
+                    <Button Grid.Column="1" Content="Browse" Command="{Binding BrowseCommand}" Margin="8,0,0,0" Style="{StaticResource PillButton}"/>
                 </Grid>
             </GroupBox>
 
@@ -68,10 +68,14 @@
             </GroupBox>
 
             <!-- Actions -->
-            <DockPanel Grid.Row="4" HorizontalAlignment="Right" Margin="0,8,0,0">
-                <Button Click="btnCancel_Click" Content="Cancel" Width="100" Height="32" Margin="0,0,10,0" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
-                <Button Content="Export" Command="{Binding ExportLoggingSessionsCommand}" Width="100" Height="32" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
-            </DockPanel>
+            <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+                <Button Click="btnCancel_Click" Content="Cancel" Margin="0,0,8,0"
+                        Style="{StaticResource DialogPillButton}"
+                        controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                <Button Content="Export" Command="{Binding ExportLoggingSessionsCommand}"
+                        Style="{StaticResource DialogAccentPillButton}"
+                        controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+            </StackPanel>
         </Grid>
 
         <!-- ══════════════════════════════ Exporting ══════════════════════════════ -->
@@ -80,7 +84,7 @@
             <TextBlock Text="Exporting…" FontSize="16" HorizontalAlignment="Center" Foreground="{StaticResource TextPrimary}"/>
             <controls:MetroProgressBar Minimum="0" Maximum="100" Value="{Binding ExportProgress}" Height="6" Margin="0,18,0,0"/>
             <TextBlock Text="{Binding ExportProgress, StringFormat={}{0}%}" HorizontalAlignment="Center" Foreground="{StaticResource TextSecondary}" Margin="0,12,0,22"/>
-            <Button Content="Cancel" Command="{Binding CancelExportCommand}" Width="120" Height="32" HorizontalAlignment="Center" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+            <Button Content="Cancel" Command="{Binding CancelExportCommand}" HorizontalAlignment="Center" Style="{StaticResource DialogPillButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
         </StackPanel>
 
         <!-- ════════════════════════════════ Result ═══════════════════════════════ -->
@@ -97,11 +101,11 @@
                        Foreground="{StaticResource TextSecondary}" Margin="0,0,0,22"
                        Visibility="{Binding ExportSucceeded, Converter={StaticResource BoolToVis}}"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                <Button Content="Open Folder" Command="{Binding OpenExportLocationCommand}" Width="120" Height="32" Margin="0,0,10,0"
-                        Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"
+                <Button Content="Open Folder" Command="{Binding OpenExportLocationCommand}" Margin="0,0,8,0"
+                        Style="{StaticResource DialogPillButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"
                         Visibility="{Binding ExportSucceeded, Converter={StaticResource BoolToVis}}"/>
-                <Button Content="Done" Click="btnDone_Click" Width="120" Height="32"
-                        Style="{StaticResource MahApps.Styles.Button.Square.Accent}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                <Button Content="Done" Click="btnDone_Click"
+                        Style="{StaticResource DialogAccentPillButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
             </StackPanel>
         </StackPanel>
 

--- a/Daqifi.Desktop/View/FirmwareDialog.xaml
+++ b/Daqifi.Desktop/View/FirmwareDialog.xaml
@@ -19,7 +19,7 @@
         </ResourceDictionary>
     </controls:MetroWindow.Resources>
 
-    <Grid Background="{StaticResource Surface}" TextElement.Foreground="{StaticResource TextPrimary}">
+    <Grid Margin="16" Background="{StaticResource Surface}" TextElement.Foreground="{StaticResource TextPrimary}">
         
         <!-- Before Upload -->
         <Grid Visibility="{Binding IsUploadComplete, Converter={StaticResource InvertedBoolToVis}}">
@@ -46,23 +46,33 @@
 
                     <!-- Or browse for a specific .hex file -->
                     <TextBlock Text="Or browse for a firmware file" Foreground="{StaticResource TextTertiary}" FontSize="11" Margin="2,12,2,4"/>
+                    <!-- Field-adjacent button: no explicit height, so it stretches to the
+                         field's 32px rather than needing to be kept in sync with it. -->
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="85"/>
+                            <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Grid.Column="0" Height="34" VerticalAlignment="Top" Margin="0,0,5,0" Text="{Binding FirmwareFilePath, Mode=OneWay}"/>
-                        <Button Grid.Column="1" Content="Browse" Width="75" Height="34" VerticalAlignment="Top" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal" Command="{Binding BrowseFirmwarePathCommand}"/>
+                        <TextBox Grid.Column="0" Text="{Binding FirmwareFilePath, Mode=OneWay}"/>
+                        <Button Grid.Column="1" Content="Browse" Margin="8,0,0,0"
+                                Style="{StaticResource PillButton}"
+                                controls:ControlsHelper.ContentCharacterCasing="Normal"
+                                Command="{Binding BrowseFirmwarePathCommand}"/>
                     </Grid>
                 </StackPanel>
             </GroupBox>
 
             <Label Visibility="{Binding HasErrorOccured, Converter={StaticResource BoolToVis}}" Grid.Row="2" Content="Sorry, something went wrong uploading the firmware.  :(" HorizontalContentAlignment="Center" Foreground="{StaticResource StatusRed}"/>
 
-            <DockPanel Grid.Row="3" HorizontalAlignment="Right" VerticalAlignment="Bottom" LastChildFill="True" Margin="5">
-                <Button Click="btnCancel_Click" Content="Cancel" Width="100" Height="30" Margin="0,0,10,0" Style="{StaticResource DarkSecondaryButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
-                <Button DockPanel.Dock="Bottom" Content="Upload" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal" Command="{Binding UploadFirmwareCommand}"/>
-            </DockPanel>
+            <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,16,0,0">
+                <Button Click="btnCancel_Click" Content="Cancel" Margin="0,0,8,0"
+                        Style="{StaticResource DialogPillButton}"
+                        controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                <Button Content="Upload"
+                        Style="{StaticResource DialogAccentPillButton}"
+                        controls:ControlsHelper.ContentCharacterCasing="Normal"
+                        Command="{Binding UploadFirmwareCommand}"/>
+            </StackPanel>
 
             <Grid Grid.RowSpan="4" Background="{StaticResource Scrim}" Visibility="{Binding IsFirmwareUploading, Converter={StaticResource BoolToVis}}" >
                 <Grid.RowDefinitions>
@@ -92,9 +102,11 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <Label Grid.Row="2" Content="Upload Complete"  HorizontalAlignment="Center" />
-                <DockPanel Grid.Row="3" HorizontalAlignment="Right" VerticalAlignment="Bottom" LastChildFill="True" Margin="5">
-                    <Button Click="btnOk_Click" Content="OK"  DockPanel.Dock="Bottom" Width="100" Height="30" HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent }" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
-                </DockPanel>
+                <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,16,0,0">
+                    <Button Click="btnOk_Click" Content="OK"
+                            Style="{StaticResource DialogAccentPillButton}"
+                            controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+                </StackPanel>
             </Grid>
         </Grid>
     </Grid>

--- a/Daqifi.Desktop/View/MigrationStatusWindow.xaml
+++ b/Daqifi.Desktop/View/MigrationStatusWindow.xaml
@@ -9,6 +9,14 @@
         Background="{StaticResource Surface}"
         Topmost="True"
         AllowsTransparency="True">
+    <!--
+        Chromeless splash, not a dialog: this is shown during startup DB migration, before the
+        main window exists, and has no title bar to hang chrome off. It is therefore the one
+        documented exception to the dialog chrome convention (border 0 + accent glow) — a
+        plain Window cannot use MetroWindow's GlowBrush, and giving a startup splash a title
+        bar just to conform would be worse. The 1px border below is what separates it from the
+        desktop behind it, so it stays. See docs/style-guide.md "Window chrome".
+    -->
     <Border Background="{StaticResource Surface}"
             BorderBrush="{StaticResource BorderDim}"
             BorderThickness="1"

--- a/Daqifi.Desktop/View/ProfilesPane.xaml
+++ b/Daqifi.Desktop/View/ProfilesPane.xaml
@@ -26,64 +26,8 @@
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
 
-        <Style x:Key="PillButton" TargetType="Button">
-            <Setter Property="Background"      Value="Transparent"/>
-            <Setter Property="BorderBrush"     Value="{StaticResource BorderDim}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Foreground"      Value="{StaticResource TextSecondary}"/>
-            <Setter Property="Padding"         Value="14,5"/>
-            <Setter Property="FontSize"        Value="10"/>
-            <Setter Property="FontWeight"      Value="SemiBold"/>
-            <Setter Property="Cursor"          Value="Hand"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="14"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="BorderBrush" Value="{StaticResource BorderBright}"/>
-                    <Setter Property="Background"  Value="#141821"/>
-                    <Setter Property="Foreground"  Value="{StaticResource TextPrimary}"/>
-                </Trigger>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Opacity" Value="0.35"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="AccentPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
-            <Setter Property="Background"  Value="{StaticResource Accent}"/>
-            <Setter Property="BorderBrush" Value="{StaticResource Accent}"/>
-            <Setter Property="Foreground"  Value="White"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background"  Value="#0D8CC4"/>
-                    <Setter Property="BorderBrush" Value="#0D8CC4"/>
-                    <Setter Property="Foreground"  Value="White"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="DangerPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
-            <Setter Property="BorderBrush" Value="{StaticResource StatusRed}"/>
-            <Setter Property="Foreground"  Value="{StaticResource StatusRed}"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background"  Value="#1A0A0D"/>
-                    <Setter Property="BorderBrush" Value="{StaticResource StatusRed}"/>
-                    <Setter Property="Foreground"  Value="{StaticResource StatusRed}"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
+        <!-- The PillButton / AccentPillButton / DangerPillButton family comes from
+             /Resources/Controls.xaml via App.xaml. See docs/style-guide.md. -->
 
         <Style x:Key="DrawerTextBox" TargetType="TextBox">
             <Setter Property="Background"               Value="{StaticResource Surface}"/>
@@ -957,7 +901,7 @@
                                 Command="{Binding ConfirmOverlay.NegativeCommand}"/>
                         <Button Content="{Binding ConfirmOverlay.AffirmativeLabel}"
                                 Style="{StaticResource AccentPillButton}"
-                                Margin="10,0,0,0"
+                                Margin="8,0,0,0"
                                 Command="{Binding ConfirmOverlay.AffirmativeCommand}"/>
                     </StackPanel>
                 </StackPanel>

--- a/Daqifi.Desktop/View/Prototype/ChannelsPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/ChannelsPanePrototype.xaml
@@ -27,37 +27,8 @@
             <Setter Property="FontWeight" Value="Normal"/>
         </Style>
 
-        <Style x:Key="PillButton" TargetType="Button">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="BorderBrush" Value="{StaticResource BorderDim}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
-            <Setter Property="Padding" Value="12,4"/>
-            <Setter Property="Margin" Value="0,0,6,0"/>
-            <Setter Property="FontSize" Value="10"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="14"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="BorderBrush" Value="{StaticResource BorderBright}"/>
-                    <Setter Property="Background" Value="#141821"/>
-                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
+        <!-- PillButton and the rest of the button family come from /Resources/Controls.xaml
+             via App.xaml. See docs/style-guide.md. -->
 
         <!-- Defined before ChannelTileTemplate: a StaticResource inside a template cannot
              forward-reference a resource declared later in the same dictionary. -->

--- a/Daqifi.Desktop/View/Prototype/DevicesPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/DevicesPanePrototype.xaml
@@ -58,66 +58,8 @@
             <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
         </Style>
 
-        <Style x:Key="PillButton" TargetType="Button">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="BorderBrush" Value="{StaticResource BorderDim}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
-            <Setter Property="Padding" Value="12,4"/>
-            <Setter Property="Margin" Value="0,0,6,0"/>
-            <Setter Property="FontSize" Value="10"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="14"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="BorderBrush" Value="{StaticResource BorderBright}"/>
-                    <Setter Property="Background" Value="#141821"/>
-                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="AccentPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
-            <Setter Property="Background" Value="{StaticResource Accent}"/>
-            <Setter Property="BorderBrush" Value="{StaticResource Accent}"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="Padding" Value="16,6"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#1EB3F0"/>
-                    <Setter Property="BorderBrush" Value="#1EB3F0"/>
-                    <Setter Property="Foreground" Value="White"/>
-                </Trigger>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Opacity" Value="0.4"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="DangerPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
-            <Setter Property="BorderBrush" Value="#4A1F28"/>
-            <Setter Property="Foreground" Value="{StaticResource StatusRed}"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#2A0F14"/>
-                    <Setter Property="BorderBrush" Value="{StaticResource StatusRed}"/>
-                    <Setter Property="Foreground" Value="{StaticResource StatusRed}"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
+        <!-- The PillButton / AccentPillButton / DangerPillButton family comes from
+             /Resources/Controls.xaml via App.xaml. See docs/style-guide.md. -->
 
         <Style x:Key="DrawerTextBox" TargetType="TextBox">
             <Setter Property="Background" Value="Transparent"/>
@@ -987,6 +929,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{StaticResource PillButton}"
                                         Content="REBOOT"
+                                        Margin="0,0,8,0"
                                         Command="{Binding RebootSelectedCommand}"/>
                                 <Button Style="{StaticResource DangerPillButton}"
                                         Content="DISCONNECT"

--- a/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/LoggedDataPanePrototype.xaml
@@ -38,66 +38,8 @@
             <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
         </Style>
 
-        <Style x:Key="PillButton" TargetType="Button">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="BorderBrush" Value="{StaticResource BorderDim}"/>
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
-            <Setter Property="Padding" Value="12,4"/>
-            <Setter Property="Margin" Value="0,0,6,0"/>
-            <Setter Property="FontSize" Value="10"/>
-            <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Border Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="14"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="BorderBrush" Value="{StaticResource BorderBright}"/>
-                    <Setter Property="Background" Value="#141821"/>
-                    <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
-                </Trigger>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Opacity" Value="0.35"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="DangerPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
-            <Setter Property="BorderBrush" Value="#4A1F28"/>
-            <Setter Property="Foreground" Value="{StaticResource StatusRed}"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#2A0F14"/>
-                    <Setter Property="BorderBrush" Value="{StaticResource StatusRed}"/>
-                    <Setter Property="Foreground" Value="{StaticResource StatusRed}"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="AccentPillButton" TargetType="Button" BasedOn="{StaticResource PillButton}">
-            <Setter Property="Background" Value="{StaticResource Accent}"/>
-            <Setter Property="BorderBrush" Value="{StaticResource Accent}"/>
-            <Setter Property="Foreground" Value="White"/>
-            <Setter Property="Padding" Value="16,6"/>
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#1EB3F0"/>
-                    <Setter Property="BorderBrush" Value="#1EB3F0"/>
-                    <Setter Property="Foreground" Value="White"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
+        <!-- The PillButton / AccentPillButton / DangerPillButton family comes from
+             /Resources/Controls.xaml via App.xaml. See docs/style-guide.md. -->
 
         <Style x:Key="SegmentedToggle" TargetType="RadioButton">
             <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
@@ -899,6 +841,7 @@
                             <Button Style="{StaticResource PillButton}"
                                     AutomationProperties.AutomationId="ExportAllSessionsButton"
                                     Content="EXPORT ALL"
+                                    Margin="0,0,8,0"
                                     Command="{Binding ExportAllLoggingSessionCommand}"
                                     ToolTip="Export all sessions"/>
                             <Button Style="{StaticResource DangerPillButton}"
@@ -1054,6 +997,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <Button Style="{StaticResource PillButton}"
                                         Content="EXPORT"
+                                        Margin="0,0,8,0"
                                         Command="{Binding ExportLoggingSessionCommand}"
                                         CommandParameter="{Binding SelectedLoggingSession}"/>
                                 <Button Style="{StaticResource DangerPillButton}"
@@ -1133,14 +1077,14 @@
                         <Button Content="{Binding ConfirmOverlay.AffirmativeLabel}"
                                 AutomationProperties.AutomationId="ConfirmAffirmativeButton"
                                 Style="{StaticResource AccentPillButton}"
-                                Margin="10,0,0,0"
+                                Margin="8,0,0,0"
                                 Command="{Binding ConfirmOverlay.AffirmativeCommand}"
                                 Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive,
                                              Converter={StaticResource InvertedBoolToVis}}"/>
                         <Button Content="{Binding ConfirmOverlay.AffirmativeLabel}"
                                 AutomationProperties.AutomationId="ConfirmAffirmativeButton"
                                 Style="{StaticResource DangerPillButton}"
-                                Margin="10,0,0,0"
+                                Margin="8,0,0,0"
                                 Command="{Binding ConfirmOverlay.AffirmativeCommand}"
                                 Visibility="{Binding ConfirmOverlay.AffirmativeIsDestructive,
                                              Converter={StaticResource BoolToVis}}"/>

--- a/Daqifi.Desktop/View/SuccessDialog.xaml
+++ b/Daqifi.Desktop/View/SuccessDialog.xaml
@@ -34,8 +34,8 @@
                  FontSize="14" VerticalAlignment="Center" Foreground="{StaticResource TextPrimary}"/>
 
         <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Content="Ok" Click="btnOk_Click"
-                IsDefault="True" Width="80" Height="30" Margin="0,20,0,0"
-                HorizontalAlignment="Right" Style="{StaticResource MahApps.Styles.Button.Square.Accent}"
+                IsDefault="True" Margin="0,20,0,0"
+                HorizontalAlignment="Right" Style="{StaticResource DialogAccentPillButton}"
                 controls:ControlsHelper.ContentCharacterCasing="Normal"/>
     </Grid>
 </controls:MetroWindow>

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -2,6 +2,8 @@
 
 This is the north star for DAQiFi Desktop's visual and interaction design. It is not a style guide — there are no hex codes, widths, or control specs here. It is the set of principles that decisions should be measured against. When something feels off, come back to this document.
 
+For the concrete counterpart — which style key to use, what a button or field actually measures, the hex value behind each token — see **[style-guide.md](style-guide.md)**. This document says why; that one says what. If the two ever disagree, this one wins and the style guide is the bug.
+
 The application is an instrument. People use it to watch signals from hardware, not to admire an interface. Everything that follows flows from that.
 
 ## Principles

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,191 @@
+# Style Guide
+
+Concrete control specs for DAQiFi Desktop. This is the companion to
+[design-philosophy.md](design-philosophy.md): that document says *why* (principles, no numbers), this one
+says *what* (hex codes, sizes, style keys). When the two disagree, the philosophy wins and this document
+is the bug.
+
+Scope: what a control should look like and which style key to reach for. It does not dictate layout —
+where things sit on a surface is a design decision per surface, with the Channels pane as the exemplar.
+
+## Where the styles live
+
+| File | Scope | Holds |
+| --- | --- | --- |
+| `Resources/DesignTokens.xaml` | app (via `App.xaml`) | Color tokens only — surfaces, borders, text, status. |
+| `Resources/Controls.xaml` | app (via `App.xaml`) | **The canonical control specs.** Keyed styles: button family, field, dropdown. |
+| `Resources/DarkDialog.xaml` | window (merged per dialog) | Implicit skins that re-dress a dialog's default controls (`Label`, `TextBox`, `RadioButton`, `GroupBox`). Merges `Controls.xaml` so those skins inherit from it. |
+
+Two rules keep this from re-fragmenting:
+
+- **Shared control specs go in `Controls.xaml`, keyed.** Never redeclare `PillButton` (or any other key
+  here) in a view. That is exactly how the app ended up with five copies of the pill family that had
+  drifted in padding, hover color, and disabled state ([#627](https://github.com/daqifi/daqifi-desktop/issues/627)).
+- **Implicit (unkeyed) styles never go in `Controls.xaml`.** An implicit style at app scope restyles every
+  control in the app. Window-scoped implicit skins belong in `DarkDialog.xaml`.
+
+A view-scoped style is still correct for something genuinely local — a connection-type stripe color, the
+Debug console's `DataGrid`. The test: *would a second view want this?* If yes, it belongs in `Controls.xaml`.
+
+Tokens inside `Controls.xaml` and `DarkDialog.xaml` are referenced with `DynamicResource`, because
+`DesignTokens.xaml` is a sibling merged dictionary and its keys are not in their static lookup scope.
+`BasedOn` is the exception — it cannot take a `DynamicResource`, which is why `DarkDialog.xaml` merges
+`Controls.xaml` rather than relying on app scope.
+
+## Window chrome
+
+Every dialog uses one convention:
+
+```xml
+BorderThickness="0"
+Background="{StaticResource Surface}"
+GlowBrush="{DynamicResource AccentColorBrush}"
+```
+
+No 1px outline — the accent glow is the window edge. This requires a MahApps `MetroWindow`.
+
+Content sits in a root container with **`Margin="16"`**. Dialogs that autosize to a message
+(Error, Success, DuplicateDevice) use `Margin="20"`, which suits their icon-plus-text layout.
+
+**The one exception** is `MigrationStatusWindow`: a chromeless startup splash (`WindowStyle="None"`,
+`AllowsTransparency="True"`) shown before the main window exists. A plain `Window` has no `GlowBrush`, and
+giving a splash a title bar just to conform would be worse. It keeps a 1px `BorderDim` border, which is
+what separates it from the desktop behind it. Do not copy this for anything the user interacts with.
+
+## Buttons
+
+One family. Three intents, two sizes, all in `Controls.xaml`:
+
+| Key | Use for |
+| --- | --- |
+| `PillButton` | Neutral action. **The default** — use it unless the action is *the* primary one. |
+| `AccentPillButton` | The primary action. At most one per surface. |
+| `DangerPillButton` | Destructive action (delete, disconnect). |
+| `DialogPillButton` | Neutral action in a dialog's action row. |
+| `DialogAccentPillButton` | Primary action in a dialog's action row. |
+
+There is deliberately no `DialogDangerPillButton`: no dialog currently has a destructive action —
+destructive confirms are in-pane overlays, which use the compact `DangerPillButton`. Add it to
+`Controls.xaml` if a dialog ever needs one.
+
+Shared geometry: `CornerRadius="14"`, 1px border, `SemiBold`, `Cursor="Hand"`.
+
+| | Compact (panes, drawers, toolbars) | Dialog action row |
+| --- | --- | --- |
+| Font size | 10 | 11 |
+| Padding (neutral / danger) | `12,4` | `24,8` |
+| Padding (accent) | `16,6` | `24,8` |
+| MinWidth | — | 96 (so OK and Cancel match) |
+
+Colors:
+
+| | Rest | Hover |
+| --- | --- | --- |
+| Neutral | transparent bg, `BorderDim`, `TextSecondary` | `#141821` bg, `BorderBright`, `TextPrimary` |
+| Accent | `Accent` bg + border, white text | `#1EB3F0` bg + border |
+| Danger | transparent bg, `#4A1F28` border, `StatusRed` text | `#2A0F14` bg, `StatusRed` border |
+
+Disabled is `Opacity="0.35"` on all of them.
+
+Danger is outline-only at rest on purpose: the red is a warning, not an invitation, so it never competes
+with the accent for the eye.
+
+### Rules
+
+- **Never set `Width`/`Height` on a button.** Padding sizes it; `MinWidth` handles dialog action rows. A
+  fixed height is how the Firmware dialog ended up clipping descenders.
+- **Never put `Margin` in a button style.** Spacing between controls is the call site's business — a style
+  that carries margin cannot be right-aligned or centered without fighting it (views were already setting
+  `Margin="0"` to undo it).
+- **Action row order is Cancel → primary**, left to right, so the accent lands nearest the bottom-right
+  corner in every dialog.
+- **Field-adjacent buttons** (a Browse next to a path field) use `PillButton` with `Margin="8,0,0,0"` and
+  **no explicit height** — in a `Grid` they stretch to the field's height, so the two can't drift apart.
+
+## Fields
+
+`DarkTextBox` in `Controls.xaml` is the canonical input. Dialogs that merge `DarkDialog.xaml` get it
+implicitly on every `TextBox`; elsewhere apply it by key.
+
+- Height: **`MinHeight="32"`** — the standard field height. (`MinHeight`, not `Height`, so a field can grow
+  with wrapped content.) 30px clips descenders; don't go below 32.
+- Padding `10,0`, `CornerRadius="3"`, 1px `BorderDim` border, `Surface` background.
+- Border on hover `BorderBright`, on keyboard focus `Accent`. Disabled `Opacity="0.5"`.
+
+`DarkComboBox` matches the field spec (`MinHeight="32"`, padding `10,0`, same border states) and pairs with
+`DarkComboBoxItem` via `ItemContainerStyle` — it is opt-in by key, so it never silently overrides a
+`ComboBox` in a dialog that merges `DarkDialog.xaml`. It is a full replacement template, not a re-skin,
+because the app runs on the MahApps `Light.Blue` theme whose combo brings a white toggle and popup that
+swallow light text.
+
+Drawer fields (`DrawerTextBox` in the panes, `DarkTextFieldInput` in the Connection dialog) are a
+deliberate variant: a borderless, transparent TextBox that sits inside an already-bordered container, so
+the container draws the field and the TextBox only carries the text. The composite adds up to the same
+thing `DarkTextBox` draws on its own. They are view-scoped, and they must **not** reuse the `DarkTextBox`
+key — one key, one control.
+
+## Spacing
+
+| Situation | Value |
+| --- | --- |
+| Dialog content margin | `16` (autosizing alert dialogs: `20`) |
+| Between adjacent buttons | `8` |
+| Between a field and its adjacent button | `8` |
+| Action row top margin | `16` |
+
+## Typography
+
+Faces: **Segoe UI** (inherited default) for everything, **Consolas** for numeric readouts and identifiers —
+values, serial numbers, timestamps. Monospace is a signal that the text is data, not chrome; don't use it
+for labels or prose.
+
+The intended scale — per design-philosophy §6, the vocabulary is small on purpose:
+
+| Size | Weight | Use |
+| --- | --- | --- |
+| 9–10 | `Bold` / `SemiBold`, uppercase | Section labels, pill buttons, column headers, status chips |
+| 11 | `SemiBold` | Dialog action buttons, secondary labels |
+| 12–13 | normal | Body text, list rows, readouts |
+| 14 | normal | Dialog message text |
+| 16+ | normal / `Light` | Headline numbers and empty-state titles only |
+
+Hierarchy comes from **size and opacity** (`TextPrimary` → `TextSecondary` → `TextTertiary`), not from
+bold/italic. There are no typography tokens in `DesignTokens.xaml` — it holds brushes only — so these are
+set per control.
+
+> **Honest status:** the codebase does not fully conform to this scale yet. A sweep at the time of writing
+> found 13 distinct font sizes and 4 weights in `View/`. The table above is the target for new work and the
+> direction to converge on when touching an existing surface — not a description of what's there today.
+> Narrowing the existing usage is worth its own ticket.
+
+## Color
+
+All from `DesignTokens.xaml`; never hardcode a hex outside a style in `Controls.xaml`.
+
+| Token | Value | Use |
+| --- | --- | --- |
+| `Surface` | `#0D0F12` | Window and pane background |
+| `SurfaceHover` | `#13161C` | Row hover |
+| `SurfaceRaised` | `#171A20` | Cards, drawers, panels, headers |
+| `SurfaceActive` | `#1E2530` | Selected/active surface |
+| `BorderDim` | `#2A2F38` | Default border, dividers |
+| `BorderBright` | `#3A4252` | Hover border |
+| `TextPrimary` | `#F5F5F7` | Values, primary labels |
+| `TextSecondary` | `#8E9199` | Secondary labels |
+| `TextTertiary` | `#5A5E66` | Column headers, hints |
+| `Accent` | `#119EDA` | Primary action, focus, selection |
+| `StatusGreen` | `#4ADE80` | Success, connected |
+| `StatusAmber` | `#F59E0B` | Warning, locked |
+| `StatusRed` | `#F43F5E` | Error, destructive |
+| `Scrim` | `#CC000000` | Modal overlay |
+
+Per design-philosophy §3, color is a channel of information. A channel's user-chosen plot color is that
+channel's identity everywhere it appears, and it outranks these tokens on its own tile.
+
+## Adding a new surface
+
+1. Read [design-philosophy.md](design-philosophy.md), then study the Channels pane.
+2. Use `Surface` as the background; use `SurfaceRaised` for cards and drawers.
+3. Reach for `Controls.xaml` keys before writing a style. If you need a shared control that isn't there,
+   add it there — not to your view.
+4. Prefer an inline drawer to a dialog (§4). If it must be a dialog, follow the chrome convention above.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -139,24 +139,29 @@ Faces: **Segoe UI** (inherited default) for everything, **Consolas** for numeric
 values, serial numbers, timestamps. Monospace is a signal that the text is data, not chrome; don't use it
 for labels or prose.
 
-The intended scale — per design-philosophy §6, the vocabulary is small on purpose:
+Per design-philosophy §6 the vocabulary is small on purpose. Sizes are not arbitrary — each one is a
+**role**, and the app already applies them consistently across surfaces. Pick the role, not the number:
 
-| Size | Weight | Use |
+| Size | Weight | Role |
 | --- | --- | --- |
-| 9–10 | `Bold` / `SemiBold`, uppercase | Section labels, pill buttons, column headers, status chips |
-| 11 | `SemiBold` | Dialog action buttons, secondary labels |
-| 12–13 | normal | Body text, list rows, readouts |
+| 9 | `Bold`, uppercase | Status chips (`LOGGING · LOCKED`), the smallest annotations |
+| 10 | `SemiBold` / `Bold`, uppercase | Section labels, compact pill buttons, column headers |
+| 11 | `SemiBold` (or normal) | Dialog action buttons, secondary labels, field hints |
+| 12–13 | normal (`Consolas` for values) | Body text, list rows, numeric readouts |
 | 14 | normal | Dialog message text |
-| 16+ | normal / `Light` | Headline numbers and empty-state titles only |
+| 15 | `Light` | Empty-state body copy ("Connect a DAQiFi device to get started.") |
+| 20 | `Medium` + `Consolas` | Drawer header — the selected channel/device name |
+| 24 | `Light` | Headline: empty-state titles, hero numbers |
 
 Hierarchy comes from **size and opacity** (`TextPrimary` → `TextSecondary` → `TextTertiary`), not from
 bold/italic. There are no typography tokens in `DesignTokens.xaml` — it holds brushes only — so these are
 set per control.
 
-> **Honest status:** the codebase does not fully conform to this scale yet. A sweep at the time of writing
-> found 13 distinct font sizes and 4 weights in `View/`. The table above is the target for new work and the
-> direction to converge on when touching an existing surface — not a description of what's there today.
-> Narrowing the existing usage is worth its own ticket.
+> **Honest status:** a handful of call sites sit outside this table — a lone `8`, a lone `22`, two `18`s,
+> and some `16`s that are doing the job of `15` or `20`. They are leftovers, not a competing scale: fold
+> them into the nearest role when you next touch that surface. Note the legacy flyouts
+> (`View/Flyouts/`) are uniformly `16`/`Bold` throughout; they are a transition state per
+> design-philosophy §9 and get the table above when they're redesigned, not a find-and-replace.
 
 ## Color
 


### PR DESCRIPTION
Closes #627

Establishes `docs/style-guide.md` as the concrete companion to `docs/design-philosophy.md` — that one says *why* (principles, no numbers), this one says *what* (hex codes, sizes, style keys) — and consolidates the app onto it.

## The actual problem

`PillButton` had been copy-pasted into **five views** and drifted apart:

| | Canon (Devices/LoggedData/Channels/DeviceLogs) | ProfilesPane | ConnectionDialog |
|---|---|---|---|
| Padding | `12,4` | `14,5` | `24,8` |
| Accent hover | `#1EB3F0` | `#0D8CC4` | `#1EB3F0` |
| Danger border | `#4A1F28` | `StatusRed` | — |

ChannelsPane's copy had also silently lost the disabled-state trigger. Nothing documented the concrete specs, so new work and the legacy MahApps dialogs disagreed about buttons, chrome, margins, and field heights.

## What changed

**`Resources/Controls.xaml`** is the new single home for shared control specs, merged at app scope. Every style now has exactly one definition. Two rules keep it from re-fragmenting (documented in the file and the guide):

- Shared control specs go there, **keyed**.
- **Implicit styles never do** — an implicit style at app scope would restyle every control in the app. Those stay window-scoped in `DarkDialog.xaml`, which now merges `Controls.xaml` so its dialog skins *inherit* rather than redeclare.

**Buttons no longer carry `Margin`.** It's a layout property, and baking it into a control style meant a right-aligned or centered pill had to fight it — `DeviceLogsView` was already setting `Margin="0"` to undo it. Removing it *corrects* several latent misalignments (right-aligned and centered pills were offset by 6px/3px); the few adjacent-pill pairs now set an explicit 8px gap at the call site.

**Legacy dialogs migrated** onto the standard chrome + button family. `MahApps.Styles.Button.Square.Accent` (including both trailing-space typo'd refs) and `DarkSecondaryButton` are gone — both legacy families fully removed.

- **Firmware** gained the standard 16px content margin (content hugged the window edge), and its Browse field is no longer a fixed 30/34px that clipped descenders — the field-adjacent button now stretches to the field instead of being kept in sync by hand.
- **Debug** was still fully light-themed with a full-width accent banner; now dark, with a raised header strip and a readable DataGrid. Accent is for the primary action, not decoration.

## Judgment calls worth a look

1. **Duplicate dialog's buttons are reordered** to Cancel → OK, so the accent lands nearest the bottom-right corner in every dialog. Functionally safe (handlers are per-button), but users will notice.
2. **`MigrationStatusWindow` keeps its 1px border.** The issue lists it as a chrome outlier, but it's a chromeless startup splash (`WindowStyle=None`, `AllowsTransparency`) with no title bar — a plain `Window` can't use MetroWindow's `GlowBrush`, and giving a splash a title bar just to conform would be worse. Documented as the one explicit exception.
3. **`ConnectionDialog`'s view-scoped `DarkTextBox` was a *different control*** from the new canonical one (borderless, meant to sit inside its `DarkTextField` border). Renamed to `DarkTextFieldInput` — one key, one control.
4. **No `DialogDangerPillButton`.** No dialog has a destructive action (destructive confirms are in-pane overlays using the compact `DangerPillButton`), so shipping one would be dead code. The guide says to add it when a dialog needs it.

## Typography: documented by role

An earlier draft of this PR claimed typography "does not conform" off a raw count (13 sizes, 4 weights) and promised a follow-up sweep ticket. Checking where those sizes actually land, that was wrong: they are consistent semantic roles the app already applies across surfaces — `15/Light` is empty-state body copy in five files, `20/Medium/Consolas` is the drawer header in both panes, `24/Light` is the headline. The old table omitted those roles and would have sent new work to the wrong size.

The count also blamed the wrong code: the legacy flyouts look like the worst offenders (38 of the 50 `FontSize="16"` are in `SummaryFlyout` alone) but are internally uniform at `16`/`Bold` — a transition state per design-philosophy §9.

The guide now documents the eight real roles and scopes the genuine residue honestly: a lone `8`, a lone `22`, two `18`s, and some `16`s doing the job of `15` or `20`. That is a handful of call sites to fold in on touch — **no sweep ticket needed**.

## Verification

A green build proves nothing here — XAML resource resolution fails at **runtime**, when a window loads. So beyond the build and the **550-test unit gate**:

- **FlaUI launch smoke + manual-connect** pass — main window, all four panes, and `ConnectionDialog` all resolving the family from app scope.
- A **throwaway probe** constructed and rendered **all 7 dialogs** offscreen; every `StaticResource` resolved, and the renders confirm the migrated chrome, pill buttons, and 32px fields.

Cross-checked that every referenced style key is defined, and that no view still declares a duplicate.

## Acceptance criteria

- [x] `docs/style-guide.md` documents window chrome, buttons, fields, spacing, typography with concrete values
- [x] A single shared dictionary holds the canonical button/field/combobox styles; duplicates removed
- [x] All app dialogs use one window-chrome convention (splash documented as the exception)
- [x] All buttons use the documented family — no legacy `Square.Accent` / one-off styles
- [x] Consistent content margins and field heights across dialogs
- [x] `design-philosophy.md` links to the style guide as its concrete companion
- [x] Typo'd `Square.Accent ` reference removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

