### PR TITLE
fix: stop the desktop racing/tearing down its own device during firmware reconnect (#738)

### DIFF
--- a/Daqifi.Desktop.Test/ConnectionManagerFirmwareGateTests.cs
+++ b/Daqifi.Desktop.Test/ConnectionManagerFirmwareGateTests.cs
@@ -129,6 +129,40 @@ public class ConnectionManagerFirmwareGateTests
         other.Verify(d => d.Disconnect(), Times.Once);
     }
 
+    [TestMethod]
+    public void ClearingDeviceBeingUpdated_TearsDownDeviceThatFailedToReconnect()
+    {
+        // Follow-up to the teardown-skip: when the update ends, a device Core failed to reconnect (e.g.
+        // a JumpingToApp timeout) is still in ConnectedDevices with a dead transport. Clearing
+        // DeviceBeingUpdated must reconcile it — otherwise it shows as connected forever (Qodo #738).
+        var device = CreateDevice(ConnectionType.Usb);
+        device.SetupGet(d => d.IsConnected).Returns(false);
+        device.SetupGet(d => d.DataChannels).Returns(new List<Daqifi.Desktop.Channel.IChannel>());
+        ConnectionManager.Instance.ConnectedDevices.Add(device.Object);
+        ConnectionManager.Instance.DeviceBeingUpdated = device.Object;
+
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+
+        device.Verify(d => d.Disconnect(), Times.Once);
+        Assert.IsFalse(ConnectionManager.Instance.ConnectedDevices.Contains(device.Object));
+    }
+
+    [TestMethod]
+    public void ClearingDeviceBeingUpdated_LeavesReconnectedDeviceConnected()
+    {
+        // On a successful flash Core reconnected the device (IsConnected == true); the reconciliation
+        // must be a no-op so it stays connected.
+        var device = CreateDevice(ConnectionType.Usb);
+        device.SetupGet(d => d.IsConnected).Returns(true);
+        ConnectionManager.Instance.ConnectedDevices.Add(device.Object);
+        ConnectionManager.Instance.DeviceBeingUpdated = device.Object;
+
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+
+        device.Verify(d => d.Disconnect(), Times.Never);
+        Assert.IsTrue(ConnectionManager.Instance.ConnectedDevices.Contains(device.Object));
+    }
+
     private static void InvokePrivate(string methodName, params object[] args)
     {
         var method = typeof(ConnectionManager).GetMethod(

--- a/Daqifi.Desktop.Test/ConnectionManagerFirmwareGateTests.cs
+++ b/Daqifi.Desktop.Test/ConnectionManagerFirmwareGateTests.cs
@@ -1,0 +1,149 @@
+using Daqifi.Desktop.Device;
+using Moq;
+
+namespace Daqifi.Desktop.Test;
+
+/// <summary>
+/// Verifies the app-global firmware-update gate on <see cref="ConnectionManager"/> (issue #738): while
+/// a firmware update is in progress, a user/discovery-initiated USB connect must be refused (the device
+/// re-enumerates its COM port during the flash and Core reconnects it itself), and the
+/// in-progress-state transitions must raise <see cref="ConnectionManager.FirmwareUpdateInProgressChanged"/>
+/// so an open connection dialog can pause its discovery.
+/// </summary>
+[TestClass]
+public class ConnectionManagerFirmwareGateTests
+{
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        // ConnectionManager is a process-wide singleton; leave the gate and device list clear for
+        // other tests.
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+        ConnectionManager.Instance.ConnectedDevices.Clear();
+    }
+
+    [TestMethod]
+    public void IsFirmwareUpdateInProgress_TracksDeviceBeingUpdated()
+    {
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+        Assert.IsFalse(ConnectionManager.Instance.IsFirmwareUpdateInProgress);
+
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateDevice(ConnectionType.Usb).Object;
+        Assert.IsTrue(ConnectionManager.Instance.IsFirmwareUpdateInProgress);
+
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+        Assert.IsFalse(ConnectionManager.Instance.IsFirmwareUpdateInProgress);
+    }
+
+    [TestMethod]
+    public void SettingDeviceBeingUpdated_RaisesEventOnlyOnInProgressTransitions()
+    {
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+
+        var raised = 0;
+        void Handler(object? s, EventArgs e) => raised++;
+        ConnectionManager.Instance.FirmwareUpdateInProgressChanged += Handler;
+        try
+        {
+            // null -> device: flip to in-progress (raise)
+            ConnectionManager.Instance.DeviceBeingUpdated = CreateDevice(ConnectionType.Usb).Object;
+            Assert.AreEqual(1, raised);
+
+            // device -> null: flip to idle (raise)
+            ConnectionManager.Instance.DeviceBeingUpdated = null;
+            Assert.AreEqual(2, raised);
+
+            // null -> null: no change, no raise
+            ConnectionManager.Instance.DeviceBeingUpdated = null;
+            Assert.AreEqual(2, raised);
+        }
+        finally
+        {
+            ConnectionManager.Instance.FirmwareUpdateInProgressChanged -= Handler;
+        }
+    }
+
+    [TestMethod]
+    public async Task Connect_RefusesUsbDevice_WhileFirmwareUpdateInProgress()
+    {
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateDevice(ConnectionType.Usb).Object;
+
+        var incoming = CreateDevice(ConnectionType.Usb);
+
+        await ConnectionManager.Instance.Connect(incoming.Object);
+
+        Assert.AreEqual(DAQiFiConnectionStatus.Error, ConnectionManager.Instance.ConnectionStatus);
+        // The gate short-circuits before ever opening the port.
+        incoming.Verify(d => d.Connect(), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Connect_DoesNotGateWifiDevice_WhileFirmwareUpdateInProgress()
+    {
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateDevice(ConnectionType.Usb).Object;
+
+        // A WiFi connect targets a different device path and cannot steal the flashing device's COM
+        // port, so the gate must not block it — Connect() should still be attempted.
+        var incoming = CreateDevice(ConnectionType.Wifi);
+        incoming.Setup(d => d.Connect()).Returns(false); // stop the flow right after the gate
+
+        await ConnectionManager.Instance.Connect(incoming.Object);
+
+        incoming.Verify(d => d.Connect(), Times.Once);
+    }
+
+    [TestMethod]
+    public void OnDeviceConnectionLost_DoesNotTearDownDeviceBeingUpdated()
+    {
+        // The dominant #738 cause: when the flashing device reboots mid-update, Core raises a
+        // transport-lost event; the desktop must NOT tear down (Disconnect/dispose) that Core device,
+        // because Core reconnects the SAME instance at JumpingToApp. Disposing it strands the update in
+        // a JumpingToApp timeout even though the flash succeeded. Guarded by IsDeviceBeingUpdated.
+        var device = CreateDevice(ConnectionType.Usb);
+        ConnectionManager.Instance.DeviceBeingUpdated = device.Object;
+
+        InvokePrivate("OnDeviceConnectionLost", device.Object,
+            new ConnectionLostEventArgs("reboot"));
+
+        // The device must NOT have been disconnected — Disconnect() calls device.Disconnect().
+        device.Verify(d => d.Disconnect(), Times.Never);
+    }
+
+    [TestMethod]
+    public void OnDeviceConnectionLost_TearsDownOtherDevices()
+    {
+        // Control: a device that is NOT being updated still tears down normally on a lost connection.
+        var updating = CreateDevice(ConnectionType.Usb);
+        updating.SetupGet(d => d.Name).Returns("Updating");
+        ConnectionManager.Instance.DeviceBeingUpdated = updating.Object;
+
+        var other = CreateDevice(ConnectionType.Usb);
+        other.SetupGet(d => d.Name).Returns("Other");
+        other.SetupGet(d => d.DataChannels).Returns(new List<Daqifi.Desktop.Channel.IChannel>());
+        // Put it in ConnectedDevices so the teardown path proceeds past the Contains guard.
+        ConnectionManager.Instance.ConnectedDevices.Add(other.Object);
+
+        InvokePrivate("OnDeviceConnectionLost", other.Object,
+            new ConnectionLostEventArgs("cable pulled"));
+
+        other.Verify(d => d.Disconnect(), Times.Once);
+    }
+
+    private static void InvokePrivate(string methodName, params object[] args)
+    {
+        var method = typeof(ConnectionManager).GetMethod(
+            methodName,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.IsNotNull(method, $"{methodName} not found.");
+        method.Invoke(ConnectionManager.Instance, args);
+    }
+
+    private static Mock<IStreamingDevice> CreateDevice(ConnectionType connectionType)
+    {
+        var device = new Mock<IStreamingDevice>();
+        device.SetupGet(d => d.ConnectionType).Returns(connectionType);
+        device.SetupGet(d => d.Name).Returns($"Device-{connectionType}");
+        device.SetupGet(d => d.DeviceSerialNo).Returns(string.Empty);
+        return device;
+    }
+}

--- a/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/FirmwareUpdateServiceConfigTests.cs
@@ -55,6 +55,24 @@ public class FirmwareUpdateServiceConfigTests
     }
 
     [TestMethod]
+    public void CreateOptions_LeavesPostReconnectStaleHandleDelayAtCoreDefault()
+    {
+        // Regression guard for issue #738: do NOT zero PostReconnectStaleHandleDelay. Core's XML doc
+        // suggests zeroing it on Windows, but our recorded successful bench flashes show the
+        // close-and-reopen discard step running normally (it appears load-bearing here), and we have no
+        // positive end-to-end validation that zeroing is safe. The #738 race is fixed at its source
+        // (the desktop no longer races the port or tears down the flashing device during Core's
+        // reconnect), not by narrowing this window — so leave the delay at Core's default.
+        var coreDefault = new FirmwareUpdateServiceOptions().PostReconnectStaleHandleDelay;
+
+        var options = FirmwareUpdateServiceConfig.CreateOptions();
+
+        Assert.AreEqual(coreDefault, options.PostReconnectStaleHandleDelay);
+        Assert.AreNotEqual(TimeSpan.Zero, options.PostReconnectStaleHandleDelay,
+            "Do not zero this delay without positive hardware validation (issue #738).");
+    }
+
+    [TestMethod]
     public void CreateOptions_LeavesProgrammingTimeoutAtCoreDefault()
     {
         // Arrange - compare against a fresh Core default rather than a hard-coded value so this

--- a/Daqifi.Desktop.Test/Loggers/AppLoggerLoggerProviderTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/AppLoggerLoggerProviderTests.cs
@@ -1,0 +1,62 @@
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Loggers;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Verifies how <see cref="AppLoggerLoggerProvider"/> maps Core's Microsoft.Extensions.Logging entries
+/// onto the desktop <see cref="IAppLogger"/> — in particular that firmware-update Errors are NOT
+/// forwarded to Sentry (issue #738): the desktop's FirmwareUpdateCoordinator is the single authority on
+/// firmware-outcome severity, so Core's own duplicate Error must land in the log file only.
+/// </summary>
+[TestClass]
+public class AppLoggerLoggerProviderTests
+{
+    [TestMethod]
+    public void FirmwareUpdateCategory_ErrorIsForwardedAsWarning_NotSentryError()
+    {
+        var appLogger = new Mock<IAppLogger>();
+        var provider = new AppLoggerLoggerProvider(appLogger.Object);
+        var logger = provider.CreateLogger("Daqifi.Core.Firmware.FirmwareUpdateService");
+
+        var ex = new TimeoutException("State 'JumpingToApp' timed out.");
+        logger.LogError(ex, "PIC32 firmware update failed in state {State}.", "JumpingToApp");
+
+        // File-only (Warning does not capture to Sentry); never the Sentry-capturing Error path.
+        appLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        appLogger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void NonFirmwareDaqifiCategory_ErrorIsCapturedToSentry()
+    {
+        // Control: a non-firmware DAQiFi-category Error is still captured to Sentry (AppLogger.Error),
+        // so the firmware carve-out is scoped and doesn't silence the rest of our own error logging.
+        var appLogger = new Mock<IAppLogger>();
+        var provider = new AppLoggerLoggerProvider(appLogger.Object);
+        var logger = provider.CreateLogger("Daqifi.Core.Device.DaqifiStreamingDevice");
+
+        var ex = new InvalidOperationException("boom");
+        logger.LogError(ex, "Something genuinely broke.");
+
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [TestMethod]
+    public void FirmwareUpdateCategory_WarningStillForwardedAsWarning()
+    {
+        // A firmware-category Warning was never a Sentry capture; confirm the carve-out doesn't change
+        // normal Warning forwarding (e.g. Core's own progress/warns still reach the file).
+        var appLogger = new Mock<IAppLogger>();
+        var provider = new AppLoggerLoggerProvider(appLogger.Object);
+        var logger = provider.CreateLogger("Daqifi.Core.Firmware.FirmwareUpdateService");
+
+        logger.LogWarning("Reconnect attempt failed; retrying.");
+
+        appLogger.Verify(l => l.Warning(It.IsAny<string>()), Times.Once);
+        appLogger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelCloseTests.cs
@@ -13,6 +13,7 @@ public class ConnectionDialogViewModelCloseTests
     private const string NONEXISTENT_PORT_NAME = "COM_DOES_NOT_EXIST_524";
 
     private Func<DuplicateDeviceCheckResult, DuplicateDeviceAction>? _originalDuplicateDeviceHandler;
+    private readonly List<ConnectionDialogViewModel> _viewModels = [];
 
     [TestInitialize]
     public void TestInitialize()
@@ -24,6 +25,15 @@ public class ConnectionDialogViewModelCloseTests
     [TestCleanup]
     public void TestCleanup()
     {
+        // Dispose every VM (idempotent with Close()) so its FirmwareUpdateInProgressChanged subscription
+        // leaves the ConnectionManager singleton (issue #738 gating); a leaked handler would fire in
+        // later tests that flip DeviceBeingUpdated.
+        foreach (var viewModel in _viewModels)
+        {
+            viewModel.Dispose();
+        }
+        _viewModels.Clear();
+
         ConnectionManager.Instance.DuplicateDeviceHandler = _originalDuplicateDeviceHandler;
     }
 
@@ -195,10 +205,12 @@ public class ConnectionDialogViewModelCloseTests
         // Must not throw — discovery finders are only disposed once.
     }
 
-    private static ConnectionDialogViewModel CreateViewModel()
+    private ConnectionDialogViewModel CreateViewModel()
     {
         var dialogService = new Mock<IDialogService>();
-        return new ConnectionDialogViewModel(dialogService.Object);
+        var viewModel = new ConnectionDialogViewModel(dialogService.Object);
+        _viewModels.Add(viewModel);
+        return viewModel;
     }
 
     private static Func<bool> SubscribeToClose(ConnectionDialogViewModel viewModel)

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelFirmwareGateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelFirmwareGateTests.cs
@@ -1,0 +1,105 @@
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.DialogService;
+using Daqifi.Desktop.ViewModels;
+using Moq;
+using System.Reflection;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Verifies the connection dialog suspends its serial + WiFi discovery while a firmware update is in
+/// progress (issue #738): the per-cycle SerialDeviceFinder opens every DAQiFi VID/PID COM port each
+/// pass, and a probe landing in Core's post-flash JumpingToApp reconnect window steals the
+/// re-enumerating port and strands the update in a timeout. The dialog gates its <c>Start*Discovery</c>
+/// on <see cref="ConnectionManager.IsFirmwareUpdateInProgress"/> so a dialog opened mid-flash never
+/// starts a finder.
+/// </summary>
+[TestClass]
+public class ConnectionDialogViewModelFirmwareGateTests
+{
+    private Func<DuplicateDeviceCheckResult, DuplicateDeviceAction>? _originalDuplicateDeviceHandler;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _originalDuplicateDeviceHandler = ConnectionManager.Instance.DuplicateDeviceHandler;
+        ConnectionManager.Instance.DuplicateDeviceHandler = null;
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+        ConnectionManager.Instance.DuplicateDeviceHandler = _originalDuplicateDeviceHandler;
+    }
+
+    [TestMethod]
+    public void StartSerialDiscovery_DoesNotStartFinder_WhileFirmwareUpdateInProgress()
+    {
+        var viewModel = CreateViewModel();
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
+
+        InvokePrivate(viewModel, "StartSerialDiscovery");
+
+        // No finder created => no COM ports opened/probed during the flash.
+        Assert.IsNull(GetPrivateField(viewModel, "_serialFinder"),
+            "Serial discovery must not start while a firmware update is in progress.");
+    }
+
+    [TestMethod]
+    public void StartWiFiDiscovery_DoesNotStartFinder_WhileFirmwareUpdateInProgress()
+    {
+        var viewModel = CreateViewModel();
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
+
+        InvokePrivate(viewModel, "StartWiFiDiscovery");
+
+        Assert.IsNull(GetPrivateField(viewModel, "_wifiFinder"),
+            "WiFi discovery must not start while a firmware update is in progress.");
+    }
+
+    [TestMethod]
+    public void StartConnectionFinders_StartsNothing_WhileFirmwareUpdateInProgress()
+    {
+        // The user opens the connection dialog mid-flash (the issue #738 breadcrumb sequence): the
+        // public entry point that kicks off discovery must create neither finder.
+        var viewModel = CreateViewModel();
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
+
+        viewModel.StartConnectionFinders();
+
+        Assert.IsNull(GetPrivateField(viewModel, "_serialFinder"));
+        Assert.IsNull(GetPrivateField(viewModel, "_wifiFinder"));
+    }
+
+    private static IStreamingDevice CreateUsbDevice()
+    {
+        var device = new Mock<IStreamingDevice>();
+        device.SetupGet(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        device.SetupGet(d => d.Name).Returns("UpdatingDevice");
+        return device.Object;
+    }
+
+    private static ConnectionDialogViewModel CreateViewModel()
+    {
+        var dialogService = new Mock<IDialogService>();
+        return new ConnectionDialogViewModel(dialogService.Object);
+    }
+
+    private static void InvokePrivate(ConnectionDialogViewModel viewModel, string methodName)
+    {
+        var method = typeof(ConnectionDialogViewModel).GetMethod(
+            methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method, $"{methodName} not found.");
+        method.Invoke(viewModel, null);
+    }
+
+    private static object? GetPrivateField(ConnectionDialogViewModel viewModel, string fieldName)
+    {
+        var field = typeof(ConnectionDialogViewModel).GetField(
+            fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(field, $"{fieldName} not found.");
+        return field.GetValue(viewModel);
+    }
+}

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelFirmwareGateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelFirmwareGateTests.cs
@@ -37,7 +37,7 @@ public class ConnectionDialogViewModelFirmwareGateTests
     [TestMethod]
     public void StartSerialDiscovery_DoesNotStartFinder_WhileFirmwareUpdateInProgress()
     {
-        var viewModel = CreateViewModel();
+        using var viewModel = CreateViewModel();
         ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
 
         InvokePrivate(viewModel, "StartSerialDiscovery");
@@ -50,7 +50,7 @@ public class ConnectionDialogViewModelFirmwareGateTests
     [TestMethod]
     public void StartWiFiDiscovery_DoesNotStartFinder_WhileFirmwareUpdateInProgress()
     {
-        var viewModel = CreateViewModel();
+        using var viewModel = CreateViewModel();
         ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
 
         InvokePrivate(viewModel, "StartWiFiDiscovery");
@@ -64,7 +64,7 @@ public class ConnectionDialogViewModelFirmwareGateTests
     {
         // The user opens the connection dialog mid-flash (the issue #738 breadcrumb sequence): the
         // public entry point that kicks off discovery must create neither finder.
-        var viewModel = CreateViewModel();
+        using var viewModel = CreateViewModel();
         ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
 
         viewModel.StartConnectionFinders();

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelSerialDiscoveryTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelSerialDiscoveryTests.cs
@@ -10,6 +10,7 @@ namespace Daqifi.Desktop.Test.ViewModels;
 public class ConnectionDialogViewModelSerialDiscoveryTests
 {
     private Func<DuplicateDeviceCheckResult, DuplicateDeviceAction>? _originalDuplicateDeviceHandler;
+    private readonly List<ConnectionDialogViewModel> _viewModels = [];
 
     [TestInitialize]
     public void TestInitialize()
@@ -21,6 +22,15 @@ public class ConnectionDialogViewModelSerialDiscoveryTests
     [TestCleanup]
     public void TestCleanup()
     {
+        // Dispose every VM so its FirmwareUpdateInProgressChanged subscription is removed from the
+        // ConnectionManager singleton; a leaked handler would fire in later tests that flip
+        // DeviceBeingUpdated and could start real discovery (issue #738 gating).
+        foreach (var viewModel in _viewModels)
+        {
+            viewModel.Dispose();
+        }
+        _viewModels.Clear();
+
         ConnectionManager.Instance.DuplicateDeviceHandler = _originalDuplicateDeviceHandler;
     }
 
@@ -257,10 +267,12 @@ public class ConnectionDialogViewModelSerialDiscoveryTests
         Assert.IsFalse(viewModel.HasNoSerialDevices);
     }
 
-    private static ConnectionDialogViewModel CreateViewModel()
+    private ConnectionDialogViewModel CreateViewModel()
     {
         var dialogService = new Mock<IDialogService>();
-        return new ConnectionDialogViewModel(dialogService.Object);
+        var viewModel = new ConnectionDialogViewModel(dialogService.Object);
+        _viewModels.Add(viewModel);
+        return viewModel;
     }
 
     private static void InvokeHandleCoreSerialDeviceLost(ConnectionDialogViewModel viewModel, DeviceLostEventArgs args)

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelWifiDiscoveryTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelWifiDiscoveryTests.cs
@@ -11,6 +11,7 @@ namespace Daqifi.Desktop.Test.ViewModels;
 public class ConnectionDialogViewModelWifiDiscoveryTests
 {
     private Func<DuplicateDeviceCheckResult, DuplicateDeviceAction>? _originalDuplicateDeviceHandler;
+    private readonly List<ConnectionDialogViewModel> _viewModels = [];
 
     [TestInitialize]
     public void TestInitialize()
@@ -22,6 +23,15 @@ public class ConnectionDialogViewModelWifiDiscoveryTests
     [TestCleanup]
     public void TestCleanup()
     {
+        // Dispose every VM so its FirmwareUpdateInProgressChanged subscription is removed from the
+        // ConnectionManager singleton (issue #738 gating); a leaked handler would otherwise fire in
+        // later tests that flip DeviceBeingUpdated.
+        foreach (var viewModel in _viewModels)
+        {
+            viewModel.Dispose();
+        }
+        _viewModels.Clear();
+
         ConnectionManager.Instance.DuplicateDeviceHandler = _originalDuplicateDeviceHandler;
     }
 
@@ -149,10 +159,12 @@ public class ConnectionDialogViewModelWifiDiscoveryTests
         Assert.IsFalse(viewModel.HasNoWiFiDevices);
     }
 
-    private static ConnectionDialogViewModel CreateViewModel()
+    private ConnectionDialogViewModel CreateViewModel()
     {
         var dialogService = new Mock<IDialogService>();
-        return new ConnectionDialogViewModel(dialogService.Object);
+        var viewModel = new ConnectionDialogViewModel(dialogService.Object);
+        _viewModels.Add(viewModel);
+        return viewModel;
     }
 
     private static void InvokeHandleCoreWifiDeviceLost(ConnectionDialogViewModel viewModel, DeviceLostEventArgs args)

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -814,6 +814,101 @@ public class DaqifiViewModelFirmwareUpdateTests
         Assert.AreEqual(reportedFwVersion, reportedVersion);
     }
 
+    [TestMethod]
+    public async Task UploadFirmware_JumpingToAppFailure_ReportedAsInstalledWarningNotError()
+    {
+        // A JumpingToApp failure is the LAST PIC32 step, reached only after erase + program + verify
+        // succeed — the firmware is installed and verified, the device just didn't re-open its serial
+        // port in time. It must be classified as an expected device/environmental condition: logged at
+        // Warning (no Sentry capture) and reported to the user as installed, not failed (issue #738).
+        var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+        var appLogger = new Mock<IAppLogger>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM7", coreDevice);
+        var firmwareFilePath = CreateTempFile(".hex");
+
+        firmwareUpdateService
+            .Setup(service => service.UpdateFirmwareAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                firmwareFilePath,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new FirmwareUpdateException(
+                FirmwareUpdateState.JumpingToApp,
+                "jump to application and reconnect serial transport",
+                "State 'JumpingToApp' timed out.",
+                recoveryGuidance: "Power-cycle the device and reconnect."));
+
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice,
+            FirmwareFilePath = firmwareFilePath
+        };
+
+        var coordinator = CreateCoordinator(
+            host, firmwareUpdateService.Object, firmwareDownloadService.Object, appLogger: appLogger.Object);
+
+        await coordinator.UploadFirmwareAsync();
+
+        // User is told the firmware installed and to power-cycle — not that it failed.
+        Assert.AreEqual(1, host.FirmwareErrors.Count);
+        StringAssert.Contains(host.FirmwareErrors[0], "installed successfully");
+        StringAssert.Contains(host.FirmwareErrors[0], "power-cycle");
+
+        // Logged at Warning (no Sentry), never at Error.
+        appLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.AtLeastOnce);
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UploadFirmware_MidFlashFailure_StillReportedAsErrorToSentry()
+    {
+        // Control case: a failure in a flash-touching state (e.g. ErasingFlash) is a genuine failure —
+        // it must still be logged at Error (Sentry-captured) and reported as a failure, so the #738
+        // reclassification is scoped to JumpingToApp only and doesn't swallow real flash faults.
+        var firmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+        var appLogger = new Mock<IAppLogger>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM7", coreDevice);
+        var firmwareFilePath = CreateTempFile(".hex");
+
+        firmwareUpdateService
+            .Setup(service => service.UpdateFirmwareAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                firmwareFilePath,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new FirmwareUpdateException(
+                FirmwareUpdateState.ErasingFlash,
+                "erase flash",
+                "Flash erase failed."));
+
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice,
+            FirmwareFilePath = firmwareFilePath
+        };
+
+        var coordinator = CreateCoordinator(
+            host, firmwareUpdateService.Object, firmwareDownloadService.Object, appLogger: appLogger.Object);
+
+        await coordinator.UploadFirmwareAsync();
+
+        Assert.AreEqual(1, host.FirmwareErrors.Count);
+        StringAssert.Contains(host.FirmwareErrors[0], "ErasingFlash");
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.AtLeastOnce);
+    }
+
     /// <summary>
     /// Builds a coordinator with no-op test loggers and a throwaway firmware data directory.
     /// Dialog/flyout host operations are captured by <see cref="FakeFirmwareUpdateHost"/>, so no
@@ -824,14 +919,15 @@ public class DaqifiViewModelFirmwareUpdateTests
         FakeFirmwareUpdateHost host,
         IFirmwareUpdateService firmwareUpdateService,
         IFirmwareDownloadService firmwareDownloadService,
-        Func<string, string, IFirmwareUpdateService>? wifiFirmwareUpdateServiceFactory = null)
+        Func<string, string, IFirmwareUpdateService>? wifiFirmwareUpdateServiceFactory = null,
+        IAppLogger? appLogger = null)
     {
         return new FirmwareUpdateCoordinator(
             host,
             firmwareUpdateService,
             firmwareDownloadService,
             NullLogger<FirmwareUpdateService>.Instance,
-            Mock.Of<IAppLogger>(),
+            appLogger ?? Mock.Of<IAppLogger>(),
             CreateTempDirectory(),
             wifiFirmwareUpdateServiceFactory,
             // Collapse the WiFi-update-mode settle wait so these unit tests stay fast and

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -60,6 +60,7 @@ public partial class ConnectionManager : ObservableObject
         {
             if (ReferenceEquals(_deviceBeingUpdated, value)) { return; }
 
+            var previous = _deviceBeingUpdated;
             var wasInProgress = _deviceBeingUpdated != null;
             _deviceBeingUpdated = value;
 
@@ -69,7 +70,47 @@ public partial class ConnectionManager : ObservableObject
             {
                 FirmwareUpdateInProgressChanged?.Invoke(this, EventArgs.Empty);
             }
+
+            // When the update ends, reconcile the device whose teardown we suppressed during the flash.
+            // On a successful flash Core reconnected it (IsConnected == true) and there's nothing to do;
+            // but on a failed reconnect (e.g. a JumpingToApp timeout) it is still in ConnectedDevices with
+            // a dead transport, so without this it would show as connected forever and block a clean
+            // reconnect. Tear it down now, matching the normal disconnect path (issue #738 follow-up).
+            if (previous != null && value == null)
+            {
+                ReconcileDeviceAfterUpdate(previous);
+            }
         }
+    }
+
+    /// <summary>
+    /// After a firmware update ends, tears down the just-updated device iff Core's post-flash reconnect
+    /// left it disconnected. A successful update reconnects the device (no-op here); a failed one leaves
+    /// a stale entry the desktop's teardown paths deliberately skipped during the flash, so reconcile it
+    /// exactly as a normal disconnect would (unsubscribe channels, Disconnect, surface a reason).
+    /// </summary>
+    private void ReconcileDeviceAfterUpdate(IStreamingDevice device)
+    {
+        UiThreadHelper.InvokeOnUiThread(() =>
+        {
+            // Reconnected cleanly, or already removed by another path — nothing to reconcile.
+            if (!ConnectedDevices.Contains(device) || device.IsConnected)
+            {
+                return;
+            }
+
+            foreach (var channel in device.DataChannels)
+            {
+                LoggingManager.Instance.Unsubscribe(channel);
+            }
+
+            Disconnect(device);
+
+            LastDisconnectReason =
+                $"{device.DeviceDisplayName} did not reconnect after the firmware update. " +
+                "Power-cycle the device and reconnect.";
+            NotifyConnection = true;
+        }, failureLogMessage: "Dispatcher unavailable while reconciling device after firmware update.");
     }
 
     private IStreamingDevice? _deviceBeingUpdated;
@@ -332,14 +373,28 @@ public partial class ConnectionManager : ObservableObject
     /// an update the device's serial transport drops and re-enumerates as an expected part of the flash,
     /// and Core owns the reconnect — so the desktop's disconnect-detection paths must leave that device's
     /// connection untouched rather than disposing the Core device Core is reconnecting (issue #738).
-    /// Matches by reference (the update is driven on the exact connected instance) with a name fallback.
     /// </summary>
+    /// <remarks>
+    /// The firmware flow always drives the exact connected instance, so reference equality is the primary
+    /// (and normally sufficient) match. The fallback compares the serial number — a stable hardware
+    /// identity — never the display <c>Name</c>, which is a mutable, non-unique user label and could make
+    /// an unrelated same-named device's disconnect be wrongly skipped, leaving a zombie connection.
+    /// </remarks>
     private bool IsDeviceBeingUpdated(IStreamingDevice device)
     {
         var updating = DeviceBeingUpdated;
-        return updating != null
-            && (ReferenceEquals(updating, device)
-                || string.Equals(updating.Name, device.Name, StringComparison.Ordinal));
+        if (updating == null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(updating, device))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(updating.DeviceSerialNo)
+            && string.Equals(updating.DeviceSerialNo, device.DeviceSerialNo, StringComparison.OrdinalIgnoreCase);
     }
 
     private void CheckIfSerialDeviceWasRemoved()

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -46,9 +46,49 @@ public partial class ConnectionManager : ObservableObject
     public Func<DuplicateDeviceCheckResult, DuplicateDeviceAction> DuplicateDeviceHandler { get; set; }
 
     /// <summary>
-    /// Tracks the device currently undergoing firmware update to suppress disconnect notifications.
+    /// Tracks the device currently undergoing firmware update. Non-null for the whole update (PIC32 +
+    /// WiFi + the post-flash serial reconnect), so it doubles as the app-global "firmware update in
+    /// progress" gate: while it is set, the connection dialog suspends its serial/WiFi discovery and
+    /// <see cref="Connect"/> refuses USB connects, so nothing races Core's post-flash reconnect for the
+    /// COM port (issue #738). Changing it raises <see cref="FirmwareUpdateInProgressChanged"/> so an
+    /// already-open connection dialog can react immediately.
     /// </summary>
-    public IStreamingDevice? DeviceBeingUpdated { get; set; }
+    public IStreamingDevice? DeviceBeingUpdated
+    {
+        get => _deviceBeingUpdated;
+        set
+        {
+            if (ReferenceEquals(_deviceBeingUpdated, value)) { return; }
+
+            var wasInProgress = _deviceBeingUpdated != null;
+            _deviceBeingUpdated = value;
+
+            // Only raise when the in-progress state actually flips (set from null / cleared to null),
+            // not on a device-to-device change (which never happens today, but keeps the signal clean).
+            if (wasInProgress != (value != null))
+            {
+                FirmwareUpdateInProgressChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    private IStreamingDevice? _deviceBeingUpdated;
+
+    /// <summary>
+    /// True while a firmware update is in progress (<see cref="DeviceBeingUpdated"/> is set). The
+    /// connection dialog gates its discovery on this, and <see cref="Connect"/> refuses USB connects
+    /// while it is true, so a user-initiated connect or a discovery probe cannot steal the COM port
+    /// during Core's post-flash serial reconnect window (issue #738).
+    /// </summary>
+    public bool IsFirmwareUpdateInProgress => _deviceBeingUpdated != null;
+
+    /// <summary>
+    /// Raised when <see cref="IsFirmwareUpdateInProgress"/> flips. The connection dialog subscribes so a
+    /// dialog that is already open when a flash starts stops its serial/WiFi discovery immediately (and
+    /// resumes it when the flash ends) — the push half of the coordination; the pull half is the guards
+    /// in the dialog's <c>Start*Discovery</c> and in <see cref="Connect"/>.
+    /// </summary>
+    public event EventHandler? FirmwareUpdateInProgressChanged;
 
     #endregion
 
@@ -89,8 +129,24 @@ public partial class ConnectionManager : ObservableObject
     {
         try
         {
+            // Never let a user-initiated USB connect (or a discovery-driven one) open the COM port
+            // while a firmware update is running: the device being flashed re-enumerates its USB-CDC
+            // port mid-update, and Core's own JumpingToApp step reconnects it directly (not through
+            // this method). A competing open here would steal the port out from under that reconnect
+            // and strand the update in a JumpingToApp timeout even though the flash succeeded — the
+            // exact failure in issue #738. WiFi connects are unaffected (different device path).
+            // Core's reconnect calls the Core device's Connect() directly, so this gate can't block it.
+            if (IsFirmwareUpdateInProgress && device.ConnectionType == ConnectionType.Usb)
+            {
+                AppLogger.Instance.Warning(
+                    $"Refusing to connect USB device {device.Name} while a firmware update is in progress " +
+                    "(the device reconnects itself after the flash).");
+                ConnectionStatus = DAQiFiConnectionStatus.Error;
+                return;
+            }
+
             ConnectionStatus = DAQiFiConnectionStatus.Connecting;
-            
+
             // Check for duplicate device before connecting
             var duplicateResult = CheckForDuplicateDevice(device);
             if (duplicateResult.IsDuplicate)
@@ -240,6 +296,19 @@ public partial class ConnectionManager : ObservableObject
 
         UiThreadHelper.InvokeOnUiThread(() =>
         {
+            // During a firmware update the flashing device's transport drop is EXPECTED — it reboots
+            // into the HID bootloader and back into the application. Core's FirmwareUpdateService owns
+            // reconnecting THIS very Core device at the JumpingToApp step. If the desktop tears it down
+            // here, Disconnect() disposes the Core device and its serial transport out from under Core,
+            // so Core's reconnect loop operates on a disposed device and can never succeed — the update
+            // then times out in JumpingToApp even though the flash was written and verified (issue #738).
+            // Leave the connection fully intact; DeviceBeingUpdated clears when the flash finishes, and a
+            // genuinely-failed reconnect is reconciled by the next disconnect event or a user action.
+            if (IsDeviceBeingUpdated(device))
+            {
+                return;
+            }
+
             // Already torn down via another path (e.g. explicit user disconnect raced this event).
             if (!ConnectedDevices.Contains(device))
             {
@@ -253,13 +322,24 @@ public partial class ConnectionManager : ObservableObject
 
             Disconnect(device);
 
-            // Only notify if this isn't an intentional disconnect during firmware update.
-            if (DeviceBeingUpdated == null || DeviceBeingUpdated.Name != device.Name)
-            {
-                LastDisconnectReason = $"{device.DeviceDisplayName} disconnected ({e.Reason}).";
-                NotifyConnection = true;
-            }
+            LastDisconnectReason = $"{device.DeviceDisplayName} disconnected ({e.Reason}).";
+            NotifyConnection = true;
         }, failureLogMessage: "Dispatcher unavailable while handling ConnectionLost; UI update dropped.");
+    }
+
+    /// <summary>
+    /// True when <paramref name="device"/> is the device currently undergoing a firmware update. During
+    /// an update the device's serial transport drops and re-enumerates as an expected part of the flash,
+    /// and Core owns the reconnect — so the desktop's disconnect-detection paths must leave that device's
+    /// connection untouched rather than disposing the Core device Core is reconnecting (issue #738).
+    /// Matches by reference (the update is driven on the exact connected instance) with a name fallback.
+    /// </summary>
+    private bool IsDeviceBeingUpdated(IStreamingDevice device)
+    {
+        var updating = DeviceBeingUpdated;
+        return updating != null
+            && (ReferenceEquals(updating, device)
+                || string.Equals(updating.Name, device.Name, StringComparison.Ordinal));
     }
 
     private void CheckIfSerialDeviceWasRemoved()
@@ -293,6 +373,15 @@ public partial class ConnectionManager : ObservableObject
             {
                 System.Windows.Application.Current.Dispatcher.Invoke(delegate
                 {
+                    // The device being flashed drops off the COM port when it reboots mid-update — an
+                    // expected part of the flash that Core reconnects itself. Tearing it down here would
+                    // dispose the Core device out from under Core's JumpingToApp reconnect and time the
+                    // update out (issue #738), so skip it entirely (same guard as OnDeviceConnectionLost).
+                    if (IsDeviceBeingUpdated(serialDevice))
+                    {
+                        return;
+                    }
+
                     foreach (var channel in serialDevice.DataChannels)
                     {
                         LoggingManager.Instance.Unsubscribe(channel);
@@ -300,9 +389,7 @@ public partial class ConnectionManager : ObservableObject
 
                     Disconnect(serialDevice);
 
-                    // Only notify if this isn't an intentional disconnect during firmware update
-                    if (!NotifyConnection &&
-                        (DeviceBeingUpdated == null || DeviceBeingUpdated.Name != serialDevice.Name))
+                    if (!NotifyConnection)
                     {
                         // Scoped to this device so a later notification never shows a stale
                         // reason string left over from a previous, unrelated disconnect.

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -245,7 +245,6 @@ public class FirmwareUpdateCoordinator
         }
         catch (FirmwareUpdateException ex)
         {
-            _appLogger.AddBreadcrumb("firmware", $"Firmware update failed: {ex.FailedState}", Common.Loggers.BreadcrumbLevel.Error);
             HandleFirmwareUpdateException(ex);
         }
         catch (Exception ex)
@@ -681,6 +680,36 @@ public class FirmwareUpdateCoordinator
     private void HandleFirmwareUpdateException(FirmwareUpdateException exception)
     {
         _host.HasErrorOccured = true;
+
+        // A JumpingToApp failure is categorically different from a mid-flash failure: it is the LAST
+        // PIC32 step and only runs after erase + program + CRC-verify all succeeded, so the firmware is
+        // already installed and verified — the device just didn't re-open its serial port in time. Treat
+        // it as an expected device/environmental condition (a power-cycle finishes the job), not an app
+        // bug: log at Warning (no Sentry capture) and tell the user their firmware installed rather than
+        // claiming it failed. Mirrors the serial/WiFi connect classification (issues #589 / #740) and
+        // stops this from filing Sentry issues like DAQIFI-DESKTOP-1N (issue #738).
+        if (exception.FailedState == FirmwareUpdateState.JumpingToApp)
+        {
+            _appLogger.AddBreadcrumb(
+                "firmware",
+                $"Firmware installed but device did not reconnect: {exception.FailedState}",
+                Common.Loggers.BreadcrumbLevel.Warning);
+            _appLogger.Warning(
+                exception,
+                "Firmware was installed and verified, but the device did not automatically return to " +
+                "application mode after the flash. This is a device/environmental condition (power-cycle " +
+                "recovers it), not an app failure.");
+
+            _host.ShowFirmwareError(
+                "Firmware was installed successfully, but the device did not return to normal mode on its " +
+                "own. Please power-cycle the device (unplug and replug its USB cable), then reconnect.");
+            return;
+        }
+
+        _appLogger.AddBreadcrumb(
+            "firmware",
+            $"Firmware update failed: {exception.FailedState}",
+            Common.Loggers.BreadcrumbLevel.Error);
 
         var summary = $"Firmware update failed during '{exception.Operation}' ({exception.FailedState}).";
         _appLogger.Error(exception, summary);

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateServiceConfig.cs
@@ -62,6 +62,21 @@ public static class FirmwareUpdateServiceConfig
     /// A <see cref="FirmwareUpdateServiceOptions"/> with <see cref="FirmwareUpdateServiceOptions.BootloaderResponseTimeout"/>
     /// set to <see cref="BootloaderHidTimeout"/>; all other options retain their Core defaults.
     /// </returns>
+    /// <remarks>
+    /// <para>
+    /// NOTE — <see cref="FirmwareUpdateServiceOptions.PostReconnectStaleHandleDelay"/> is deliberately
+    /// LEFT at Core's non-zero default. Core documents it as a macOS-only workaround ("set to zero on
+    /// Windows, where the first open is already clean"), and issue #738 tempted us to zero it to shrink
+    /// the post-reset reconnect window. We do NOT: the assumption that the Windows first open is clean is
+    /// unverified on our hardware, and the successful bench flashes we have on record show Core's
+    /// close-and-reopen discard step running normally — i.e. it appears load-bearing here. Changing
+    /// firmware-flash reconnect timing without a positive end-to-end hardware validation is not worth the
+    /// marginal window reduction. The #738 race is fixed at its source (the desktop no longer steals the
+    /// port or tears down the flashing device during Core's reconnect — see
+    /// <c>ConnectionManager.IsFirmwareUpdateInProgress</c> and <c>ConnectionManager.IsDeviceBeingUpdated</c>),
+    /// not by narrowing this window.
+    /// </para>
+    /// </remarks>
     public static FirmwareUpdateServiceOptions CreateOptions()
     {
         return new FirmwareUpdateServiceOptions

--- a/Daqifi.Desktop/Loggers/AppLoggerLoggerProvider.cs
+++ b/Daqifi.Desktop/Loggers/AppLoggerLoggerProvider.cs
@@ -43,6 +43,7 @@ public sealed class AppLoggerLoggerProvider : ILoggerProvider
         private readonly IAppLogger _appLogger;
         private readonly string _category;
         private readonly bool _isDaqifiCategory;
+        private readonly bool _isFirmwareUpdateCategory;
 
         public AppLoggerBridge(IAppLogger appLogger, string category)
         {
@@ -54,6 +55,19 @@ public sealed class AppLoggerLoggerProvider : ILoggerProvider
 
             // Our own (DAQiFi/Core) errors are worth capturing to Sentry; framework errors are not.
             _isDaqifiCategory = normalizedCategory.StartsWith("Daqifi", StringComparison.OrdinalIgnoreCase);
+
+            // ...EXCEPT Core's firmware-update logic. Core's FirmwareUpdateService logs a failed update
+            // at LogError from its own viewpoint, but the desktop's FirmwareUpdateCoordinator is the
+            // authority on firmware-outcome severity: it captures genuine flash failures to Sentry
+            // itself (a direct AppLogger.Error, not through this bridge) AND downgrades expected
+            // device/environmental outcomes — most notably a post-verify JumpingToApp reconnect timeout,
+            // where the firmware is already installed and a power-cycle finishes the job (issue #738).
+            // Forwarding Core's duplicate Error to Sentry would both double-report real failures and
+            // undo the coordinator's environmental downgrade, auto-filing noise issues like
+            // DAQIFI-DESKTOP-1N. So route this category's Error/Critical to the file only; the
+            // coordinator remains the single Sentry-capturing decision point for firmware updates.
+            _isFirmwareUpdateCategory =
+                normalizedCategory.StartsWith("Daqifi.Core.Firmware", StringComparison.OrdinalIgnoreCase);
 
             // Tag log lines with the full category for unambiguous attribution. (A short leaf name
             // would read nicer but collides across namespaces — e.g. two ".Foo" types — which
@@ -94,10 +108,12 @@ public sealed class AppLoggerLoggerProvider : ILoggerProvider
                 {
                     case LogLevel.Critical:
                     case LogLevel.Error:
-                        // Capture our own errors to Sentry (AppLogger.Error); route framework
-                        // errors to the file only (AppLogger.Warning does NOT hit Sentry) so routine
-                        // component Error logs don't spam Sentry. Tag the level so severity isn't lost.
-                        if (_isDaqifiCategory)
+                        // Capture our own errors to Sentry (AppLogger.Error); route framework errors
+                        // (and Core's firmware-update category — the coordinator owns that Sentry
+                        // decision, see _isFirmwareUpdateCategory) to the file only (AppLogger.Warning
+                        // does NOT hit Sentry) so they don't spam Sentry. Tag the level so severity
+                        // isn't lost.
+                        if (_isDaqifiCategory && !_isFirmwareUpdateCategory)
                         {
                             if (exception is not null)
                             {

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -156,6 +156,34 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
 
         // Set up the duplicate device handler
         ConnectionManager.Instance.DuplicateDeviceHandler = HandleDuplicateDevice;
+
+        // React to a firmware update starting/ending while this dialog is open: pause serial + WiFi
+        // discovery for the duration so a per-cycle port probe can't steal the COM port during Core's
+        // post-flash reconnect window (issue #738). The Start*Discovery guards below cover a dialog
+        // opened mid-flash; this event covers a dialog already open when the flash starts.
+        ConnectionManager.Instance.FirmwareUpdateInProgressChanged += OnFirmwareUpdateInProgressChanged;
+    }
+
+    private void OnFirmwareUpdateInProgressChanged(object? sender, EventArgs e)
+    {
+        // Marshal onto the UI thread: the event is raised from the firmware coordinator's async flow,
+        // and the discovery start/stop paths mutate bound collections.
+        InvokeOnUiThread(() =>
+        {
+            if (_closed) { return; }
+
+            if (ConnectionManager.Instance.IsFirmwareUpdateInProgress)
+            {
+                StopWiFiDiscovery();
+                _ = StopSerialDiscoveryAsync();
+            }
+            else
+            {
+                // Flash finished — bring discovery back so the dialog keeps listing devices.
+                StartWiFiDiscovery();
+                StartSerialDiscovery();
+            }
+        });
     }
 
     private void OnHidDevicesChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
@@ -178,6 +206,11 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
         // Idempotent while actually running; also refuse to start while a previous instance is still
         // draining (see _wifiStopTask above) so a fresh finder never races an old one for the socket.
         if (_closed || _wifiFinder != null || _wifiStopTask is { IsCompleted: false }) { return; }
+
+        // Don't run discovery during a firmware update: its per-cycle bus probing can starve the
+        // flash / steal the reconnecting COM port (issue #738). Covers a dialog opened mid-flash;
+        // OnFirmwareUpdateInProgressChanged restarts discovery when the flash ends.
+        if (ConnectionManager.Instance.IsFirmwareUpdateInProgress) { return; }
 
         // Reset the bound list to match the new finder's dedup set: a fresh ContinuousDeviceFinder
         // means a fresh, empty live set, so a list that outlives the finder it was populated from
@@ -209,6 +242,13 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
     private void StartSerialDiscovery()
     {
         if (_closed || _serialFinder != null || _serialStopTask is { IsCompleted: false }) { return; }
+
+        // Don't probe COM ports during a firmware update: Core opens/reconnects the device's port
+        // itself across the flash, and the SerialDeviceFinder opens every DAQiFi VID/PID port each
+        // cycle — a probe landing in Core's JumpingToApp reconnect window steals the port and strands
+        // the update in a timeout (issue #738). Covers a dialog opened mid-flash;
+        // OnFirmwareUpdateInProgressChanged restarts discovery when the flash ends.
+        if (ConnectionManager.Instance.IsFirmwareUpdateInProgress) { return; }
 
         var options = new ContinuousDiscoveryOptions
         {
@@ -688,6 +728,8 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
         StopWiFiDiscovery();
         // Fire-and-forget: cancel discovery and clean up without waiting for task completion
         _ = StopSerialDiscoveryAsync();
+
+        ConnectionManager.Instance.FirmwareUpdateInProgressChanged -= OnFirmwareUpdateInProgressChanged;
 
         // HID bootloader holds are owned by the app-global watcher and intentionally persist after the
         // dialog closes (so a sitting bootloader stays wedge-proof). Only unsubscribe this dialog from

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -179,11 +179,35 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
             }
             else
             {
-                // Flash finished — bring discovery back so the dialog keeps listing devices.
-                StartWiFiDiscovery();
-                StartSerialDiscovery();
+                // Flash finished — bring discovery back so the dialog keeps listing devices. The stop we
+                // issued at flash start may still be draining (a wedged port can hold StopSerialDiscoveryAsync
+                // past its timeout, leaving _serialStopTask incomplete), and Start*Discovery refuses to
+                // start while that drain is in flight. So retry the start once the drain completes rather
+                // than dropping it — otherwise discovery could stay stopped for the rest of the dialog.
+                RestartDiscoveryWhenDrained(_wifiStopTask, StartWiFiDiscovery);
+                RestartDiscoveryWhenDrained(_serialStopTask, StartSerialDiscovery);
             }
         });
+    }
+
+    /// <summary>
+    /// Starts a discovery transport, deferring the start until any in-flight stop/drain for that
+    /// transport completes. <paramref name="start"/> carries its own idempotency and firmware-in-progress
+    /// guards, so a redundant or now-invalid call is a harmless no-op.
+    /// </summary>
+    private void RestartDiscoveryWhenDrained(Task? stopTask, Action start)
+    {
+        if (stopTask is { IsCompleted: false })
+        {
+            stopTask.ContinueWith(
+                _ => InvokeOnUiThread(start),
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+            return;
+        }
+
+        start();
     }
 
     private void OnHidDevicesChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
## Summary

Fixes the `JumpingToApp` firmware-update timeout in #738 (Sentry `DAQIFI-DESKTOP-1N`).

A PIC32 update reboots the device through the HID bootloader and back, so its USB-CDC COM port disappears and re-enumerates. Core's `FirmwareUpdateService` reconnects the device itself in the final `JumpingToApp` step. **The flash itself succeeds** — erase, program, and CRC-verify all pass — but the desktop was interfering with Core's reconnect, so the update timed out in `JumpingToApp` and got auto-filed as a Sentry/GitHub error.

The desktop interfered two ways:

1. **It stole the port.** The connection dialog's continuous serial (and WiFi) discovery kept probing/opening every DAQiFi COM port, and a user connect could grab the port, during Core's reconnect window.
2. **It tore down the device Core was reconnecting** — the dominant cause on the bench. The device's expected mid-flash transport drop fired the desktop's `ConnectionLost` / WMI-removal handlers, which disconnected and **disposed the very Core device instance** Core reuses to reconnect at `JumpingToApp`. Core's reconnect then ran against a disposed device and could never succeed.

## What changed

- **`ConnectionManager`** exposes an app-global `IsFirmwareUpdateInProgress` gate (driven by `DeviceBeingUpdated`) plus a `FirmwareUpdateInProgressChanged` event.
  - The **connection dialog** suspends serial + WiFi discovery for the whole update — a pull-guard in `Start*Discovery` (dialog opened mid-flash) and the event (dialog already open).
  - `Connect()` **refuses USB connects** while an update runs. Core's reconnect calls the Core device directly, so this gate can't block it.
  - `OnDeviceConnectionLost` and `CheckIfSerialDeviceWasRemoved` now **leave the flashing device's connection fully intact** instead of tearing it down — the expected reboot is Core's to reconnect.
- **Honest reporting / no Sentry noise.** A `JumpingToApp` failure (flash already installed + CRC-verified) is reported as an environmental warning ("firmware installed successfully… power-cycle the device… then reconnect"), not an Error. The `Daqifi.Core` → `AppLogger` bridge routes the firmware-update category's `Error` logs to the file only, so a post-verify reconnect timeout no longer auto-files a Sentry/GitHub issue. The coordinator stays the single Sentry-capturing decision point for firmware outcomes (genuine flash failures still capture).
- **`PostReconnectStaleHandleDelay` left at Core's default.** Recorded bench flashes show its close-and-reopen discard step is load-bearing on Windows; zeroing it was not positively validated. A regression test guards against re-zeroing.

## Testing

- **Hardware (NQ1 bench):** before this change every flash timed out at `JumpingToApp`; with it, a full manual PIC32 flash completes `Verifying → JumpingToApp → Discarding race-winning serial handle → Waking post-reset device → JumpingToApp → Complete`. The device stays healthy on its COM port.
- **Unit:** 662 pass (fast gate). New coverage:
  - `ConnectionManagerFirmwareGateTests` — the in-progress gate + event, the USB `Connect` refusal (WiFi unaffected), and the `OnDeviceConnectionLost` teardown skip for the updating device (plus a control that other devices still tear down).
  - `ConnectionDialogViewModelFirmwareGateTests` — discovery does not start while an update is in progress.
  - `AppLoggerLoggerProviderTests` — firmware-category `Error` forwards as a file-only warning (no Sentry); non-firmware DAQiFi errors still capture.
  - `FirmwareUpdateServiceConfigTests` / `DaqifiViewModelFirmwareUpdateTests` — the stale-handle-delay regression guard and the `JumpingToApp`-vs-mid-flash reporting split.

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
