### PR TITLE
chore: add unit tests for the untested value converters (#730)

### DIFF
--- a/Daqifi.Desktop.Test/Converters/BoolAndToVisibilityConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/BoolAndToVisibilityConverterTests.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+using System.Windows;
+using Daqifi.Desktop.Converters;
+
+namespace Daqifi.Desktop.Test.Converters;
+
+[TestClass]
+public class BoolAndToVisibilityConverterTests
+{
+    private BoolAndToVisibilityConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new BoolAndToVisibilityConverter();
+    }
+
+    [TestMethod]
+    public void Convert_AllTrue_ReturnsVisible()
+    {
+        // Arrange
+        var values = new object[] { true, true, true };
+
+        // Act
+        var result = _converter.Convert(values, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_AnyFalse_ReturnsCollapsed()
+    {
+        // Arrange
+        var values = new object[] { true, false, true };
+
+        // Act
+        var result = _converter.Convert(values, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_NonBooleanValue_ReturnsCollapsed()
+    {
+        // Arrange
+        var values = new object[] { true, "true", true };
+
+        // Act
+        var result = _converter.Convert(values, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_EmptyValues_ReturnsCollapsed()
+    {
+        // Arrange
+        var values = Array.Empty<object>();
+
+        // Act
+        var result = _converter.Convert(values, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_NullValues_ReturnsCollapsed()
+    {
+        // Arrange
+        object[] values = null;
+
+        // Act
+        var result = _converter.Convert(values, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Always_ThrowsNotSupported()
+    {
+        // Arrange
+        var value = Visibility.Visible;
+
+        // Act & Assert
+        Assert.ThrowsExactly<NotSupportedException>(() =>
+            _converter.ConvertBack(value, new[] { typeof(bool) }, null, CultureInfo.InvariantCulture));
+    }
+}

--- a/Daqifi.Desktop.Test/Converters/BrushColorMatchConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/BrushColorMatchConverterTests.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+using Daqifi.Desktop.Converters;
+
+namespace Daqifi.Desktop.Test.Converters;
+
+[TestClass]
+public class BrushColorMatchConverterTests
+{
+    private BrushColorMatchConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new BrushColorMatchConverter();
+    }
+
+    [TestMethod]
+    public void Convert_SameColorDifferentInstances_TargetBool_ReturnsTrue()
+    {
+        // Arrange
+        var values = new object[] { new SolidColorBrush(Colors.Red), new SolidColorBrush(Colors.Red) };
+
+        // Act
+        var result = _converter.Convert(values, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, result);
+    }
+
+    [TestMethod]
+    public void Convert_DifferentColors_TargetBool_ReturnsFalse()
+    {
+        // Arrange
+        var values = new object[] { new SolidColorBrush(Colors.Red), new SolidColorBrush(Colors.Blue) };
+
+        // Act
+        var result = _converter.Convert(values, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void Convert_SameColor_TargetVisibility_ReturnsVisible()
+    {
+        // Arrange
+        var values = new object[] { new SolidColorBrush(Colors.Green), new SolidColorBrush(Colors.Green) };
+
+        // Act
+        var result = _converter.Convert(values, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_DifferentColors_TargetVisibility_ReturnsCollapsed()
+    {
+        // Arrange
+        var values = new object[] { new SolidColorBrush(Colors.Green), new SolidColorBrush(Colors.Yellow) };
+
+        // Act
+        var result = _converter.Convert(values, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_FewerThanTwoValues_ReturnsFalse()
+    {
+        // Arrange
+        var values = new object[] { new SolidColorBrush(Colors.Red) };
+
+        // Act
+        var result = _converter.Convert(values, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void Convert_NonBrushValues_ReturnsFalse()
+    {
+        // Arrange
+        var values = new object[] { "red", "red" };
+
+        // Act
+        var result = _converter.Convert(values, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Always_ThrowsNotImplemented()
+    {
+        // Arrange
+        var value = Visibility.Visible;
+
+        // Act & Assert
+        Assert.ThrowsExactly<NotImplementedException>(() =>
+            _converter.ConvertBack(value, new[] { typeof(SolidColorBrush) }, null, CultureInfo.InvariantCulture));
+    }
+}

--- a/Daqifi.Desktop.Test/Converters/ConnectionTypeToColorConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/ConnectionTypeToColorConverterTests.cs
@@ -1,0 +1,71 @@
+using System.Globalization;
+using System.Windows.Media;
+using Daqifi.Desktop.Converters;
+using Daqifi.Desktop.Device;
+
+namespace Daqifi.Desktop.Test.Converters;
+
+[TestClass]
+public class ConnectionTypeToColorConverterTests
+{
+    private ConnectionTypeToColorConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new ConnectionTypeToColorConverter();
+    }
+
+    [TestMethod]
+    public void Convert_Usb_ReturnsGreenBrush()
+    {
+        // Arrange
+        var value = ConnectionType.Usb;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Brush), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.IsInstanceOfType<SolidColorBrush>(result);
+        Assert.AreEqual(Colors.Green, ((SolidColorBrush)result).Color);
+    }
+
+    [TestMethod]
+    public void Convert_Wifi_ReturnsOrangeBrush()
+    {
+        // Arrange
+        var value = ConnectionType.Wifi;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Brush), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.IsInstanceOfType<SolidColorBrush>(result);
+        Assert.AreEqual(Colors.Orange, ((SolidColorBrush)result).Color);
+    }
+
+    [TestMethod]
+    public void Convert_NonConnectionTypeValue_ReturnsGrayBrush()
+    {
+        // Arrange
+        object value = "not a connection type";
+
+        // Act
+        var result = _converter.Convert(value, typeof(Brush), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.IsInstanceOfType<SolidColorBrush>(result);
+        Assert.AreEqual(Colors.Gray, ((SolidColorBrush)result).Color);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Always_ThrowsNotImplemented()
+    {
+        // Arrange
+        var value = new SolidColorBrush(Colors.Green);
+
+        // Act & Assert
+        Assert.ThrowsExactly<NotImplementedException>(() =>
+            _converter.ConvertBack(value, typeof(ConnectionType), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/Daqifi.Desktop.Test/Converters/InvertedBoolToVisibilityConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/InvertedBoolToVisibilityConverterTests.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using System.Windows;
+using Daqifi.Desktop.Converters;
+
+namespace Daqifi.Desktop.Test.Converters;
+
+[TestClass]
+public class InvertedBoolToVisibilityConverterTests
+{
+    private InvertedBoolToVisibilityConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new InvertedBoolToVisibilityConverter();
+    }
+
+    [TestMethod]
+    public void Convert_True_ReturnsCollapsed()
+    {
+        // Arrange
+        const bool value = true;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_False_ReturnsVisible()
+    {
+        // Arrange
+        const bool value = false;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_NonBooleanValue_ReturnsCollapsed()
+    {
+        // Arrange
+        object value = "true";
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Collapsed_ReturnsTrue()
+    {
+        // Arrange
+        var value = Visibility.Collapsed;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Visible_ReturnsFalse()
+    {
+        // Arrange
+        var value = Visibility.Visible;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_NonVisibilityValue_ReturnsFalse()
+    {
+        // Arrange
+        object value = 42;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+}

--- a/Daqifi.Desktop.Test/Converters/ListToStringConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/ListToStringConverterTests.cs
@@ -1,0 +1,131 @@
+using System.Globalization;
+using Daqifi.Desktop.Converters;
+
+namespace Daqifi.Desktop.Test.Converters;
+
+[TestClass]
+public class ListToStringConverterTests
+{
+    private ListToStringConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new ListToStringConverter();
+    }
+
+    [TestMethod]
+    public void Convert_NullValue_ReturnsEmptyString()
+    {
+        // Arrange
+        object value = null;
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    [TestMethod]
+    public void Convert_EmptyList_ReturnsEmptyString()
+    {
+        // Arrange
+        var value = new List<string>();
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    [TestMethod]
+    public void Convert_DefaultFormat_JoinsWithCommaSpace()
+    {
+        // Arrange
+        var value = new List<string> { "a", "b", "c" };
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("a, b, c", result);
+    }
+
+    [TestMethod]
+    public void Convert_BracketsFormat_WrapsInBrackets()
+    {
+        // Arrange
+        var value = new List<string> { "a", "b" };
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), "brackets", CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("[a, b]", result);
+    }
+
+    [TestMethod]
+    public void Convert_ShortFormat_WithinThreeItems_JoinsWithoutEllipsis()
+    {
+        // Arrange
+        var value = new List<string> { "a", "b", "c" };
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), "short", CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("a,b,c", result);
+    }
+
+    [TestMethod]
+    public void Convert_ShortFormat_MoreThanThreeItems_TruncatesWithEllipsis()
+    {
+        // Arrange
+        var value = new List<string> { "a", "b", "c", "d", "e" };
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), "short", CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("a,b,c...", result);
+    }
+
+    [TestMethod]
+    public void Convert_FormatParameterIsCaseInsensitive()
+    {
+        // Arrange
+        var value = new List<string> { "a", "b" };
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), "BRACKETS", CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("[a, b]", result);
+    }
+
+    [TestMethod]
+    public void Convert_NonEnumerableValue_ReturnsToString()
+    {
+        // Arrange
+        object value = 42;
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("42", result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Always_ThrowsNotImplemented()
+    {
+        // Arrange
+        object value = "a, b, c";
+
+        // Act & Assert
+        Assert.ThrowsExactly<NotImplementedException>(() =>
+            _converter.ConvertBack(value, typeof(object), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/Daqifi.Desktop.Test/Converters/NotNullToVisibilityConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/NotNullToVisibilityConverterTests.cs
@@ -1,0 +1,54 @@
+using System.Globalization;
+using System.Windows;
+using Daqifi.Desktop.Converters;
+
+namespace Daqifi.Desktop.Test.Converters;
+
+[TestClass]
+public class NotNullToVisibilityConverterTests
+{
+    private NotNullToVisibilityConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new NotNullToVisibilityConverter();
+    }
+
+    [TestMethod]
+    public void Convert_NonNullValue_ReturnsVisible()
+    {
+        // Arrange
+        object value = "something";
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_NullValue_ReturnsCollapsed()
+    {
+        // Arrange
+        object value = null;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Always_ThrowsNotImplemented()
+    {
+        // Arrange
+        var value = Visibility.Visible;
+
+        // Act & Assert
+        Assert.ThrowsExactly<NotImplementedException>(() =>
+            _converter.ConvertBack(value, typeof(object), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/Daqifi.Desktop.Test/Converters/OxyColorToBrushConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/OxyColorToBrushConverterTests.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using System.Windows.Media;
+using Daqifi.Desktop.Converters;
+using OxyPlot;
+
+namespace Daqifi.Desktop.Test.Converters;
+
+[TestClass]
+public class OxyColorToBrushConverterTests
+{
+    private OxyColorToBrushConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new OxyColorToBrushConverter();
+    }
+
+    [TestMethod]
+    public void Convert_OxyColor_ReturnsMatchingSolidColorBrush()
+    {
+        // Arrange
+        var oxyColor = OxyColor.FromArgb(200, 10, 20, 30);
+
+        // Act
+        var result = _converter.Convert(oxyColor, typeof(Brush), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.IsInstanceOfType<SolidColorBrush>(result);
+        var color = ((SolidColorBrush)result).Color;
+        Assert.AreEqual(Color.FromArgb(200, 10, 20, 30), color);
+    }
+
+    [TestMethod]
+    public void Convert_NonOxyColorValue_ReturnsTransparentBrush()
+    {
+        // Arrange
+        object value = "not a color";
+
+        // Act
+        var result = _converter.Convert(value, typeof(Brush), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreSame(Brushes.Transparent, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Always_ThrowsNotImplemented()
+    {
+        // Arrange
+        var value = new SolidColorBrush(Colors.Red);
+
+        // Act & Assert
+        Assert.ThrowsExactly<NotImplementedException>(() =>
+            _converter.ConvertBack(value, typeof(OxyColor), null, CultureInfo.InvariantCulture));
+    }
+}


### PR DESCRIPTION
## What

Adds unit tests for the seven `IValueConverter`/`IMultiValueConverter` implementations in
`Daqifi.Desktop/Converters/` that are all live (each referenced from XAML) but had **zero**
test coverage. Closes #730.

| Converter | Branches covered |
|---|---|
| `BoolAndToVisibilityConverter` | all-true, any-false, non-bool, empty, null; `ConvertBack` throws |
| `BrushColorMatchConverter` | same/different Color, <2 args, non-brush, Visibility-vs-bool target; `ConvertBack` throws |
| `ConnectionTypeToColorConverter` | Usb->Green, Wifi->Orange, fallback->Gray; `ConvertBack` throws |
| `InvertedBoolToVisibilityConverter` | true/false/non-bool; both `ConvertBack` directions |
| `NotNullToVisibilityConverter` | null / non-null; `ConvertBack` throws |
| `ListToStringConverter` | default / brackets / short (first-3 + ellipsis) / case-insensitive / null / empty / non-enumerable; `ConvertBack` throws |
| `OxyColorToBrushConverter` | OxyColor->ARGB brush, non-color fallback; `ConvertBack` throws |

## Why

These converters carry real branching logic (three format modes in `ListToStringConverter`,
arity/type guards in the multi-value converters) that was previously unguarded against
regressions, below the project's 80% coverage bar.

## Notes

- **Test-only** — no production code changes.
- Tests follow the existing `EnumDescriptionConverterTests` convention (one file per converter,
  explicit Arrange/Act/Assert) and use `Assert.ThrowsExactly`/generic `IsInstanceOfType<T>` to
  match the repo's dominant assertion style.
- Full unit gate green: 586 passed, 0 failed.

Not merging — opening for review per the autonomous loop.
