### PR TITLE
fix: stop misclassifying serial connect's SCPI-init error as a bug

### DIFF
--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -1,0 +1,68 @@
+using Daqifi.Desktop.Device.SerialDevice;
+
+namespace Daqifi.Desktop.Test.Device;
+
+/// <summary>
+/// Tests for <see cref="SerialStreamingDevice"/>'s connect-failure classification (issue #589):
+/// Core's SCPI-error-during-initialization InvalidOperationException is a device/environmental
+/// condition, not an app bug, so it must be downgraded to a Warning (no Sentry capture) rather
+/// than the default Error path.
+/// </summary>
+[TestClass]
+public class SerialStreamingDeviceLogConnectFailureTests
+{
+    // Exact wording Daqifi.Core 1.1.1 throws from DaqifiStreamingDevice.InitializeAsync()
+    // (verified against the NuGet package's DLL strings) when any command in its init sequence
+    // gets back a SCPI -200 execution error — e.g. "SYSTem:STReam:INTerface 0" (setting the
+    // stream interface to USB) rejected because firmware persisted WiFi as the last interface.
+    private const string CORE_SCPI_INIT_ERROR_MESSAGE =
+        "Device returned a SCPI error during initialization: -200,\"Execution error\"";
+
+    [TestMethod]
+    public void IsScpiInitializationError_MatchesCoresInitializationErrorMessage()
+    {
+        var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
+
+        Assert.IsTrue(SerialStreamingDevice.IsScpiInitializationError(ex));
+    }
+
+    [TestMethod]
+    public void IsScpiInitializationError_IsCaseInsensitive()
+    {
+        var ex = new InvalidOperationException("device returned a scpi error during initialization: whatever");
+
+        Assert.IsTrue(SerialStreamingDevice.IsScpiInitializationError(ex));
+    }
+
+    [TestMethod]
+    public void IsScpiInitializationError_DoesNotMatchUnrelatedInvalidOperationException()
+    {
+        // Regression guard: an unrelated InvalidOperationException bug must still hit the
+        // default Error path instead of being silently downgraded.
+        var ex = new InvalidOperationException("Transport exploded.");
+
+        Assert.IsFalse(SerialStreamingDevice.IsScpiInitializationError(ex));
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithScpiInitializationError_DoesNotThrow()
+    {
+        var device = new TestableSerialStreamingDevice("COM_TEST_589");
+        var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
+
+        device.ExposedLogConnectFailure(ex);
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithUnrelatedException_DoesNotThrow()
+    {
+        var device = new TestableSerialStreamingDevice("COM_TEST_589");
+
+        device.ExposedLogConnectFailure(new InvalidOperationException("Transport exploded."));
+    }
+
+    private sealed class TestableSerialStreamingDevice(string portName) : SerialStreamingDevice(portName)
+    {
+        public void ExposedLogConnectFailure(Exception ex) => LogConnectFailure(ex);
+    }
+}

--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -45,12 +45,30 @@ public class SerialStreamingDeviceLogConnectFailureTests
     }
 
     [TestMethod]
+    public void IsScpiInitializationError_DoesNotMatchUnrelatedScpiErrorMention()
+    {
+        // Regression guard: the predicate matches Core's full known prefix, not the bare
+        // substring "SCPI error" — an unrelated failure that happens to mention a SCPI error in
+        // some other context must not be misclassified as the initialization error.
+        var ex = new InvalidOperationException("SCPI error while doing something unrelated to initialization.");
+
+        Assert.IsFalse(SerialStreamingDevice.IsScpiInitializationError(ex));
+    }
+
+    [TestMethod]
     public void LogConnectFailure_WithScpiInitializationError_DoesNotThrow()
     {
         var device = new TestableSerialStreamingDevice("COM_TEST_589");
         var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
 
-        device.ExposedLogConnectFailure(ex);
+        try
+        {
+            device.ExposedLogConnectFailure(ex);
+        }
+        catch (Exception caught)
+        {
+            Assert.Fail($"LogConnectFailure must not throw for the SCPI-init-error case, but threw: {caught}");
+        }
     }
 
     [TestMethod]
@@ -58,7 +76,14 @@ public class SerialStreamingDeviceLogConnectFailureTests
     {
         var device = new TestableSerialStreamingDevice("COM_TEST_589");
 
-        device.ExposedLogConnectFailure(new InvalidOperationException("Transport exploded."));
+        try
+        {
+            device.ExposedLogConnectFailure(new InvalidOperationException("Transport exploded."));
+        }
+        catch (Exception caught)
+        {
+            Assert.Fail($"LogConnectFailure must not throw for the default case, but threw: {caught}");
+        }
     }
 
     private sealed class TestableSerialStreamingDevice(string portName) : SerialStreamingDevice(portName)

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
@@ -69,15 +69,25 @@ public class ConnectionDialogViewModelCloseTests
     public async Task ConnectSerialCommand_WhenConnectFails_SetsSerialConnectErrorAndDoesNotRaiseCloseRequested()
     {
         var viewModel = CreateViewModel();
-        var device = new SerialStreamingDevice(NONEXISTENT_PORT_NAME);
-        var closeRaised = SubscribeToClose(viewModel);
+        try
+        {
+            var device = new SerialStreamingDevice(NONEXISTENT_PORT_NAME);
+            var closeRaised = SubscribeToClose(viewModel);
 
-        await viewModel.ConnectSerialCommand.ExecuteAsync(new[] { device });
+            await viewModel.ConnectSerialCommand.ExecuteAsync(new[] { device });
 
-        Assert.IsFalse(closeRaised(),
-            "CloseRequested should not fire when the selected device fails to connect.");
-        Assert.IsNotNull(viewModel.SerialConnectError,
-            "SerialConnectError should be set when the selected device fails to connect.");
+            Assert.IsFalse(closeRaised(),
+                "CloseRequested should not fire when the selected device fails to connect.");
+            Assert.IsNotNull(viewModel.SerialConnectError,
+                "SerialConnectError should be set when the selected device fails to connect.");
+        }
+        finally
+        {
+            // The error path restarts serial discovery (ContinuousDeviceFinder) so the dialog
+            // keeps finding devices after a failed attempt — tear it down or it keeps running
+            // across tests and can cause flakiness/resource contention on CI.
+            viewModel.Close();
+        }
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
@@ -60,6 +60,26 @@ public class ConnectionDialogViewModelCloseTests
         Assert.IsFalse(closeRaised(), "CloseRequested should not fire when no serial devices are selected.");
     }
 
+    /// <summary>
+    /// A discovered device that fails to connect (e.g. a nonexistent/vanished port) must keep
+    /// the dialog open and surface the inline <c>SerialConnectError</c> message instead of
+    /// closing silently (issue #589).
+    /// </summary>
+    [TestMethod]
+    public async Task ConnectSerialCommand_WhenConnectFails_SetsSerialConnectErrorAndDoesNotRaiseCloseRequested()
+    {
+        var viewModel = CreateViewModel();
+        var device = new SerialStreamingDevice(NONEXISTENT_PORT_NAME);
+        var closeRaised = SubscribeToClose(viewModel);
+
+        await viewModel.ConnectSerialCommand.ExecuteAsync(new[] { device });
+
+        Assert.IsFalse(closeRaised(),
+            "CloseRequested should not fire when the selected device fails to connect.");
+        Assert.IsNotNull(viewModel.SerialConnectError,
+            "SerialConnectError should be set when the selected device fails to connect.");
+    }
+
     [TestMethod]
     public async Task ConnectManualSerialCommand_WithBlankPort_DoesNotRaiseCloseRequested()
     {

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -144,11 +144,13 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
 
     /// <summary>
     /// True when <paramref name="ex"/> is Core's SCPI-error-during-initialization
-    /// <see cref="InvalidOperationException"/> (issue #589). Extracted as a pure predicate so
-    /// the classification is unit-testable without exercising the logger.
+    /// <see cref="InvalidOperationException"/> (issue #589). Matched on Core's full known prefix
+    /// rather than the bare substring "SCPI error" so an unrelated InvalidOperationException that
+    /// happens to mention a SCPI error elsewhere in its message isn't misclassified. Extracted as
+    /// a pure predicate so the classification is unit-testable without exercising the logger.
     /// </summary>
     internal static bool IsScpiInitializationError(Exception ex) =>
-        ex.Message.Contains("SCPI error", StringComparison.OrdinalIgnoreCase);
+        ex.Message.Contains("SCPI error during initialization", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Sends a message to the device using Core's DaqifiDevice.

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -122,11 +122,33 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
                 // #517, #632).
                 AppLogger.Warning(ex, $"Device on {PortName} did not respond within the connection timeout");
                 break;
+            case InvalidOperationException when IsScpiInitializationError(ex):
+                // Core's InitializeAsync throws a bare InvalidOperationException, message
+                // "Device returned a SCPI error during initialization: ...", when any command in
+                // its init sequence (echo/stop/power/stream-format/sysinfo, including
+                // "SYSTem:STReam:INTerface 0" which sets the stream interface to USB) gets a SCPI
+                // -200 execution error back. Firmware persists the last stream interface across
+                // sessions, so a device previously left streaming over WiFi is a common trigger on
+                // the very next USB connect, but any command in the sequence can hit this
+                // transient/timing condition. Matched by message substring (Core doesn't yet throw
+                // a typed exception for this — daqifi-core issue tracks that) so other
+                // InvalidOperationException bugs still hit Error. Device/environmental condition,
+                // not an app bug (issue #589).
+                AppLogger.Warning(ex, $"Device on {PortName} returned a SCPI error during initialization");
+                break;
             default:
                 AppLogger.Error(ex, $"Failed to connect on {PortName}");
                 break;
         }
     }
+
+    /// <summary>
+    /// True when <paramref name="ex"/> is Core's SCPI-error-during-initialization
+    /// <see cref="InvalidOperationException"/> (issue #589). Extracted as a pure predicate so
+    /// the classification is unit-testable without exercising the logger.
+    /// </summary>
+    internal static bool IsScpiInitializationError(Exception ex) =>
+        ex.Message.Contains("SCPI error", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Sends a message to the device using Core's DaqifiDevice.

--- a/Daqifi.Desktop/View/ConnectionDialog.xaml
+++ b/Daqifi.Desktop/View/ConnectionDialog.xaml
@@ -307,6 +307,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
                     <Grid Grid.Row="0">
@@ -369,7 +370,14 @@
                         </StackPanel>
                     </Grid>
 
-                    <Border Grid.Row="1"
+                    <TextBlock Grid.Row="1"
+                               Text="{Binding SerialConnectError}"
+                               AutomationProperties.AutomationId="SerialConnectError"
+                               FontSize="11" Foreground="{StaticResource StatusRed}"
+                               Margin="0,8,0,0" TextWrapping="Wrap"
+                               Visibility="{Binding SerialConnectError, Converter={StaticResource NotNullToVis}}"/>
+
+                    <Border Grid.Row="2"
                             BorderBrush="{StaticResource BorderDim}" BorderThickness="0,1,0,0"
                             Padding="0,12,0,0" Margin="0,12,0,0">
                         <Button HorizontalAlignment="Right"

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -86,6 +86,14 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
 
     public SerialStreamingDevice ManualSerialDevice { get; set; }
 
+    /// <summary>
+    /// User-facing error message for the discovered-device USB tab. Non-null when a selected
+    /// device failed to connect (e.g. it returns a SCPI error while switching its stream
+    /// interface to USB — issue #589). Cleared automatically at the start of the next attempt.
+    /// </summary>
+    [ObservableProperty]
+    private string? _serialConnectError;
+
     [ObservableProperty]
     private string? _manualIpAddress;
 
@@ -255,11 +263,28 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
         var selectedDevices = ToStreamingDevices(selectedItems);
         if (selectedDevices.Count == 0) { return; }
 
+        SerialConnectError = null;
+
         await StopSerialDiscoveryAsync();
 
         foreach (var device in selectedDevices)
         {
             await ConnectionManager.Instance.Connect(device);
+        }
+
+        // Post-connect status check mirrors the manual-serial path: a discovered device can
+        // still fail to connect (e.g. a device left streaming over WiFi returns a SCPI error
+        // when told to switch to USB — issue #589). Without this the dialog would close
+        // silently and the user would have no idea the connection failed.
+        if (ConnectionManager.Instance.ConnectionStatus == DAQiFiConnectionStatus.Error)
+        {
+            var deviceLabel = selectedDevices.Count == 1 ? $"'{selectedDevices[0].Name}'" : "the selected device(s)";
+            SerialConnectError =
+                $"Could not connect to {deviceLabel}. " +
+                "The device may be in use by another application or not responding.";
+            // Restart discovery so the dialog keeps finding devices after a failed connect attempt.
+            StartSerialDiscovery();
+            return;
         }
 
         RaiseCloseRequested();

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -267,24 +267,26 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
 
         await StopSerialDiscoveryAsync();
 
+        // Check status after each device rather than only once at the end: ConnectionStatus is a
+        // single shared field on ConnectionManager, so with multi-select (Extended) a later
+        // device's success would otherwise overwrite an earlier device's failure and the dialog
+        // would close despite a failed connect. A discovered device can still fail here (e.g. one
+        // left streaming over WiFi returns a SCPI error when told to switch to USB — issue #589),
+        // and without this check the dialog would close silently with no feedback to the user.
         foreach (var device in selectedDevices)
         {
             await ConnectionManager.Instance.Connect(device);
-        }
 
-        // Post-connect status check mirrors the manual-serial path: a discovered device can
-        // still fail to connect (e.g. a device left streaming over WiFi returns a SCPI error
-        // when told to switch to USB — issue #589). Without this the dialog would close
-        // silently and the user would have no idea the connection failed.
-        if (ConnectionManager.Instance.ConnectionStatus == DAQiFiConnectionStatus.Error)
-        {
-            var deviceLabel = selectedDevices.Count == 1 ? $"'{selectedDevices[0].Name}'" : "the selected device(s)";
-            SerialConnectError =
-                $"Could not connect to {deviceLabel}. " +
-                "The device may be in use by another application or not responding.";
-            // Restart discovery so the dialog keeps finding devices after a failed connect attempt.
-            StartSerialDiscovery();
-            return;
+            var status = ConnectionManager.Instance.ConnectionStatus;
+            if (status != DAQiFiConnectionStatus.Connected && status != DAQiFiConnectionStatus.AlreadyConnected)
+            {
+                SerialConnectError =
+                    $"Could not connect to '{device.Name}'. " +
+                    "The device may be in use by another application or not responding.";
+                // Restart discovery so the dialog keeps finding devices after a failed connect attempt.
+                StartSerialDiscovery();
+                return;
+            }
         }
 
         RaiseCloseRequested();


### PR DESCRIPTION
## Summary

- Core's `InitializeAsync()` throws a bare `InvalidOperationException` ("Device returned a SCPI
  error during initialization: ...") when any command in its init sequence gets a SCPI `-200`
  response back on USB/serial connect — most commonly `SYSTem:STReam:INTerface 0`, since firmware
  persists the last stream interface across sessions and a device previously left streaming over
  WiFi rejects it on the next USB connect. `SerialStreamingDevice.LogConnectFailure` had no case
  for this, so it fell to the default `Error` path and was captured to Sentry as an app bug.
- The discovered-device USB tab (`ConnectSerialAsync`) had no post-connect status check, so on
  this failure it closed the dialog unconditionally with zero feedback — unlike the manual-serial
  and manual-WiFi tabs, which already surface an inline error (issue #517/#595 pattern).
- This PR downgrades the classification to a `Warning` (message-substring matched, since Core
  doesn't yet throw a typed exception for it — tracked in
  [daqifi-core#310](https://github.com/daqifi/daqifi-core/issues/310)) and adds the same
  post-connect check to `ConnectSerialAsync`, with a new `SerialConnectError` bound to an inline
  message on the USB tab.

## Test plan

- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 556/556 passing
- [x] Bench-verified the exact exception text against the installed `Daqifi.Core` 1.1.1 NuGet DLL
      (`"Device returned a SCPI error during initialization: ..."`) — the classification matches
      the real message, not just the narrower wording quoted in the original Sentry issue title
- [x] Bench-verified the happy path (serial connect → set stream interface to WiFi → reconnect over
      serial) round-trips correctly against a physical device with no regression; the actual
      timing race that produces the SCPI error is a rare/transient condition and did not
      re-trigger across several manual cycles (consistent with the original issue analysis)
- [ ] Filed [daqifi-core#310](https://github.com/daqifi/daqifi-core/issues/310) for the root-cause
      fix (retry the transient error / typed exception) — out of scope for this repo

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
