### PR TITLE
fix: stop reporting disconnected-device firmware guard as a Sentry error

### DIFF
--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -166,7 +166,7 @@ public class FirmwareUpdateCoordinator
 
             if (!coreDevice.IsConnected)
             {
-                _appLogger.Error($"Device {serialStreamingDevice.Name} is not connected. Cannot update firmware on a disconnected device.");
+                _appLogger.Warning($"Device {serialStreamingDevice.Name} is not connected. Cannot update firmware on a disconnected device.");
                 _host.Notifications.Add(new Notifications
                 {
                     Message = $"Please connect device {serialStreamingDevice.Name} before attempting firmware update.",


### PR DESCRIPTION
## Summary
- Sentry issue #577 (`System.Exception: Device Nq1 is not connected...`) was not a crash — it's the existing, graceful guard in `FirmwareUpdateCoordinator.UploadFirmwareAsync` that already logs and shows the user a "please connect the device" notification when a firmware update is attempted on a disconnected device.
- `AppLogger.Error(string message)` synthesizes a `new Exception(message)` and calls `SentrySdk.CaptureException` for every single-string `.Error(...)` call, so this expected/handled condition was being reported to Sentry as if it were an unhandled crash.
- Downgraded the log call to `Warning`, which the codebase already uses elsewhere specifically to keep expected/environmental conditions out of Sentry while still logging locally.

## Test plan
- [x] `dotnet build` — succeeds
- [x] `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 545 passed, 0 failed

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)