### PR TITLE
fix: degrade gracefully when the device's SD subsystem is unavailable

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
@@ -61,12 +61,14 @@ public class SdCardDownloadFailureTests
             });
 
         // Act
-        var ex = await Assert.ThrowsExactlyAsync<TimeoutException>(() =>
+        var ex = await Assert.ThrowsExactlyAsync<SdCardDownloadStalledException>(() =>
             _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, CancellationToken.None));
 
-        // Assert — a TimeoutException is what the failure classifier turns into "power-cycle the
-        // device", so the type is load-bearing, not incidental.
+        // Assert — this type is what the failure classifier turns into "power-cycle the device",
+        // so it is load-bearing, not incidental. It derives from TimeoutException so callers that
+        // only care that the operation timed out still catch it.
         StringAssert.Contains(ex.Message, FileName);
+        Assert.IsInstanceOfType<TimeoutException>(ex);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
@@ -1,0 +1,171 @@
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Loggers;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Covers how <see cref="SdCardSessionImporter"/> bounds and reports a download that the device
+/// does not honour.
+///
+/// The stall watchdog exists because neither public <c>DaqifiStreamingDevice.DownloadSdCardFileAsync</c>
+/// overload in Daqifi.Core 1.3.0 exposes the timeout its underlying <c>SdCardFileReceiver.ReceiveAsync</c>
+/// accepts, so the desktop cannot bound an SD download through Core. Issue #754 showed what that
+/// costs: an import sat on a busy overlay for two minutes with no error. Until Core exposes the
+/// knob, the importer bounds the wait itself — but on <i>silence</i>, not on total elapsed time,
+/// so a large file that is downloading steadily is never cut off.
+///
+/// The empty-download cases cover issue #593: the importer's own "0 bytes" guard is the same
+/// wedged-SD-subsystem condition, and used to escape as a bare <see cref="InvalidOperationException"/>
+/// that the Error path filed to Sentry.
+/// </summary>
+[TestClass]
+public class SdCardDownloadFailureTests
+{
+    private const string FileName = "log_20260623_143217.bin";
+
+    // Long enough that scheduling jitter cannot trip it spuriously, short enough to keep the test
+    // fast. The production value is SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT.
+    private static readonly TimeSpan StallTimeout = TimeSpan.FromMilliseconds(300);
+
+    private Mock<IStreamingDevice> _mockDevice;
+    private SdCardSessionImporter _importer;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockDevice = new Mock<IStreamingDevice>();
+        _mockDevice.Setup(d => d.DeviceSerialNo).Returns("DAQ-TEST-001");
+
+        // The watchdog runs entirely before anything is written, so a stub context factory is
+        // enough — these tests never reach the database.
+        _importer = new SdCardSessionImporter(
+            new Mock<IDbContextFactory<LoggingContext>>().Object, StallTimeout);
+    }
+
+    [TestMethod]
+    public async Task Download_WhenDeviceGoesSilent_ThrowsTimeout()
+    {
+        // Arrange — a device that accepts the request and then never answers. This is the failure
+        // Core cannot detect for us, and the one that hung the UI in issue #754.
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, IProgress<SdCardTransferProgress> _, CancellationToken ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new SdCardDownloadResult(FileName, 0, TimeSpan.Zero, null);
+            });
+
+        // Act
+        var ex = await Assert.ThrowsExactlyAsync<TimeoutException>(() =>
+            _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, CancellationToken.None));
+
+        // Assert — a TimeoutException is what the failure classifier turns into "power-cycle the
+        // device", so the type is load-bearing, not incidental.
+        StringAssert.Contains(ex.Message, FileName);
+    }
+
+    [TestMethod]
+    public async Task Download_WhileProgressKeepsArriving_IsNotCutOff()
+    {
+        // Arrange — a slow but healthy transfer: it runs for several stall windows, reporting a
+        // chunk at a time. Regression guard against turning the watchdog into a wall-clock cap,
+        // which would break exactly the large downloads it is supposed to protect.
+        var totalTransferTime = StallTimeout * 4;
+        var chunkInterval = StallTimeout / 4;
+        var expected = new SdCardDownloadResult(FileName, 4096, totalTransferTime, "C:\\temp\\file.bin");
+
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, IProgress<SdCardTransferProgress> progress, CancellationToken ct) =>
+            {
+                var chunks = (int)(totalTransferTime / chunkInterval);
+                for (var i = 1; i <= chunks; i++)
+                {
+                    await Task.Delay(chunkInterval, ct);
+                    progress?.Report(new SdCardTransferProgress(i * 1024L, FileName));
+                }
+
+                return expected;
+            });
+
+        // Act
+        var result = await _importer.DownloadWithStallWatchdogAsync(
+            _mockDevice.Object, FileName, CancellationToken.None);
+
+        // Assert
+        Assert.AreEqual(expected, result);
+    }
+
+    [TestMethod]
+    public async Task Import_WhenTheDownloadedFileIsEmpty_ReportsTheWedgedSubsystemCondition()
+    {
+        // Arrange — the device lists the file and "downloads" it, but nothing lands on disk. This
+        // is issue #593: previously an InvalidOperationException, which the ViewModel could only
+        // treat as an app fault and file to Sentry.
+        var tempPath = Path.Combine(Path.GetTempPath(), $"daqifi_test_{Guid.NewGuid():N}.bin");
+        await File.WriteAllBytesAsync(tempPath, []);
+
+        try
+        {
+            _mockDevice
+                .Setup(d => d.DownloadSdCardFileAsync(
+                    It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SdCardDownloadResult(FileName, 0, TimeSpan.Zero, tempPath));
+
+            // Act & Assert — the typed exception is what routes this to Warning plus
+            // "power-cycle the device" instead of the Error path.
+            await Assert.ThrowsExactlyAsync<SdCardEmptyTransferException>(() =>
+                _importer.ImportFromDeviceAsync(_mockDevice.Object, FileName));
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task Import_WhenNoFileIsDelivered_ReportsTheWedgedSubsystemCondition()
+    {
+        // Arrange — the download "succeeds" without producing a local file at all.
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SdCardDownloadResult(FileName, 0, TimeSpan.Zero, null));
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<SdCardEmptyTransferException>(() =>
+            _importer.ImportFromDeviceAsync(_mockDevice.Object, FileName));
+    }
+
+    [TestMethod]
+    public async Task Download_WhenCallerCancels_StaysCancelledRatherThanBecomingATimeout()
+    {
+        // Arrange — a caller-requested cancel must not be relabelled as a device timeout, or the
+        // UI would tell the user to power-cycle a perfectly healthy device.
+        using var cts = new CancellationTokenSource();
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, IProgress<SdCardTransferProgress> _, CancellationToken ct) =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new SdCardDownloadResult(FileName, 0, TimeSpan.Zero, null);
+            });
+
+        // Act
+        var downloadTask = _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, cts.Token);
+        await cts.CancelAsync();
+
+        // Assert
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => downloadTask);
+    }
+}

--- a/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
@@ -1,0 +1,248 @@
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.Common.Loggers;
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Loggers;
+using Daqifi.Desktop.Models;
+using Daqifi.Desktop.ViewModels;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Covers how <see cref="DeviceLogsViewModel"/> reports a failed SD card import.
+///
+/// Issue #754: importing from a device whose SD subsystem is wedged let Core's typed
+/// <see cref="SdCardEmptyTransferException"/> escape to the generic Error path. That filed a
+/// Sentry issue for a condition only a power cycle fixes, and told the user nothing beyond
+/// "check the device connection". These tests pin the replacement behaviour: expected device
+/// conditions log at Warning, never at Error, and land in the SD card status surface the view
+/// already binds to.
+/// </summary>
+[TestClass]
+public class DeviceLogsViewModelImportTests
+{
+    private const string FileName = "log_20260623_143217.bin";
+
+    private Mock<IStreamingDevice> _mockDevice;
+    private Mock<ISdCardSessionImporter> _mockImporter;
+    private Mock<IAppLogger> _mockLogger;
+    private DeviceLogsViewModel _viewModel;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockDevice = new Mock<IStreamingDevice>();
+        _mockDevice.Setup(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        _mockDevice.Setup(d => d.DeviceSerialNo).Returns("DAQ-TEST-001");
+        _mockDevice.Setup(d => d.SdCardFiles).Returns(new List<SdCardFile>().AsReadOnly());
+
+        _mockImporter = new Mock<ISdCardSessionImporter>();
+        _mockLogger = new Mock<IAppLogger>();
+
+        // DeviceLogsViewModel's constructor reads the process-wide ConnectionManager.Instance
+        // singleton; other test classes leave devices on it, so reset it for order-independence.
+        ConnectionManager.Instance.ConnectedDevices.Clear();
+
+        _viewModel = new DeviceLogsViewModel(_mockLogger.Object, _mockImporter.Object)
+        {
+            SelectedDevice = _mockDevice.Object
+        };
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        ConnectionManager.Instance.ConnectedDevices.Clear();
+    }
+
+    /// <summary>
+    /// Selecting a USB device kicks off an auto-refresh that ends by setting the card state to Ok.
+    /// Awaiting it keeps that late write from racing the state each test asserts on.
+    /// </summary>
+    private async Task SettleInitialRefreshAsync()
+    {
+        if (_viewModel.InitialRefreshTask != null)
+        {
+            await _viewModel.InitialRefreshTask;
+        }
+    }
+
+    private void SetupImportToThrow(Exception ex)
+    {
+        _mockImporter
+            .Setup(i => i.ImportFromDeviceAsync(
+                It.IsAny<IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<ImportOptions>(),
+                It.IsAny<IProgress<ImportProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(ex);
+    }
+
+    private Task ImportAsync(string fileName = FileName) =>
+        _viewModel.ImportFileCommand.ExecuteAsync(new SdCardFile { FileName = fileName });
+
+    [TestMethod]
+    public async Task ImportFile_EmptyTransfer_LogsWarningNotError()
+    {
+        // Arrange — the exception Sentry issue #754 was filed from.
+        await SettleInitialRefreshAsync();
+        SetupImportToThrow(new SdCardEmptyTransferException(FileName));
+
+        // Act
+        await ImportAsync();
+
+        // Assert
+        _mockLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once,
+            "A wedged SD subsystem is an expected device condition and belongs in the local log.");
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never,
+            "Logging at Error captures to Sentry, which is exactly what issue #754 was about.");
+        _mockLogger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ImportFile_EmptyTransfer_SurfacesPowerCycleGuidanceOnTheCardPanel()
+    {
+        // Arrange
+        await SettleInitialRefreshAsync();
+        SetupImportToThrow(new SdCardEmptyTransferException(FileName));
+
+        // Act
+        await ImportAsync();
+
+        // Assert — the user gets an actionable state instead of a silent busy overlay.
+        Assert.AreEqual(SdCardState.Error, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasSdCardError);
+        Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, _viewModel.SdCardErrorGuidance);
+        Assert.IsFalse(string.IsNullOrEmpty(_viewModel.SdCardErrorMessage));
+    }
+
+    [TestMethod]
+    public async Task ImportFile_Timeout_LogsWarningAndReportsTheStall()
+    {
+        // Arrange — what the importer's stall watchdog raises when the device goes quiet.
+        await SettleInitialRefreshAsync();
+        SetupImportToThrow(new TimeoutException("The device sent no data."));
+
+        // Act
+        await ImportAsync();
+
+        // Assert
+        _mockLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        Assert.AreEqual(SdCardState.Error, _viewModel.SdCardState);
+        Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, _viewModel.SdCardErrorGuidance);
+    }
+
+    [TestMethod]
+    public async Task ImportFile_NotPresent_ShowsTheMissingCardState()
+    {
+        // Arrange
+        await SettleInitialRefreshAsync();
+        SetupImportToThrow(new SdCardNotPresentException(new List<string>(), "No card"));
+
+        // Act
+        await ImportAsync();
+
+        // Assert
+        Assert.AreEqual(SdCardState.NotPresent, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasSdCardNotPresent);
+        _mockLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ImportFile_UnexpectedFailure_KeepsErrorLoggingAndDoesNotBlameTheCard()
+    {
+        // Arrange — a defect in the import pipeline, not a device condition. Regression guard: the
+        // #754 fix must not silence real bugs, nor hide a healthy file list behind an error panel.
+        await SettleInitialRefreshAsync();
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState, "Precondition: the card refreshed cleanly.");
+        SetupImportToThrow(new InvalidOperationException("Bulk insert failed."));
+
+        // Act
+        await ImportAsync();
+
+        // Assert
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once,
+            "An unrecognised failure must still reach Sentry.");
+        _mockLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState,
+            "A failure the desktop cannot attribute to the card must leave the card state alone.");
+    }
+
+    [TestMethod]
+    public async Task ImportFile_Failure_ClearsTheBusyOverlay()
+    {
+        // Arrange — the #754 symptom was a busy overlay that never went away.
+        await SettleInitialRefreshAsync();
+        SetupImportToThrow(new SdCardEmptyTransferException(FileName));
+
+        // Act
+        await ImportAsync();
+
+        // Assert
+        Assert.IsFalse(_viewModel.IsBusy);
+        Assert.IsTrue(string.IsNullOrEmpty(_viewModel.BusyMessage));
+    }
+
+    [TestMethod]
+    public async Task ImportAllFiles_WhenCardIsUnavailable_StopsAfterTheFirstFile()
+    {
+        // Arrange — three files on a device whose SD subsystem is wedged. Every download would
+        // burn Core's full retry window (~50s observed on the bench), so the batch must give up
+        // rather than make the user wait through all of them.
+        await SettleInitialRefreshAsync();
+        foreach (var name in new[] { "log_a.bin", "log_b.bin", "log_c.bin" })
+        {
+            _viewModel.DeviceFiles.Add(new SdCardFile { FileName = name });
+        }
+
+        SetupImportToThrow(new SdCardEmptyTransferException("log_a.bin"));
+
+        // Act
+        await _viewModel.ImportAllFilesCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockImporter.Verify(
+            i => i.ImportFromDeviceAsync(
+                It.IsAny<IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<ImportOptions>(),
+                It.IsAny<IProgress<ImportProgress>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Once the card is known to be unavailable the remaining files must not be attempted.");
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        Assert.IsFalse(_viewModel.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task ImportAllFiles_WhenOneFileFails_StillTriesTheRest()
+    {
+        // Arrange — a per-file SCPI rejection says nothing about the other files, so the batch
+        // must carry on. Counterpart to the early-abort case above.
+        await SettleInitialRefreshAsync();
+        foreach (var name in new[] { "log_a.bin", "log_b.bin", "log_c.bin" })
+        {
+            _viewModel.DeviceFiles.Add(new SdCardFile { FileName = name });
+        }
+
+        SetupImportToThrow(new SdCardOperationException(
+            "SCPI error", new List<string>(), "-200,\"Execution error\"", null));
+
+        // Act
+        await _viewModel.ImportAllFilesCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockImporter.Verify(
+            i => i.ImportFromDeviceAsync(
+                It.IsAny<IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<ImportOptions>(),
+                It.IsAny<IProgress<ImportProgress>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
@@ -118,11 +118,11 @@ public class DeviceLogsViewModelImportTests
     }
 
     [TestMethod]
-    public async Task ImportFile_Timeout_LogsWarningAndReportsTheStall()
+    public async Task ImportFile_DownloadStalled_LogsWarningAndReportsTheStall()
     {
         // Arrange — what the importer's stall watchdog raises when the device goes quiet.
         await SettleInitialRefreshAsync();
-        SetupImportToThrow(new TimeoutException("The device sent no data."));
+        SetupImportToThrow(new SdCardDownloadStalledException(FileName, TimeSpan.FromSeconds(90)));
 
         // Act
         await ImportAsync();
@@ -184,6 +184,47 @@ public class DeviceLogsViewModelImportTests
         // Assert
         Assert.IsFalse(_viewModel.IsBusy);
         Assert.IsTrue(string.IsNullOrEmpty(_viewModel.BusyMessage));
+    }
+
+    [TestMethod]
+    public async Task ImportFile_WhenSelectionChangesMidImport_UsesTheOriginalDeviceAndLeavesTheNewOneAlone()
+    {
+        // Arrange — an import runs for many seconds on a background thread, so the user can select
+        // a different device while it is in flight. Re-reading SelectedDevice inside the lambda
+        // would download from whichever device is selected by then, and paint the first device's
+        // failure onto the second device's panel.
+        await SettleInitialRefreshAsync();
+
+        var otherDevice = new Mock<IStreamingDevice>();
+        otherDevice.Setup(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        otherDevice.Setup(d => d.DeviceSerialNo).Returns("DAQ-TEST-002");
+        otherDevice.Setup(d => d.SdCardFiles).Returns(new List<SdCardFile>().AsReadOnly());
+
+        IStreamingDevice importedFrom = null;
+        _mockImporter
+            .Setup(i => i.ImportFromDeviceAsync(
+                It.IsAny<IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<ImportOptions>(),
+                It.IsAny<IProgress<ImportProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task<SdCardImportResult> (IStreamingDevice device, string _, ImportOptions _,
+                IProgress<ImportProgress> _, CancellationToken _) =>
+            {
+                importedFrom = device;
+                _viewModel.SelectedDevice = otherDevice.Object;
+                throw new SdCardEmptyTransferException(FileName);
+            });
+
+        // Act
+        await ImportAsync();
+        await SettleInitialRefreshAsync();
+
+        // Assert
+        Assert.AreSame(_mockDevice.Object, importedFrom,
+            "The import must run against the device that was selected when it started.");
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState,
+            "The first device's failure must not be shown against the newly selected device.");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
@@ -1,4 +1,5 @@
 using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.Loggers;
 using Daqifi.Desktop.ViewModels;
 
 namespace Daqifi.Desktop.Test.ViewModels;
@@ -35,10 +36,10 @@ public class SdCardFailureClassifierTests
     }
 
     [TestMethod]
-    public void Classify_Timeout_IsExpectedDeviceConditionAndAdvisesPowerCycle()
+    public void Classify_DownloadStalled_IsExpectedDeviceConditionAndAdvisesPowerCycle()
     {
         // Arrange — what the importer's stall watchdog throws when the device goes quiet.
-        var ex = new TimeoutException("The device sent no data.");
+        var ex = new SdCardDownloadStalledException(FileName, TimeSpan.FromSeconds(90));
 
         // Act
         var failure = SdCardFailureClassifier.Classify(ex);
@@ -48,6 +49,24 @@ public class SdCardFailureClassifierTests
         Assert.IsTrue(failure.IsCardUnavailable);
         Assert.AreEqual(SdCardState.Error, failure.State);
         Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, failure.Guidance);
+    }
+
+    [TestMethod]
+    public void Classify_UnrelatedTimeout_KeepsTheErrorPath()
+    {
+        // Arrange — a timeout from some other layer (a database call, an HTTP request) that
+        // happens to reach an SD catch block. Regression guard: matching TimeoutException by base
+        // type would tell the user to power-cycle a healthy device over an unrelated failure, and
+        // would keep that failure off the Error path where it belongs.
+        var ex = new TimeoutException("The operation has timed out.");
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.IsFalse(failure.IsExpectedDeviceCondition);
+        Assert.IsFalse(failure.IsCardUnavailable);
+        Assert.AreNotEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, failure.Guidance);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
@@ -1,0 +1,121 @@
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.ViewModels;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Covers the classification that decides how an SD card failure reaches the user and the log.
+/// The load-bearing distinction is <c>IsExpectedDeviceCondition</c>: it routes a failure to
+/// Warning (local log only) instead of Error (captured to Sentry). Before issue #754 a wedged SD
+/// subsystem — which only a power cycle fixes — filed a Sentry issue on every import attempt.
+/// </summary>
+[TestClass]
+public class SdCardFailureClassifierTests
+{
+    private const string FileName = "log_20260623_143217.bin";
+
+    [TestMethod]
+    public void Classify_EmptyTransfer_IsExpectedDeviceConditionAndAdvisesPowerCycle()
+    {
+        // Arrange — the exact exception Core 1.3.0 throws for the wedged SD subsystem, and the
+        // one Sentry issue #754 was filed from.
+        var ex = new SdCardEmptyTransferException(FileName);
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.IsTrue(failure.IsExpectedDeviceCondition,
+            "A wedged SD subsystem is a device condition, so it must log at Warning and not file a Sentry issue.");
+        Assert.IsTrue(failure.IsCardUnavailable,
+            "Nothing else on the card will download either, so a batch import must stop early.");
+        Assert.AreEqual(SdCardState.Error, failure.State);
+        Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, failure.Guidance,
+            "Only a power cycle clears this state, so that is what the user must be told.");
+    }
+
+    [TestMethod]
+    public void Classify_Timeout_IsExpectedDeviceConditionAndAdvisesPowerCycle()
+    {
+        // Arrange — what the importer's stall watchdog throws when the device goes quiet.
+        var ex = new TimeoutException("The device sent no data.");
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.IsTrue(failure.IsExpectedDeviceCondition);
+        Assert.IsTrue(failure.IsCardUnavailable);
+        Assert.AreEqual(SdCardState.Error, failure.State);
+        Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, failure.Guidance);
+    }
+
+    [TestMethod]
+    public void Classify_NotPresent_MapsToNotPresentStateWithNoSecondaryMessage()
+    {
+        // Arrange
+        var ex = new SdCardNotPresentException(new List<string>(), "No card");
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.AreEqual(SdCardState.NotPresent, failure.State);
+        Assert.AreEqual(string.Empty, failure.StatusMessage,
+            "The 'no card installed' panel is self-explanatory; a raw device string would only add noise.");
+        Assert.IsTrue(failure.IsExpectedDeviceCondition);
+        Assert.IsTrue(failure.IsCardUnavailable);
+    }
+
+    [TestMethod]
+    public void Classify_FilesystemError_SurfacesTheDeviceMessage()
+    {
+        // Arrange
+        const string deviceMessage = "FS corrupt";
+        var ex = new SdCardFilesystemException(new List<string>(), "Filesystem error", deviceMessage);
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.AreEqual(SdCardState.Error, failure.State);
+        Assert.AreEqual(deviceMessage, failure.StatusMessage);
+        Assert.IsTrue(failure.IsExpectedDeviceCondition);
+        Assert.AreEqual(SdCardFailureClassifier.GENERIC_CARD_GUIDANCE, failure.Guidance);
+    }
+
+    [TestMethod]
+    public void Classify_OperationError_SurfacesScpiErrorAndKeepsTheRestOfTheCardUsable()
+    {
+        // Arrange
+        const string scpiError = "-200,\"Execution error\"";
+        var ex = new SdCardOperationException("SCPI error", new List<string>(), scpiError, null);
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.AreEqual(scpiError, failure.StatusMessage);
+        Assert.IsTrue(failure.IsExpectedDeviceCondition);
+        Assert.IsFalse(failure.IsCardUnavailable,
+            "A rejected command can be specific to one file, so the remaining files are still worth trying.");
+    }
+
+    [TestMethod]
+    public void Classify_UnknownException_KeepsTheErrorPath()
+    {
+        // Arrange — a defect in the import pipeline, not a device condition. Regression guard:
+        // downgrading these too would silence the Sentry reporting that catches real bugs.
+        const string message = "Object reference not set to an instance of an object.";
+        var ex = new NullReferenceException(message);
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.IsFalse(failure.IsExpectedDeviceCondition,
+            "An unrecognised failure must keep logging at Error so it still reaches Sentry.");
+        Assert.IsFalse(failure.IsCardUnavailable);
+        Assert.AreEqual(message, failure.StatusMessage);
+    }
+}

--- a/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
+++ b/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
@@ -1,0 +1,35 @@
+namespace Daqifi.Desktop.Loggers;
+
+/// <summary>
+/// Thrown when a device accepts an SD card download request and then stops sending data, with the
+/// transfer neither completing nor failing. Raised by the desktop's own stall watchdog (see
+/// <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>), because Daqifi.Core exposes no
+/// timeout on either public <c>DownloadSdCardFileAsync</c> overload.
+///
+/// Derives from <see cref="TimeoutException"/> so callers that only care that the operation timed
+/// out still catch it, while giving the SD failure classifier a type that means specifically
+/// "this device went silent". Classifying every <see cref="TimeoutException"/> as a wedged SD
+/// subsystem would tell a user to power-cycle their device over an unrelated timeout — and would
+/// keep that unrelated timeout off the Error path, where it belongs.
+/// </summary>
+public sealed class SdCardDownloadStalledException : TimeoutException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SdCardDownloadStalledException"/> class.
+    /// </summary>
+    /// <param name="fileName">The SD card file whose transfer stalled.</param>
+    /// <param name="stallTimeout">How long the device was silent before the download was abandoned.</param>
+    public SdCardDownloadStalledException(string fileName, TimeSpan stallTimeout)
+        : base($"The device sent no data for '{fileName}' for {stallTimeout.TotalSeconds:N0} seconds, " +
+               "so the download was abandoned.")
+    {
+        FileName = fileName;
+        StallTimeout = stallTimeout;
+    }
+
+    /// <summary>The SD card file whose transfer stalled.</summary>
+    public string FileName { get; }
+
+    /// <summary>How long the device was silent before the download was abandoned.</summary>
+    public TimeSpan StallTimeout { get; }
+}

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -11,15 +11,63 @@ using ChannelType = Daqifi.Core.Channel.ChannelType;
 
 namespace Daqifi.Desktop.Loggers;
 
-public class SdCardSessionImporter
+/// <summary>
+/// Imports SD card log files into the local logging database. Extracted as an interface so the
+/// ViewModels that drive an import can be unit-tested against a device that fails.
+/// </summary>
+public interface ISdCardSessionImporter
+{
+    /// <summary>
+    /// Downloads an SD card log file from a connected USB device and imports it.
+    /// </summary>
+    /// <exception cref="TimeoutException">
+    /// Thrown when the device stops sending data mid-transfer (see
+    /// <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>).
+    /// </exception>
+    Task<SdCardImportResult> ImportFromDeviceAsync(
+        IStreamingDevice device,
+        string fileName,
+        ImportOptions? options = null,
+        IProgress<ImportProgress>? progress = null,
+        CancellationToken ct = default);
+}
+
+public class SdCardSessionImporter : ISdCardSessionImporter
 {
     private const int BatchSize = 1000;
+
+    /// <summary>
+    /// How long the desktop waits for the device to deliver more of an SD card file before it
+    /// gives up. The deadline is reset on every chunk received, so this bounds a stall, not the
+    /// total transfer — a large file downloading steadily is never cut off.
+    ///
+    /// Deliberately longer than Core's own empty-transfer retry window (~50s observed): when the
+    /// SD subsystem is wedged, Core's typed <c>SdCardEmptyTransferException</c> carries a better
+    /// message than a bare timeout, so it must be allowed to win the race. This watchdog is the
+    /// backstop for the case Core cannot detect — a transfer that simply never completes, which
+    /// otherwise left the UI sitting on a busy overlay indefinitely (issue #754).
+    /// </summary>
+    internal static readonly TimeSpan DOWNLOAD_STALL_TIMEOUT = TimeSpan.FromSeconds(90);
+
     private readonly IDbContextFactory<LoggingContext> _loggingContext;
     private readonly AppLogger _logger = AppLogger.Instance;
+    private readonly TimeSpan _downloadStallTimeout;
 
     public SdCardSessionImporter(IDbContextFactory<LoggingContext> loggingContext)
+        : this(loggingContext, DOWNLOAD_STALL_TIMEOUT)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: constructs an importer with a shortened download stall timeout so the watchdog
+    /// can be exercised without a 90-second unit test.
+    /// </summary>
+    internal SdCardSessionImporter(
+        IDbContextFactory<LoggingContext> loggingContext,
+        TimeSpan downloadStallTimeout)
     {
         _loggingContext = loggingContext;
+        _downloadStallTimeout = downloadStallTimeout;
     }
 
     /// <summary>
@@ -51,9 +99,7 @@ public class SdCardSessionImporter
         return await ImportSessionAsync(logSession, options, progress, ct);
     }
 
-    /// <summary>
-    /// Downloads an SD card log file from a connected USB device and imports it.
-    /// </summary>
+    /// <inheritdoc />
     public async Task<SdCardImportResult> ImportFromDeviceAsync(
         IStreamingDevice device,
         string fileName,
@@ -65,12 +111,17 @@ public class SdCardSessionImporter
 
         _logger.Information($"Starting import of '{fileName}' from device {device.DeviceSerialNo}");
 
-        // Download to temp file
-        var downloadResult = await device.DownloadSdCardFileAsync(fileName, null, ct);
+        // Download to temp file, bounded by a stall watchdog. Core exposes no timeout on either
+        // public DownloadSdCardFileAsync overload (daqifi-core), so the desktop has to impose the
+        // bound itself or a silent device leaves the import hanging forever.
+        var downloadResult = await DownloadWithStallWatchdogAsync(device, fileName, ct);
 
         if (string.IsNullOrEmpty(downloadResult.FilePath))
         {
-            throw new InvalidOperationException($"Download completed but no local file path was returned for '{fileName}'.");
+            // The device answered but delivered nothing to disk — the same "SD subsystem is not
+            // ready" condition Core raises this exception for, so report it the same way rather
+            // than as a generic fault the user cannot act on.
+            throw new SdCardEmptyTransferException(fileName);
         }
 
         // Validate the downloaded file is in a temp directory
@@ -93,9 +144,11 @@ public class SdCardSessionImporter
 
             if (fileInfo.Length == 0)
             {
-                throw new InvalidOperationException(
-                    $"Downloaded file '{fileName}' is empty (0 bytes). " +
-                    "The SD card log file may not contain any data.");
+                // Issue #593 was this check firing as a bare InvalidOperationException, which the
+                // Error path then filed to Sentry. A file the device listed but served as 0 bytes
+                // is the wedged-SD-subsystem condition, not an app fault: same typed exception as
+                // the marker-only transfer Core detects, so it degrades the same way.
+                throw new SdCardEmptyTransferException(fileName);
             }
 
             // Parse using the original device filename (not the temp path)
@@ -148,6 +201,62 @@ public class SdCardSessionImporter
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Downloads <paramref name="fileName"/> while watching for a stalled transfer: the deadline
+    /// restarts every time the device delivers another chunk, so only a device that goes quiet
+    /// trips it.
+    /// </summary>
+    /// <exception cref="TimeoutException">
+    /// Thrown when no data arrives for <see cref="_downloadStallTimeout"/>. Callers surface this
+    /// as an expected device condition rather than an app error.
+    /// </exception>
+    internal async Task<SdCardDownloadResult> DownloadWithStallWatchdogAsync(
+        IStreamingDevice device,
+        string fileName,
+        CancellationToken ct)
+    {
+        using var stallCts = new CancellationTokenSource();
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, stallCts.Token);
+
+        stallCts.CancelAfter(_downloadStallTimeout);
+        var transferProgress = new SynchronousProgress<SdCardTransferProgress>(_ =>
+        {
+            // Another chunk arrived, so the device is alive — restart the deadline.
+            try
+            {
+                stallCts.CancelAfter(_downloadStallTimeout);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The download already finished and disposed the source; nothing left to extend.
+            }
+        });
+
+        try
+        {
+            return await device.DownloadSdCardFileAsync(fileName, transferProgress, linkedCts.Token);
+        }
+        catch (OperationCanceledException) when (stallCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            // Distinguish our watchdog from a caller-requested cancel: only the watchdog becomes a
+            // TimeoutException, so a genuine user cancel still propagates as OperationCanceledException.
+            throw new TimeoutException(
+                $"The device sent no data for '{fileName}' for " +
+                $"{_downloadStallTimeout.TotalSeconds:N0} seconds, so the download was abandoned.");
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IProgress{T}"/> that invokes its handler inline instead of posting to the
+    /// captured <see cref="SynchronizationContext"/> like <see cref="Progress{T}"/> does. The
+    /// stall watchdog must observe progress the moment it happens; a callback queued behind a
+    /// busy UI thread would let the deadline expire on a healthy transfer.
+    /// </summary>
+    private sealed class SynchronousProgress<T>(Action<T> handler) : IProgress<T>
+    {
+        public void Report(T value) => handler(value);
     }
 
     /// <summary>

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -32,6 +32,11 @@ public interface ISdCardSessionImporter
         CancellationToken ct = default);
 }
 
+/// <summary>
+/// Imports SD card log files — from a local path, a stream, or straight off a connected device —
+/// into the local logging database, mapping Daqifi.Core's parsed samples onto desktop entities and
+/// bulk-inserting them into SQLite.
+/// </summary>
 public class SdCardSessionImporter : ISdCardSessionImporter
 {
     private const int BatchSize = 1000;
@@ -53,6 +58,10 @@ public class SdCardSessionImporter : ISdCardSessionImporter
     private readonly AppLogger _logger = AppLogger.Instance;
     private readonly TimeSpan _downloadStallTimeout;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SdCardSessionImporter"/> class.
+    /// </summary>
+    /// <param name="loggingContext">Factory for the logging database imported samples are written to.</param>
     public SdCardSessionImporter(IDbContextFactory<LoggingContext> loggingContext)
         : this(loggingContext, DOWNLOAD_STALL_TIMEOUT)
     {
@@ -208,7 +217,7 @@ public class SdCardSessionImporter : ISdCardSessionImporter
     /// restarts every time the device delivers another chunk, so only a device that goes quiet
     /// trips it.
     /// </summary>
-    /// <exception cref="TimeoutException">
+    /// <exception cref="SdCardDownloadStalledException">
     /// Thrown when no data arrives for <see cref="_downloadStallTimeout"/>. Callers surface this
     /// as an expected device condition rather than an app error.
     /// </exception>
@@ -241,10 +250,8 @@ public class SdCardSessionImporter : ISdCardSessionImporter
         catch (OperationCanceledException) when (stallCts.IsCancellationRequested && !ct.IsCancellationRequested)
         {
             // Distinguish our watchdog from a caller-requested cancel: only the watchdog becomes a
-            // TimeoutException, so a genuine user cancel still propagates as OperationCanceledException.
-            throw new TimeoutException(
-                $"The device sent no data for '{fileName}' for " +
-                $"{_downloadStallTimeout.TotalSeconds:N0} seconds, so the download was abandoned.");
+            // stall, so a genuine user cancel still propagates as OperationCanceledException.
+            throw new SdCardDownloadStalledException(fileName, _downloadStallTimeout);
         }
     }
 

--- a/Daqifi.Desktop/View/DeviceLogsView.xaml
+++ b/Daqifi.Desktop/View/DeviceLogsView.xaml
@@ -309,7 +309,7 @@
                         </Style>
                     </TextBlock.Style>
                 </TextBlock>
-                <TextBlock Text="The card may be corrupt or busy. Try a different card or reformat (FAT32)."
+                <TextBlock Text="{Binding SdCardErrorGuidance}"
                            FontSize="13"
                            FontWeight="Light"
                            Foreground="{StaticResource TextPrimary}"

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -142,6 +142,10 @@ public partial class DeviceLogsViewModel : ObservableObject
         _ => string.Empty
     };
 
+    /// <summary>
+    /// Initializes the ViewModel against the application's own logger and logging database, and
+    /// begins tracking the connected-device list.
+    /// </summary>
     public DeviceLogsViewModel()
         : this(null, null)
     {
@@ -313,7 +317,11 @@ public partial class DeviceLogsViewModel : ObservableObject
     [RelayCommand]
     private async Task ImportFile(SdCardFile? file)
     {
-        if (file == null || SelectedDevice == null || !CanAccessSdCard) return;
+        // Snapshot the selection: an import runs for many seconds on a background thread, and the
+        // user can select another device or disconnect this one while it does. Re-reading
+        // SelectedDevice inside the lambda would download from whatever is selected by then.
+        var device = SelectedDevice;
+        if (file == null || device is not { ConnectionType: ConnectionType.Usb }) return;
 
         try
         {
@@ -328,7 +336,7 @@ public partial class DeviceLogsViewModel : ObservableObject
             });
 
             var result = await Task.Run(() =>
-                importer.ImportFromDeviceAsync(SelectedDevice, file.FileName, null, progress, CancellationToken.None));
+                importer.ImportFromDeviceAsync(device, file.FileName, null, progress, CancellationToken.None));
 
             AddImportedSession(result.Session);
 
@@ -347,7 +355,7 @@ public partial class DeviceLogsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            var failure = HandleImportFailure(ex, file.FileName);
+            var failure = HandleImportFailure(ex, file.FileName, device);
             await ShowMessage("Import Failed",
                 $"Could not import {file.FileName}.\n\n{failure.Guidance}",
                 MessageDialogStyle.Affirmative);
@@ -362,7 +370,9 @@ public partial class DeviceLogsViewModel : ObservableObject
     [RelayCommand]
     private async Task ImportAllFiles()
     {
-        if (SelectedDevice == null || !CanAccessSdCard || DeviceFiles == null || !DeviceFiles.Any()) return;
+        // Snapshot the selection once for the whole batch — see ImportFile.
+        var device = SelectedDevice;
+        if (device is not { ConnectionType: ConnectionType.Usb } || DeviceFiles == null || !DeviceFiles.Any()) return;
 
         var filesToImport = DeviceFiles.ToList();
         var successCount = 0;
@@ -390,7 +400,7 @@ public partial class DeviceLogsViewModel : ObservableObject
                     });
 
                     var result = await Task.Run(() =>
-                        importer.ImportFromDeviceAsync(SelectedDevice, file.FileName, null, progress, CancellationToken.None));
+                        importer.ImportFromDeviceAsync(device, file.FileName, null, progress, CancellationToken.None));
 
                     AddImportedSession(result.Session);
 
@@ -403,7 +413,7 @@ public partial class DeviceLogsViewModel : ObservableObject
                 }
                 catch (Exception ex)
                 {
-                    var failure = HandleImportFailure(ex, file.FileName);
+                    var failure = HandleImportFailure(ex, file.FileName, device);
                     failCount++;
 
                     if (failure.IsCardUnavailable)
@@ -484,20 +494,26 @@ public partial class DeviceLogsViewModel : ObservableObject
     /// Classifies a failed import, reflects it in the SD card status surface, and logs it at the
     /// severity the failure deserves.
     /// </summary>
+    /// <param name="ex">The exception the import failed with.</param>
+    /// <param name="fileName">The SD card file being imported.</param>
+    /// <param name="device">
+    /// The device the import ran against, captured when it started. The selection may have moved
+    /// on since, so the on-screen state is only updated while it is still the selected device.
+    /// </param>
     /// <returns>The classification, so the caller can build the user-facing message from it.</returns>
-    private SdCardFailure HandleImportFailure(Exception ex, string fileName)
+    private SdCardFailure HandleImportFailure(Exception ex, string fileName, IStreamingDevice device)
     {
         var failure = SdCardFailureClassifier.Classify(ex);
 
         // Only an expected device condition tells us anything about the card. An unexpected
         // failure (a defect in the import pipeline, a database error) must not blame the card and
         // hide a perfectly good file list behind an error panel.
-        if (failure.IsExpectedDeviceCondition)
+        if (failure.IsExpectedDeviceCondition && ReferenceEquals(SelectedDevice, device))
         {
             ApplyFailureState(failure);
         }
 
-        LogFailure(ex, failure, $"Error importing {fileName} from device {SelectedDevice?.DeviceSerialNo}");
+        LogFailure(ex, failure, $"Error importing {fileName} from device {device.DeviceSerialNo}");
         return failure;
     }
 

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -35,7 +35,13 @@ public enum SdCardState
 
 public partial class DeviceLogsViewModel : ObservableObject
 {
-    private readonly AppLogger _logger = AppLogger.Instance;
+    private readonly IAppLogger _logger;
+
+    /// <summary>
+    /// Importer injected by tests. <c>null</c> in production, where each import resolves a fresh
+    /// importer from the service provider (which is not available under unit test).
+    /// </summary>
+    private readonly ISdCardSessionImporter? _importerOverride;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -61,6 +67,14 @@ public partial class DeviceLogsViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(HasSdCardError))]
     [NotifyPropertyChangedFor(nameof(SdCardStatusLine))]
     private string _sdCardErrorMessage = string.Empty;
+
+    /// <summary>
+    /// The actionable sentence shown under the SD card error panel. Varies by failure — a wedged
+    /// SD subsystem needs a power cycle, a bad filesystem needs a reformat — so the view binds it
+    /// instead of hard-coding one piece of advice for every error.
+    /// </summary>
+    [ObservableProperty]
+    private string _sdCardErrorGuidance = SdCardFailureClassifier.GENERIC_CARD_GUIDANCE;
 
     private ObservableCollection<SdCardFile> _deviceFiles;
 
@@ -89,6 +103,13 @@ public partial class DeviceLogsViewModel : ObservableObject
     }
 
     public bool CanAccessSdCard => SelectedDevice?.ConnectionType == ConnectionType.Usb;
+
+    /// <summary>
+    /// The auto-refresh kicked off when a USB device is selected. Production code fires and
+    /// forgets it; tests await it so a late-landing refresh cannot overwrite the state they are
+    /// asserting on. <c>null</c> until a USB device has been selected.
+    /// </summary>
+    internal Task? InitialRefreshTask { get; private set; }
 
     /// <summary>True when the USB device has an OK SD card but no log files on it.</summary>
     public bool HasNoFiles => (DeviceFiles?.Any() != true) && CanAccessSdCard && SdCardState == SdCardState.Ok;
@@ -122,7 +143,20 @@ public partial class DeviceLogsViewModel : ObservableObject
     };
 
     public DeviceLogsViewModel()
+        : this(null, null)
     {
+    }
+
+    /// <summary>
+    /// Test seam: lets unit tests observe the log level a failure is reported at and drive the
+    /// import path without the <see cref="App.ServiceProvider"/> / <see cref="Application.Current"/>
+    /// singletons, neither of which exists under test.
+    /// </summary>
+    internal DeviceLogsViewModel(IAppLogger? logger, ISdCardSessionImporter? importer)
+    {
+        _logger = logger ?? AppLogger.Instance;
+        _importerOverride = importer;
+
         ConnectedDevices = new ObservableCollection<IStreamingDevice>();
         DeviceFiles = new ObservableCollection<SdCardFile>();
         DeviceFiles.CollectionChanged += OnDeviceFilesCollectionChanged;
@@ -181,7 +215,7 @@ public partial class DeviceLogsViewModel : ObservableObject
         {
             if (CanAccessSdCard)
             {
-                _ = RefreshFilesAsync();
+                InitialRefreshTask = RefreshFilesAsync();
             }
             else
             {
@@ -238,29 +272,13 @@ public partial class DeviceLogsViewModel : ObservableObject
 
             SdCardState = SdCardState.Ok;
         }
-        catch (SdCardNotPresentException ex)
-        {
-            SdCardState = SdCardState.NotPresent;
-            SdCardErrorMessage = string.Empty;
-            _logger.Warning($"SD card not present in device {device.DeviceSerialNo}: {ex.Message}");
-        }
-        catch (SdCardFilesystemException ex)
-        {
-            SdCardState = SdCardState.Error;
-            SdCardErrorMessage = ex.DeviceMessage ?? ex.Message;
-            _logger.Error(ex, "SD card filesystem error");
-        }
-        catch (SdCardOperationException ex)
-        {
-            SdCardState = SdCardState.Error;
-            SdCardErrorMessage = ex.LastScpiError ?? ex.Message;
-            _logger.Error(ex, "SD card operation error");
-        }
         catch (Exception ex)
         {
-            SdCardState = SdCardState.Error;
-            SdCardErrorMessage = ex.Message;
-            _logger.Error(ex, "Failed to refresh SD card files");
+            // Every refresh failure lands the card in a non-Ok state, including the unexpected
+            // ones: the file list on screen is stale either way.
+            var failure = SdCardFailureClassifier.Classify(ex);
+            ApplyFailureState(failure);
+            LogFailure(ex, failure, $"Failed to refresh SD card files on device {device.DeviceSerialNo}");
         }
         finally
         {
@@ -302,8 +320,7 @@ public partial class DeviceLogsViewModel : ObservableObject
             IsBusy = true;
             BusyMessage = $"Downloading {file.FileName}...";
 
-            var loggingContext = App.ServiceProvider.GetRequiredService<IDbContextFactory<LoggingContext>>();
-            var importer = new SdCardSessionImporter(loggingContext);
+            var importer = ResolveImporter();
 
             var progress = new Progress<ImportProgress>(p =>
             {
@@ -313,10 +330,7 @@ public partial class DeviceLogsViewModel : ObservableObject
             var result = await Task.Run(() =>
                 importer.ImportFromDeviceAsync(SelectedDevice, file.FileName, null, progress, CancellationToken.None));
 
-            Application.Current.Dispatcher.Invoke(() =>
-            {
-                LoggingManager.Instance.LoggingSessions.Add(result.Session);
-            });
+            AddImportedSession(result.Session);
 
             var message = $"Successfully imported {file.FileName}";
             var timestampWarning = result.TimestampQuality.BuildUserWarning();
@@ -333,9 +347,9 @@ public partial class DeviceLogsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            _logger.Error(ex, $"Error importing {file.FileName}");
+            var failure = HandleImportFailure(ex, file.FileName);
             await ShowMessage("Import Failed",
-                $"Failed to import {file.FileName}. Please check the device connection and try again.",
+                $"Could not import {file.FileName}.\n\n{failure.Guidance}",
                 MessageDialogStyle.Affirmative);
         }
         finally
@@ -355,12 +369,13 @@ public partial class DeviceLogsViewModel : ObservableObject
         var failCount = 0;
         var timestampWarningCount = 0;
 
+        SdCardFailure? abortingFailure = null;
+
         try
         {
             IsBusy = true;
 
-            var loggingContext = App.ServiceProvider.GetRequiredService<IDbContextFactory<LoggingContext>>();
-            var importer = new SdCardSessionImporter(loggingContext);
+            var importer = ResolveImporter();
 
             for (var i = 0; i < filesToImport.Count; i++)
             {
@@ -377,10 +392,7 @@ public partial class DeviceLogsViewModel : ObservableObject
                     var result = await Task.Run(() =>
                         importer.ImportFromDeviceAsync(SelectedDevice, file.FileName, null, progress, CancellationToken.None));
 
-                    Application.Current.Dispatcher.Invoke(() =>
-                    {
-                        LoggingManager.Instance.LoggingSessions.Add(result.Session);
-                    });
+                    AddImportedSession(result.Session);
 
                     if (result.TimestampQuality.HasDegenerateTimeAxis)
                     {
@@ -391,8 +403,16 @@ public partial class DeviceLogsViewModel : ObservableObject
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, $"Error importing {file.FileName}");
+                    var failure = HandleImportFailure(ex, file.FileName);
                     failCount++;
+
+                    if (failure.IsCardUnavailable)
+                    {
+                        // The card itself is gone or wedged: every remaining file would fail the
+                        // same way, each burning the same multi-second timeout. Stop here.
+                        abortingFailure = failure;
+                        break;
+                    }
                 }
             }
 
@@ -400,6 +420,11 @@ public partial class DeviceLogsViewModel : ObservableObject
             if (failCount > 0)
             {
                 message += $"\n{failCount} file(s) failed to import.";
+            }
+
+            if (abortingFailure != null)
+            {
+                message += $"\n\nImport stopped early: {abortingFailure.Guidance}";
             }
 
             if (timestampWarningCount > 0)
@@ -424,9 +449,93 @@ public partial class DeviceLogsViewModel : ObservableObject
         }
     }
 
-    private async Task ShowMessage(string title, string message, MessageDialogStyle dialogStyle)
+    /// <summary>
+    /// Resolves the importer to use: the injected test double when present, otherwise a fresh
+    /// importer over the application's logging database.
+    /// </summary>
+    private ISdCardSessionImporter ResolveImporter()
     {
-        var window = Application.Current.MainWindow as MetroWindow;
+        if (_importerOverride != null)
+        {
+            return _importerOverride;
+        }
+
+        var loggingContext = App.ServiceProvider.GetRequiredService<IDbContextFactory<LoggingContext>>();
+        return new SdCardSessionImporter(loggingContext);
+    }
+
+    /// <summary>
+    /// Publishes a freshly imported session to the session list on the UI thread.
+    /// </summary>
+    private static void AddImportedSession(LoggingSession session)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher != null && !dispatcher.CheckAccess())
+        {
+            dispatcher.Invoke(() => LoggingManager.Instance.LoggingSessions.Add(session));
+        }
+        else
+        {
+            LoggingManager.Instance.LoggingSessions.Add(session);
+        }
+    }
+
+    /// <summary>
+    /// Classifies a failed import, reflects it in the SD card status surface, and logs it at the
+    /// severity the failure deserves.
+    /// </summary>
+    /// <returns>The classification, so the caller can build the user-facing message from it.</returns>
+    private SdCardFailure HandleImportFailure(Exception ex, string fileName)
+    {
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Only an expected device condition tells us anything about the card. An unexpected
+        // failure (a defect in the import pipeline, a database error) must not blame the card and
+        // hide a perfectly good file list behind an error panel.
+        if (failure.IsExpectedDeviceCondition)
+        {
+            ApplyFailureState(failure);
+        }
+
+        LogFailure(ex, failure, $"Error importing {fileName} from device {SelectedDevice?.DeviceSerialNo}");
+        return failure;
+    }
+
+    /// <summary>
+    /// Reflects a classified failure in the properties the SD card panel and status line bind to.
+    /// </summary>
+    private void ApplyFailureState(SdCardFailure failure)
+    {
+        SdCardState = failure.State;
+        SdCardErrorMessage = failure.StatusMessage;
+        SdCardErrorGuidance = failure.Guidance;
+    }
+
+    /// <summary>
+    /// Logs a classified failure: Warning (local log only) for expected device conditions, Error
+    /// (captured to Sentry) for everything else. Keeping expected conditions off the Error path is
+    /// what stopped a wedged SD card from filing issues like #754.
+    /// </summary>
+    private void LogFailure(Exception ex, SdCardFailure failure, string context)
+    {
+        if (failure.IsExpectedDeviceCondition)
+        {
+            _logger.Warning(ex, $"{context}: {failure.Guidance}");
+        }
+        else
+        {
+            _logger.Error(ex, context);
+        }
+    }
+
+    private static async Task ShowMessage(string title, string message, MessageDialogStyle dialogStyle)
+    {
+        // Null under unit test (no WPF Application) — and there is no user to show a dialog to.
+        if (Application.Current?.MainWindow is not MetroWindow window)
+        {
+            return;
+        }
+
         await window.ShowMessageAsync(title, message, dialogStyle);
     }
 }

--- a/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
+++ b/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
@@ -1,4 +1,5 @@
 using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.Loggers;
 
 namespace Daqifi.Desktop.ViewModels;
 
@@ -121,8 +122,10 @@ public static class SdCardFailureClassifier
                 IsCardUnavailable: false),
 
             // Raised by the desktop's own stall watchdog (see SdCardSessionImporter) when the
-            // device stops sending data mid-transfer without ever failing the request.
-            TimeoutException => new SdCardFailure(
+            // device stops sending data mid-transfer without ever failing the request. Matched by
+            // its specific type, not by TimeoutException: an unrelated timeout reaching here is
+            // not evidence that the SD subsystem is wedged, and must keep the Error path.
+            SdCardDownloadStalledException => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device stopped responding during the transfer.",
                 Guidance: POWER_CYCLE_GUIDANCE,

--- a/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
+++ b/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
@@ -1,0 +1,141 @@
+using Daqifi.Core.Device.SdCard;
+
+namespace Daqifi.Desktop.ViewModels;
+
+/// <summary>
+/// How an SD card operation failed, expressed in terms the UI can act on.
+/// </summary>
+/// <param name="State">
+/// The <see cref="SdCardState"/> the card should be shown in. Only applied when
+/// <paramref name="IsExpectedDeviceCondition"/> is <c>true</c> — an unexpected failure
+/// (an app bug) says nothing about the card, so the existing state is left alone.
+/// </param>
+/// <param name="StatusMessage">
+/// Terse description bound to <see cref="DeviceLogsViewModel.SdCardErrorMessage"/> (status line
+/// and error panel). Empty when the state itself already says everything, as for a missing card.
+/// </param>
+/// <param name="Guidance">
+/// The actionable sentence shown to the user: what they should do about it.
+/// </param>
+/// <param name="IsExpectedDeviceCondition">
+/// <c>true</c> for device/environmental conditions the desktop cannot prevent (no card, wedged SD
+/// subsystem, filesystem error). These are logged at Warning so they do not raise Sentry issues;
+/// anything else is a genuine defect and keeps the Error path.
+/// </param>
+/// <param name="IsCardUnavailable">
+/// <c>true</c> when the SD subsystem — not just this one file — is unusable, so further file
+/// operations against the same device would fail the same way. Batch imports stop early on these
+/// rather than retrying every remaining file through the same multi-second failure.
+/// </param>
+public sealed record SdCardFailure(
+    SdCardState State,
+    string StatusMessage,
+    string Guidance,
+    bool IsExpectedDeviceCondition,
+    bool IsCardUnavailable);
+
+/// <summary>
+/// Maps exceptions raised by SD card operations onto the user-facing
+/// <see cref="SdCardState"/> surface, and decides whether a failure is an expected device
+/// condition (log at Warning, no Sentry issue) or a genuine defect (log at Error).
+///
+/// Daqifi.Core throws typed, already-actionable exceptions for the device conditions
+/// (<see cref="SdCardNotPresentException"/>, <see cref="SdCardEmptyTransferException"/>, …).
+/// Before issue #754 the desktop let those escape to the generic Error path, which filed a
+/// Sentry issue for what is really "power-cycle the device" — and told the user nothing.
+/// </summary>
+public static class SdCardFailureClassifier
+{
+    #region Constants
+    /// <summary>Guidance shown when the card is readable but its contents are not.</summary>
+    internal const string GENERIC_CARD_GUIDANCE =
+        "The card may be corrupt or busy. Try a different card or reformat (FAT32).";
+
+    /// <summary>
+    /// Guidance for the wedged-SD-subsystem family. The device answers SCPI and lists files but
+    /// serves no data; only a power cycle clears it (firmware issue daqifi-nyquist-firmware#567).
+    /// </summary>
+    internal const string POWER_CYCLE_GUIDANCE =
+        "The device's SD card subsystem is not responding. Power-cycle the device and try again.";
+
+    /// <summary>Guidance for a device with no card in the slot.</summary>
+    internal const string NO_CARD_GUIDANCE =
+        "No SD card is installed in the device. Insert a card and refresh.";
+
+    /// <summary>Guidance for a failure the desktop could not attribute to the card.</summary>
+    internal const string UNEXPECTED_FAILURE_GUIDANCE =
+        "Please check the device connection and try again.";
+    #endregion
+
+    #region Public Methods
+    /// <summary>
+    /// Classifies an exception thrown by an SD card refresh, download, or import.
+    /// </summary>
+    /// <param name="ex">The exception to classify. Never null.</param>
+    /// <returns>The UI-facing description of the failure.</returns>
+    public static SdCardFailure Classify(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        return ex switch
+        {
+            SdCardNotPresentException => new SdCardFailure(
+                State: SdCardState.NotPresent,
+                // The NotPresent panel is self-explanatory, so it carries no secondary message.
+                StatusMessage: string.Empty,
+                Guidance: NO_CARD_GUIDANCE,
+                IsExpectedDeviceCondition: true,
+                IsCardUnavailable: true),
+
+            // The device opened the file and closed it again without sending a byte. Core only
+            // throws this after exhausting its own retries, so by the time it reaches us the SD
+            // subsystem is wedged rather than merely slow.
+            SdCardEmptyTransferException => new SdCardFailure(
+                State: SdCardState.Error,
+                StatusMessage: "The device returned no data for this file.",
+                Guidance: POWER_CYCLE_GUIDANCE,
+                IsExpectedDeviceCondition: true,
+                IsCardUnavailable: true),
+
+            SdCardBusyException => new SdCardFailure(
+                State: SdCardState.Error,
+                StatusMessage: "The device's SD card is busy.",
+                Guidance: "The device is still using the SD card. Stop logging, wait a moment, and try again.",
+                IsExpectedDeviceCondition: true,
+                IsCardUnavailable: true),
+
+            SdCardFilesystemException filesystem => new SdCardFailure(
+                State: SdCardState.Error,
+                StatusMessage: filesystem.DeviceMessage ?? filesystem.Message,
+                Guidance: GENERIC_CARD_GUIDANCE,
+                IsExpectedDeviceCondition: true,
+                IsCardUnavailable: true),
+
+            SdCardOperationException operation => new SdCardFailure(
+                State: SdCardState.Error,
+                StatusMessage: operation.LastScpiError ?? operation.Message,
+                Guidance: GENERIC_CARD_GUIDANCE,
+                IsExpectedDeviceCondition: true,
+                // A rejected SCPI command can be specific to one file, so the rest of the card
+                // is still worth trying.
+                IsCardUnavailable: false),
+
+            // Raised by the desktop's own stall watchdog (see SdCardSessionImporter) when the
+            // device stops sending data mid-transfer without ever failing the request.
+            TimeoutException => new SdCardFailure(
+                State: SdCardState.Error,
+                StatusMessage: "The device stopped responding during the transfer.",
+                Guidance: POWER_CYCLE_GUIDANCE,
+                IsExpectedDeviceCondition: true,
+                IsCardUnavailable: true),
+
+            _ => new SdCardFailure(
+                State: SdCardState.Error,
+                StatusMessage: ex.Message,
+                Guidance: UNEXPECTED_FAILURE_GUIDANCE,
+                IsExpectedDeviceCondition: false,
+                IsCardUnavailable: false)
+        };
+    }
+    #endregion
+}


### PR DESCRIPTION
## Why

DAQiFi devices sometimes get into a state where the SD card subsystem stops serving data. The device still answers commands and still lists its log files, but any attempt to download one comes back empty. Only a power cycle clears it. The root cause is firmware (daqifi-nyquist-firmware#567) and is **not** what this PR fixes.

What this PR fixes is how badly the desktop handled it.

Importing a file from a device in that state did two bad things:

1. **The user got nothing useful.** The busy overlay sat there for the better part of a minute, then a dialog said "check the device connection and try again" — advice that does not help, for a problem that is not the connection.
2. **It filed a Sentry issue every time.** Daqifi.Core already throws a typed, actionable exception here, but the desktop let it fall through to the generic `catch` that logs at Error, and logging at Error captures to Sentry. So a device condition that no code change can prevent kept generating error reports.

Reproduced on the bench (Core 1.3.0, device `9090539562006014104`):

```
2026-07-25 12:51:37.3161 LEVEL=ERROR: Error importing log_20260623_143217.bin
 Daqifi.Core.Device.SdCard.SdCardEmptyTransferException: Received an empty (marker-only)
 transfer for SD card file 'log_20260623_143217.bin'. The device's SD subsystem may not be
 ready; retry or power-cycle the device.
```

Core's message is exactly what the user needed to be told. It just never reached them.

This closes both #754 (the Sentry issue from the run above) and #593, which is the same condition seen before Core had a typed exception for it — back then it surfaced as the importer's own `InvalidOperationException: Downloaded file ... is empty (0 bytes)`.

## What

**Expected device conditions are now told apart from bugs, and treated differently.**

A missing card, a wedged SD subsystem, a filesystem error, a stalled transfer — these are things the hardware does, not things the code got wrong. Anything else is a defect.

| | Expected device condition | Unrecognised failure |
|---|---|---|
| **Log level** | `Warning` — full stack trace still goes to the local log, nothing goes to Sentry | `Error` — still captured, so real defects still get reported |
| **Card state on screen** | Shown in the SD card panel with advice specific to that failure | Left alone — a bug in the import pipeline must not blame the card and hide a healthy file list |
| **Import-all** | Stops as soon as the *card* is unavailable, rather than retrying every remaining file through the same ~50s failure | Skips the one file, carries on |

**The advice on screen now matches the failure.** The error panel used to hard-code "The card may be corrupt or busy. Try a different card or reformat (FAT32)." That fits one failure out of several. A wedged subsystem now says "power-cycle the device"; a missing card says to insert one.

**A silent device can no longer hang the import.** Previously there was no bound at all on an SD download, which is how #754 produced a two-minute freeze with no error.

## How

**One classifier, three consumers.** `SdCardFailureClassifier.Classify(exception)` maps an exception onto a small record: which `SdCardState` to show, the terse status message, the actionable guidance sentence, whether it is an expected device condition, and whether the whole card is unavailable. `DeviceLogsViewModel` calls it from refresh, single import, and batch import, and drives log level, on-screen state, and batch continuation off the result. Adding a new SD failure mode means adding one `switch` arm, not touching three `catch` ladders.

**Warning vs. Error is the existing seam, not a new one.** `AppLogger.Warning(ex, message)` already exists specifically to log an exception locally *without* capturing to Sentry. This change just routes the right failures into it.

**The download is bounded on silence, not on elapsed time.** `SdCardSessionImporter` wraps the download in a watchdog whose deadline restarts on every chunk received. A device that goes quiet trips it; a large file downloading steadily never does. A plain wall-clock cap would have been simpler but would abort exactly the slow-but-healthy transfers it is meant to protect.

Two details worth knowing if you touch this:

- The stall timeout (90s) is deliberately **longer** than Core's own empty-transfer retry window (~50s observed). Core's typed exception carries a better message than a bare stall, so it must be allowed to win the race. The watchdog is the backstop for the case Core cannot detect — a transfer that simply never completes.
- The watchdog throws `SdCardDownloadStalledException`, which derives from `TimeoutException`. The classifier matches the specific type, not the base: an unrelated timeout reaching an SD catch block is not evidence the card is wedged, and must keep the Error path.

This is desktop-side because neither public `DaqifiStreamingDevice.DownloadSdCardFileAsync` overload exposes the timeout its underlying `SdCardFileReceiver.ReceiveAsync` already accepts. If Core exposes it, this watchdog can go away.

Closes #754
Closes #593

## Testing

Fast gate green: **686 passed, 0 failed** — `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`.

22 new tests covering classification, the ViewModel's Warning-not-Error behaviour under each mocked device condition, batch early-abort vs. carry-on, the device snapshot across a mid-import selection change, and the watchdog — including the two guards that matter most:

- an **unrecognised** exception still logs at Error and still reaches Sentry, so this change cannot silence real bugs;
- a **steadily-progressing** download is not cut off, so the watchdog cannot turn into a wall-clock cap.

No hardware run: the bench device was power-cycled mid-investigation and reads fine now, and this change is exercised entirely through mocks.

## Follow-up, not in this PR

`AbstractStreamingDevice.StartSdCardLogging` still calls Core's compatibility `StartSdCardLoggingAsync`. Core 1.3.0's `StartSdCardLoggingSessionAsync` returns the effective on-card filename (daqifi-core#336), which would let the UI-test harness stop guessing which file a run produced by set-differencing the directory listing. That touches `IStreamingDevice` and the FlaUI harness and wants a hardware run, so it belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
