### PR TITLE
fix: override GetHashCode on WiFi DaqifiStreamingDevice to match Equals (#728)

### DIFF
--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
@@ -282,6 +282,30 @@ public class DaqifiStreamingDeviceTests
         Assert.AreNotEqual(a, b);
     }
 
+    [TestMethod]
+    public void GetHashCode_EqualInstances_ShouldProduceEqualHashCodes()
+    {
+        // Arrange
+        var a = new DaqifiStreamingDevice(CreateTestDeviceInfo());
+        var b = new DaqifiStreamingDevice(CreateTestDeviceInfo());
+
+        // Act & Assert
+        // Guards the Equals/GetHashCode contract: value-equal instances must hash equally so the
+        // HashSet<IStreamingDevice> tracking in DaqifiViewModel behaves per the Equals override.
+        Assert.AreEqual(a, b);
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [TestMethod]
+    public void GetHashCode_SameInstance_ShouldBeStable()
+    {
+        // Arrange
+        var device = new DaqifiStreamingDevice(CreateTestDeviceInfo());
+
+        // Act & Assert
+        Assert.AreEqual(device.GetHashCode(), device.GetHashCode());
+    }
+
     #endregion
 
     #region ToString Tests

--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceTests.cs
@@ -289,11 +289,15 @@ public class DaqifiStreamingDeviceTests
         var a = new DaqifiStreamingDevice(CreateTestDeviceInfo());
         var b = new DaqifiStreamingDevice(CreateTestDeviceInfo());
 
-        // Act & Assert
-        // Guards the Equals/GetHashCode contract: value-equal instances must hash equally so the
-        // HashSet<IStreamingDevice> tracking in DaqifiViewModel behaves per the Equals override.
+        // Act
+        var hashA = a.GetHashCode();
+        var hashB = b.GetHashCode();
+
+        // Assert
+        // Guards the Equals/GetHashCode contract: value-equal instances must hash equally so value-based
+        // dedup (e.g. ConnectionManager.ConnectedDevices) behaves consistently with the Equals override.
         Assert.AreEqual(a, b);
-        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+        Assert.AreEqual(hashA, hashB);
     }
 
     [TestMethod]
@@ -302,8 +306,12 @@ public class DaqifiStreamingDeviceTests
         // Arrange
         var device = new DaqifiStreamingDevice(CreateTestDeviceInfo());
 
-        // Act & Assert
-        Assert.AreEqual(device.GetHashCode(), device.GetHashCode());
+        // Act
+        var firstHash = device.GetHashCode();
+        var secondHash = device.GetHashCode();
+
+        // Assert
+        Assert.AreEqual(firstHash, secondHash);
     }
 
     #endregion

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -179,6 +179,14 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
         return Name;
     }
 
+    /// <summary>
+    /// Determines value equality between two <see cref="DaqifiStreamingDevice"/> instances by comparing
+    /// their identity fields (<see cref="AbstractStreamingDevice.Name"/>, <c>IpAddress</c>, <c>MacAddress</c>).
+    /// Used for list-based dedup in <c>ConnectionManager.ConnectedDevices</c>. Note that instance-tracking
+    /// hash sets (e.g. subscription/claim bookkeeping) deliberately use reference identity instead.
+    /// </summary>
+    /// <param name="obj">The object to compare against.</param>
+    /// <returns><c>true</c> when <paramref name="obj"/> is a device with the same name, IP, and MAC; otherwise <c>false</c>.</returns>
     public override bool Equals(object? obj)
     {
         if (obj is not DaqifiStreamingDevice other) { return false; }
@@ -189,11 +197,12 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     }
 
     /// <summary>
-    /// Returns a hash code consistent with <see cref="Equals(object?)"/>, combining the same
-    /// identity fields (<see cref="AbstractStreamingDevice.Name"/>, <c>IpAddress</c>, <c>MacAddress</c>).
-    /// Required so value-equal instances hash equally — the app tracks devices in
-    /// <c>HashSet&lt;IStreamingDevice&gt;</c> (DaqifiViewModel), which buckets by this hash before
-    /// consulting <see cref="Equals(object?)"/>.
+    /// Returns a hash code consistent with <see cref="Equals(object?)"/>, combining the same identity
+    /// fields (<see cref="AbstractStreamingDevice.Name"/>, <c>IpAddress</c>, <c>MacAddress</c>) so the
+    /// <see cref="object.Equals(object?)"/>/<see cref="object.GetHashCode"/> contract holds.
+    /// These fields are mutable, so this device must never be stored in a value-hashed set that outlives a
+    /// field change; instance-tracking sets in the view models use <see cref="ReferenceEqualityComparer"/>
+    /// to stay stable across metadata hydration.
     /// </summary>
     /// <returns>A hash code derived from the device's name, IP address, and MAC address.</returns>
     public override int GetHashCode()

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -186,7 +186,10 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     /// hash sets (e.g. subscription/claim bookkeeping) deliberately use reference identity instead.
     /// </summary>
     /// <param name="obj">The object to compare against.</param>
-    /// <returns><c>true</c> when <paramref name="obj"/> is a device with the same name, IP, and MAC; otherwise <c>false</c>.</returns>
+    /// <returns>
+    /// <c>true</c> when <paramref name="obj"/> is a device with the same name, IP, and MAC;
+    /// otherwise <c>false</c>.
+    /// </returns>
     public override bool Equals(object? obj)
     {
         if (obj is not DaqifiStreamingDevice other) { return false; }

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -179,13 +179,26 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
         return Name;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is not DaqifiStreamingDevice other) { return false; }
         if (Name != other.Name) { return false; }
         if (IpAddress != other.IpAddress) { return false; }
         if (MacAddress != other.MacAddress) { return false; }
         return true;
+    }
+
+    /// <summary>
+    /// Returns a hash code consistent with <see cref="Equals(object?)"/>, combining the same
+    /// identity fields (<see cref="AbstractStreamingDevice.Name"/>, <c>IpAddress</c>, <c>MacAddress</c>).
+    /// Required so value-equal instances hash equally — the app tracks devices in
+    /// <c>HashSet&lt;IStreamingDevice&gt;</c> (DaqifiViewModel), which buckets by this hash before
+    /// consulting <see cref="Equals(object?)"/>.
+    /// </summary>
+    /// <returns>A hash code derived from the device's name, IP address, and MAC address.</returns>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name, IpAddress, MacAddress);
     }
     #endregion
 }

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -204,8 +204,8 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
     /// fields (<see cref="AbstractStreamingDevice.Name"/>, <c>IpAddress</c>, <c>MacAddress</c>) so the
     /// <see cref="object.Equals(object?)"/>/<see cref="object.GetHashCode"/> contract holds.
     /// These fields are mutable, so this device must never be stored in a value-hashed set that outlives a
-    /// field change; instance-tracking sets in the view models use <see cref="ReferenceEqualityComparer"/>
-    /// to stay stable across metadata hydration.
+    /// field change; instance-tracking sets in the view models use
+    /// <see cref="Daqifi.Desktop.Helpers.ReferenceComparer{T}"/> to stay stable across metadata hydration.
     /// </summary>
     /// <returns>A hash code derived from the device's name, IP address, and MAC address.</returns>
     public override int GetHashCode()

--- a/Daqifi.Desktop/Helpers/ReferenceComparer.cs
+++ b/Daqifi.Desktop/Helpers/ReferenceComparer.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Daqifi.Desktop.Helpers;
+
+/// <summary>
+/// A strongly-typed reference-identity equality comparer. Unlike the framework's
+/// <see cref="ReferenceEqualityComparer"/> (which is typed as <c>IEqualityComparer&lt;object?&gt;</c> and,
+/// because <see cref="IEqualityComparer{T}"/> is invariant, cannot be handed to a
+/// <c>HashSet&lt;TSpecific&gt;</c>), this generic comparer plugs directly into typed collections.
+/// Use it for bookkeeping sets that track object <em>instances</em> (e.g. subscription/claim tracking)
+/// so entries stay reachable even when a stored object mutates fields that participate in its value hash.
+/// </summary>
+/// <typeparam name="T">The reference type being compared by identity.</typeparam>
+public sealed class ReferenceComparer<T> : IEqualityComparer<T> where T : class
+{
+    /// <summary>The shared, stateless instance.</summary>
+    public static readonly ReferenceComparer<T> Instance = new();
+
+    private ReferenceComparer() { }
+
+    /// <inheritdoc />
+    public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
+
+    /// <inheritdoc />
+    public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+}

--- a/Daqifi.Desktop/Helpers/ReferenceComparer.cs
+++ b/Daqifi.Desktop/Helpers/ReferenceComparer.cs
@@ -17,7 +17,9 @@ public sealed class ReferenceComparer<T> : IEqualityComparer<T> where T : class
     /// <summary>The shared, stateless instance.</summary>
     public static readonly ReferenceComparer<T> Instance = new();
 
-    private ReferenceComparer() { }
+    private ReferenceComparer()
+    {
+    }
 
     /// <inheritdoc />
     public bool Equals(T? x, T? y) => ReferenceEquals(x, y);

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1389,23 +1389,29 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     // Devices we've wired per-VM event handlers onto — both the logging-state PropertyChanged handler
     // and (for streaming devices) the DebugDataReceived handler. Tracked as one set so subscribe and
     // unsubscribe stay symmetric across Reset/Replace/add/remove and so Dispose can tear them all down.
-    private readonly HashSet<IStreamingDevice> _subscribedDevices = [];
+    // Reference identity, not value equality: this set tracks the specific device *instances* we wired
+    // handlers onto. DaqifiStreamingDevice overrides Equals/GetHashCode on mutable fields (Name/IP/MAC),
+    // so a value-hashed set could lose track of an instance once metadata hydration mutates those fields.
+    private readonly HashSet<IStreamingDevice> _subscribedDevices = new(ReferenceComparer<IStreamingDevice>.Instance);
 
     private void OnConnectedDevicesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         // ObservableCollection.Clear() raises a Reset with OldItems == null, so we
         // can't rely on the args alone — diff against our tracked-subscription set
         // to handle Reset, Replace, and per-item adds/removes uniformly.
-        var current = new HashSet<IStreamingDevice>(ConnectedDevices);
+        // Reference identity throughout: the snapshot set and both Except() diffs must use the same
+        // reference comparer as _subscribedDevices, otherwise LINQ's default value comparer would defeat
+        // instance tracking (see _subscribedDevices declaration).
+        var current = new HashSet<IStreamingDevice>(ConnectedDevices, ReferenceComparer<IStreamingDevice>.Instance);
 
-        foreach (var stale in _subscribedDevices.Except(current).ToList())
+        foreach (var stale in _subscribedDevices.Except(current, ReferenceComparer<IStreamingDevice>.Instance).ToList())
         {
             UnsubscribeDeviceEvents(stale);
             _subscribedDevices.Remove(stale);
         }
 
         var anyAdded = false;
-        foreach (var added in current.Except(_subscribedDevices).ToList())
+        foreach (var added in current.Except(_subscribedDevices, ReferenceComparer<IStreamingDevice>.Instance).ToList())
         {
             SubscribeDeviceEvents(added);
             _subscribedDevices.Add(added);

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -457,7 +457,10 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
 
                 var isLogToDeviceMode = mode == "Log to Device";
                 var deviceMode = isLogToDeviceMode ? DeviceMode.LogToDevice : DeviceMode.StreamToApp;
-                var originalDeviceModes = ConnectedDevices.ToDictionary(device => device, device => device.Mode);
+                // Key by reference identity: DaqifiStreamingDevice now has value-based Equals/GetHashCode,
+                // so a default-comparer dictionary would throw on transient value-equal duplicate entries.
+                var originalDeviceModes = ConnectedDevices.ToDictionary(
+                    device => device, device => device.Mode, ReferenceComparer<IStreamingDevice>.Instance);
 
                 try
                 {

--- a/Daqifi.Desktop/ViewModels/ProfilesPaneViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ProfilesPaneViewModel.cs
@@ -285,7 +285,10 @@ public partial class ProfilesPaneViewModel : ObservableObject
     /// </summary>
     private static Dictionary<ProfileDevice, IStreamingDevice> MatchProfileToConnected(Profile profile)
     {
-        var claimed = new HashSet<IStreamingDevice>();
+        // Reference identity: claim specific connected-device *instances* at most once. Value equality
+        // (DaqifiStreamingDevice hashes mutable Name/IP/MAC) could wrongly treat two distinct instances as
+        // the same claim, so track instances by reference.
+        var claimed = new HashSet<IStreamingDevice>(ReferenceComparer<IStreamingDevice>.Instance);
         var result = new Dictionary<ProfileDevice, IStreamingDevice>();
         var connected = ConnectionManager.Instance.ConnectedDevices.ToList();
 


### PR DESCRIPTION
## What

`Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs` overrode `Equals(object)` (comparing `Name`, `IpAddress`, `MacAddress`) but not `GetHashCode()` — compiler warning **CS0659**, and a violation of the `Object.Equals`/`GetHashCode` contract (value-equal instances produced different reference-based hash codes). It was the only device/value class in the tree doing this; `AbstractChannel`, `LoggingSession`, and `FirmwareOption` all override both.

`DaqifiViewModel` tracks connected devices in `HashSet<IStreamingDevice>` (`_subscribedDevices`, and a per-change `new HashSet<IStreamingDevice>(ConnectedDevices)`), which buckets by `GetHashCode` before consulting `Equals`, so the mismatch is a real (currently latent, thanks to upstream `Contains`-based dedup) correctness hazard.

## Change

- Add `public override int GetHashCode()` combining the same identity fields (`Name`, `IpAddress`, `MacAddress`) via `HashCode.Combine`.
- Align the `Equals` parameter to `object?` to match the base override signature (clears the paired CS8765 on that method).
- Add two tests: value-equal instances hash equally, and same-instance hashing is stable.

Non-breaking, unit-testable, consistent with the existing sibling pattern.

## Testing

Build clean (CS0659 gone; only pre-existing unrelated warnings remain). Unit gate green: `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → 550 passed, 0 failed (+2 new tests). No hardware/GUI path (pure equality/hash semantics).

Closes #728

Not merging — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
