### PR TITLE
chore: convert the pane ViewModels' hand-wired RelayCommands to [RelayCommand] (part of #720)

### DIFF
--- a/Daqifi.Desktop/ViewModels/ChannelsPaneViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ChannelsPaneViewModel.cs
@@ -71,7 +71,11 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
     /// removing subscribed channels mid-session would corrupt the
     /// per-session device metadata captured at session start.
     /// </summary>
-    [ObservableProperty] private bool _isLoggingActive;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ToggleChannelCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SelectAllCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ClearAllCommand))]
+    private bool _isLoggingActive;
 
     private static readonly Brush[] ColorPaletteBrushes = BuildPalette(
     [
@@ -95,34 +99,9 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         return result;
     }
 
-    /// <summary>Toggles the clicked channel between active and inactive.</summary>
-    public IRelayCommand<ChannelTileViewModel> ToggleChannelCommand { get; }
-
-    /// <summary>Activates every channel in a section ("AI", "DI", or "DO").</summary>
-    public IRelayCommand<string> SelectAllCommand { get; }
-
-    /// <summary>Deactivates every channel across all sections.</summary>
-    public IRelayCommand ClearAllCommand { get; }
-
-    /// <summary>Opens the inline settings drawer for a channel.</summary>
-    public IRelayCommand<ChannelTileViewModel> OpenSettingsCommand { get; }
-
-    /// <summary>Closes the inline settings drawer.</summary>
-    public IRelayCommand CloseSettingsCommand { get; }
-
-    /// <summary>Sets the selected channel's plot color.</summary>
-    public IRelayCommand<Brush> SetColorCommand { get; }
-
     /// <summary>Creates the view-model and begins watching for connected devices.</summary>
     public ChannelsPaneViewModel()
     {
-        ToggleChannelCommand = new RelayCommand<ChannelTileViewModel>(ToggleChannel, _ => !IsLoggingActive);
-        SelectAllCommand = new RelayCommand<string>(SelectAll, _ => !IsLoggingActive);
-        ClearAllCommand = new RelayCommand(ClearAll, () => !IsLoggingActive);
-        OpenSettingsCommand = new RelayCommand<ChannelTileViewModel>(OpenSettings);
-        CloseSettingsCommand = new RelayCommand(CloseSettings);
-        SetColorCommand = new RelayCommand<Brush>(SetColor);
-
         _valueRefreshTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
         _valueRefreshTimer.Tick += OnValueRefreshTick;
         _valueRefreshTimer.Start();
@@ -133,12 +112,11 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         Rebuild();
     }
 
-    partial void OnIsLoggingActiveChanged(bool value)
-    {
-        ToggleChannelCommand.NotifyCanExecuteChanged();
-        SelectAllCommand.NotifyCanExecuteChanged();
-        ClearAllCommand.NotifyCanExecuteChanged();
-    }
+    /// <summary>
+    /// Gates channel activation, select-all, and clear-all: disabled while a
+    /// logging session is active. Re-queried when <see cref="IsLoggingActive"/> changes.
+    /// </summary>
+    private bool CanModifyChannels() => !IsLoggingActive;
 
     private void OnLoggingManagerPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -251,6 +229,8 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         TotalActive = ActiveAnalogCount + ActiveDigitalInCount + ActiveDigitalOutCount;
     }
 
+    /// <summary>Toggles the clicked channel between active and inactive.</summary>
+    [RelayCommand(CanExecute = nameof(CanModifyChannels))]
     private void ToggleChannel(ChannelTileViewModel? tile)
     {
         if (tile == null) return;
@@ -271,6 +251,8 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         RecomputeCounts();
     }
 
+    /// <summary>Activates every channel in a section ("AI", "DI", or "DO").</summary>
+    [RelayCommand(CanExecute = nameof(CanModifyChannels))]
     private void SelectAll(string? section)
     {
         IEnumerable<ChannelTileViewModel> tiles = section switch
@@ -286,6 +268,8 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         }
     }
 
+    /// <summary>Deactivates every channel across all sections.</summary>
+    [RelayCommand(CanExecute = nameof(CanModifyChannels))]
     private void ClearAll()
     {
         var active = AnalogInputs
@@ -296,6 +280,8 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         foreach (var tile in active) ToggleChannel(tile);
     }
 
+    /// <summary>Opens the inline settings drawer for a channel.</summary>
+    [RelayCommand]
     private void OpenSettings(ChannelTileViewModel? tile)
     {
         if (tile == null) return;
@@ -315,6 +301,8 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
             .FirstOrDefault(d => d.DeviceSerialNo == channel.DeviceSerialNo);
     }
 
+    /// <summary>Closes the inline settings drawer.</summary>
+    [RelayCommand]
     private void CloseSettings()
     {
         IsSettingsOpen = false;
@@ -322,6 +310,8 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         SelectedDevice = null;
     }
 
+    /// <summary>Sets the selected channel's plot color.</summary>
+    [RelayCommand]
     private void SetColor(Brush? brush)
     {
         if (SelectedChannel == null || brush == null) return;

--- a/Daqifi.Desktop/ViewModels/DevicesPaneViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DevicesPaneViewModel.cs
@@ -35,6 +35,8 @@ public partial class DevicesPaneViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(SelectedDevice))]
     [NotifyPropertyChangedFor(nameof(SelectedDeviceSupportsFirmwareUpdate))]
     [NotifyPropertyChangedFor(nameof(FrequencyHz))]
+    [NotifyCanExecuteChangedFor(nameof(DisconnectSelectedCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RebootSelectedCommand))]
     private DeviceTileViewModel? _selectedTile;
 
     [ObservableProperty] private bool _isSettingsOpen;
@@ -64,53 +66,18 @@ public partial class DevicesPaneViewModel : ObservableObject, IDisposable
         }
     }
 
-    /// <summary>Opens the inline settings drawer for a device tile.</summary>
-    public IRelayCommand<DeviceTileViewModel> OpenSettingsCommand { get; }
-
-    /// <summary>Closes the inline settings drawer.</summary>
-    public IRelayCommand CloseSettingsCommand { get; }
-
-    /// <summary>Shows the Add-Device dialog via the shell view-model.</summary>
-    public IRelayCommand AddDeviceCommand { get; }
-
-    /// <summary>Disconnects the currently selected device and closes the drawer.</summary>
-    public IRelayCommand DisconnectSelectedCommand { get; }
-
-    /// <summary>Reboots the currently selected device.</summary>
-    public IRelayCommand RebootSelectedCommand { get; }
-
-    /// <summary>
-    /// Writes the chosen logging-mode label ("Stream to App" or "Log to
-    /// Device") to the shell. Parameterized so the XAML can wire both
-    /// segmented-toggle RadioButtons to the same command.
-    /// </summary>
-    public IRelayCommand<string> SetLoggingModeCommand { get; }
-
     /// <summary>Creates the view-model bound to the shell view-model.</summary>
     public DevicesPaneViewModel(DaqifiViewModel? shell)
     {
         _shell = shell;
         _dispatcher = Dispatcher.CurrentDispatcher;
 
-        OpenSettingsCommand = new RelayCommand<DeviceTileViewModel>(OpenSettings);
-        CloseSettingsCommand = new RelayCommand(CloseSettings);
-        AddDeviceCommand = new RelayCommand(AddDevice);
-        DisconnectSelectedCommand = new RelayCommand(DisconnectSelected, () => SelectedDevice != null);
-        RebootSelectedCommand = new RelayCommand(RebootSelected, () => SelectedDevice != null);
-        SetLoggingModeCommand = new RelayCommand<string>(SetLoggingMode);
-
         ConnectionManager.Instance.PropertyChanged += OnConnectionManagerPropertyChanged;
         Rebuild();
     }
 
-    partial void OnSelectedTileChanged(DeviceTileViewModel? value)
-    {
-        // Derived-property change notifications are declared via
-        // [NotifyPropertyChangedFor] attributes above; the partial is only
-        // for imperative work the source generator can't do.
-        DisconnectSelectedCommand.NotifyCanExecuteChanged();
-        RebootSelectedCommand.NotifyCanExecuteChanged();
-    }
+    /// <summary>Gates the selected-device commands; re-queried when the drawer selection changes.</summary>
+    private bool HasSelectedDevice() => SelectedDevice != null;
 
     private void OnConnectionManagerPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -158,6 +125,8 @@ public partial class DevicesPaneViewModel : ObservableObject, IDisposable
         }
     }
 
+    /// <summary>Opens the inline settings drawer for a device tile.</summary>
+    [RelayCommand]
     private void OpenSettings(DeviceTileViewModel? tile)
     {
         if (tile == null) return;
@@ -176,12 +145,16 @@ public partial class DevicesPaneViewModel : ObservableObject, IDisposable
         IsSettingsOpen = true;
     }
 
+    /// <summary>Closes the inline settings drawer.</summary>
+    [RelayCommand]
     private void CloseSettings()
     {
         IsSettingsOpen = false;
         SelectedTile = null;
     }
 
+    /// <summary>Shows the Add-Device dialog via the shell view-model.</summary>
+    [RelayCommand]
     private void AddDevice()
     {
         if (_shell?.ShowConnectionDialogCommand.CanExecute(null) == true)
@@ -190,6 +163,8 @@ public partial class DevicesPaneViewModel : ObservableObject, IDisposable
         }
     }
 
+    /// <summary>Disconnects the currently selected device and closes the drawer.</summary>
+    [RelayCommand(CanExecute = nameof(HasSelectedDevice))]
     private void DisconnectSelected()
     {
         var device = SelectedDevice;
@@ -201,6 +176,12 @@ public partial class DevicesPaneViewModel : ObservableObject, IDisposable
         CloseSettings();
     }
 
+    /// <summary>
+    /// Writes the chosen logging-mode label ("Stream to App" or "Log to
+    /// Device") to the shell. Parameterized so the XAML can wire both
+    /// segmented-toggle RadioButtons to the same command.
+    /// </summary>
+    [RelayCommand]
     private void SetLoggingMode(string? mode)
     {
         // The shell setter takes the label, drives device SwitchMode, and
@@ -209,6 +190,8 @@ public partial class DevicesPaneViewModel : ObservableObject, IDisposable
         _shell.SelectedLoggingMode = mode;
     }
 
+    /// <summary>Reboots the currently selected device.</summary>
+    [RelayCommand(CanExecute = nameof(HasSelectedDevice))]
     private void RebootSelected()
     {
         var device = SelectedDevice;

--- a/Daqifi.Desktop/ViewModels/ProfilesPaneViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ProfilesPaneViewModel.cs
@@ -48,7 +48,9 @@ public partial class ProfilesPaneViewModel : ObservableObject
     // New-profile form fields (active only when IsNewProfile = true)
 
     /// <summary>Name bound to the new-profile form.</summary>
-    [ObservableProperty] private string _newProfileName = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveNewProfileCommand))]
+    private string _newProfileName = string.Empty;
 
     /// <summary>Sampling frequency (Hz) bound to the new-profile form. Capped at 1000Hz in the UI.</summary>
     [ObservableProperty] private int _newProfileFrequency = 1000;
@@ -76,45 +78,14 @@ public partial class ProfilesPaneViewModel : ObservableObject
     public ConfirmOverlayViewModel ConfirmOverlay { get; } = new();
     #endregion
 
-    #region Commands
-    /// <summary>Opens the drawer to edit the supplied profile.</summary>
-    public IRelayCommand<Profile> OpenEditDrawerCommand { get; }
-
-    /// <summary>Opens the drawer in new-profile mode with the device list pre-populated.</summary>
-    public IRelayCommand OpenNewDrawerCommand { get; }
-
-    /// <summary>Closes the drawer, persisting edits to the selected profile.</summary>
-    public IRelayCommand CloseDrawerCommand { get; }
-
-    /// <summary>Toggles the supplied profile on/off with a user confirmation when switching.</summary>
-    public IAsyncRelayCommand<Profile> ActivateProfileCommand { get; }
-
-    /// <summary>Deletes the supplied profile when it is not currently active.</summary>
-    public IRelayCommand<Profile> DeleteProfileCommand { get; }
-
-    /// <summary>Saves the new-profile form as a new <see cref="Profile"/>.</summary>
-    public IRelayCommand SaveNewProfileCommand { get; }
-
-    /// <summary>Snapshots the current device configuration into a new profile.</summary>
-    public IRelayCommand SaveCurrentSettingsCommand { get; }
-    #endregion
-
     #region Constructor
     /// <summary>
-    /// Wires up commands, subscribes to <see cref="LoggingManager"/> and profile
-    /// collection events, and seeds the initial <see cref="HasProfiles"/> /
-    /// <see cref="ActiveProfileName"/> state.
+    /// Subscribes to <see cref="LoggingManager"/> and profile collection events,
+    /// and seeds the initial <see cref="HasProfiles"/> / <see cref="ActiveProfileName"/>
+    /// state. Commands are generated from <c>[RelayCommand]</c>-annotated methods.
     /// </summary>
     public ProfilesPaneViewModel()
     {
-        OpenEditDrawerCommand = new RelayCommand<Profile>(OpenEditDrawer);
-        OpenNewDrawerCommand = new RelayCommand(OpenNewDrawer);
-        CloseDrawerCommand = new RelayCommand(CloseDrawer);
-        ActivateProfileCommand = new AsyncRelayCommand<Profile>(ActivateProfile);
-        DeleteProfileCommand = new RelayCommand<Profile>(DeleteProfile);
-        SaveNewProfileCommand = new RelayCommand(SaveNewProfile, CanSaveNewProfile);
-        SaveCurrentSettingsCommand = new RelayCommand(SaveCurrentSettings);
-
         LoggingManager.Instance.PropertyChanged += OnLoggingManagerPropertyChanged;
         IsLoggingActive = LoggingManager.Instance.Active;
         HasProfiles = Profiles.Count > 0;
@@ -148,9 +119,6 @@ public partial class ProfilesPaneViewModel : ObservableObject
             IsLoggingActive = LoggingManager.Instance.Active;
     }
 
-    partial void OnNewProfileNameChanged(string value) =>
-        SaveNewProfileCommand.NotifyCanExecuteChanged();
-
     private void OnNewDeviceItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (sender is not NewProfileDeviceItem deviceItem ||
@@ -172,6 +140,8 @@ public partial class ProfilesPaneViewModel : ObservableObject
     #endregion
 
     #region Drawer Lifecycle
+    /// <summary>Opens the drawer to edit the supplied profile.</summary>
+    [RelayCommand]
     private void OpenEditDrawer(Profile? profile)
     {
         if (profile == null) return;
@@ -186,6 +156,8 @@ public partial class ProfilesPaneViewModel : ObservableObject
         IsDrawerOpen = true;
     }
 
+    /// <summary>Opens the drawer in new-profile mode with the device list pre-populated.</summary>
+    [RelayCommand]
     private void OpenNewDrawer()
     {
         if (LoggingManager.Instance.Active)
@@ -213,6 +185,8 @@ public partial class ProfilesPaneViewModel : ObservableObject
         IsDrawerOpen = true;
     }
 
+    /// <summary>Closes the drawer, persisting edits to the selected profile.</summary>
+    [RelayCommand]
     private void CloseDrawer()
     {
         if (!IsNewProfile && SelectedProfile != null &&
@@ -228,6 +202,8 @@ public partial class ProfilesPaneViewModel : ObservableObject
     #endregion
 
     #region Activation
+    /// <summary>Toggles the supplied profile on/off with a user confirmation when switching.</summary>
+    [RelayCommand]
     private async Task ActivateProfile(Profile? profile)
     {
         if (profile == null) return;
@@ -389,6 +365,8 @@ public partial class ProfilesPaneViewModel : ObservableObject
         DrawerError = message;
     }
 
+    /// <summary>Deletes the supplied profile when it is not currently active.</summary>
+    [RelayCommand]
     private void DeleteProfile(Profile? profile)
     {
         if (profile == null) return;
@@ -409,6 +387,8 @@ public partial class ProfilesPaneViewModel : ObservableObject
         LoggingManager.Instance.UnsubscribeProfile(profile);
     }
 
+    /// <summary>Saves the new-profile form as a new <see cref="Profile"/>.</summary>
+    [RelayCommand(CanExecute = nameof(CanSaveNewProfile))]
     private void SaveNewProfile()
     {
         if (!CanSaveNewProfile()) return;
@@ -453,6 +433,8 @@ public partial class ProfilesPaneViewModel : ObservableObject
         CloseDrawer();
     }
 
+    /// <summary>Snapshots the current device configuration into a new profile.</summary>
+    [RelayCommand]
     private void SaveCurrentSettings()
     {
         var connected = ConnectionManager.Instance.ConnectedDevices.ToList();


### PR DESCRIPTION
## What

Continues **#720** (finish the CommunityToolkit.Mvvm conversion). The tile/observable-property/earlier-RelayCommand slices already landed (#723, #725, #727); this slice collapses the **19 remaining hand-instantiated `RelayCommand`/`AsyncRelayCommand`** declarations in the three unified-pane view-models onto the `[RelayCommand]` source generator.

| ViewModel | Commands converted |
|---|---|
| `ChannelsPaneViewModel` | 6 (ToggleChannel, SelectAll, ClearAll, OpenSettings, CloseSettings, SetColor) |
| `DevicesPaneViewModel` | 6 (OpenSettings, CloseSettings, AddDevice, DisconnectSelected, RebootSelected, SetLoggingMode) |
| `ProfilesPaneViewModel` | 7 (OpenEditDrawer, OpenNewDrawer, CloseDrawer, ActivateProfile, DeleteProfile, SaveNewProfile, SaveCurrentSettings) |

Each conversion removes the `public IRelayCommand Xyz { get; }` declaration plus its constructor `new RelayCommand(...)` line — the attribute generates both.

### `CanExecute` wiring

The three commands that carried predicates are converted to `[RelayCommand(CanExecute = nameof(...))]` and re-queried via `[NotifyCanExecuteChangedFor]` on the driving observable property, which lets the corresponding manual `OnXxxChanged` partials be deleted:

- `ChannelsPaneViewModel`: `_ => !IsLoggingActive` → `CanModifyChannels`, notified from `IsLoggingActive`.
- `DevicesPaneViewModel`: `() => SelectedDevice != null` → `HasSelectedDevice`, notified from `SelectedTile`.
- `ProfilesPaneViewModel`: `CanSaveNewProfile`, notified from `NewProfileName`.

One imperative `SaveNewProfileCommand.NotifyCanExecuteChanged()` is deliberately **kept** in `OnNewDeviceItemPropertyChanged` — device-item selection is not an observable property, so no attribute covers that trigger.

## Why

Removes the mixed-style trap (the same file wiring commands two different ways) and follows the convention AGENTS.md already mandates. Net **-45 lines**.

## Scope note

This is **part of #720, not the whole thing** — `DaqifiViewModel.RegisterCommands()` (4 commands, including a concrete-typed `AsyncRelayCommand` and two that delegate to a collaborator) and the section-3 dispatcher/`UiThreadHelper` dedup are intentionally left for their own slices, since they touch the god class's init-guard semantics and are riskier. Does not close #720.

## Validation

Behavior-preserving: generated command property names are unchanged, so the XAML `{Binding XxxCommand}` sites resolve identically (verified no non-XAML C# references to the affected command properties exist).

- `dotnet build Daqifi.Desktop` — 0 errors
- `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — **630 passed / 0 failed**

Not merging — opening for review.
