### PR TITLE
chore: convert mechanical manual observable properties to [ObservableProperty] (part of #720)

### DIFF
--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.IO.Ports;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Daqifi.Core.Device;
 using Daqifi.Core.Communication.Transport;
 using Daqifi.Core.Communication.Messages;
@@ -9,25 +10,14 @@ using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
 
 namespace Daqifi.Desktop.Device.SerialDevice;
 
-public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvider
+public partial class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvider
 {
     #region Properties
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DisplayIdentifier))]
     private SerialPort? _port;
-    private SerialStreamTransport? _transport;
 
-    public SerialPort? Port
-    {
-        get => _port;
-        set
-        {
-            if (_port != value)
-            {
-                _port = value;
-                OnPropertyChanged();
-                OnPropertyChanged(nameof(DisplayIdentifier));
-            }
-        }
-    }
+    private SerialStreamTransport? _transport;
 
     /// <summary>
     /// Gets the actual COM port name for UART communication

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -10,6 +10,9 @@ using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
 
 namespace Daqifi.Desktop.Device.SerialDevice;
 
+/// <summary>
+/// Streaming device that communicates with DAQiFi hardware over a serial (USB CDC / UART) port.
+/// </summary>
 public partial class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvider
 {
     #region Properties

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -18,11 +18,13 @@ namespace Daqifi.Desktop.Logger;
 public partial class PlotLogger : ObservableObject, ILogger
 {
     #region Private Data
+    [ObservableProperty]
     private PlotModel _plotModel;
     private readonly Stopwatch _stopwatch = new();
     private long _lastUpdateMilliSeconds;
     private int _precision = 4;
     private Dictionary<(string deviceSerial, string channelName), List<DataPoint>> _loggedPoints = [];
+    [ObservableProperty]
     private Dictionary<(string deviceSerial, string channelName), LineSeries> _loggedChannels = [];
     private readonly TimestampGapDetector _gapDetector = new();
     private string _plotStatsSummary = EMPTY_PLOT_STATS_SUMMARY;
@@ -56,28 +58,15 @@ public partial class PlotLogger : ObservableObject, ILogger
     #endregion
 
     #region Properties
-    public PlotModel PlotModel
-    {
-        get => _plotModel;
-        set
-        {
-            _plotModel = value;
-            OnPropertyChanged();
-        }
-    }
-
     public DateTime? FirstTime { get; set; }
 
+    // LoggedPoints keeps its explicit setter because it is intentionally private-set;
+    // [ObservableProperty] would widen it to a public setter (the source generator
+    // can't preserve setter accessibility).
     public Dictionary<(string deviceSerial, string channelName), List<DataPoint>> LoggedPoints
     {
         get => _loggedPoints;
         private set { _loggedPoints = value; OnPropertyChanged(); }
-    }
-
-    public Dictionary<(string deviceSerial, string channelName), LineSeries> LoggedChannels
-    {
-        get => _loggedChannels;
-        set { _loggedChannels = value; OnPropertyChanged(); }
     }
 
     public int Precision

--- a/Daqifi.Desktop/ViewModels/SuccessDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/SuccessDialogViewModel.cs
@@ -3,23 +3,11 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Daqifi.Desktop.ViewModels;
 
-public class SuccessDialogViewModel : ObservableObject
+public partial class SuccessDialogViewModel : ObservableObject
 {
-    #region Private Variables
-    private string _successMessage;
-    #endregion
-
     #region Properties
-
-    public string SuccessMessage
-    {
-        get => _successMessage;
-        set
-        {
-            _successMessage = value;
-            OnPropertyChanged();
-        }
-    }
+    [ObservableProperty]
+    private string _successMessage;
     #endregion
 
     public SuccessDialogViewModel(string successmessage)

--- a/Daqifi.Desktop/ViewModels/SuccessDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/SuccessDialogViewModel.cs
@@ -3,6 +3,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Daqifi.Desktop.ViewModels;
 
+/// <summary>
+/// View model backing the success dialog; exposes the success message shown to the user.
+/// </summary>
 public partial class SuccessDialogViewModel : ObservableObject
 {
     #region Properties


### PR DESCRIPTION
## What

Part of #720 (item 2 — the manual observable-property tail). Converts the genuinely
mechanical `_x = value; OnPropertyChanged()` setters to CommunityToolkit.Mvvm
`[ObservableProperty]`, the convention AGENTS.md already mandates. Behavior-preserving.

- `SuccessDialogViewModel.SuccessMessage` — sibling `ErrorDialogViewModel` is already migrated.
- `PlotLogger.PlotModel` and `PlotLogger.LoggedChannels` — both were plain public-get/public-set.
- `SerialStreamingDevice.Port` — `[ObservableProperty]` + `[NotifyPropertyChangedFor(nameof(DisplayIdentifier))]`,
  which reproduces the setter's extra `DisplayIdentifier` notification; the generator's
  built-in equality check matches the old `if (_port != value)` guard.

## Intentionally left manual

`PlotLogger.LoggedPoints` keeps its explicit setter: it is `private set`, and
`[ObservableProperty]` can't preserve setter accessibility (it would widen to a public
setter). An inline comment documents this. The remaining manual setters in these files are
intentional delegating/coercing wrappers and stay as-is, per the issue.

## Validation

- `dotnet build` clean (0 errors).
- Unit gate green: `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 548 passed, 0 failed.
- No hardware/GUI path involved; pure MVVM plumbing, source-generator-equivalent output.

Closes part of #720. Not merging — opened for your review.
