### PR TITLE
feat: display detected device type in the device information panel (#258)

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DeviceTileViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceTileViewModelTests.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
-using Daqifi.Core.Communication.Messages;
+using System.ComponentModel;
 using Daqifi.Desktop.Device;
 using Daqifi.Desktop.ViewModels;
+using Moq;
 using DeviceType = Daqifi.Core.Device.DeviceType;
 
 namespace Daqifi.Desktop.Test.ViewModels;
@@ -21,48 +22,51 @@ public class DeviceTileViewModelTests
     [DataRow(DeviceType.Unknown, "Unknown")]
     public void DeviceTypeDisplay_MapsEachTypeToFriendlyName(DeviceType type, string expected)
     {
-        var device = new TileTestDevice { DeviceType = type };
-        using var tile = new DeviceTileViewModel(device);
+        // Arrange
+        var deviceMock = new Mock<IStreamingDevice>();
+        deviceMock.SetupGet(d => d.DeviceType).Returns(type);
 
-        Assert.AreEqual(expected, tile.DeviceTypeDisplay);
+        // Act
+        using var tile = new DeviceTileViewModel(deviceMock.Object);
+        var actual = tile.DeviceTypeDisplay;
+
+        // Assert
+        Assert.AreEqual(expected, actual);
     }
 
     [TestMethod]
     public void DeviceTypeDisplay_DefaultsToUnknown_BeforeDetection()
     {
-        var device = new TileTestDevice();
-        using var tile = new DeviceTileViewModel(device);
+        // Arrange
+        var deviceMock = new Mock<IStreamingDevice>();
+        deviceMock.SetupGet(d => d.DeviceType).Returns(DeviceType.Unknown);
 
-        Assert.AreEqual("Unknown", tile.DeviceTypeDisplay);
+        // Act
+        using var tile = new DeviceTileViewModel(deviceMock.Object);
+        var actual = tile.DeviceTypeDisplay;
+
+        // Assert
+        Assert.AreEqual("Unknown", actual);
     }
 
     [TestMethod]
     public void DeviceType_Change_RaisesDeviceTypeDisplayPropertyChanged_AndUpdatesValue()
     {
-        var device = new TileTestDevice();
-        using var tile = new DeviceTileViewModel(device);
+        // Arrange
+        var deviceMock = new Mock<IStreamingDevice>();
+        deviceMock.SetupGet(d => d.DeviceType).Returns(DeviceType.Unknown);
+        using var tile = new DeviceTileViewModel(deviceMock.Object);
         var changed = new List<string>();
         tile.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
 
-        device.DeviceType = DeviceType.Nyquist3;
+        // Act
+        deviceMock.SetupGet(d => d.DeviceType).Returns(DeviceType.Nyquist3);
+        deviceMock.Raise(d => d.PropertyChanged += null,
+            new PropertyChangedEventArgs(nameof(IStreamingDevice.DeviceType)));
 
+        // Assert
         CollectionAssert.Contains(changed, nameof(DeviceTileViewModel.DeviceTypeDisplay),
             "Tile must refresh DeviceTypeDisplay when the device reports a new type");
         Assert.AreEqual("Nyquist 3", tile.DeviceTypeDisplay);
-    }
-
-    private sealed class TileTestDevice : AbstractStreamingDevice
-    {
-        public override ConnectionType ConnectionType => ConnectionType.Usb;
-
-        public override bool Connect() => true;
-
-        public override bool Disconnect() => true;
-
-        public override bool Write(string command) => true;
-
-        protected override void SendMessage(IOutboundMessage<string> message)
-        {
-        }
     }
 }

--- a/Daqifi.Desktop.Test/ViewModels/DeviceTileViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceTileViewModelTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.ViewModels;
+using DeviceType = Daqifi.Core.Device.DeviceType;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Verifies the device-tile presentation of the detected device type (issue #258):
+/// the tile maps <see cref="DeviceType"/> to a user-friendly label and refreshes it
+/// in place when the underlying device reports a newly-detected type.
+/// </summary>
+[TestClass]
+public class DeviceTileViewModelTests
+{
+    [TestMethod]
+    [DataRow(DeviceType.Nyquist1, "Nyquist 1")]
+    [DataRow(DeviceType.Nyquist2, "Nyquist 2")]
+    [DataRow(DeviceType.Nyquist3, "Nyquist 3")]
+    [DataRow(DeviceType.Unknown, "Unknown")]
+    public void DeviceTypeDisplay_MapsEachTypeToFriendlyName(DeviceType type, string expected)
+    {
+        var device = new TileTestDevice { DeviceType = type };
+        using var tile = new DeviceTileViewModel(device);
+
+        Assert.AreEqual(expected, tile.DeviceTypeDisplay);
+    }
+
+    [TestMethod]
+    public void DeviceTypeDisplay_DefaultsToUnknown_BeforeDetection()
+    {
+        var device = new TileTestDevice();
+        using var tile = new DeviceTileViewModel(device);
+
+        Assert.AreEqual("Unknown", tile.DeviceTypeDisplay);
+    }
+
+    [TestMethod]
+    public void DeviceType_Change_RaisesDeviceTypeDisplayPropertyChanged_AndUpdatesValue()
+    {
+        var device = new TileTestDevice();
+        using var tile = new DeviceTileViewModel(device);
+        var changed = new List<string>();
+        tile.PropertyChanged += (_, e) => changed.Add(e.PropertyName!);
+
+        device.DeviceType = DeviceType.Nyquist3;
+
+        CollectionAssert.Contains(changed, nameof(DeviceTileViewModel.DeviceTypeDisplay),
+            "Tile must refresh DeviceTypeDisplay when the device reports a new type");
+        Assert.AreEqual("Nyquist 3", tile.DeviceTypeDisplay);
+    }
+
+    private sealed class TileTestDevice : AbstractStreamingDevice
+    {
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        public override bool Connect() => true;
+
+        public override bool Disconnect() => true;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+    }
+}

--- a/Daqifi.Desktop/Device/IStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/IStreamingDevice.cs
@@ -3,6 +3,7 @@ using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
 using Daqifi.Core.Device.Network;
 using Daqifi.Core.Device.SdCard;
 using Daqifi.Desktop.Models;
+using DeviceType = Daqifi.Core.Device.DeviceType;
 
 namespace Daqifi.Desktop.Device;
 
@@ -55,6 +56,12 @@ public interface IStreamingDevice : IDevice
     string DeviceSerialNo { get; set; }
     string DeviceVersion { get; set; }
     bool IsFirmwareOutdated { get; set; }
+
+    /// <summary>
+    /// Gets the detected device type (e.g. Nyquist 1/2/3), or <see cref="DeviceType.Unknown"/>
+    /// when the device has not yet been identified.
+    /// </summary>
+    DeviceType DeviceType { get; }
 
     /// <summary>
     /// Gets whether this device has a separately-flashable WINC1500 WiFi module — i.e. it is

--- a/Daqifi.Desktop/View/Prototype/DevicesPanePrototype.xaml
+++ b/Daqifi.Desktop/View/Prototype/DevicesPanePrototype.xaml
@@ -604,6 +604,12 @@
                                         <TextBlock Text="{Binding SelectedTile.WifiVersion}"
                                                    Style="{StaticResource InfoValue}"/>
                                     </StackPanel>
+                                    <StackPanel Grid.Column="1" Grid.Row="2" Margin="0,10,0,0">
+                                        <TextBlock Text="TYPE" Style="{StaticResource InfoLabel}"/>
+                                        <TextBlock Text="{Binding SelectedTile.DeviceTypeDisplay}"
+                                                   AutomationProperties.AutomationId="DeviceType"
+                                                   Style="{StaticResource InfoValue}"/>
+                                    </StackPanel>
                                 </Grid>
                             </Border>
 

--- a/Daqifi.Desktop/ViewModels/DeviceTileViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceTileViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Daqifi.Desktop.Device;
 using Daqifi.Desktop.Helpers;
 using Brush = System.Windows.Media.Brush;
+using DeviceType = Daqifi.Core.Device.DeviceType;
 
 namespace Daqifi.Desktop.ViewModels;
 
@@ -29,6 +30,18 @@ public sealed class DeviceTileViewModel : ObservableObject, IDisposable
 
     /// <summary>Firmware version as shown on the tile.</summary>
     public string Version => Device.DeviceVersion;
+
+    /// <summary>
+    /// User-friendly detected device type — "Nyquist 1/2/3" for the recognized family,
+    /// "Unknown" before detection completes or for unrecognized hardware.
+    /// </summary>
+    public string DeviceTypeDisplay => Device.DeviceType switch
+    {
+        DeviceType.Nyquist1 => "Nyquist 1",
+        DeviceType.Nyquist2 => "Nyquist 2",
+        DeviceType.Nyquist3 => "Nyquist 3",
+        _ => "Unknown"
+    };
 
     /// <summary>COM port (USB) or IP address (WiFi).</summary>
     public string Identifier => Device.DisplayIdentifier;
@@ -109,6 +122,9 @@ public sealed class DeviceTileViewModel : ObservableObject, IDisposable
                 break;
             case nameof(IStreamingDevice.DeviceVersion):
                 OnPropertyChanged(nameof(Version));
+                break;
+            case nameof(IStreamingDevice.DeviceType):
+                OnPropertyChanged(nameof(DeviceTypeDisplay));
                 break;
             case nameof(IStreamingDevice.IpAddress):
             case nameof(IStreamingDevice.DisplayIdentifier):


### PR DESCRIPTION
Closes #258.

## What
Adds a **TYPE** field to the device INFORMATION panel showing the detected
device type as a user-friendly label — "Nyquist 1", "Nyquist 2", "Nyquist 3",
or "Unknown" before detection completes / for unrecognized hardware.

## Why
Per #258 (Device Type Detection & Identification epic): users and developers
can verify their device is correctly identified — helpful for debugging.

## How
- `IStreamingDevice` gains a read-only `DeviceType`. It was already a public
  `[ObservableProperty]` on `AbstractStreamingDevice`, so every production
  device already satisfies the new member — no implementers change.
- `DeviceTileViewModel.DeviceTypeDisplay` maps the Core enum to the friendly
  label and is re-raised in place when the device reports a newly-detected
  type (same PropertyChanged pattern as the other tile fields).
- Bound into the INFORMATION grid (row 2, col 1) with
  `AutomationProperties.AutomationId="DeviceType"` for future UI-test reach.

## Testing
- New `DeviceTileViewModelTests`: every enum value maps correctly, defaults to
  "Unknown" before detection, and a `DeviceType` change raises
  `DeviceTypeDisplay` change notification.
- Unit gate green: 636 passed (`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`).

Not merging — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
