### PR TITLE
fix: classify Core's "SCPI error while setting stream interface" as environmental (#589)

### DIFF
--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -18,10 +18,27 @@ public class SerialStreamingDeviceLogConnectFailureTests
     private const string CORE_SCPI_INIT_ERROR_MESSAGE =
         "Device returned a SCPI error during initialization: -200,\"Execution error\"";
 
+    // The exact message Core throws from DaqifiStreamingDevice.OnDeviceInitializingAsync when the
+    // "SYSTem:STReam:INTerface 0" (stream-interface -> USB) switch is rejected. This is the message
+    // issue #589 and its Sentry alert DAQIFI-DESKTOP-Y are filed for; the original #589 fix only
+    // matched CORE_SCPI_INIT_ERROR_MESSAGE, so this variant was still hitting the Error path.
+    private const string CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE =
+        "Device returned a SCPI error while setting stream interface to USB.";
+
     [TestMethod]
     public void IsScpiInitializationError_MatchesCoresInitializationErrorMessage()
     {
         var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
+
+        Assert.IsTrue(SerialStreamingDevice.IsScpiInitializationError(ex));
+    }
+
+    [TestMethod]
+    public void IsScpiInitializationError_MatchesCoresStreamInterfaceErrorMessage()
+    {
+        // Regression guard for #589: the actual reported message (Sentry DAQIFI-DESKTOP-Y) must be
+        // classified as the environmental SCPI-init error, not fall through to the Error path.
+        var ex = new InvalidOperationException(CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE);
 
         Assert.IsTrue(SerialStreamingDevice.IsScpiInitializationError(ex));
     }
@@ -68,6 +85,22 @@ public class SerialStreamingDeviceLogConnectFailureTests
         catch (Exception caught)
         {
             Assert.Fail($"LogConnectFailure must not throw for the SCPI-init-error case, but threw: {caught}");
+        }
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithScpiStreamInterfaceError_DoesNotThrow()
+    {
+        var device = new TestableSerialStreamingDevice("COM_TEST_589");
+        var ex = new InvalidOperationException(CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE);
+
+        try
+        {
+            device.ExposedLogConnectFailure(ex);
+        }
+        catch (Exception caught)
+        {
+            Assert.Fail($"LogConnectFailure must not throw for the SCPI stream-interface case, but threw: {caught}");
         }
     }
 

--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -36,11 +36,16 @@ public class SerialStreamingDeviceLogConnectFailureTests
     [TestMethod]
     public void IsScpiInitializationError_MatchesCoresStreamInterfaceErrorMessage()
     {
-        // Regression guard for #589: the actual reported message (Sentry DAQIFI-DESKTOP-Y) must be
-        // classified as the environmental SCPI-init error, not fall through to the Error path.
+        // Arrange — regression guard for #589: the actual reported message (Sentry
+        // DAQIFI-DESKTOP-Y) must be classified as the environmental SCPI-init error, not fall
+        // through to the Error path.
         var ex = new InvalidOperationException(CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE);
 
-        Assert.IsTrue(SerialStreamingDevice.IsScpiInitializationError(ex));
+        // Act
+        var isScpiInitError = SerialStreamingDevice.IsScpiInitializationError(ex);
+
+        // Assert
+        Assert.IsTrue(isScpiInitError);
     }
 
     [TestMethod]
@@ -91,9 +96,11 @@ public class SerialStreamingDeviceLogConnectFailureTests
     [TestMethod]
     public void LogConnectFailure_WithScpiStreamInterfaceError_DoesNotThrow()
     {
+        // Arrange
         var device = new TestableSerialStreamingDevice("COM_TEST_589");
         var ex = new InvalidOperationException(CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE);
 
+        // Act & Assert — classifying + logging the stream-interface variant must not throw.
         try
         {
             device.ExposedLogConnectFailure(ex);

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -123,17 +123,20 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
                 AppLogger.Warning(ex, $"Device on {PortName} did not respond within the connection timeout");
                 break;
             case InvalidOperationException when IsScpiInitializationError(ex):
-                // Core's InitializeAsync throws a bare InvalidOperationException, message
-                // "Device returned a SCPI error during initialization: ...", when any command in
-                // its init sequence (echo/stop/power/stream-format/sysinfo, including
-                // "SYSTem:STReam:INTerface 0" which sets the stream interface to USB) gets a SCPI
-                // -200 execution error back. Firmware persists the last stream interface across
-                // sessions, so a device previously left streaming over WiFi is a common trigger on
-                // the very next USB connect, but any command in the sequence can hit this
-                // transient/timing condition. Matched by message substring (Core doesn't yet throw
-                // a typed exception for this — daqifi-core issue tracks that) so other
-                // InvalidOperationException bugs still hit Error. Device/environmental condition,
-                // not an app bug (issue #589).
+                // Core's init sequence throws a bare InvalidOperationException when a command gets
+                // a SCPI -200 execution error back, from two sibling sites with distinct wording:
+                //   * "Device returned a SCPI error during initialization: ..." (a command in the
+                //     echo/stop/power/stream-format/sysinfo sequence), and
+                //   * "Device returned a SCPI error while setting stream interface to USB." (the
+                //     "SYSTem:STReam:INTerface 0" switch specifically, thrown from Core's
+                //     DaqifiStreamingDevice.OnDeviceInitializingAsync — the message this device's
+                //     Sentry issue DAQIFI-DESKTOP-Y actually reports).
+                // Firmware persists the last stream interface across sessions, so a device
+                // previously left streaming over WiFi is a common trigger on the very next USB
+                // connect, but any command in the sequence can hit this transient/timing condition.
+                // Matched by message substring (Core doesn't yet throw a typed exception for this —
+                // daqifi-core issue tracks that) so other InvalidOperationException bugs still hit
+                // Error. Device/environmental condition, not an app bug (issue #589).
                 AppLogger.Warning(ex, $"Device on {PortName} returned a SCPI error during initialization");
                 break;
             default:
@@ -143,14 +146,20 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     }
 
     /// <summary>
-    /// True when <paramref name="ex"/> is Core's SCPI-error-during-initialization
-    /// <see cref="InvalidOperationException"/> (issue #589). Matched on Core's full known prefix
-    /// rather than the bare substring "SCPI error" so an unrelated InvalidOperationException that
-    /// happens to mention a SCPI error elsewhere in its message isn't misclassified. Extracted as
-    /// a pure predicate so the classification is unit-testable without exercising the logger.
+    /// True when <paramref name="ex"/> is one of Core's SCPI-error-during-initialization
+    /// <see cref="InvalidOperationException"/>s (issue #589, Sentry DAQIFI-DESKTOP-Y). Core's init
+    /// path throws this from two sibling sites with distinct wording:
+    /// <c>"...SCPI error during initialization..."</c> (a command in the init sequence returned
+    /// -200) and <c>"...SCPI error while setting stream interface to USB..."</c> (the stream-
+    /// interface switch specifically — the exact message #589/DAQIFI-DESKTOP-Y is filed for).
+    /// Matched on each site's full known phrase rather than the bare substring "SCPI error" so an
+    /// unrelated InvalidOperationException that merely mentions a SCPI error elsewhere in its
+    /// message isn't misclassified. Extracted as a pure predicate so the classification is
+    /// unit-testable without exercising the logger.
     /// </summary>
     internal static bool IsScpiInitializationError(Exception ex) =>
-        ex.Message.Contains("SCPI error during initialization", StringComparison.OrdinalIgnoreCase);
+        ex.Message.Contains("SCPI error during initialization", StringComparison.OrdinalIgnoreCase) ||
+        ex.Message.Contains("SCPI error while setting stream interface", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Sends a message to the device using Core's DaqifiDevice.

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -137,7 +137,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
                 // Matched by message substring (Core doesn't yet throw a typed exception for this —
                 // daqifi-core issue tracks that) so other InvalidOperationException bugs still hit
                 // Error. Device/environmental condition, not an app bug (issue #589).
-                AppLogger.Warning(ex, $"Device on {PortName} returned a SCPI error during initialization");
+                AppLogger.Warning(ex, $"Device on {PortName} returned a SCPI error during initialization (including stream-interface setup)");
                 break;
             default:
                 AppLogger.Error(ex, $"Failed to connect on {PortName}");
@@ -159,7 +159,7 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
     /// </summary>
     internal static bool IsScpiInitializationError(Exception ex) =>
         ex.Message.Contains("SCPI error during initialization", StringComparison.OrdinalIgnoreCase) ||
-        ex.Message.Contains("SCPI error while setting stream interface", StringComparison.OrdinalIgnoreCase);
+        ex.Message.Contains("SCPI error while setting stream interface to USB", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Sends a message to the device using Core's DaqifiDevice.

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -137,7 +137,9 @@ public class SerialStreamingDevice : AbstractStreamingDevice, ILanChipInfoProvid
                 // Matched by message substring (Core doesn't yet throw a typed exception for this —
                 // daqifi-core issue tracks that) so other InvalidOperationException bugs still hit
                 // Error. Device/environmental condition, not an app bug (issue #589).
-                AppLogger.Warning(ex, $"Device on {PortName} returned a SCPI error during initialization (including stream-interface setup)");
+                AppLogger.Warning(ex,
+                    $"Device on {PortName} returned a SCPI error during initialization " +
+                    "(including stream-interface setup)");
                 break;
             default:
                 AppLogger.Error(ex, $"Failed to connect on {PortName}");


### PR DESCRIPTION
## What

Fixes the incomplete #589 fix. Issue #589 (auto-filed from Sentry **DAQIFI-DESKTOP-Y**, still `unresolved`/`ongoing`, 19 occurrences) is filed for:

> `System.InvalidOperationException: Device returned a SCPI error while setting stream interface to USB.`

Core throws this from `DaqifiStreamingDevice.OnDeviceInitializingAsync` when the `SYSTem:STReam:INTerface` switch is rejected with a SCPI -200 — the common trigger being firmware persisting WiFi as the last stream interface, so the very next USB connect fails.

## The bug

The fix that closed #589 added `SerialStreamingDevice.IsScpiInitializationError`, but it only matched the substring **`"SCPI error during initialization"`** — a *different* Core message. The message #589 is actually about, **`"SCPI error while setting stream interface to USB"`**, does not contain that substring, so it never matched and kept falling through to the default `Error` branch (`"Failed to connect on {PortName}"`) → captured to Sentry as an app bug.

## The fix

Broaden `IsScpiInitializationError` to also match `"SCPI error while setting stream interface"`, keeping the existing `"during initialization"` match for other/older Core throw sites. Both are the same environmental (device/firmware-state) condition, not an app bug, so they are downgraded to a `Warning`. Still matched on each site's full known phrase (not the bare `"SCPI error"`) so unrelated `InvalidOperationException`s are not misclassified — the existing negative-regression tests still pass.

## Tests

- `IsScpiInitializationError_MatchesCoresStreamInterfaceErrorMessage` — the real reported message now classifies.
- `LogConnectFailure_WithScpiStreamInterfaceError_DoesNotThrow` — smoke test through the switch.
- Existing negative guards (`DoesNotMatchUnrelatedInvalidOperationException`, `DoesNotMatchUnrelatedScpiErrorMention`) unchanged and passing.

Unit gate green (550 passed, 0 failed). No hardware validation needed — the exception only fires on a real device left in the persisted-WiFi-interface state; the classification is a pure, unit-tested string predicate.

Closes #589

_Not merging — opened for your review._
