### PR TITLE
chore: build SD parse config via Core's SdCardDeviceConfiguration.FromDevice

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -776,6 +776,18 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
+    public void GetSdCardParseConfiguration_WhenNotUsbConnected_ReturnsNull()
+    {
+        // A Core SD device could theoretically still be set on a non-USB connection type;
+        // the USB gate must be explicit rather than relying on that being impossible.
+        var device = new NonUsbSdCoreTestDevice();
+        device.PopulateCoreChannels(BuildStatusMessage("1.0.0", 1.5f));
+
+        Assert.IsNull(device.GetSdCardParseConfiguration(),
+            "SD parse configuration should only be available over a USB connection.");
+    }
+
+    [TestMethod]
     public void SwitchMode_WhenEnteringLogToDevice_DoesNotSendInterfaceCommands()
     {
         // Core's StartSdCardLoggingAsync now handles SD interface setup,
@@ -1077,6 +1089,41 @@ public class AbstractStreamingDeviceTests
         protected override void SendMessage(IOutboundMessage<string> message)
         {
             SentCommands.Add($"desktop:{message.Data}");
+        }
+    }
+
+    /// <summary>
+    /// A non-USB-connected device that still has a Core device wired up for SD operations,
+    /// so tests can prove <see cref="AbstractStreamingDevice.GetSdCardParseConfiguration"/>
+    /// gates on <see cref="ConnectionType"/> rather than only on <c>CoreDeviceForSd</c>.
+    /// </summary>
+    private sealed class NonUsbSdCoreTestDevice : AbstractStreamingDevice
+    {
+        private readonly RecordingCoreStreamingDevice _coreDevice;
+
+        public NonUsbSdCoreTestDevice()
+        {
+            _coreDevice = new RecordingCoreStreamingDevice([], throwOnCommandData: null);
+            _coreDevice.Connect();
+        }
+
+        public override ConnectionType ConnectionType => ConnectionType.Wifi;
+
+        protected override CoreStreamingDevice? CoreDeviceForSd => _coreDevice;
+
+        public override bool Connect() => true;
+
+        public override bool Disconnect() => true;
+
+        public override bool Write(string command) => true;
+
+        public void PopulateCoreChannels(DaqifiOutMessage message)
+        {
+            _coreDevice.PopulateChannelsFromStatus(message);
+        }
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
         }
     }
 

--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -751,6 +751,31 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
+    public void GetSdCardParseConfiguration_WithAnalogChannels_ReturnsCoreConfiguration()
+    {
+        var device = new SdCardLoggingTestDevice();
+        device.PopulateCoreChannels(BuildStatusMessage("1.0.0", 1.5f));
+
+        var config = device.GetSdCardParseConfiguration();
+
+        Assert.IsNotNull(config, "A device with analog channels should produce a configuration.");
+        Assert.AreEqual(1, config.AnalogPortCount);
+        Assert.AreEqual(1, config.DigitalPortCount);
+        Assert.AreEqual(1.5d, config.CalibrationValues![0].Slope, 0.001d);
+        Assert.AreEqual(0u, config.TimestampFrequency,
+            "TimestampFrequency should be 0 so the parser falls back to file-embedded/device frequency.");
+    }
+
+    [TestMethod]
+    public void GetSdCardParseConfiguration_WithoutCoreDevice_ReturnsNull()
+    {
+        var device = new TestStreamingDevice();
+
+        Assert.IsNull(device.GetSdCardParseConfiguration(),
+            "A device with no Core device for SD operations should return null.");
+    }
+
+    [TestMethod]
     public void SwitchMode_WhenEnteringLogToDevice_DoesNotSendInterfaceCommands()
     {
         // Core's StartSdCardLoggingAsync now handles SD interface setup,
@@ -1043,6 +1068,11 @@ public class AbstractStreamingDeviceTests
         public override bool Disconnect() => true;
 
         public override bool Write(string command) => true;
+
+        public void PopulateCoreChannels(DaqifiOutMessage message)
+        {
+            _coreDevice.PopulateChannelsFromStatus(message);
+        }
 
         protected override void SendMessage(IOutboundMessage<string> message)
         {

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1057,7 +1057,12 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// <inheritdoc />
     public SdCardDeviceConfiguration? GetSdCardParseConfiguration()
     {
-        return CoreDeviceForSd is null ? null : SdCardDeviceConfiguration.FromDevice(CoreDeviceForSd);
+        if (ConnectionType != ConnectionType.Usb || CoreDeviceForSd is null)
+        {
+            return null;
+        }
+
+        return SdCardDeviceConfiguration.FromDevice(CoreDeviceForSd);
     }
 
     /// <summary>

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1054,6 +1054,12 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         OnPropertyChanged(nameof(SdCardFiles));
     }
 
+    /// <inheritdoc />
+    public SdCardDeviceConfiguration? GetSdCardParseConfiguration()
+    {
+        return CoreDeviceForSd is null ? null : SdCardDeviceConfiguration.FromDevice(CoreDeviceForSd);
+    }
+
     /// <summary>
     /// Returns the given Core device, or throws <see cref="InvalidOperationException"/> with
     /// <paramref name="unavailableMessage"/> when the operation is not available.

--- a/Daqifi.Desktop/Device/IStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/IStreamingDevice.cs
@@ -199,4 +199,12 @@ public interface IStreamingDevice : IDevice
     /// Deletes a file from the device's SD card.
     /// </summary>
     Task DeleteSdCardFileAsync(string fileName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Builds an <see cref="SdCardDeviceConfiguration"/> from this device's channel
+    /// configuration — calibration, resolution, port range, and internal scale — so the
+    /// SD card parser can convert raw ADC counts to real voltage values. Returns <c>null</c>
+    /// when the device has no analog channels or is not connected via USB.
+    /// </summary>
+    SdCardDeviceConfiguration? GetSdCardParseConfiguration();
 }

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -103,7 +103,7 @@ public class SdCardSessionImporter
             // Build a ConfigurationOverride from the connected device's channels
             // so the parser has calibration, resolution, and port range data for
             // scaling raw ADC values to real voltage.
-            var deviceConfig = BuildDeviceConfiguration(device);
+            var deviceConfig = device.GetSdCardParseConfiguration();
             var parseOptions = new SdCardParseOptions
             {
                 ConfigurationOverride = deviceConfig
@@ -368,40 +368,6 @@ public class SdCardSessionImporter
         using var transaction = context.Database.BeginTransaction();
         context.BulkInsert(batch);
         transaction.Commit();
-    }
-
-    /// <summary>
-    /// Builds an <see cref="SdCardDeviceConfiguration"/> from the connected device's channel data.
-    /// This provides calibration, resolution, port range, and internal scale values so the
-    /// SD card parser can convert raw ADC counts to real voltage values.
-    /// </summary>
-    private static SdCardDeviceConfiguration? BuildDeviceConfiguration(IStreamingDevice device)
-    {
-        var analogChannels = device.DataChannels
-            .OfType<AnalogChannel>()
-            .ToList();
-
-        if (analogChannels.Count == 0)
-        {
-            return null;
-        }
-
-        var digitalCount = device.DataChannels
-            .Count(ch => ch.Type == Daqifi.Core.Channel.ChannelType.Digital);
-
-        return new SdCardDeviceConfiguration(
-            AnalogPortCount: analogChannels.Count,
-            DigitalPortCount: digitalCount,
-            TimestampFrequency: 0, // Let the parser use file-embedded or fallback frequency
-            DeviceSerialNumber: device.DeviceSerialNo,
-            DevicePartNumber: device.DevicePartNumber,
-            FirmwareRevision: device.DeviceVersion,
-            CalibrationValues: analogChannels
-                .Select(ch => (ch.CalibrationMValue, ch.CalibrationBValue))
-                .ToArray(),
-            Resolution: analogChannels[0].Resolution,
-            PortRange: analogChannels.Select(ch => ch.PortRange).ToArray(),
-            InternalScaleM: analogChannels.Select(ch => ch.InternalScaleMValue).ToArray());
     }
 
     private static void AssignChannelColors(


### PR DESCRIPTION
## Summary
- `SdCardSessionImporter.BuildDeviceConfiguration` hand-rolled what Core's `SdCardDeviceConfiguration.FromDevice(DaqifiDevice)` already produces from the same underlying Core channel objects
- Added `IStreamingDevice.GetSdCardParseConfiguration()`, implemented in `AbstractStreamingDevice` as `CoreDeviceForSd is null ? null : SdCardDeviceConfiguration.FromDevice(CoreDeviceForSd)` — the seam the issue proposed
- `SdCardSessionImporter` now calls the new seam instead of assembling the config field-by-field; the ~33-line `BuildDeviceConfiguration` method is deleted

## Verify-before-deleting check (per the issue)
Confirmed Core's `FromDevice` also hard-codes `TimestampFrequency: 0` with the identical "let the parser use file-embedded or fallback frequency" comment as our old code, so precedence through `SdCardCsvFileParser.MergeConfiguration` / `SdCardFileParser.MergeConfigurations` is unchanged — no Core ticket needed.

Closes #705

## Test plan
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 547 passed
- [x] Added `GetSdCardParseConfiguration_WithAnalogChannels_ReturnsCoreConfiguration` and `GetSdCardParseConfiguration_WithoutCoreDevice_ReturnsNull` covering the new seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)