### PR TITLE
chore: small Core-delegation cleanups in AbstractStreamingDevice

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -723,31 +723,21 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
-    public void StartSdCardLogging_UsesCombinedAnalogMaskAndConfiguresDigitalPortsOnce()
+    public void StartSdCardLogging_NoLongerHandRollsChannelConfiguration()
     {
+        // Core's StartSdCardLoggingAsync(channelMask: null) now computes the ADC enable mask and
+        // DIO enable state itself from its own channel configuration (issue #706) — the desktop
+        // no longer builds an analog mask or sends EnableDioPorts/DisableDioPorts directly. The
+        // mask/DIO computation itself is Core's responsibility and is covered by Core's own tests.
         var device = new SdCardLoggingTestDevice();
-        device.DataChannels.Add(new AnalogChannel(device, BuildAnalogInputCoreChannel(0)) { IsActive = true });
-        device.DataChannels.Add(new AnalogChannel(device, BuildAnalogInputCoreChannel(2)) { IsActive = true });
-        device.DataChannels.Add(new AnalogChannel(device, BuildAnalogInputCoreChannel(4)) { IsActive = true });
-        device.DataChannels.Add(new DigitalChannel(device, BuildDigitalInputCoreChannel(0)) { IsActive = true });
-        device.DataChannels.Add(new DigitalChannel(device, BuildDigitalInputCoreChannel(1)) { IsActive = true });
         device.SwitchMode(DeviceMode.LogToDevice);
 
         device.StartSdCardLogging();
 
-        Assert.AreEqual(
-            1,
-            device.SentCommands.Count(command => command == $"desktop:{ScpiMessageProducer.EnableDioPorts().Data}"),
-            "Desktop should enable digital ports once before starting SD logging.");
         Assert.IsFalse(
-            device.SentCommands.Any(c =>
-                c.StartsWith("desktop:") && c.Contains("ENAble:VOLTage:DC")),
-            "Desktop should not send any EnableAdcChannels commands — " +
-            "Core handles this via the channelMask parameter.");
-        CollectionAssert.Contains(
-            device.SentCommands,
-            $"core:{ScpiMessageProducer.EnableAdcChannels("21").Data}",
-            "Core should receive a decimal channel mask for the active SD logging channels.");
+            device.SentCommands.Any(c => c.StartsWith("desktop:", StringComparison.Ordinal)),
+            "The desktop should not send any SCPI commands directly for SD logging start — " +
+            "channel configuration now flows entirely through Core's channelMask: null path.");
     }
 
     [TestMethod]
@@ -866,28 +856,6 @@ public class AbstractStreamingDeviceTests
         coreDevice.Metadata.UpdateFromProtobuf(statusMessage);
         coreDevice.PopulateChannelsFromStatus(statusMessage);
         return coreDevice;
-    }
-
-    private static Daqifi.Core.Channel.AnalogChannel BuildAnalogInputCoreChannel(int index)
-    {
-        return new Daqifi.Core.Channel.AnalogChannel(index, 4096)
-        {
-            Name = $"AI{index}",
-            Direction = Daqifi.Core.Channel.ChannelDirection.Input,
-            CalibrationB = 0,
-            CalibrationM = 1,
-            InternalScaleM = 1,
-            PortRange = 5
-        };
-    }
-
-    private static Daqifi.Core.Channel.DigitalChannel BuildDigitalInputCoreChannel(int index)
-    {
-        return new Daqifi.Core.Channel.DigitalChannel(index)
-        {
-            Name = $"DIO{index}",
-            Direction = Daqifi.Core.Channel.ChannelDirection.Input
-        };
     }
 
     private static DaqifiOutMessage BuildStatusMessage(string firmwareVersion, float calibrationM)

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -1,6 +1,7 @@
 ﻿using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device;
 using Daqifi.Desktop.Device.SerialDevice;
+using Daqifi.Desktop.Helpers;
 using Daqifi.Desktop.Logger;
 using System.ComponentModel;
 using System.IO.Ports;
@@ -237,7 +238,7 @@ public partial class ConnectionManager : ObservableObject
             return;
         }
 
-        InvokeOnUiThread(() =>
+        UiThreadHelper.InvokeOnUiThread(() =>
         {
             // Already torn down via another path (e.g. explicit user disconnect raced this event).
             if (!ConnectedDevices.Contains(device))
@@ -258,37 +259,7 @@ public partial class ConnectionManager : ObservableObject
                 LastDisconnectReason = $"{device.DeviceDisplayName} disconnected ({e.Reason}).";
                 NotifyConnection = true;
             }
-        });
-    }
-
-    /// <summary>
-    /// Runs <paramref name="action"/> on the WPF UI thread — required here because
-    /// <see cref="IDevice.ConnectionLost"/> can fire from a background/transport thread and this
-    /// handler mutates the UI-bound <see cref="ConnectedDevices"/> collection. Runs inline when
-    /// there is no dispatcher (unit tests) or the caller is already on it; uses the non-blocking
-    /// <c>BeginInvoke</c> so teardown can never freeze the UI thread, and swallows failures during
-    /// app/dispatcher shutdown since there is nothing left to update.
-    /// </summary>
-    private static void InvokeOnUiThread(Action action)
-    {
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.CheckAccess())
-        {
-            action();
-            return;
-        }
-
-        try
-        {
-            if (!dispatcher.HasShutdownStarted)
-            {
-                dispatcher.BeginInvoke(action);
-            }
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Instance.Warning(ex, "Dispatcher unavailable while handling ConnectionLost; UI update dropped.");
-        }
+        }, failureLogMessage: "Dispatcher unavailable while handling ConnectionLost; UI update dropped.");
     }
 
     private void CheckIfSerialDeviceWasRemoved()

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1,5 +1,6 @@
 ﻿using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Helpers;
 using Daqifi.Core.Communication;
 using Daqifi.Core.Device.Network;
 using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
@@ -67,12 +68,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     private const int MAX_DISCARDED_LEFTOVER_FRAMES = 5;
 
-    /// <summary>
-    /// Fallback device counter frequency in Hz when the device has not reported one.
-    /// Matches the 20 ns tick period assumed by Core's <see cref="TimestampProcessor"/>.
-    /// </summary>
-    private const uint DEFAULT_TIMESTAMP_FREQUENCY = 50_000_000;
-
     private const string SD_UNAVAILABLE_MESSAGE = "Core SD card operations are not available for this device.";
     private const string STREAMING_UNAVAILABLE_MESSAGE = "Core live streaming operations are not available for this device.";
     private const string NOT_CONNECTED_MESSAGE = "Device is not connected.";
@@ -135,7 +130,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// this gate keeps them from reaching the desktop's channels.
     /// </summary>
     private bool _acceptChannelSamples;
-    private DateTime _currentFrameTimestamp;
     private double? _currentFrameFirmwareDeltaMs;
 
     /// <summary>
@@ -531,42 +525,13 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         // Core can raise StatusChanged from a transport/background thread — DeviceState and
         // IsConnected are WPF-bound, so the mutation and its change notification must be
         // marshalled onto the UI thread (issue #638 code review).
-        InvokeOnUiThread(() =>
+        UiThreadHelper.InvokeOnUiThread(() =>
         {
             DeviceState = DeviceState.Disconnected;
             OnPropertyChanged(nameof(IsConnected));
         });
 
         ConnectionLost?.Invoke(this, new ConnectionLostEventArgs(reason));
-    }
-
-    /// <summary>
-    /// Runs <paramref name="action"/> on the WPF UI thread. Runs inline when there is no
-    /// dispatcher (unit tests — <c>Application.Current</c> is null) or the caller is already on
-    /// it. Uses the non-blocking <c>BeginInvoke</c> so a background-thread caller (e.g. Core's
-    /// <c>StatusChanged</c>) can never block on the UI thread; failures during app/dispatcher
-    /// shutdown are swallowed since there is nothing left to update.
-    /// </summary>
-    private static void InvokeOnUiThread(Action action)
-    {
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.CheckAccess())
-        {
-            action();
-            return;
-        }
-
-        try
-        {
-            if (!dispatcher.HasShutdownStarted)
-            {
-                dispatcher.BeginInvoke(action);
-            }
-        }
-        catch (Exception)
-        {
-            // Dispatcher unavailable / shutting down — drop the UI update.
-        }
     }
     #endregion
 
@@ -719,7 +684,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         // Open the gate for Core's decode of this exact frame, which runs synchronously right
         // after this method returns (see _acceptChannelSamples).
-        _currentFrameTimestamp = messageTimestamp;
         _currentFrameFirmwareDeltaMs = firmwareDeltaMs;
         _acceptChannelSamples = true;
 
@@ -758,7 +722,9 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// immediately after <see cref="ProcessStreamMessage"/> returns, for every enabled channel —
     /// gated by <see cref="_acceptChannelSamples"/> so leftover/held frames (which Core still
     /// decodes, since Core has no notion of the desktop's leftover-frame heuristics) never reach
-    /// desktop channels.
+    /// desktop channels. Uses <c>coreSample.Timestamp</c> — the same rollover-aware reconstruction
+    /// <see cref="ProcessStreamMessage"/> computed for this frame via <see cref="_timestampProcessor"/> —
+    /// rather than recomputing it, so the two can never diverge.
     /// </summary>
     private void OnCoreChannelSampleReceived(IChannel desktopChannel, Daqifi.Core.Channel.IDataSample coreSample)
     {
@@ -768,7 +734,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         }
 
         desktopChannel.ActiveSample = new DataSample(
-            this, desktopChannel, _currentFrameTimestamp, coreSample.Value, _currentFrameFirmwareDeltaMs);
+            this, desktopChannel, coreSample.Timestamp, coreSample.Value, _currentFrameFirmwareDeltaMs);
     }
 
     /// <summary>
@@ -836,7 +802,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return false;
         }
 
-        var timestampFrequency = TimestampFrequency != 0 ? TimestampFrequency : DEFAULT_TIMESTAMP_FREQUENCY;
+        var timestampFrequency = TimestampFrequency != 0 ? TimestampFrequency : TimestampProcessor.DefaultTimestampFrequency;
         var elapsedSeconds = unchecked(deviceTimestamp - _lastSeenDeviceTimestamp) / (double)timestampFrequency;
         if (elapsedSeconds >= STALE_FRAME_WINDOW_SECONDS)
         {
@@ -872,7 +838,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return;
         }
 
-        var timestampFrequency = TimestampFrequency != 0 ? TimestampFrequency : DEFAULT_TIMESTAMP_FREQUENCY;
+        var timestampFrequency = TimestampFrequency != 0 ? TimestampFrequency : TimestampProcessor.DefaultTimestampFrequency;
         var elapsedSeconds = unchecked(message.MsgTimeStamp - heldFrame.MsgTimeStamp) / (double)timestampFrequency;
         if (elapsedSeconds >= STALE_FRAME_WINDOW_SECONDS
             && _discardedLeftoverFrameCount < MAX_DISCARDED_LEFTOVER_FRAMES)
@@ -960,34 +926,15 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         try
         {
-            // Build channel bitmask — Core's StartSdCardLoggingAsync sends EnableAdcChannels
-            var analogChannelMask = 0u;
-            var hasDigitalChannels = false;
-
-            foreach (var channel in DataChannels.Where(c => c.IsActive))
-            {
-                if (channel.Type == ChannelType.Analog)
-                {
-                    analogChannelMask |= 1u << channel.Index;
-                }
-                else if (channel.Type == ChannelType.Digital)
-                {
-                    hasDigitalChannels = true;
-                }
-            }
-
-            // Core doesn't handle DIO enable yet, so desktop still sends this directly
-            SendMessage(hasDigitalChannels
-                ? ScpiMessageProducer.EnableDioPorts()
-                : ScpiMessageProducer.DisableDioPorts());
-
             var coreDevice = GetCoreDevice(CoreDeviceForSd, SD_UNAVAILABLE_MESSAGE);
             coreDevice.StreamingFrequency = StreamingFrequency;
 
+            // channelMask: null makes Core use the current device channel configuration — already
+            // in sync at this point via AddChannel(s), which enables/disables both the ADC mask and
+            // the global DIO state on Core's channels as they're added.
             // The Core package resumes StartSdCardLoggingAsync continuations on the caller's
             // synchronization context. Running it on the thread pool prevents UI deadlocks.
-            var channelMaskString = analogChannelMask.ToString(CultureInfo.InvariantCulture);
-            Task.Run(() => coreDevice.StartSdCardLoggingAsync(channelMask: channelMaskString, format: SdCardLogFormat)).GetAwaiter().GetResult();
+            Task.Run(() => coreDevice.StartSdCardLoggingAsync(channelMask: null, format: SdCardLogFormat)).GetAwaiter().GetResult();
 
             IsLoggingToSdCard = coreDevice.IsLoggingToSdCard;
             IsStreaming = true; // We're streaming to SD card
@@ -1772,7 +1719,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
     public void Reboot()
     {
-        SendMessage(ScpiMessageProducer.RebootDevice);
+        CoreDevice?.Reboot();
         Disconnect();
     }
 

--- a/Daqifi.Desktop/Helpers/UiThreadHelper.cs
+++ b/Daqifi.Desktop/Helpers/UiThreadHelper.cs
@@ -28,12 +28,18 @@ internal static class UiThreadHelper
             return;
         }
 
+        if (dispatcher.HasShutdownStarted)
+        {
+            if (failureLogMessage != null)
+            {
+                AppLogger.Instance.Warning(failureLogMessage);
+            }
+            return;
+        }
+
         try
         {
-            if (!dispatcher.HasShutdownStarted)
-            {
-                dispatcher.BeginInvoke(action);
-            }
+            dispatcher.BeginInvoke(action);
         }
         catch (Exception ex)
         {

--- a/Daqifi.Desktop/Helpers/UiThreadHelper.cs
+++ b/Daqifi.Desktop/Helpers/UiThreadHelper.cs
@@ -1,0 +1,46 @@
+using Daqifi.Desktop.Common.Loggers;
+
+namespace Daqifi.Desktop.Helpers;
+
+/// <summary>
+/// Marshals actions onto the WPF UI thread from background-thread event handlers (e.g. Core's
+/// <c>StatusChanged</c>/<c>ConnectionLost</c>, which can fire from a transport thread).
+/// </summary>
+internal static class UiThreadHelper
+{
+    /// <summary>
+    /// Runs <paramref name="action"/> on the WPF UI thread. Runs inline when there is no
+    /// dispatcher (unit tests — <c>Application.Current</c> is null) or the caller is already on
+    /// it. Uses the non-blocking <c>BeginInvoke</c> so a background-thread caller can never block
+    /// on the UI thread; failures during app/dispatcher shutdown are swallowed since there is
+    /// nothing left to update.
+    /// </summary>
+    /// <param name="action">The action to run on the UI thread.</param>
+    /// <param name="failureLogMessage">
+    /// When non-null, logged as a warning if dispatching fails (e.g. dispatcher shutting down).
+    /// </param>
+    public static void InvokeOnUiThread(Action action, string? failureLogMessage = null)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        try
+        {
+            if (!dispatcher.HasShutdownStarted)
+            {
+                dispatcher.BeginInvoke(action);
+            }
+        }
+        catch (Exception ex)
+        {
+            if (failureLogMessage != null)
+            {
+                AppLogger.Instance.Warning(ex, failureLogMessage);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Change

A bundle of small, independent cleanups in `Daqifi.Desktop/Device/AbstractStreamingDevice.cs` where Core already provides the thing we hand-roll. None of these need a Core change.

### 1. Duplicate timestamp constant

`DEFAULT_TIMESTAMP_FREQUENCY = 50_000_000` restated Core's public `TimestampProcessor.DefaultTimestampFrequency`. Replaced both uses.

### 2. Frame timestamp recomputed after Core already computed it

`OnCoreChannelSampleReceived` now uses `coreSample.Timestamp` directly instead of the cached `_currentFrameTimestamp`, closing a hazard where two independent `TimestampProcessor` rollover states over the same frame stream could diverge.

### 3. `Reboot()` re-sent a command Core owns

Replaced `SendMessage(ScpiMessageProducer.RebootDevice)` with `CoreDevice?.Reboot()`. Removes one of the few remaining raw-SCPI call sites.

### 4. Hand-rolled ADC mask + DIO enable in `StartSdCardLogging`

The stale "Core doesn't handle DIO enable yet" comment is gone. Core's `StartSdCardLoggingAsync(channelMask: null)` uses the current device channel configuration, which is already in sync at that point via `AddChannel(s)` (which drives Core's `SendAdcEnableMask`/`SendDioEnableState` as channels are enabled/disabled). The desktop-side mask-building loop and `EnableDioPorts`/`DisableDioPorts` calls are gone.

`StartSdCardLogging_UsesCombinedAnalogMaskAndConfiguresDigitalPortsOnce` asserted the old desktop-side mask/DIO commands, so it's replaced with `StartSdCardLogging_NoLongerHandRollsChannelConfiguration`, which asserts the desktop sends no commands directly during SD logging start. The mask/DIO computation itself is Core's responsibility and is exercised by Core's own test suite.

### 5. `InvokeOnUiThread` duplicated verbatim

Extracted the identical implementation in `AbstractStreamingDevice.cs` and `ConnectionManager.cs` into `Daqifi.Desktop/Helpers/UiThreadHelper.cs`.

## Testing

- `dotnet build "DAQiFi Desktop.sln"` — 0 errors.
- `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 548/548 passed.
- No hardware bench exercise for this PR — the changes are structural delegation to Core APIs that are already covered by existing/updated unit tests; #4 in particular carries the caveat (noted in the issue) that Core's channel `IsEnabled` sync via `AddChannel(s)` should be spot-checked on hardware before merge if a bench is available.

Closes #706
