### PR TITLE
chore: add CI detection for unused PackageReferences (#711)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,13 @@ jobs:
     - name: Build with Analysis
       run: dotnet build --no-restore --configuration Release /p:EnforceCodeStyleInBuild=true
 
+    - name: Check for unused PackageReferences (non-blocking)
+      # Reports declared <PackageReference> items with no detectable C#/XAML usage as
+      # ::warning annotations. Runs after the build so SDK-generated compile inputs
+      # (global usings, XAML .g.cs) are present. Non-blocking for now (issue #711); to
+      # promote to a hard failure once it has proven quiet, add `-- . --fail-on-unused`.
+      run: dotnet run eng/CheckUnusedPackages.cs -- .
+
     - name: Publish app (framework-dependent)
       run: dotnet publish Daqifi.Desktop/Daqifi.Desktop.csproj -c Release --no-restore
 

--- a/eng/CheckUnusedPackages.cs
+++ b/eng/CheckUnusedPackages.cs
@@ -61,8 +61,9 @@ var projects = Directory.EnumerateFiles(repoRoot, "*.csproj", SearchOption.AllDi
 
 if (projects.Count == 0)
 {
-    Console.Error.WriteLine($"No .csproj files found under '{repoRoot}'.");
-    return 2;
+    // Nothing to analyze is not a build error -- stay non-blocking and just flag it.
+    Console.WriteLine($"::warning::[unused-package-check] No .csproj files found under '{repoRoot}'.");
+    return 0;
 }
 
 Console.WriteLine($"Unused-PackageReference check over {projects.Count} project(s) in {repoRoot}");
@@ -87,81 +88,112 @@ foreach (var proj in projects)
         continue;
     }
 
-    using var doc = JsonDocument.Parse(File.ReadAllText(assetsPath));
-    var root = doc.RootElement;
-    var folders = root.GetProperty("packageFolders").EnumerateObject().Select(p => p.Name).ToList();
-    var target = root.GetProperty("targets").EnumerateObject().First().Value;
-    var libraries = root.GetProperty("libraries");
-
-    var (csText, xamlText) = LoadCorpus(projDir);
-
-    foreach (var pkg in declared.OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+    // Any per-project failure (malformed/partial assets, IO, unexpected schema) must not
+    // sink the whole check: emit a diagnostic ::warning and move on. The run only exits
+    // non-zero when --fail-on-unused is set AND a genuine unused package is found.
+    try
     {
-        if (allowlist.Contains(pkg))
+        using var doc = JsonDocument.Parse(File.ReadAllText(assetsPath));
+        var root = doc.RootElement;
+        var folders = root.GetProperty("packageFolders").EnumerateObject().Select(p => p.Name).ToList();
+        var libraries = root.GetProperty("libraries");
+
+        // A restore can emit several target graphs (e.g. a TFM-only graph plus RID-specific
+        // ones). Search every graph and union each package's compile assets rather than
+        // trusting an arbitrary "first" entry, which could be the wrong (or an empty) graph.
+        var targetGraphs = new List<JsonElement>();
+        if (root.TryGetProperty("targets", out var targetsEl) && targetsEl.ValueKind == JsonValueKind.Object)
         {
+            targetGraphs.AddRange(targetsEl.EnumerateObject().Select(t => t.Value));
+        }
+        if (targetGraphs.Count == 0)
+        {
+            Console.WriteLine($"  {projName}: project.assets.json has no target graphs -- skipped");
             continue;
         }
 
-        // Locate the "<id>/<version>" entry for this package in the target graph.
-        JsonElement entry = default;
-        string? libKey = null;
-        foreach (var t in target.EnumerateObject())
-        {
-            var slash = t.Name.IndexOf('/');
-            if (slash > 0 && string.Equals(t.Name[..slash], pkg, StringComparison.OrdinalIgnoreCase))
-            {
-                entry = t.Value;
-                libKey = t.Name;
-                break;
-            }
-        }
-        if (libKey is null)
-        {
-            continue; // Unresolved (e.g. a project reference dressed as a package) -- ignore.
-        }
+        var (csText, xamlText) = LoadCorpus(projDir);
 
-        if (!entry.TryGetProperty("compile", out var compile))
+        foreach (var pkg in declared.OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
         {
-            continue; // No compile-time surface -> not detectable, auto-skip.
-        }
-        var compileKeys = compile.EnumerateObject()
-            .Select(c => c.Name)
-            .Where(k => !k.EndsWith("_._", StringComparison.Ordinal))
-            .ToList();
-        if (compileKeys.Count == 0)
-        {
-            continue; // Placeholder / native / analyzer package -> auto-skip.
-        }
-
-        var libPath = libraries.GetProperty(libKey).GetProperty("path").GetString() ?? "";
-        var namespaces = new HashSet<string>(StringComparer.Ordinal);
-        var xmlnsUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var asmNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var ck in compileKeys)
-        {
-            var dll = ResolveDll(folders, libPath, ck);
-            if (dll is null)
+            if (allowlist.Contains(pkg))
             {
                 continue;
             }
-            asmNames.Add(Path.GetFileNameWithoutExtension(ck));
-            CollectFromAssembly(dll, namespaces, xmlnsUrls);
-        }
 
-        if (namespaces.Count == 0 && xmlnsUrls.Count == 0)
-        {
-            continue; // Could not read any public surface -> avoid a false positive.
-        }
+            // Locate the "<id>/<version>" entry for this package across every target graph
+            // and union the compile assets. libKey is identical across graphs (it keys the
+            // shared "libraries" table), so the last non-null wins harmlessly.
+            string? libKey = null;
+            var compileKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var graph in targetGraphs)
+            {
+                foreach (var t in graph.EnumerateObject())
+                {
+                    var slash = t.Name.IndexOf('/');
+                    if (slash <= 0 || !string.Equals(t.Name[..slash], pkg, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                    libKey = t.Name;
+                    if (t.Value.TryGetProperty("compile", out var compile))
+                    {
+                        foreach (var c in compile.EnumerateObject())
+                        {
+                            if (!c.Name.EndsWith("_._", StringComparison.Ordinal))
+                            {
+                                compileKeys.Add(c.Name);
+                            }
+                        }
+                    }
+                    break; // At most one entry per package per graph.
+                }
+            }
+            if (libKey is null)
+            {
+                continue; // Unresolved (e.g. a project reference dressed as a package) -- ignore.
+            }
+            if (compileKeys.Count == 0)
+            {
+                continue; // No compile surface (placeholder / native / analyzer) -> auto-skip.
+            }
 
-        if (!IsUsed(namespaces, xmlnsUrls, asmNames, csText, xamlText))
-        {
-            var rel = Path.GetRelativePath(repoRoot, proj).Replace('\\', '/');
-            Console.WriteLine(
-                $"::warning file={rel}::[unused-package] '{pkg}' is declared in {projName} " +
-                $"but no C# or XAML usage was detected. If this is intentional (used only via a " +
-                $"channel the checker cannot see), add it to the allowlist in eng/CheckUnusedPackages.cs.");
-            totalUnused++;
+            var libPath = libraries.GetProperty(libKey).GetProperty("path").GetString() ?? "";
+            var namespaces = new HashSet<string>(StringComparer.Ordinal);
+            var xmlnsUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var asmNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var ck in compileKeys)
+            {
+                var dll = ResolveDll(folders, libPath, ck);
+                if (dll is null)
+                {
+                    continue;
+                }
+                asmNames.Add(Path.GetFileNameWithoutExtension(ck));
+                CollectFromAssembly(dll, namespaces, xmlnsUrls);
+            }
+
+            if (namespaces.Count == 0 && xmlnsUrls.Count == 0)
+            {
+                continue; // Could not read any public surface -> avoid a false positive.
+            }
+
+            if (!IsUsed(namespaces, xmlnsUrls, asmNames, csText, xamlText))
+            {
+                var rel = Path.GetRelativePath(repoRoot, proj).Replace('\\', '/');
+                Console.WriteLine(
+                    $"::warning file={rel}::[unused-package] '{pkg}' is declared in {projName} " +
+                    $"but no C# or XAML usage was detected. If this is intentional (used only via a " +
+                    $"channel the checker cannot see), add it to the allowlist in eng/CheckUnusedPackages.cs.");
+                totalUnused++;
+            }
         }
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine(
+            $"::warning file={Path.GetRelativePath(repoRoot, proj).Replace('\\', '/')}::" +
+            $"[unused-package-check-skipped] {projName} could not be analyzed ({ex.GetType().Name}: {ex.Message}).");
     }
 }
 

--- a/eng/CheckUnusedPackages.cs
+++ b/eng/CheckUnusedPackages.cs
@@ -1,0 +1,366 @@
+// Detects declared <PackageReference> items that have no detectable compile-time usage.
+//
+// Part 1 of issue #711. Run as a .NET 10 file-based app (no project required):
+//
+//     dotnet run eng/CheckUnusedPackages.cs -- [repoRoot] [--fail-on-unused]
+//
+// How it decides "unused" (all signals come from real build artifacts, not guesses):
+//   * Only DIRECT PackageReference items are considered (transitive deps are ignored).
+//   * A package is auto-skipped when it contributes no compile-time assembly for the
+//     project's target framework (project.assets.json "compile" group empty or "_._").
+//     This automatically excludes analyzers, build/tooling packages (PrivateAssets),
+//     and native runtime providers such as SQLitePCLRaw.bundle_e_sqlite3 -- none of
+//     which are referenced by C# symbols and none of which should ever be flagged.
+//   * For the remaining packages, the checker reads the actual public namespaces and
+//     any XmlnsDefinition xml-namespace URLs out of the restored assemblies (via
+//     System.Reflection.Metadata) and looks for usage in the project's C# (namespace
+//     tokens) and XAML (clr-namespace assembly= and xmlns URLs). If nothing matches,
+//     the package is reported.
+//
+// The check is NON-BLOCKING by default: it prints GitHub Actions ::warning annotations
+// and exits 0. Pass --fail-on-unused to make it exit 1 (only once it has proven quiet
+// for a few PRs, per the issue's suggested rollout).
+//
+// The allowlist below is the documented tuning knob for the rare package that is
+// legitimately declared but exercised only through a channel this checker cannot see.
+
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+string repoRoot = Directory.GetCurrentDirectory();
+bool failOnUnused = false;
+foreach (var a in args)
+{
+    if (a == "--fail-on-unused") failOnUnused = true;
+    else if (!a.StartsWith("--", StringComparison.Ordinal)) repoRoot = Path.GetFullPath(a);
+}
+
+// Packages legitimately declared but not detectably referenced by C# symbols or XAML.
+// Keep this list short and documented -- most build/native/analyzer packages are already
+// auto-skipped by the "no compile assembly" rule above.
+var allowlist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+{
+    // Provider package: its own assembly exposes only EFCore.BulkExtensions.SqlAdapters.Sqlite,
+    // while the EFCore.BulkExtensions API namespace the code actually calls (BulkInsert, etc.) is
+    // delivered by its transitive EFCore.BulkExtensions.Core dependency. The direct reference is
+    // required to select the SQLite adapter, so it can never be attributed by first-party surface.
+    "EFCore.BulkExtensions.Sqlite",
+};
+
+var projects = Directory.EnumerateFiles(repoRoot, "*.csproj", SearchOption.AllDirectories)
+    .Select(p => p.Replace('\\', '/'))
+    .Where(p => !p.Contains("/Daqifi.Desktop.Setup/"))
+    .Where(p => !p.Contains("/obj/") && !p.Contains("/bin/"))
+    .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+    .ToList();
+
+if (projects.Count == 0)
+{
+    Console.Error.WriteLine($"No .csproj files found under '{repoRoot}'.");
+    return 2;
+}
+
+Console.WriteLine($"Unused-PackageReference check over {projects.Count} project(s) in {repoRoot}");
+int totalUnused = 0;
+int skippedNoAssets = 0;
+
+foreach (var proj in projects)
+{
+    var projDir = Path.GetDirectoryName(proj)!;
+    var projName = Path.GetFileName(proj);
+    var assetsPath = Path.Combine(projDir, "obj", "project.assets.json");
+    if (!File.Exists(assetsPath))
+    {
+        Console.WriteLine($"  {projName}: no obj/project.assets.json (not restored) -- skipped");
+        skippedNoAssets++;
+        continue;
+    }
+
+    var declared = ParseDirectPackageRefs(proj);
+    if (declared.Count == 0)
+    {
+        continue;
+    }
+
+    using var doc = JsonDocument.Parse(File.ReadAllText(assetsPath));
+    var root = doc.RootElement;
+    var folders = root.GetProperty("packageFolders").EnumerateObject().Select(p => p.Name).ToList();
+    var target = root.GetProperty("targets").EnumerateObject().First().Value;
+    var libraries = root.GetProperty("libraries");
+
+    var (csText, xamlText) = LoadCorpus(projDir);
+
+    foreach (var pkg in declared.OrderBy(p => p, StringComparer.OrdinalIgnoreCase))
+    {
+        if (allowlist.Contains(pkg))
+        {
+            continue;
+        }
+
+        // Locate the "<id>/<version>" entry for this package in the target graph.
+        JsonElement entry = default;
+        string? libKey = null;
+        foreach (var t in target.EnumerateObject())
+        {
+            var slash = t.Name.IndexOf('/');
+            if (slash > 0 && string.Equals(t.Name[..slash], pkg, StringComparison.OrdinalIgnoreCase))
+            {
+                entry = t.Value;
+                libKey = t.Name;
+                break;
+            }
+        }
+        if (libKey is null)
+        {
+            continue; // Unresolved (e.g. a project reference dressed as a package) -- ignore.
+        }
+
+        if (!entry.TryGetProperty("compile", out var compile))
+        {
+            continue; // No compile-time surface -> not detectable, auto-skip.
+        }
+        var compileKeys = compile.EnumerateObject()
+            .Select(c => c.Name)
+            .Where(k => !k.EndsWith("_._", StringComparison.Ordinal))
+            .ToList();
+        if (compileKeys.Count == 0)
+        {
+            continue; // Placeholder / native / analyzer package -> auto-skip.
+        }
+
+        var libPath = libraries.GetProperty(libKey).GetProperty("path").GetString() ?? "";
+        var namespaces = new HashSet<string>(StringComparer.Ordinal);
+        var xmlnsUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var asmNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var ck in compileKeys)
+        {
+            var dll = ResolveDll(folders, libPath, ck);
+            if (dll is null)
+            {
+                continue;
+            }
+            asmNames.Add(Path.GetFileNameWithoutExtension(ck));
+            CollectFromAssembly(dll, namespaces, xmlnsUrls);
+        }
+
+        if (namespaces.Count == 0 && xmlnsUrls.Count == 0)
+        {
+            continue; // Could not read any public surface -> avoid a false positive.
+        }
+
+        if (!IsUsed(namespaces, xmlnsUrls, asmNames, csText, xamlText))
+        {
+            var rel = Path.GetRelativePath(repoRoot, proj).Replace('\\', '/');
+            Console.WriteLine(
+                $"::warning file={rel}::[unused-package] '{pkg}' is declared in {projName} " +
+                $"but no C# or XAML usage was detected. If this is intentional (used only via a " +
+                $"channel the checker cannot see), add it to the allowlist in eng/CheckUnusedPackages.cs.");
+            totalUnused++;
+        }
+    }
+}
+
+Console.WriteLine(
+    $"Done. {totalUnused} likely-unused PackageReference(s) found" +
+    (skippedNoAssets > 0 ? $" ({skippedNoAssets} project(s) skipped: not restored)." : "."));
+
+if (totalUnused > 0 && failOnUnused)
+{
+    return 1;
+}
+return 0;
+
+// ---- helpers ----
+
+static HashSet<string> ParseDirectPackageRefs(string proj)
+{
+    var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    var xd = XDocument.Load(proj);
+    foreach (var e in xd.Descendants().Where(x => x.Name.LocalName == "PackageReference"))
+    {
+        var inc = e.Attribute("Include")?.Value ?? e.Attribute("Update")?.Value;
+        if (!string.IsNullOrWhiteSpace(inc))
+        {
+            set.Add(inc.Trim());
+        }
+    }
+    return set;
+}
+
+static (string cs, string xaml) LoadCorpus(string projDir)
+{
+    var sbCs = new StringBuilder();
+    var sbXaml = new StringBuilder();
+    foreach (var file in Directory.EnumerateFiles(projDir, "*.*", SearchOption.AllDirectories))
+    {
+        var norm = file.Replace('\\', '/');
+        // bin/ holds build outputs, never source. obj/ IS kept: it carries SDK-generated
+        // compile inputs -- global usings (e.g. MSTest's Microsoft.VisualStudio.TestTools.UnitTesting)
+        // and XAML .g.cs -- that are genuine references and must count as usage.
+        if (norm.Contains("/bin/"))
+        {
+            continue;
+        }
+        if (norm.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+        {
+            sbCs.Append(File.ReadAllText(file)).Append('\n');
+        }
+        else if (norm.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
+        {
+            sbXaml.Append(File.ReadAllText(file)).Append('\n');
+        }
+    }
+    return (sbCs.ToString(), sbXaml.ToString());
+}
+
+static string? ResolveDll(List<string> folders, string libPath, string compileKey)
+{
+    var rel = compileKey.Replace('/', Path.DirectorySeparatorChar);
+    foreach (var f in folders)
+    {
+        var p = Path.Combine(f, libPath, rel);
+        if (File.Exists(p))
+        {
+            return p;
+        }
+    }
+    return null;
+}
+
+static void CollectFromAssembly(string dll, HashSet<string> namespaces, HashSet<string> xmlnsUrls)
+{
+    try
+    {
+        using var fs = File.OpenRead(dll);
+        using var pe = new PEReader(fs);
+        if (!pe.HasMetadata)
+        {
+            return;
+        }
+        var mr = pe.GetMetadataReader();
+
+        foreach (var th in mr.TypeDefinitions)
+        {
+            var td = mr.GetTypeDefinition(th);
+            if ((td.Attributes & TypeAttributes.VisibilityMask) != TypeAttributes.Public)
+            {
+                continue; // Only the public, top-level API surface carries usable namespaces.
+            }
+            var ns = mr.GetString(td.Namespace);
+            if (!string.IsNullOrEmpty(ns))
+            {
+                namespaces.Add(ns);
+            }
+        }
+
+        // Type-forwarding facade assemblies (e.g. MSTest.TestFramework forwards
+        // Microsoft.VisualStudio.TestTools.UnitTesting) expose their API as ExportedType
+        // rows rather than TypeDefinitions -- count those namespaces too.
+        foreach (var eth in mr.ExportedTypes)
+        {
+            var et = mr.GetExportedType(eth);
+            if ((et.Attributes & TypeAttributes.VisibilityMask) != TypeAttributes.Public)
+            {
+                continue;
+            }
+            var ns = mr.GetString(et.Namespace);
+            if (!string.IsNullOrEmpty(ns))
+            {
+                namespaces.Add(ns);
+            }
+        }
+
+        foreach (var cah in mr.GetAssemblyDefinition().GetCustomAttributes())
+        {
+            var ca = mr.GetCustomAttribute(cah);
+            if (AttributeTypeName(mr, ca) != "XmlnsDefinitionAttribute")
+            {
+                continue;
+            }
+            try
+            {
+                var br = mr.GetBlobReader(ca.Value);
+                if (br.ReadUInt16() != 1)
+                {
+                    continue; // Not the standard custom-attribute prolog.
+                }
+                var url = br.ReadSerializedString(); // First ctor arg = xml namespace URL.
+                if (!string.IsNullOrEmpty(url))
+                {
+                    xmlnsUrls.Add(url);
+                }
+            }
+            catch
+            {
+                // Ignore attributes we cannot decode.
+            }
+        }
+    }
+    catch
+    {
+        // Unreadable assembly -> contributes nothing; caller treats as no surface.
+    }
+}
+
+static string AttributeTypeName(MetadataReader mr, CustomAttribute ca)
+{
+    switch (ca.Constructor.Kind)
+    {
+        case HandleKind.MemberReference:
+            var m = mr.GetMemberReference((MemberReferenceHandle)ca.Constructor);
+            if (m.Parent.Kind == HandleKind.TypeReference)
+            {
+                return mr.GetString(mr.GetTypeReference((TypeReferenceHandle)m.Parent).Name);
+            }
+            break;
+        case HandleKind.MethodDefinition:
+            var md = mr.GetMethodDefinition((MethodDefinitionHandle)ca.Constructor);
+            return mr.GetString(mr.GetTypeDefinition(md.GetDeclaringType()).Name);
+    }
+    return "";
+}
+
+static bool IsUsed(
+    HashSet<string> namespaces,
+    HashSet<string> xmlnsUrls,
+    HashSet<string> asmNames,
+    string csText,
+    string xamlText)
+{
+    // C#: any of the package's public namespaces appears as a dotted token.
+    foreach (var ns in namespaces)
+    {
+        var pattern = $@"(?<![A-Za-z0-9_.]){Regex.Escape(ns)}(?![A-Za-z0-9_])";
+        if (Regex.IsMatch(csText, pattern))
+        {
+            return true;
+        }
+    }
+
+    if (xamlText.Length > 0)
+    {
+        // XAML: assembly-qualified clr-namespace, e.g. assembly=OxyPlot.Wpf
+        foreach (var asm in asmNames)
+        {
+            if (Regex.IsMatch(xamlText, $@"assembly\s*=\s*{Regex.Escape(asm)}(?![A-Za-z0-9_.])"))
+            {
+                return true;
+            }
+        }
+        // XAML: URL xmlns declared by the assembly's [XmlnsDefinition], e.g. MahApps/Behaviors.
+        foreach (var url in xmlnsUrls)
+        {
+            if (xamlText.Contains(url, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
## What

Adds a **non-blocking** CI check that flags declared `<PackageReference>` items with no detectable compile-time usage — catching the dependency drift that was previously only found by manual cross-repo audits (e.g. the redundant `System.Configuration.ConfigurationManager` references removed in #703).

This is **part 1** of #711 (unused `PackageReference` detection). Part 2 (unused XAML resources) is deferred as the issue recommends.

## How

`eng/CheckUnusedPackages.cs` is a self-contained **.NET 10 file-based app** — no new project, no external tool/version to pin, and it never enters the solution build. All signals come from real build artifacts, not guesses:

- Considers only **direct** `PackageReference` items.
- **Auto-skips** packages with no compile-time assembly for the target framework (`project.assets.json` compile group empty or `_._`): analyzers, build/tooling packages under `PrivateAssets`, and native runtime providers such as `SQLitePCLRaw.bundle_e_sqlite3` — none of which are referenced by C# symbols, so none should ever be flagged.
- For the rest, reads the actual public namespaces and `[XmlnsDefinition]` xml-namespace URLs out of the restored assemblies via `System.Reflection.Metadata` (including type-forwarded `ExportedType`s, so facades like `MSTest.TestFramework` resolve), then looks for usage across the project's **C#** (namespace tokens — including SDK-generated global usings and XAML `.g.cs`) and **XAML** (`clr-namespace ... assembly=` and xmlns URLs).
- One documented allowlist entry: `EFCore.BulkExtensions.Sqlite` — a provider package whose `EFCore.BulkExtensions` API namespace is delivered by its transitive `EFCore.BulkExtensions.Core` dependency, so it has no first-party surface to attribute.

Wired into `build.yaml` right after the build step, emitting GitHub Actions `::warning` annotations and **exiting 0** (non-blocking) per the issue's rollout plan. Pass `-- . --fail-on-unused` to promote to a hard failure once it has proven quiet for a few PRs.

## Validation

- **0 findings** on the current tree (proves it's quiet).
- **Positive test**: temporarily adding an unused `Newtonsoft.Json` reference to `Daqifi.Desktop.Common` was correctly flagged, and the flag cleared on revert (proves it isn't always-green).
- The two false positives found during development (`MSTest.TestFramework` via SDK global-using; `EFCore.BulkExtensions.Sqlite` provider package) are both handled — see the commit body.

Closes #711.

Not merging — opened for review.
