### PR TITLE
chore: run required checks on merge_group to support a GitHub merge queue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   build-and-test:

--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -3,20 +3,25 @@ name: Prebuild
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  merge_group:
 
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
     steps:
+      # There is no PR title on a merge_group (queue) build, so the validation
+      # steps below are gated to pull_request events. On merge_group the job
+      # still runs and reports success, satisfying the required check without hanging.
       - name: PR Conventional Commit Validation
         id: check_title
+        if: ${{ github.event_name == 'pull_request' }}
         uses: ytanikin/PRConventionalCommits@1.3.0
         with:
           task_types: '["feat","fix","docs", "deps", "chore"]'
           add_label: 'false'
 
       - name: Leave a comment if PR title is invalid
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v9
         with:
           script: |
@@ -56,7 +61,7 @@ jobs:
             }
 
       - name: Remove comment if PR title is valid
-        if: ${{ success() }}
+        if: ${{ success() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## What

Make the two required-check workflows fire on the `merge_group` event so a GitHub merge queue can validate PRs on the `gh-readonly-queue/...` combined branch. Without this the queue hangs waiting for checks that only trigger on `pull_request`.

- **`.github/workflows/build.yaml`** (`build-and-test`): added `merge_group:` to `on:`. The coverage summary/comment steps were already gated to `pull_request`, so on a queue build only the build → publish → test → MSI validation runs.
- **`.github/workflows/prebuild.yaml`** (`validate-pr-title`): added `merge_group:` and gated the title-validation steps to `pull_request`. A queue build has no PR title, so on `merge_group` the job runs with every step skipped and reports **success** — satisfying the required check without hanging.

## Not in this PR (must follow after merge)

The second deliverable in the issue — adding a **merge-queue rule (squash merge method)** to the `main` ruleset (`4636537`) — is a repo-settings change, not a file change, and it can't be applied via a PR merge. It must be applied **after** these workflow changes are on `main`; otherwise the very first queued PR would hang, because `main`'s workflows wouldn't yet fire on `merge_group`. I'll apply it via the rulesets API once this merges (keeping the existing 1-required-review rule, which the queue enforces before entry).

## Acceptance criteria

- [x] `build-and-test` and `validate-pr-title` are configured to run on `merge_group`.
- [ ] Verified green on a real queue batch (requires the ruleset rule, applied post-merge).

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)
