### PR TITLE
fix: harden EnumDescriptionConverter against NRE on undefined enum values and non-Description attributes

### DIFF
--- a/Daqifi.Desktop.Test/Converters/EnumDescriptionConverterTests.cs
+++ b/Daqifi.Desktop.Test/Converters/EnumDescriptionConverterTests.cs
@@ -33,6 +33,20 @@ public class EnumDescriptionConverterTests
         Value3
     }
 
+    // Test enum whose members carry a non-Description attribute (with and without a Description).
+    private enum AttributedEnum
+    {
+        // Only a non-Description attribute -> should fall back to the member name.
+        [System.ComponentModel.Browsable(false)]
+        NonDescriptionOnly,
+
+        // A non-Description attribute alongside a Description -> the Description must still win,
+        // regardless of attribute ordering returned by reflection.
+        [System.ComponentModel.Browsable(false)]
+        [System.ComponentModel.Description("Mixed Description")]
+        MixedAttributes
+    }
+
     [TestInitialize]
     public void Setup()
     {
@@ -128,6 +142,45 @@ public class EnumDescriptionConverterTests
             // Assert
             Assert.AreEqual(enumValue.ToString(), result, $"Failed for enum value: {enumValue}");
         }
+    }
+
+    [TestMethod]
+    public void Convert_UndefinedEnumValue_ReturnsNumericString()
+    {
+        // Arrange - a value with no corresponding named member (previously threw NullReferenceException).
+        var undefinedValue = (TestEnum)999;
+
+        // Act
+        var result = _converter.Convert(undefinedValue, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("999", result);
+    }
+
+    [TestMethod]
+    public void Convert_MemberWithOnlyNonDescriptionAttribute_ReturnsEnumName()
+    {
+        // Arrange - member carries a [Browsable] attribute but no [Description] (previously threw NRE).
+        var enumValue = AttributedEnum.NonDescriptionOnly;
+
+        // Act
+        var result = _converter.Convert(enumValue, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("NonDescriptionOnly", result);
+    }
+
+    [TestMethod]
+    public void Convert_MemberWithMixedAttributes_ReturnsDescription()
+    {
+        // Arrange - Description must be found even when another attribute is also present.
+        var enumValue = AttributedEnum.MixedAttributes;
+
+        // Act
+        var result = _converter.Convert(enumValue, typeof(string), null, CultureInfo.InvariantCulture);
+
+        // Assert
+        Assert.AreEqual("Mixed Description", result);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop/Helpers/EnumDescriptionConverter.cs
+++ b/Daqifi.Desktop/Helpers/EnumDescriptionConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.Windows.Data;
 
 namespace Daqifi.Desktop.Helpers;
@@ -8,18 +9,22 @@ public class EnumDescriptionConverter : IValueConverter
 {
     private string GetEnumDescription(Enum enumObj)
     {
+        // Undefined/out-of-range enum values are not named members, so GetField returns null.
+        // Fall back to the value's string form (its numeric representation) rather than crashing.
         var fieldInfo = enumObj.GetType().GetField(enumObj.ToString());
-
-        var attribArray = fieldInfo.GetCustomAttributes(false);
-
-        if (attribArray.Length == 0)
+        if (fieldInfo == null)
         {
             return enumObj.ToString();
         }
 
-        var attrib = attribArray[0] as DescriptionAttribute;
-        return attrib.Description;
+        // Select the DescriptionAttribute specifically: a member may carry other attributes,
+        // and GetCustomAttributes order is not guaranteed. Fall back to the member name when absent.
+        var descriptionAttribute = fieldInfo
+            .GetCustomAttributes(typeof(DescriptionAttribute), false)
+            .OfType<DescriptionAttribute>()
+            .FirstOrDefault();
 
+        return descriptionAttribute?.Description ?? enumObj.ToString();
     }
 
     object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
## Summary

`EnumDescriptionConverter.GetEnumDescription` (Daqifi.Desktop/Helpers/EnumDescriptionConverter.cs) had two latent `NullReferenceException` paths. The converter is registered app-wide (`App.xaml` key `EnumDescription`) and bound to device-reported `WifiMode`/`WifiSecurityType` values in `DevicesPanePrototype.xaml`, so a device (or any caller) supplying an out-of-range or oddly-attributed enum value could crash item rendering.

**Bug 1 — undefined enum value.** `Type.GetField(enumObj.ToString())` returns `null` when the value is not a named member (its `ToString()` is the numeric string, e.g. `"999"`), so dereferencing `fieldInfo` threw. Now falls back to the value's string form.

**Bug 2 — first attribute is not a DescriptionAttribute.** `attribArray[0] as DescriptionAttribute` assumed the first custom attribute is a `DescriptionAttribute`; any other attribute (or non-guaranteed attribute order) made the cast `null` and `.Description` threw. Now selects the `DescriptionAttribute` specifically via the typed `GetCustomAttributes` overload + `FirstOrDefault`, falling back to the member name when absent.

## Why it's safe / non-breaking

Behavior is preserved for every input that previously worked (described member -> description, empty description -> empty string, no attribute -> name). Only inputs that previously **threw** change behavior. Verified by the existing 11 tests plus 3 new ones (undefined value, member with only a non-Description attribute, member mixing Description + another attribute).

## Testing

- Unit gate (`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`): 643 passed / 0 failed (+3 new).
- App-launch smoke (`Launch_MainWindowAppears_AndIsResponsive`): passed.

Closes #744

_Opened by the autonomous work loop — not merging; for maintainer review._

🤖 Generated with [Claude Code](https://claude.com/claude-code)