### PR TITLE
fix: classify serial transport-closed mid-init as environmental (#588)

### DIFF
--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -3,10 +3,11 @@ using Daqifi.Desktop.Device.SerialDevice;
 namespace Daqifi.Desktop.Test.Device;
 
 /// <summary>
-/// Tests for <see cref="SerialStreamingDevice"/>'s connect-failure classification (issue #589):
-/// Core's SCPI-error-during-initialization InvalidOperationException is a device/environmental
-/// condition, not an app bug, so it must be downgraded to a Warning (no Sentry capture) rather
-/// than the default Error path.
+/// Tests for <see cref="SerialStreamingDevice"/>'s connect-failure classification. Certain
+/// InvalidOperationExceptions raised during connect are device/environmental conditions, not app
+/// bugs, so they must be downgraded to a Warning (no Sentry capture) rather than the default Error
+/// path: Core's SCPI-error-during-initialization message (issue #589) and the serial transport
+/// reporting the COM port closed mid-initialization (issue #588).
 /// </summary>
 [TestClass]
 public class SerialStreamingDeviceLogConnectFailureTests
@@ -53,6 +54,59 @@ public class SerialStreamingDeviceLogConnectFailureTests
         var ex = new InvalidOperationException("SCPI error while doing something unrelated to initialization.");
 
         Assert.IsFalse(SerialStreamingDevice.IsScpiInitializationError(ex));
+    }
+
+    [TestMethod]
+    public void IsTransportClosedError_MatchesDotNetBaseStreamMessage()
+    {
+        // Exact wording .NET's SerialPort.BaseStream getter throws when the port has closed —
+        // the message captured in Sentry issue #588.
+        var ex = new InvalidOperationException("The BaseStream is only available when the port is open.");
+
+        Assert.IsTrue(SerialStreamingDevice.IsTransportClosedError(ex));
+    }
+
+    [TestMethod]
+    public void IsTransportClosedError_MatchesCoreTransportNotConnectedMessage()
+    {
+        // Wording Core's SerialStreamTransport throws when its SerialPort reference is null.
+        var ex = new InvalidOperationException("Transport is not connected.");
+
+        Assert.IsTrue(SerialStreamingDevice.IsTransportClosedError(ex));
+    }
+
+    [TestMethod]
+    public void IsTransportClosedError_IsCaseInsensitive()
+    {
+        var ex = new InvalidOperationException("the basestream is only available when the port is open");
+
+        Assert.IsTrue(SerialStreamingDevice.IsTransportClosedError(ex));
+    }
+
+    [TestMethod]
+    public void IsTransportClosedError_DoesNotMatchUnrelatedInvalidOperationException()
+    {
+        // Regression guard: an unrelated InvalidOperationException bug must still hit the
+        // default Error path instead of being silently downgraded.
+        var ex = new InvalidOperationException("Transport exploded.");
+
+        Assert.IsFalse(SerialStreamingDevice.IsTransportClosedError(ex));
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithTransportClosedError_DoesNotThrow()
+    {
+        var device = new TestableSerialStreamingDevice("COM_TEST_588");
+        var ex = new InvalidOperationException("The BaseStream is only available when the port is open.");
+
+        try
+        {
+            device.ExposedLogConnectFailure(ex);
+        }
+        catch (Exception caught)
+        {
+            Assert.Fail($"LogConnectFailure must not throw for the transport-closed case, but threw: {caught}");
+        }
     }
 
     [TestMethod]

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -136,6 +136,18 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
                 // not an app bug (issue #589).
                 AppLogger.Warning(ex, $"Device on {PortName} returned a SCPI error during initialization");
                 break;
+            case InvalidOperationException when IsTransportClosedError(ex):
+                // The serial transport opens the COM port during CreateCoreDevice, then Core's
+                // InitializeAsync reads/writes it. If the port closes in that window — the device
+                // is unplugged, powered off, or the USB driver drops the port mid-connect —
+                // accessing the transport stream throws an InvalidOperationException: .NET's
+                // SerialPort.BaseStream getter throws "The BaseStream is only available when the
+                // port is open." and Core's transport throws "Transport is not connected." Both
+                // mean the same thing: the port vanished mid-initialization. That's a
+                // user/environmental condition, not an app bug — same classification as the
+                // connect-timeout and SCPI-init cases above (issue #588).
+                AppLogger.Warning(ex, $"Device on {PortName} disconnected during initialization");
+                break;
             default:
                 AppLogger.Error(ex, $"Failed to connect on {PortName}");
                 break;
@@ -151,6 +163,20 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     /// </summary>
     internal static bool IsScpiInitializationError(Exception ex) =>
         ex.Message.Contains("SCPI error during initialization", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when <paramref name="ex"/> is the serial transport reporting that the COM port closed
+    /// mid-initialization (issue #588): .NET's <c>SerialPort.BaseStream</c> getter
+    /// ("The BaseStream is only available when the port is open.") or Core's transport
+    /// ("Transport is not connected."). Both indicate the device was unplugged/powered off or the
+    /// USB driver dropped the port during connect — a device/environmental condition, not an app
+    /// bug. Matched on the specific known phrases (not the bare word "port") so unrelated
+    /// <see cref="InvalidOperationException"/> bugs still hit the default Error path. Extracted as
+    /// a pure predicate so the classification is unit-testable without exercising the logger.
+    /// </summary>
+    internal static bool IsTransportClosedError(Exception ex) =>
+        ex.Message.Contains("BaseStream is only available when the port is open", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("Transport is not connected", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Sends a message to the device using Core's DaqifiDevice.


### PR DESCRIPTION
## Problem

Closes #588.

`SerialStreamingDevice` opens the COM port in `CreateCoreDevice`, then Core's `InitializeAsync` reads/writes it. If the port closes in that window — the device is unplugged, powered off, or the USB driver drops the port mid-connect — accessing the transport stream throws an `InvalidOperationException`:

- .NET's `SerialPort.BaseStream` getter: *"The BaseStream is only available when the port is open."* (the exact message in the Sentry issue)
- Core's `SerialStreamTransport`: *"Transport is not connected."*

Both fell through `LogConnectFailure`'s `default` branch, which calls `AppLogger.Error` and captures the exception to Sentry as an app bug — even though it's the same kind of user/environmental condition already downgraded for connect-timeout (#517/#632) and SCPI-init (#589).

## Fix

- Add an `InvalidOperationException when IsTransportClosedError(ex)` case to `SerialStreamingDevice.LogConnectFailure` that logs a Warning (no Sentry capture) instead of an Error.
- `IsTransportClosedError` is a pure, `internal static` predicate matching the two specific phrases (not the bare word "port"), so unrelated `InvalidOperationException` bugs still hit the default Error path — mirroring the existing `IsScpiInitializationError` design.

## Why it's safe

`CreateCoreDevice` always calls `_transport.Connect()` (which opens the port) before init runs; a failure to *open* throws earlier with a different message and is unaffected. Reaching the stream-getter-throws state therefore means the port was open and then closed = environmental, so downgrading it does not mask an app logic bug.

## Tests

Added 5 unit tests to `SerialStreamingDeviceLogConnectFailureTests` (predicate matches both messages, is case-insensitive, rejects an unrelated message, and `LogConnectFailure` does not throw for the transport-closed case). Full unit gate green: **553 passed, 0 failed**.

Not merging — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
