### PR TITLE
fix: classify Core's transport-disconnected-mid-init error as environmental on the WiFi connect path (#740)

### DIFF
--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
@@ -66,38 +66,53 @@ public class DaqifiStreamingDeviceLogConnectFailureTests
     [TestMethod]
     public void IsTransportDisconnectedError_MatchesCoreTransportNotConnectedMessage()
     {
-        // Wording Core's transport throws when the connection dropped mid-initialization. It is
-        // transport-agnostic (surfaces over TCP and serial), so the WiFi path must classify it as
-        // the environmental transport-disconnect condition (issue #740), not the default Error path.
+        // Arrange — wording Core's transport throws when the connection dropped mid-initialization.
+        // It is transport-agnostic (surfaces over TCP and serial), so the WiFi path must classify it
+        // as the environmental transport-disconnect condition (issue #740), not the default Error path.
         var ex = new InvalidOperationException("Transport is not connected.");
 
-        Assert.IsTrue(DaqifiStreamingDevice.IsTransportDisconnectedError(ex));
+        // Act
+        var isEnvironmental = DaqifiStreamingDevice.IsTransportDisconnectedError(ex);
+
+        // Assert
+        Assert.IsTrue(isEnvironmental);
     }
 
     [TestMethod]
     public void IsTransportDisconnectedError_IsCaseInsensitive()
     {
+        // Arrange
         var ex = new InvalidOperationException("transport is not connected");
 
-        Assert.IsTrue(DaqifiStreamingDevice.IsTransportDisconnectedError(ex));
+        // Act
+        var isEnvironmental = DaqifiStreamingDevice.IsTransportDisconnectedError(ex);
+
+        // Assert
+        Assert.IsTrue(isEnvironmental);
     }
 
     [TestMethod]
     public void IsTransportDisconnectedError_DoesNotMatchWiFiAppBugInvalidOperationException()
     {
-        // Regression guard: WiFi's own app-bug InvalidOperationException must NOT be downgraded as a
-        // transport-disconnect — it has to keep hitting the default Error path.
+        // Arrange — WiFi's own app-bug InvalidOperationException must NOT be downgraded as a
+        // transport-disconnect; it has to keep hitting the default Error path.
         var ex = new InvalidOperationException("Connected Core device does not support streaming operations.");
 
-        Assert.IsFalse(DaqifiStreamingDevice.IsTransportDisconnectedError(ex));
+        // Act
+        var isEnvironmental = DaqifiStreamingDevice.IsTransportDisconnectedError(ex);
+
+        // Assert
+        Assert.IsFalse(isEnvironmental);
     }
 
     [TestMethod]
     public void LogConnectFailure_WithTransportDisconnectedError_DoesNotThrow()
     {
+        // Arrange
         var device = CreateTestableDevice();
         var ex = new InvalidOperationException("Transport is not connected.");
 
+        // Act & Assert — the transport-disconnect case must be classified and logged without throwing.
         try
         {
             device.ExposedLogConnectFailure(ex);

--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
@@ -4,11 +4,12 @@ using System.Net;
 namespace Daqifi.Desktop.Test.Device.WiFiDevice;
 
 /// <summary>
-/// Tests for <see cref="DaqifiStreamingDevice"/>'s connect-failure classification (issue #732):
-/// Core's SCPI-error-during-initialization InvalidOperationException surfaces on the WiFi connect
-/// path too (the shared Connect template runs Core's InitializeAsync after ConnectTcp), so it is a
-/// device/environmental condition that must be downgraded to a Warning (no Sentry capture) rather
-/// than the default Error path — mirroring the serial classification (issues #589, #709).
+/// Tests for <see cref="DaqifiStreamingDevice"/>'s connect-failure classification. The shared Connect
+/// template runs Core's InitializeAsync after ConnectTcp, so device/environmental InvalidOperation
+/// exceptions raised during connect must be downgraded to a Warning (no Sentry capture) rather than
+/// the default Error path — mirroring the serial classification: Core's SCPI-error-during-init
+/// message (issue #732, #589, #709) and Core's transport reporting the connection dropped
+/// mid-initialization ("Transport is not connected.", issue #740; serial equivalent #588).
 /// </summary>
 [TestClass]
 public class DaqifiStreamingDeviceLogConnectFailureTests
@@ -59,6 +60,51 @@ public class DaqifiStreamingDeviceLogConnectFailureTests
         catch (Exception caught)
         {
             Assert.Fail($"LogConnectFailure must not throw for the SCPI-init-error case, but threw: {caught}");
+        }
+    }
+
+    [TestMethod]
+    public void IsTransportDisconnectedError_MatchesCoreTransportNotConnectedMessage()
+    {
+        // Wording Core's transport throws when the connection dropped mid-initialization. It is
+        // transport-agnostic (surfaces over TCP and serial), so the WiFi path must classify it as
+        // the environmental transport-disconnect condition (issue #740), not the default Error path.
+        var ex = new InvalidOperationException("Transport is not connected.");
+
+        Assert.IsTrue(DaqifiStreamingDevice.IsTransportDisconnectedError(ex));
+    }
+
+    [TestMethod]
+    public void IsTransportDisconnectedError_IsCaseInsensitive()
+    {
+        var ex = new InvalidOperationException("transport is not connected");
+
+        Assert.IsTrue(DaqifiStreamingDevice.IsTransportDisconnectedError(ex));
+    }
+
+    [TestMethod]
+    public void IsTransportDisconnectedError_DoesNotMatchWiFiAppBugInvalidOperationException()
+    {
+        // Regression guard: WiFi's own app-bug InvalidOperationException must NOT be downgraded as a
+        // transport-disconnect — it has to keep hitting the default Error path.
+        var ex = new InvalidOperationException("Connected Core device does not support streaming operations.");
+
+        Assert.IsFalse(DaqifiStreamingDevice.IsTransportDisconnectedError(ex));
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithTransportDisconnectedError_DoesNotThrow()
+    {
+        var device = CreateTestableDevice();
+        var ex = new InvalidOperationException("Transport is not connected.");
+
+        try
+        {
+            device.ExposedLogConnectFailure(ex);
+        }
+        catch (Exception caught)
+        {
+            Assert.Fail($"LogConnectFailure must not throw for the transport-disconnect case, but threw: {caught}");
         }
     }
 

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -465,6 +465,22 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         ex.Message.Contains("SCPI error while setting stream interface to USB", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// True when <paramref name="ex"/> is Core's transport reporting that the connection closed
+    /// mid-initialization: <c>InvalidOperationException("Transport is not connected.")</c>. Core's
+    /// <c>InitializeAsync()</c> runs from the shared <see cref="Connect"/> template over both the TCP
+    /// (WiFi) and serial transports, so if the connection drops in that window — device powered off,
+    /// WiFi/AP drop, USB unplug — the same transport-agnostic message surfaces regardless of
+    /// transport. That is a device/environmental condition, not an app bug (WiFi: issue #740; serial:
+    /// issue #588), so both connect paths classify it as a Warning rather than the default Error/Sentry
+    /// path. Matched on Core's distinctive phrase (via
+    /// <see cref="string.Contains(string, StringComparison)"/>) so unrelated
+    /// <see cref="InvalidOperationException"/> bugs still hit the default Error path. Extracted as a
+    /// pure predicate so the classification is unit-testable without exercising the logger.
+    /// </summary>
+    internal static bool IsTransportDisconnectedError(Exception ex) =>
+        ex.Message.Contains("Transport is not connected", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Tears down the Core device created by <see cref="Connect"/>: unsubscribes Core
     /// events, disconnects, and disposes. Safe to call when no Core device is set.
     /// Transports override to also tear down transport-specific state and must call the

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -159,12 +159,15 @@ public partial class SerialStreamingDevice : AbstractStreamingDevice, ILanChipIn
     /// ("Transport is not connected."). Both indicate the device was unplugged/powered off or the
     /// USB driver dropped the port during connect — a device/environmental condition, not an app
     /// bug. Matched on the specific known phrases (not the bare word "port") so unrelated
-    /// <see cref="InvalidOperationException"/> bugs still hit the default Error path. Extracted as
-    /// a pure predicate so the classification is unit-testable without exercising the logger.
+    /// <see cref="InvalidOperationException"/> bugs still hit the default Error path. The
+    /// transport-agnostic "Transport is not connected" half is shared with the WiFi path via
+    /// <see cref="AbstractStreamingDevice.IsTransportDisconnectedError"/> (issue #740); the
+    /// <c>BaseStream</c> phrase is .NET <c>SerialPort</c>-specific and stays serial-only. Extracted
+    /// as a pure predicate so the classification is unit-testable without exercising the logger.
     /// </summary>
     internal static bool IsTransportClosedError(Exception ex) =>
         ex.Message.Contains("BaseStream is only available when the port is open", StringComparison.OrdinalIgnoreCase)
-        || ex.Message.Contains("Transport is not connected", StringComparison.OrdinalIgnoreCase);
+        || IsTransportDisconnectedError(ex);
 
     /// <summary>
     /// Sends a message to the device using Core's DaqifiDevice.

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -143,6 +143,16 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
                 // Error/Sentry path, mirroring the serial classification (issues #589, #709).
                 AppLogger.Warning(ex, $"Device at {IpAddress}:{Port} returned a SCPI error during initialization");
                 break;
+            case InvalidOperationException when IsTransportDisconnectedError(ex):
+                // Core opens the TCP transport in CreateCoreDevice, then the shared Connect template
+                // runs InitializeAsync over it. If the connection drops in that window — device
+                // powered off, WiFi/AP drop, host roams networks — Core throws an
+                // InvalidOperationException "Transport is not connected." That's the same
+                // device/environmental condition the serial path already downgrades for a port that
+                // vanishes mid-init (issue #588); the message is transport-agnostic, so classify it
+                // as a Warning here rather than the default Error/Sentry path (issue #740).
+                AppLogger.Warning(ex, $"Device at {IpAddress}:{Port} disconnected during initialization");
+                break;
             default:
                 AppLogger.Error(ex, $"Problem with connecting to DAQiFi Device at {IpAddress}:{Port}");
                 break;


### PR DESCRIPTION
Closes #740.

## Problem
On the **WiFi** connect path, `DaqifiStreamingDevice.LogConnectFailure` classified `TimeoutException`, `SocketException`, and Core's SCPI-init `InvalidOperationException` as environmental (Warning, no Sentry capture) — but **not** the case where Core's TCP transport closes **mid-initialization**.

The shared `Connect` template runs Core's `InitializeAsync` after `ConnectTcp` (WiFi sets `InitializeDevice = false`, same as serial). If the TCP connection drops in that window — device powered off, WiFi/AP drop, host roam — Core throws `InvalidOperationException("Transport is not connected.")`, which fell through to the `default` branch and was logged at **Error** (captured to Sentry) as a false "app bug". This is the same device/environmental condition **#588** already fixed for the serial path; the message is transport-agnostic and confirmed present in `Daqifi.Core` 1.1.1.

## Change
- Extract the transport-agnostic `"Transport is not connected"` match into a shared `AbstractStreamingDevice.IsTransportDisconnectedError` predicate (next to `IsScpiInitializationError`).
- Serial's `IsTransportClosedError` now delegates to it (`IsTransportDisconnectedError(ex) || <BaseStream serial-only phrase>`), so serial classification is **identical**. The `.NET SerialPort` `BaseStream` phrase stays serial-only.
- Add `case InvalidOperationException when IsTransportDisconnectedError(ex)` to WiFi's `LogConnectFailure`, downgrading to Warning.
- Unit tests for the new predicate (match / case-insensitive / does-not-match WiFi app-bug) and `LogConnectFailure` non-throw, mirroring the existing serial/WiFi test files.

## Why it's safe
- Serial behavior is preserved (union of matched phrases unchanged; existing serial tests still green).
- WiFi only downgrades a specific message-matched `InvalidOperationException`; all others (e.g. WiFi's own "Connected Core device does not support streaming operations." app-bug) still hit the default Error path.
- Pure predicates, unit-testable without the logger.

## Testing
`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → **634 passed, 0 failed** (includes 4 new WiFi tests). No bench needed — pure classification logic; hardware can't be reliably made to drop TCP exactly mid-init.

Not merging — opened for your review.
