### PR TITLE
fix: report a locked export destination instead of claiming success (#747)

### DIFF
--- a/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
+++ b/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
@@ -208,6 +208,27 @@ stopwatch.ElapsedMilliseconds, $"Large dataset export should complete in under 5
         Assert.Contains("INVALID(", content, "Invalid timestamps should be labelled rather than throwing");
     }
 
+    /// <summary>
+    /// Issue #747: a destination held by another process used to be swallowed here, which left the
+    /// export dialog reporting "Export complete" over a file that was never written. The failure
+    /// must reach the caller.
+    /// </summary>
+    [TestMethod]
+    public void OptimizedExporter_LockedDestination_PropagatesFailure()
+    {
+        var samples = GenerateTestDataset(1, 5);
+        var loggingSession = new LoggingSession { ID = 1, DataSamples = samples };
+        var exportPath = Path.Combine(TestDirectoryPath, "locked_test.csv");
+        File.WriteAllText(exportPath, "held by another program");
+
+        var exporter = new OptimizedLoggingSessionExporter();
+
+        using var holder = new FileStream(exportPath, FileMode.Open, FileAccess.Write, FileShare.Read);
+
+        Assert.ThrowsExactly<IOException>(() => exporter.ExportLoggingSession(
+            loggingSession, exportPath, false, new Progress<int>(), CancellationToken.None, 0, 1));
+    }
+
     [TestCleanup]
     public void CleanUp()
     {

--- a/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
@@ -231,6 +231,31 @@ public class ExportDialogViewModelTests
             "The pre-flight probe must not truncate the file it could not write.");
     }
 
+    /// <summary>
+    /// A session that no longer exists is skipped by the export, so its destination must not be
+    /// pre-flighted either — a locked file for a stale id must never block the run.
+    /// </summary>
+    [TestMethod]
+    public async Task Export_WhenSessionIsMissing_LockedDestinationDoesNotBlockTheRun()
+    {
+        // Arrange — an empty database, so session 1 is never found.
+        using var factory = new TempSqliteLoggingContextFactory();
+        var exportPath = Path.Combine(TestDirectoryPath, $"stale_{Guid.NewGuid():N}.csv");
+        await File.WriteAllTextAsync(exportPath, "held open");
+        var vm = new ExportDialogViewModel(factory, sessionId: 1) { ExportFilePath = exportPath };
+
+        using (new FileStream(exportPath, FileMode.Open, FileAccess.Write, FileShare.Read))
+        {
+            // Act
+            await vm.ExportLoggingSessionsCommand.ExecuteAsync(null);
+        }
+
+        // Assert
+        Assert.IsTrue(vm.ExportSucceeded,
+            "A locked destination belonging to a skipped session must not fail the export.");
+        Assert.AreEqual("Export complete", vm.ExportResultMessage);
+    }
+
     [TestMethod]
     public async Task Export_AfterFailure_RetryReturnsToConfigureState()
     {

--- a/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
@@ -200,6 +200,58 @@ public class ExportDialogViewModelTests
         Assert.IsTrue(File.Exists(exportPath), "A successful export should have written the file.");
     }
 
+    /// <summary>
+    /// Issue #747: the destination CSV is still open in Excel/Spyder. The export must not claim
+    /// success, must name the file and say what to do, and must leave the existing file untouched.
+    /// </summary>
+    [TestMethod]
+    public async Task Export_WhenDestinationIsOpenInAnotherProgram_ReportsActionableFailure()
+    {
+        // Arrange
+        using var factory = new TempSqliteLoggingContextFactory();
+        SeedSession(factory, sessionId: 1);
+        var exportPath = Path.Combine(TestDirectoryPath, $"locked_{Guid.NewGuid():N}.csv");
+        await File.WriteAllTextAsync(exportPath, "previous export");
+        var vm = new ExportDialogViewModel(factory, sessionId: 1) { ExportFilePath = exportPath };
+
+        // Hold the file the way Excel does: write access, readers allowed.
+        using (new FileStream(exportPath, FileMode.Open, FileAccess.Write, FileShare.Read))
+        {
+            // Act
+            await vm.ExportLoggingSessionsCommand.ExecuteAsync(null);
+        }
+
+        // Assert
+        Assert.IsTrue(vm.IsExportComplete);
+        Assert.IsFalse(vm.ExportSucceeded, "A locked destination must not report success.");
+        Assert.Contains(Path.GetFileName(exportPath), vm.ExportResultMessage,
+            "The message should name the file the user has to close.");
+        Assert.Contains("open in another program", vm.ExportResultMessage);
+        Assert.AreEqual("previous export", await File.ReadAllTextAsync(exportPath),
+            "The pre-flight probe must not truncate the file it could not write.");
+    }
+
+    [TestMethod]
+    public async Task Export_AfterFailure_RetryReturnsToConfigureState()
+    {
+        // Arrange
+        var factory = new Mock<IDbContextFactory<LoggingContext>>();
+        factory.Setup(f => f.CreateDbContext()).Throws(new InvalidOperationException("boom"));
+        var vm = new ExportDialogViewModel(factory.Object, sessionId: 1)
+        {
+            ExportFilePath = Path.Combine(TestDirectoryPath, "retry.csv")
+        };
+        await vm.ExportLoggingSessionsCommand.ExecuteAsync(null);
+
+        // Act
+        vm.RetryExportCommand.Execute(null);
+
+        // Assert
+        Assert.IsTrue(vm.IsConfiguring, "Try Again should bring back the configuration form.");
+        Assert.IsFalse(vm.IsExportComplete);
+        Assert.IsTrue(vm.ExportLoggingSessionsCommand.CanExecute(null), "Export should be runnable again.");
+    }
+
     #endregion
 
     #region Helpers

--- a/Daqifi.Desktop.UITest/CsvExportTests.cs
+++ b/Daqifi.Desktop.UITest/CsvExportTests.cs
@@ -119,6 +119,59 @@ public class CsvExportTests : DaqifiAppFixture
             TryDeleteExportDir();
         }
     }
+    /// <summary>
+    /// Issue #747 — the destination CSV is still open in another program (Excel, Spyder) when the
+    /// user exports. Runs a real session against the attached device, holds the exact file the
+    /// export will target the way Excel does (write access, readers allowed), and proves the app
+    /// (a) refuses the export instead of reporting success, (b) classifies it as an environmental
+    /// warning rather than a Sentry-worthy error, (c) leaves the existing file byte-for-byte
+    /// intact, and (d) stays alive and usable.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Ui")]
+    [TestCategory("RequiresDevice")]
+    public void ExportLoggedSession_DestinationOpenInAnotherProgram_FailsCleanlyWithoutOverwriting()
+    {
+        const string SENTINEL = "previous export - must not be overwritten";
+
+        try
+        {
+            var (sessionName, _, _, _) = RunShortLoggingSession();
+
+            // Arrange — pre-create the exact file the export hook will write and hold it open.
+            Directory.CreateDirectory(_exportDir);
+            var target = Path.Combine(_exportDir, sessionName + ".csv");
+            File.WriteAllText(target, SENTINEL);
+
+            bool warned;
+            using (new FileStream(target, FileMode.Open, FileAccess.Write, FileShare.Read))
+            {
+                // Act — export while the file is locked.
+                ExportNewestLoggedSession();
+
+                warned = WaitForLogContains("Export aborted: Could not write", TimeSpan.FromSeconds(30));
+            }
+
+            // Assert
+            Assert.IsTrue(
+                warned,
+                "The app did not log the environmental warning for a locked destination. Either the " +
+                "export silently 'succeeded' (issue #747) or it was logged as an Error, which would " +
+                "raise a Sentry event for a user-side condition.");
+
+            Assert.AreEqual(
+                SENTINEL, File.ReadAllText(target),
+                "The blocked export must leave the existing file untouched — the pre-flight probe " +
+                "opens it read/write but must never truncate or rewrite it.");
+
+            Assert.IsFalse(App.HasExited, "The app must survive a blocked export.");
+            Assert.IsTrue(MainWindow.IsAvailable, "The main window must still be usable after a blocked export.");
+        }
+        finally
+        {
+            TryDeleteExportDir();
+        }
+    }
     #endregion
 
     #region Scenario Helpers

--- a/Daqifi.Desktop/Exporter/OptimizedLoggingSessionExporter.cs
+++ b/Daqifi.Desktop/Exporter/OptimizedLoggingSessionExporter.cs
@@ -69,35 +69,27 @@ public class OptimizedLoggingSessionExporter
     /// <param name="cancellationToken">Token that aborts the export.</param>
     /// <param name="sessionIndex">Zero-based index of this session within a multi-session export.</param>
     /// <param name="totalSessions">Total number of sessions in this export run.</param>
+    /// <exception cref="IOException">The destination file could not be written — most commonly
+    /// because it is open in another program (issue #747).</exception>
+    /// <remarks>Failures propagate to the caller: <see cref="ViewModels.ExportDialogViewModel"/> is the
+    /// single place that classifies them, logs them once, and tells the user. Swallowing them here
+    /// used to leave the dialog reporting "Export complete" over a file that was never written.</remarks>
     public void ExportLoggingSession(LoggingSession loggingSession, string filepath, bool exportRelativeTime,
         IProgress<int> progress, CancellationToken cancellationToken, int sessionIndex, int totalSessions)
     {
-        try
+        var source = TryBuildSource(loggingSession);
+        if (source == null)
         {
-            var source = TryBuildSource(loggingSession);
-            if (source == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            var options = new CsvExportOptions
-            {
-                Delimiter = _delimiter,
-                UseRelativeTime = exportRelativeTime,
-            };
+        var options = new CsvExportOptions
+        {
+            Delimiter = _delimiter,
+            UseRelativeTime = exportRelativeTime,
+        };
 
-            RunExport(source, filepath, options, progress, cancellationToken, sessionIndex, totalSessions);
-        }
-        catch (OperationCanceledException)
-        {
-            // Let the viewmodel's cancellation handler record the breadcrumb.
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _appLogger.Error(ex,
-                $"Exception in OptimizedExportLoggingSession (sessionId={loggingSession?.ID}, filepath={filepath}, relativeTime={exportRelativeTime})");
-        }
+        RunExport(source, filepath, options, progress, cancellationToken, sessionIndex, totalSessions);
     }
 
     /// <summary>
@@ -113,44 +105,34 @@ public class OptimizedLoggingSessionExporter
     /// <param name="cancellationToken">Token that aborts the export.</param>
     /// <param name="sessionIndex">Zero-based index of this session within a multi-session export.</param>
     /// <param name="totalSessions">Total number of sessions in this export run.</param>
+    /// <exception cref="IOException">The destination file could not be written — most commonly
+    /// because it is open in another program (issue #747).</exception>
+    /// <remarks>Failures propagate to the caller; see <see cref="ExportLoggingSession"/>.</remarks>
     public void ExportAverageSamples(LoggingSession session, string filepath, double averageQuantity,
         bool exportRelativeTime, IProgress<int> progress, CancellationToken cancellationToken, int sessionIndex, int totalSessions)
     {
-        try
+        var window = (int)averageQuantity;
+        if (window <= 0)
         {
-            var window = (int)averageQuantity;
-            if (window <= 0)
-            {
-                _appLogger.Warning(
-                    $"Skipping average export: AverageWindow must be positive (was {averageQuantity}, sessionId={session?.ID}, filepath={filepath}).");
-                return;
-            }
-
-            var source = TryBuildSource(session);
-            if (source == null)
-            {
-                return;
-            }
-
-            var options = new CsvExportOptions
-            {
-                Delimiter = _delimiter,
-                UseRelativeTime = exportRelativeTime,
-                AverageWindow = window,
-            };
-
-            RunExport(source, filepath, options, progress, cancellationToken, sessionIndex, totalSessions);
+            _appLogger.Warning(
+                $"Skipping average export: AverageWindow must be positive (was {averageQuantity}, sessionId={session?.ID}, filepath={filepath}).");
+            return;
         }
-        catch (OperationCanceledException)
+
+        var source = TryBuildSource(session);
+        if (source == null)
         {
-            // Let the viewmodel's cancellation handler record the breadcrumb.
-            throw;
+            return;
         }
-        catch (Exception ex)
+
+        var options = new CsvExportOptions
         {
-            _appLogger.Error(ex,
-                $"Failed in OptimizedExportAverageSamples (sessionId={session?.ID}, filepath={filepath}, averageWindow={averageQuantity}, relativeTime={exportRelativeTime})");
-        }
+            Delimiter = _delimiter,
+            UseRelativeTime = exportRelativeTime,
+            AverageWindow = window,
+        };
+
+        RunExport(source, filepath, options, progress, cancellationToken, sessionIndex, totalSessions);
     }
     #endregion
 

--- a/Daqifi.Desktop/View/ExportDialog.xaml
+++ b/Daqifi.Desktop/View/ExportDialog.xaml
@@ -96,14 +96,17 @@
             <iconPacks:PackIconMaterial Kind="AlertCircleOutline" Width="46" Height="46" HorizontalAlignment="Center"
                                         Foreground="{StaticResource StatusRed}"
                                         Visibility="{Binding ExportSucceeded, Converter={StaticResource InvertedBoolToVis}}"/>
-            <TextBlock Text="{Binding ExportResultMessage}" FontSize="16" HorizontalAlignment="Center" Margin="0,14,0,4" Foreground="{StaticResource TextPrimary}"/>
+            <TextBlock Text="{Binding ExportResultMessage}" FontSize="16" HorizontalAlignment="Center" TextAlignment="Center"
+                       TextWrapping="Wrap" Margin="0,14,0,4" Foreground="{StaticResource TextPrimary}"/>
             <TextBlock Text="{Binding ExportFilePath}" FontSize="11" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap"
-                       Foreground="{StaticResource TextSecondary}" Margin="0,0,0,22"
-                       Visibility="{Binding ExportSucceeded, Converter={StaticResource BoolToVis}}"/>
+                       Foreground="{StaticResource TextSecondary}" Margin="0,0,0,22"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                 <Button Content="Open Folder" Command="{Binding OpenExportLocationCommand}" Margin="0,0,8,0"
                         Style="{StaticResource DialogPillButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"
                         Visibility="{Binding ExportSucceeded, Converter={StaticResource BoolToVis}}"/>
+                <Button Content="Try Again" Command="{Binding RetryExportCommand}" Margin="0,0,8,0"
+                        Style="{StaticResource DialogPillButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"
+                        Visibility="{Binding ExportSucceeded, Converter={StaticResource InvertedBoolToVis}}"/>
                 <Button Content="Done" Click="btnDone_Click"
                         Style="{StaticResource DialogAccentPillButton}" controls:ControlsHelper.ContentCharacterCasing="Normal"/>
             </StackPanel>

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -162,61 +162,93 @@ public partial class ExportDialogViewModel : ObservableObject
 
         var cancelled = false;
         var failed = false;
+
+        // Non-null once we can tell the user *why* the export failed (a locked or unwritable
+        // destination). Everything else falls back to the generic message.
+        string failureReason = null;
+
+        // The destination currently being written, so the catch below can name the offending
+        // file even though the exception surfaces from deep inside the exporter.
+        var currentFilepath = ExportFilePath;
         try
         {
-            await Task.Run(async () =>
+            var targets = ResolveExportTargets();
+
+            // Pre-flight: the overwhelmingly common failure is a destination CSV still open in
+            // Excel/Spyder (issue #747). Checking every target before writing anything means the
+            // user gets an actionable message immediately instead of a partial export. This is
+            // inherently racy, so the catch below still handles a lock taken after the check.
+            foreach (var target in targets)
             {
-                var totalSessions = _sessionsIds.Count;
-                for (var i = 0; i < totalSessions; i++)
+                failureReason = DescribeUnwritableDestination(target.Filepath);
+                if (failureReason == null) { continue; }
+
+                currentFilepath = target.Filepath;
+                break;
+            }
+
+            if (failureReason != null)
+            {
+                failed = true;
+                AppLogger.Instance.Warning($"Export aborted: {failureReason}");
+                AppLogger.Instance.AddBreadcrumb("export", "Data export blocked by destination file",
+                    Common.Loggers.BreadcrumbLevel.Warning);
+            }
+            else
+            {
+                await Task.Run(async () =>
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var sessionId = _sessionsIds[i];
-                    var loggingSession = await GetLoggingSessionFromId(sessionId);
-                    if (loggingSession == null)
+                    var totalSessions = targets.Count;
+                    for (var i = 0; i < totalSessions; i++)
                     {
-                        AppLogger.Instance.Warning(
-                            $"Skipping export for session {sessionId}: it was not found in the database.");
-                        continue;
-                    }
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var sessionId = targets[i].SessionId;
+                        var loggingSession = await GetLoggingSessionFromId(sessionId);
+                        if (loggingSession == null)
+                        {
+                            AppLogger.Instance.Warning(
+                                $"Skipping export for session {sessionId}: it was not found in the database.");
+                            continue;
+                        }
 
-                    // Per-session file naming only applies when writing into a directory (multi-session
-                    // export, or the directory-layout test hook). Resolve the display name lazily so a
-                    // plain single-file export doesn't depend on LoggingManager — falling back to the
-                    // default "Session_{id}" form when the session is no longer in the in-memory list.
-                    string filepath;
-                    if (_forceDirectoryLayout || totalSessions > 1)
-                    {
-                        var sessionName = LoggingManager.Instance.LoggingSessions
-                            .FirstOrDefault(s => s.ID == sessionId)?.Name ?? $"Session_{sessionId}";
-                        filepath = Path.Combine(ExportFilePath, $"{MakeSafeFileName(sessionName)}.csv");
-                    }
-                    else
-                    {
-                        filepath = ExportFilePath;
-                    }
+                        currentFilepath = targets[i].Filepath;
 
-                    if (ExportAllSelected)
-                    {
-                        ExportAllSamples(loggingSession, filepath, progress, cancellationToken, i, totalSessions);
+                        if (ExportAllSelected)
+                        {
+                            ExportAllSamples(loggingSession, currentFilepath, progress, cancellationToken, i, totalSessions);
+                        }
+                        else if (ExportAverageSelected)
+                        {
+                            ExportAverageSamples(loggingSession, currentFilepath, progress, cancellationToken, i, totalSessions);
+                        }
                     }
-                    else if (ExportAverageSelected)
-                    {
-                        ExportAverageSamples(loggingSession, filepath, progress, cancellationToken, i, totalSessions);
-                    }
-                }
-            }, cancellationToken);
+                }, cancellationToken);
 
-            // Reaching here means the loop ran to completion without a cancellation being
-            // observed at a checkpoint — a Cancel click that lands after the work is done no
-            // longer suppresses the result state. Cancellation is signalled only by the
-            // OperationCanceledException path below.
-            AppLogger.Instance.AddBreadcrumb("export", "Data export completed");
+                // Reaching here means the loop ran to completion without a cancellation being
+                // observed at a checkpoint — a Cancel click that lands after the work is done no
+                // longer suppresses the result state. Cancellation is signalled only by the
+                // OperationCanceledException path below.
+                AppLogger.Instance.AddBreadcrumb("export", "Data export completed");
+            }
         }
         catch (OperationCanceledException)
         {
             cancelled = true;
             AppLogger.Instance.Information("Export operation was cancelled by user.");
             AppLogger.Instance.AddBreadcrumb("export", "Data export cancelled", Common.Loggers.BreadcrumbLevel.Warning);
+        }
+        catch (Exception ex) when (IsDestinationBlocked(ex))
+        {
+            // A destination that cannot be written — locked by another program, read-only, denied,
+            // or on a folder that disappeared — is a user/environmental condition, not an app bug.
+            // Log it as a warning (stack trace stays in the local log, no Sentry event) the same way
+            // the device layer classifies an unreachable device (issues #517 / #740). Anything else,
+            // including a database-level I/O error, still takes the Error/Sentry path below.
+            failed = true;
+            failureReason = DescribeFileFailure(ex, currentFilepath);
+            AppLogger.Instance.Warning(ex, $"Export failed writing '{currentFilepath}'.");
+            AppLogger.Instance.AddBreadcrumb("export", "Data export blocked by destination file",
+                Common.Loggers.BreadcrumbLevel.Warning);
         }
         catch (Exception ex)
         {
@@ -235,12 +267,26 @@ public partial class ExportDialogViewModel : ObservableObject
             if (!cancelled)
             {
                 ExportSucceeded = !failed;
-                ExportResultMessage = failed ? "Export failed. Please try again." : "Export complete";
+                ExportResultMessage = failed
+                    ? failureReason ?? "Export failed. Please try again."
+                    : "Export complete";
                 IsExportComplete = true;
             }
 
             IsExporting = false;
         }
+    }
+
+    /// <summary>
+    /// Returns the dialog to its configuration form after a failure so the user can close the
+    /// program holding the file (or pick a different destination) and export again.
+    /// </summary>
+    [RelayCommand]
+    private void RetryExport()
+    {
+        IsExportComplete = false;
+        ExportProgress = 0;
+        ExportResultMessage = null;
     }
 
     private bool CanExport => !string.IsNullOrWhiteSpace(ExportFilePath);
@@ -289,6 +335,115 @@ public partial class ExportDialogViewModel : ObservableObject
     {
         var loggingSessionExporter = new OptimizedLoggingSessionExporter(_loggingContext);
         loggingSessionExporter.ExportAverageSamples(session, filepath, AverageQuantity, ExportRelativeTime, progress, cancellationToken, sessionIndex, totalSessions);
+    }
+
+    /// <summary>
+    /// One session mapped to the file it will be written to.
+    /// </summary>
+    private sealed record ExportTarget(int SessionId, string Filepath);
+
+    /// <summary>
+    /// Resolves the destination file for every selected session up front, so the export can be
+    /// pre-flighted before any data is written. Per-session file naming only applies when writing
+    /// into a directory (multi-session export, or the directory-layout test hook); a plain
+    /// single-file export writes straight to <see cref="ExportFilePath"/> and so doesn't depend on
+    /// LoggingManager. Sessions no longer in the in-memory list fall back to "Session_{id}".
+    /// </summary>
+    private List<ExportTarget> ResolveExportTargets()
+    {
+        var targets = new List<ExportTarget>(_sessionsIds.Count);
+        var perSessionFiles = _forceDirectoryLayout || _sessionsIds.Count > 1;
+
+        foreach (var sessionId in _sessionsIds)
+        {
+            string filepath;
+            if (perSessionFiles)
+            {
+                var sessionName = LoggingManager.Instance.LoggingSessions
+                    .FirstOrDefault(s => s.ID == sessionId)?.Name ?? $"Session_{sessionId}";
+                filepath = Path.Combine(ExportFilePath, $"{MakeSafeFileName(sessionName)}.csv");
+            }
+            else
+            {
+                filepath = ExportFilePath;
+            }
+
+            targets.Add(new ExportTarget(sessionId, filepath));
+        }
+
+        return targets;
+    }
+
+    /// <summary>
+    /// Returns a user-facing reason why <paramref name="filepath"/> cannot be written, or null when
+    /// it looks writable. Only an existing file is probed — opening it for writing with no sharing
+    /// fails exactly when another program holds it — and the probe never truncates or creates
+    /// anything, so a blocked export leaves the destination untouched.
+    /// </summary>
+    private static string DescribeUnwritableDestination(string filepath)
+    {
+        try
+        {
+            if (!File.Exists(filepath)) { return null; }
+
+            using var probe = new FileStream(filepath, FileMode.Open, FileAccess.Write, FileShare.None);
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return DescribeFileFailure(ex, filepath);
+        }
+    }
+
+    /// <summary>
+    /// True when an export failure is the destination's fault — denied, gone, or held by another
+    /// program. Deliberately narrow: a generic <see cref="IOException"/> (a full disk, a failing
+    /// drive, an EF/SQLite read error) keeps the default Error/Sentry treatment so real problems
+    /// stay visible.
+    /// </summary>
+    private static bool IsDestinationBlocked(Exception ex) => ex switch
+    {
+        UnauthorizedAccessException => true,
+        DirectoryNotFoundException => true,
+        IOException io => IsSharingViolation(io),
+        _ => false,
+    };
+
+    /// <summary>
+    /// Turns a file-access failure into a message that tells the user what to do about it.
+    /// </summary>
+    private static string DescribeFileFailure(Exception ex, string filepath)
+    {
+        var name = string.IsNullOrWhiteSpace(filepath) ? "the export file" : $"'{Path.GetFileName(filepath)}'";
+
+        return ex switch
+        {
+            UnauthorizedAccessException =>
+                $"Could not write {name} — access was denied. Choose a different folder, or check that the file is not read-only.",
+            DirectoryNotFoundException =>
+                $"Could not write {name} — that folder no longer exists. Choose a different location and try again.",
+            IOException io when IsSharingViolation(io) =>
+                $"Could not write {name} — it is open in another program. Close it and try again.",
+            _ =>
+                $"Could not write {name}. {ex.Message}",
+        };
+    }
+
+    /// <summary>
+    /// True when the OS refused the handle because someone else already holds the file
+    /// (ERROR_SHARING_VIOLATION / ERROR_LOCK_VIOLATION) — the "it's still open in Excel" case,
+    /// as opposed to a full disk or an I/O error, which deserve a different message.
+    /// </summary>
+    private static bool IsSharingViolation(IOException ex)
+    {
+        const int FACILITY_WIN32 = unchecked((int)0x80070000);
+        const int ERROR_SHARING_VIOLATION = 32;
+        const int ERROR_LOCK_VIOLATION = 33;
+
+        if ((ex.HResult & unchecked((int)0xFFFF0000)) != FACILITY_WIN32) { return false; }
+
+        var win32Error = ex.HResult & 0xFFFF;
+        return win32Error is ERROR_SHARING_VIOLATION or ERROR_LOCK_VIOLATION;
     }
 
     /// <summary>

--- a/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ExportDialogViewModel.cs
@@ -160,6 +160,10 @@ public partial class ExportDialogViewModel : ObservableObject
         var progress = new Progress<int>(progressValue => ExportProgress = progressValue);
         AppLogger.Instance.AddBreadcrumb("export", $"Data export started ({_sessionsIds.Count} session(s))");
 
+        // Resolved here rather than on the worker below because it reads LoggingManager's
+        // UI-bound session collection. It touches no file system, so it cannot block.
+        var targets = ResolveExportTargets();
+
         var cancelled = false;
         var failed = false;
 
@@ -172,58 +176,66 @@ public partial class ExportDialogViewModel : ObservableObject
         var currentFilepath = ExportFilePath;
         try
         {
-            var targets = ResolveExportTargets();
-
-            // Pre-flight: the overwhelmingly common failure is a destination CSV still open in
-            // Excel/Spyder (issue #747). Checking every target before writing anything means the
-            // user gets an actionable message immediately instead of a partial export. This is
-            // inherently racy, so the catch below still handles a lock taken after the check.
-            foreach (var target in targets)
+            await Task.Run(async () =>
             {
-                failureReason = DescribeUnwritableDestination(target.Filepath);
-                if (failureReason == null) { continue; }
+                // Resolve the sessions that still exist first. Only their destinations are
+                // pre-flighted below, so a stale id whose row has since been deleted — which the
+                // export would skip anyway — can never block the whole run.
+                var live = new List<(LoggingSession Session, string Filepath)>(targets.Count);
+                foreach (var target in targets)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var loggingSession = await GetLoggingSessionFromId(target.SessionId);
+                    if (loggingSession == null)
+                    {
+                        AppLogger.Instance.Warning(
+                            $"Skipping export for session {target.SessionId}: it was not found in the database.");
+                        continue;
+                    }
 
-                currentFilepath = target.Filepath;
-                break;
-            }
+                    live.Add((loggingSession, target.Filepath));
+                }
+
+                // Pre-flight: the overwhelmingly common failure is a destination CSV still open in
+                // Excel/Spyder (issue #747). Checking every target before writing anything means the
+                // user gets an actionable message immediately instead of a partial export. This is
+                // inherently racy, so the catch below still handles a lock taken after the check.
+                foreach (var (_, filepath) in live)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var reason = DescribeUnwritableDestination(filepath, out var probeError);
+                    if (reason == null) { continue; }
+
+                    currentFilepath = filepath;
+                    failureReason = reason;
+                    AppLogger.Instance.Warning(probeError, $"Export aborted: {reason}");
+                    return;
+                }
+
+                for (var i = 0; i < live.Count; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    currentFilepath = live[i].Filepath;
+
+                    if (ExportAllSelected)
+                    {
+                        ExportAllSamples(live[i].Session, currentFilepath, progress, cancellationToken, i, live.Count);
+                    }
+                    else if (ExportAverageSelected)
+                    {
+                        ExportAverageSamples(live[i].Session, currentFilepath, progress, cancellationToken, i, live.Count);
+                    }
+                }
+            }, cancellationToken);
 
             if (failureReason != null)
             {
                 failed = true;
-                AppLogger.Instance.Warning($"Export aborted: {failureReason}");
                 AppLogger.Instance.AddBreadcrumb("export", "Data export blocked by destination file",
                     Common.Loggers.BreadcrumbLevel.Warning);
             }
             else
             {
-                await Task.Run(async () =>
-                {
-                    var totalSessions = targets.Count;
-                    for (var i = 0; i < totalSessions; i++)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        var sessionId = targets[i].SessionId;
-                        var loggingSession = await GetLoggingSessionFromId(sessionId);
-                        if (loggingSession == null)
-                        {
-                            AppLogger.Instance.Warning(
-                                $"Skipping export for session {sessionId}: it was not found in the database.");
-                            continue;
-                        }
-
-                        currentFilepath = targets[i].Filepath;
-
-                        if (ExportAllSelected)
-                        {
-                            ExportAllSamples(loggingSession, currentFilepath, progress, cancellationToken, i, totalSessions);
-                        }
-                        else if (ExportAverageSelected)
-                        {
-                            ExportAverageSamples(loggingSession, currentFilepath, progress, cancellationToken, i, totalSessions);
-                        }
-                    }
-                }, cancellationToken);
-
                 // Reaching here means the loop ran to completion without a cancellation being
                 // observed at a checkpoint — a Cancel click that lands after the work is done no
                 // longer suppresses the result state. Cancellation is signalled only by the
@@ -380,8 +392,13 @@ public partial class ExportDialogViewModel : ObservableObject
     /// fails exactly when another program holds it — and the probe never truncates or creates
     /// anything, so a blocked export leaves the destination untouched.
     /// </summary>
-    private static string DescribeUnwritableDestination(string filepath)
+    /// <param name="filepath">Destination to probe.</param>
+    /// <param name="error">The exception the probe caught, so the caller can log it with its stack
+    /// trace; null when the destination looks writable.</param>
+    private static string DescribeUnwritableDestination(string filepath, out Exception error)
     {
+        error = null;
+
         try
         {
             if (!File.Exists(filepath)) { return null; }
@@ -391,6 +408,7 @@ public partial class ExportDialogViewModel : ObservableObject
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            error = ex;
             return DescribeFileFailure(ex, filepath);
         }
     }


### PR DESCRIPTION
## Problem

[#747](https://github.com/daqifi/daqifi-desktop/issues/747) (Sentry `DAQIFI-DESKTOP-1P`): a user exported a session to `essai 1.csv` while the file was still open in Spyder. `new StreamWriter(filepath, …)` opens with `FileShare.Read`, so another writer's lock makes it throw `IOException`.

That crash-free failure exposed two real defects:

1. **The dialog lied.** `OptimizedLoggingSessionExporter.ExportLoggingSession` caught `Exception`, logged, and did not rethrow — so `ExportDialogViewModel`'s catch never ran, `failed` stayed `false`, and the user was shown **"Export complete"** over a file that was never written. In a multi-session export, one failed file silently reported success for the whole run.
2. **Sentry noise.** A locked output file is a user/environmental condition, but it went through `AppLogger.Error` → Sentry event → auto-filed GitHub issue. The device layer already downgrades the equivalent conditions (unreachable device, transport dropped mid-init) to `AppLogger.Warning`, which keeps the stack trace in the local log and raises nothing (#517, #588, #709, #740).

## Fix

- **Propagate.** The exporter no longer swallows failures. `ExportDialogViewModel` is now the single place that classifies, logs, and reports them.
- **Pre-flight.** Destinations are resolved for every selected session before any writing, then probed. A blocked export aborts before producing partial multi-session output, and the probe opens an *existing* file only, never truncating or creating — so a blocked export leaves the destination byte-for-byte intact.
- **Classify.** Locked / denied / missing-folder destinations log as `Warning` (no Sentry). Deliberately narrow: a generic `IOException` (full disk, failing drive, EF/SQLite read error) keeps the `Error`/Sentry path so real problems stay visible.
- **Tell the user what to do.** The result panel names the file, wraps long text, shows the destination path on failure too, and offers **Try Again** to return to the configuration form (path retained) after closing the offending program.

> Could not write 'essai 1.csv' — it is open in another program. Close it and try again.

## Verification

**Bench, real device on COM3** — all three `RequiresDevice` CSV-export UI tests pass, including a new one that runs a real 100 Hz / 16-channel session, holds the destination open the way Excel does (write access, readers allowed), and asserts the app warns, leaves the file untouched, and stays usable:

```
Passed ExportLoggedSession_ProducesValidCsv [44 s]            CSV: 289 rows x 16 channels
Passed ExportAllLoggedSessions_ProducesValidCsv [59 s]        CSV: 280 rows x 16 channels
Passed ExportLoggedSession_DestinationOpenInAnotherProgram_FailsCleanlyWithoutOverwriting [41 s]
```

**Real app, real UI** — the failure and Try Again states were verified visually by driving the shipped dialog end-to-end (per-row EXPORT → native Save As → Export) against the local 233 MB logged-data database, with the destination held open by the harness.

**Unit suite** — 646 passed, 0 failed. New coverage: the exporter now propagates a locked destination; the dialog reports the actionable failure and preserves the existing file; Try Again returns to the configuration form.

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
