### PR TITLE
chore: add unit tests for the untested Helpers/ value converters

### DIFF
--- a/Daqifi.Desktop.Test/Helpers/BooleanConverterTests.cs
+++ b/Daqifi.Desktop.Test/Helpers/BooleanConverterTests.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using System.Windows.Data;
+using Daqifi.Desktop.Helpers;
+
+namespace Daqifi.Desktop.Test.Helpers;
+
+[TestClass]
+public class BooleanConverterTests
+{
+    private IValueConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // "Y" for true, "N" for false — a simple concrete instantiation of the generic base.
+        _converter = new BooleanConverter<string>("Y", "N");
+    }
+
+    [TestMethod]
+    public void Convert_TrueValue_ReturnsTrueValue()
+    {
+        // Arrange
+        object value = true;
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("Y", result);
+    }
+
+    [TestMethod]
+    public void Convert_FalseValue_ReturnsFalseValue()
+    {
+        // Arrange
+        object value = false;
+
+        // Act
+        var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("N", result);
+    }
+
+    [TestMethod]
+    public void Convert_NonBooleanValue_ReturnsFalseValue()
+    {
+        // Arrange
+        var nonBooleanValues = new object[] { null, "true", 1, 0, new object() };
+
+        foreach (var value in nonBooleanValues)
+        {
+            // Act
+            var result = _converter.Convert(value, typeof(string), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual("N", result, $"Failed for value: {value ?? "null"}");
+        }
+    }
+
+    [TestMethod]
+    public void ConvertBack_TrueValue_ReturnsTrue()
+    {
+        // Arrange
+        object value = "Y";
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_FalseValue_ReturnsFalse()
+    {
+        // Arrange
+        object value = "N";
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_UnknownValue_ReturnsFalse()
+    {
+        // Arrange — a value of the right type but equal to neither True nor False.
+        object value = "other";
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_WrongTypeValue_ReturnsFalse()
+    {
+        // Arrange — not a T (string); the `value is T` guard must fail.
+        object value = 123;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void Convert_RoundTripsThroughConvertBack()
+    {
+        // Arrange
+        object original = true;
+
+        // Act
+        var forward = _converter.Convert(original, typeof(string), null, CultureInfo.InvariantCulture);
+        var back = _converter.ConvertBack(forward, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, back);
+    }
+}

--- a/Daqifi.Desktop.Test/Helpers/BooleanToInverseBoolConverterTests.cs
+++ b/Daqifi.Desktop.Test/Helpers/BooleanToInverseBoolConverterTests.cs
@@ -1,0 +1,112 @@
+using System.Globalization;
+using System.Windows.Data;
+using Daqifi.Desktop.Helpers;
+
+namespace Daqifi.Desktop.Test.Helpers;
+
+[TestClass]
+public class BooleanToInverseBoolConverterTests
+{
+    private IValueConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new BooleanToInverseBoolConverter();
+    }
+
+    [TestMethod]
+    public void Convert_True_ReturnsFalse()
+    {
+        // Arrange
+        object value = true;
+
+        // Act
+        var result = _converter.Convert(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void Convert_False_ReturnsTrue()
+    {
+        // Arrange
+        object value = false;
+
+        // Act
+        var result = _converter.Convert(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, result);
+    }
+
+    [TestMethod]
+    public void Convert_NonBoolean_ReturnsFalse()
+    {
+        // Arrange
+        var nonBooleanValues = new object[] { null, "true", 1, 0 };
+
+        foreach (var value in nonBooleanValues)
+        {
+            // Act
+            var result = _converter.Convert(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual(false, result, $"Failed for value: {value ?? "null"}");
+        }
+    }
+
+    [TestMethod]
+    public void ConvertBack_True_ReturnsFalse()
+    {
+        // Arrange
+        object value = true;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_False_ReturnsTrue()
+    {
+        // Arrange
+        object value = false;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_NonBoolean_ReturnsFalse()
+    {
+        // Arrange
+        object value = "not a bool";
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void Convert_RoundTripsThroughConvertBack()
+    {
+        // Arrange
+        object original = true;
+
+        // Act
+        var forward = _converter.Convert(original, typeof(bool), null, CultureInfo.InvariantCulture);
+        var back = _converter.ConvertBack(forward, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, back);
+    }
+}

--- a/Daqifi.Desktop.Test/Helpers/BooleanToVisibilityConverterTests.cs
+++ b/Daqifi.Desktop.Test/Helpers/BooleanToVisibilityConverterTests.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using Daqifi.Desktop.Helpers;
+
+namespace Daqifi.Desktop.Test.Helpers;
+
+[TestClass]
+public class BooleanToVisibilityConverterTests
+{
+    private IValueConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new BooleanToVisibilityConverter();
+    }
+
+    [TestMethod]
+    public void Convert_True_ReturnsVisible()
+    {
+        // Arrange
+        object value = true;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Visible, result);
+    }
+
+    [TestMethod]
+    public void Convert_False_ReturnsCollapsed()
+    {
+        // Arrange
+        object value = false;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_NonBoolean_ReturnsCollapsed()
+    {
+        // Arrange
+        var nonBooleanValues = new object[] { null, "true", 1 };
+
+        foreach (var value in nonBooleanValues)
+        {
+            // Act
+            var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual(Visibility.Collapsed, result, $"Failed for value: {value ?? "null"}");
+        }
+    }
+
+    [TestMethod]
+    public void ConvertBack_Visible_ReturnsTrue()
+    {
+        // Arrange
+        object value = Visibility.Visible;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(true, result);
+    }
+
+    [TestMethod]
+    public void ConvertBack_Collapsed_ReturnsFalse()
+    {
+        // Arrange
+        object value = Visibility.Collapsed;
+
+        // Act
+        var result = _converter.ConvertBack(value, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(false, result);
+    }
+
+    [TestMethod]
+    public void Convert_InvertedConfiguration_MapsTrueToCollapsed()
+    {
+        // Arrange — mirrors the App.xaml "InvertedBoolToVis" resource
+        // (True="Collapsed" False="Visible").
+        IValueConverter inverted = new BooleanToVisibilityConverter
+        {
+            True = Visibility.Collapsed,
+            False = Visibility.Visible
+        };
+
+        // Act
+        var whenTrue = inverted.Convert(true, typeof(Visibility), null, CultureInfo.InvariantCulture);
+        var whenFalse = inverted.Convert(false, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, whenTrue);
+        Assert.AreEqual(Visibility.Visible, whenFalse);
+    }
+}

--- a/Daqifi.Desktop.Test/Helpers/IntToVisibilityConverterTests.cs
+++ b/Daqifi.Desktop.Test/Helpers/IntToVisibilityConverterTests.cs
@@ -1,0 +1,90 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using Daqifi.Desktop.Helpers;
+
+namespace Daqifi.Desktop.Test.Helpers;
+
+[TestClass]
+public class IntToVisibilityConverterTests
+{
+    private IValueConverter _converter;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _converter = new IntToVisibilityConverter();
+    }
+
+    [TestMethod]
+    public void Convert_PositiveCount_ReturnsVisible()
+    {
+        // Arrange
+        var positiveCounts = new object[] { 1, 5, int.MaxValue };
+
+        foreach (var value in positiveCounts)
+        {
+            // Act
+            var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual(Visibility.Visible, result, $"Failed for value: {value}");
+        }
+    }
+
+    [TestMethod]
+    public void Convert_Zero_ReturnsCollapsed()
+    {
+        // Arrange
+        object value = 0;
+
+        // Act
+        var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual(Visibility.Collapsed, result);
+    }
+
+    [TestMethod]
+    public void Convert_NegativeCount_ReturnsCollapsed()
+    {
+        // Arrange
+        var negativeCounts = new object[] { -1, int.MinValue };
+
+        foreach (var value in negativeCounts)
+        {
+            // Act
+            var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual(Visibility.Collapsed, result, $"Failed for value: {value}");
+        }
+    }
+
+    [TestMethod]
+    public void Convert_NonInteger_ReturnsCollapsed()
+    {
+        // Arrange — anything not boxed as int (including null and other numeric types).
+        var nonIntegers = new object[] { null, "5", 5.0, 5L, true };
+
+        foreach (var value in nonIntegers)
+        {
+            // Act
+            var result = _converter.Convert(value, typeof(Visibility), null, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.AreEqual(Visibility.Collapsed, result, $"Failed for value: {value ?? "null"}");
+        }
+    }
+
+    [TestMethod]
+    public void ConvertBack_Always_ThrowsNotImplementedException()
+    {
+        // Arrange
+        object value = Visibility.Visible;
+
+        // Act & Assert
+        Assert.ThrowsExactly<NotImplementedException>(() =>
+            _converter.ConvertBack(value, typeof(int), null, CultureInfo.InvariantCulture));
+    }
+}


### PR DESCRIPTION
## What

Adds unit test coverage for the four value converters in `Daqifi.Desktop/Helpers/` that previously had none:

- `BooleanConverter<T>` (generic base) — true/false mapping, non-bool fallback to `False`, `ConvertBack` round-trip via `EqualityComparer<T>.Default`, wrong-type guard.
- `BooleanToVisibilityConverter` — default `Visible`/`Collapsed`, non-bool fallback, and the inverted `True="Collapsed" False="Visible"` configuration that `App.xaml` binds as `InvertedBoolToVis` across ~12 views.
- `BooleanToInverseBoolConverter` — both-direction inversion, non-bool fallback, round-trip.
- `IntToVisibilityConverter` — `> 0` threshold, zero/negative/non-int fallback to `Collapsed`, and `ConvertBack` throwing `NotImplementedException`.

All four are declared in `App.xaml` and bound in production XAML but had zero coverage. This is the `Helpers/`-folder complement to the `Converters/`-folder coverage in #730/#731.

## Why it's safe

Test-only; no production code touched. 26 new tests, AAA-structured to match the existing `EnumDescriptionConverterTests` convention. Read the converters first — no production bugs found; this locks in existing behavior.

## Validation

Build clean, unit gate green (574 passed, 0 failed). No hardware/GUI path (pure converter logic).

Closes #734

Not merging — opened for review.
