### PR TITLE
chore(connection): match duplicate devices with Core's DeviceIdentity

### DIFF
--- a/Daqifi.Desktop.Test/Device/DuplicateDeviceDetectionTests.cs
+++ b/Daqifi.Desktop.Test/Device/DuplicateDeviceDetectionTests.cs
@@ -20,8 +20,10 @@ public class DuplicateDeviceDetectionTests
         _mockDevice1 = new Mock<IStreamingDevice>();
         _mockDevice2 = new Mock<IStreamingDevice>();
         
-        // Clear any existing devices to ensure clean test state
+        // Clear any existing devices and handler to ensure clean test state — ConnectionManager is a
+        // singleton, so state set by one test would otherwise leak into the next.
         _connectionManager.ConnectedDevices.Clear();
+        _connectionManager.DuplicateDeviceHandler = null;
     }
     #endregion
 
@@ -121,6 +123,92 @@ public class DuplicateDeviceDetectionTests
         // Assert
         Assert.IsTrue(handlerCalled, "Duplicate device handler should be called");
         Assert.AreEqual(1, _connectionManager.ConnectedDevices.Count, "Should keep existing device");
+    }
+    #endregion
+
+    #region Identity Fallback Tests
+    /// <summary>
+    /// The WiFi path knows a device's MAC address before its serial number arrives with the first
+    /// status message, so a blank serial number must fall back to the MAC address (issue #752). The
+    /// previous serial-only comparison could not detect this case at all.
+    /// </summary>
+    [TestMethod]
+    public async Task Connect_WithBlankSerialNumberAndMatchingMacAddress_ShouldSetAlreadyConnectedStatus()
+    {
+        // Arrange
+        _mockDevice1.Setup(d => d.DeviceSerialNo).Returns(string.Empty);
+        _mockDevice1.Setup(d => d.MacAddress).Returns("AA-BB-CC-DD-EE-FF");
+        _mockDevice1.Setup(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        _mockDevice1.Setup(d => d.Connect()).Returns(true);
+
+        // Same unit, MAC reported in the other common separator style.
+        _mockDevice2.Setup(d => d.DeviceSerialNo).Returns(string.Empty);
+        _mockDevice2.Setup(d => d.MacAddress).Returns("aa:bb:cc:dd:ee:ff");
+        _mockDevice2.Setup(d => d.ConnectionType).Returns(ConnectionType.Wifi);
+        _mockDevice2.Setup(d => d.Connect()).Returns(true);
+
+        await _connectionManager.Connect(_mockDevice1.Object);
+
+        // Act
+        await _connectionManager.Connect(_mockDevice2.Object);
+
+        // Assert
+        Assert.AreEqual(DAQiFiConnectionStatus.AlreadyConnected, _connectionManager.ConnectionStatus);
+        Assert.AreEqual(1, _connectionManager.ConnectedDevices.Count, "Should only have one device connected");
+    }
+
+    /// <summary>
+    /// A serial mismatch is decisive: two units that differ by serial number are never the same
+    /// device, so a weaker discriminator can never re-merge them.
+    /// </summary>
+    [TestMethod]
+    public async Task Connect_WithDifferentSerialNumbersAndMatchingMacAddress_ShouldConnectBothDevices()
+    {
+        // Arrange
+        _mockDevice1.Setup(d => d.DeviceSerialNo).Returns("DAQ-12345");
+        _mockDevice1.Setup(d => d.MacAddress).Returns("AA-BB-CC-DD-EE-FF");
+        _mockDevice1.Setup(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        _mockDevice1.Setup(d => d.Connect()).Returns(true);
+
+        _mockDevice2.Setup(d => d.DeviceSerialNo).Returns("DAQ-67890");
+        _mockDevice2.Setup(d => d.MacAddress).Returns("AA-BB-CC-DD-EE-FF");
+        _mockDevice2.Setup(d => d.ConnectionType).Returns(ConnectionType.Wifi);
+        _mockDevice2.Setup(d => d.Connect()).Returns(true);
+
+        // Act
+        await _connectionManager.Connect(_mockDevice1.Object);
+        await _connectionManager.Connect(_mockDevice2.Object);
+
+        // Assert
+        Assert.AreEqual(DAQiFiConnectionStatus.Connected, _connectionManager.ConnectionStatus);
+        Assert.AreEqual(2, _connectionManager.ConnectedDevices.Count, "Should have both devices connected");
+    }
+
+    /// <summary>
+    /// Two devices that report no discriminator at all must never match each other — the guarantee
+    /// the previous blank-serial skip provided, kept by <c>DeviceIdentity</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task Connect_WithNoIdentityDiscriminators_ShouldConnectBothDevices()
+    {
+        // Arrange
+        _mockDevice1.Setup(d => d.DeviceSerialNo).Returns(string.Empty);
+        _mockDevice1.Setup(d => d.MacAddress).Returns(string.Empty);
+        _mockDevice1.Setup(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        _mockDevice1.Setup(d => d.Connect()).Returns(true);
+
+        _mockDevice2.Setup(d => d.DeviceSerialNo).Returns(string.Empty);
+        _mockDevice2.Setup(d => d.MacAddress).Returns(string.Empty);
+        _mockDevice2.Setup(d => d.ConnectionType).Returns(ConnectionType.Usb);
+        _mockDevice2.Setup(d => d.Connect()).Returns(true);
+
+        // Act
+        await _connectionManager.Connect(_mockDevice1.Object);
+        await _connectionManager.Connect(_mockDevice2.Object);
+
+        // Assert
+        Assert.AreEqual(DAQiFiConnectionStatus.Connected, _connectionManager.ConnectionStatus);
+        Assert.AreEqual(2, _connectionManager.ConnectedDevices.Count, "Unidentifiable devices should never match each other");
     }
     #endregion
 }

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -481,7 +481,8 @@ public partial class ConnectionManager : ObservableObject
         // With no discriminator at all there is nothing to compare against, so duplicates are undetectable.
         if (candidateIdentity.IsEmpty)
         {
-            AppLogger.Instance.Information($"Device {newDevice.Name} has no serial number or MAC address - cannot check for duplicates");
+            AppLogger.Instance.Information(
+                $"Device {newDevice.Name} has no serial number or MAC address - cannot check for duplicates");
             return new DuplicateDeviceCheckResult { IsDuplicate = false };
         }
 
@@ -493,7 +494,9 @@ public partial class ConnectionManager : ObservableObject
             var newDeviceInterface = newDevice.ConnectionType == ConnectionType.Usb ? "USB" : "WiFi";
             var existingDeviceInterface = existingDevice.ConnectionType == ConnectionType.Usb ? "USB" : "WiFi";
             
-            AppLogger.Instance.Information($"Duplicate device detected ({candidateIdentity}): Device already connected via {existingDeviceInterface}, attempted to add via {newDeviceInterface}");
+            AppLogger.Instance.Information(
+                $"Duplicate device detected ({candidateIdentity}): Device already connected via " +
+                $"{existingDeviceInterface}, attempted to add via {newDeviceInterface}");
             
             return new DuplicateDeviceCheckResult 
             { 

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.IO.Ports;
 using System.Management;
 using CommunityToolkit.Mvvm.ComponentModel;
+using DeviceIdentity = Daqifi.Core.Device.DeviceIdentity;
 
 namespace Daqifi.Desktop;
 
@@ -43,7 +44,7 @@ public partial class ConnectionManager : ObservableObject
     /// Callback for handling duplicate device situations.
     /// Should return the user's choice on how to handle the duplicate.
     /// </summary>
-    public Func<DuplicateDeviceCheckResult, DuplicateDeviceAction> DuplicateDeviceHandler { get; set; }
+    public Func<DuplicateDeviceCheckResult, DuplicateDeviceAction>? DuplicateDeviceHandler { get; set; }
 
     /// <summary>
     /// Tracks the device currently undergoing firmware update. Non-null for the whole update (PIC32 +
@@ -459,30 +460,40 @@ public partial class ConnectionManager : ObservableObject
     }
 
     /// <summary>
-    /// Checks if a device is already connected by comparing serial numbers.
+    /// Checks whether <paramref name="newDevice"/> is the same physical unit as one already in
+    /// <see cref="ConnectedDevices"/>, so the same device reached over USB and over WiFi is not
+    /// connected twice.
     /// </summary>
+    /// <remarks>
+    /// Matching is delegated to Core's transport-independent <see cref="DeviceIdentity"/> (issue #752),
+    /// which compares the serial number first and falls back to the MAC address when the serial number
+    /// is blank — the WiFi path knows a device's MAC before its serial number arrives with the first
+    /// status message, a case the previous serial-only comparison could not detect at all. A serial
+    /// mismatch is decisive, so a weaker discriminator can never merge two genuinely different units,
+    /// and devices carrying no discriminator at all still never match each other.
+    /// </remarks>
     /// <param name="newDevice">The device to check for duplicates</param>
     /// <returns>A result indicating if the device is a duplicate and which existing device it matches</returns>
     private DuplicateDeviceCheckResult CheckForDuplicateDevice(IStreamingDevice newDevice)
     {
-        // If device doesn't have a serial number, we can't check for duplicates reliably
-        if (string.IsNullOrWhiteSpace(newDevice.DeviceSerialNo))
+        var candidateIdentity = DeviceIdentity.Create(newDevice.DeviceSerialNo, newDevice.MacAddress);
+
+        // With no discriminator at all there is nothing to compare against, so duplicates are undetectable.
+        if (candidateIdentity.IsEmpty)
         {
-            AppLogger.Instance.Information($"Device {newDevice.Name} has no serial number - cannot check for duplicates");
+            AppLogger.Instance.Information($"Device {newDevice.Name} has no serial number or MAC address - cannot check for duplicates");
             return new DuplicateDeviceCheckResult { IsDuplicate = false };
         }
 
-        // Check if any existing device has the same serial number
-        var existingDevice = ConnectedDevices.FirstOrDefault(d => 
-            !string.IsNullOrWhiteSpace(d.DeviceSerialNo) && 
-            d.DeviceSerialNo.Equals(newDevice.DeviceSerialNo, StringComparison.OrdinalIgnoreCase));
+        var existingDevice = ConnectedDevices.FirstOrDefault(d =>
+            DeviceIdentity.Create(d.DeviceSerialNo, d.MacAddress).Matches(candidateIdentity));
 
         if (existingDevice != null)
         {
             var newDeviceInterface = newDevice.ConnectionType == ConnectionType.Usb ? "USB" : "WiFi";
             var existingDeviceInterface = existingDevice.ConnectionType == ConnectionType.Usb ? "USB" : "WiFi";
             
-            AppLogger.Instance.Information($"Duplicate device detected: Device already connected via {existingDeviceInterface}, attempted to add via {newDeviceInterface}");
+            AppLogger.Instance.Information($"Duplicate device detected ({candidateIdentity}): Device already connected via {existingDeviceInterface}, attempted to add via {newDeviceInterface}");
             
             return new DuplicateDeviceCheckResult 
             { 


### PR DESCRIPTION
Stage 1 of #752: `ConnectionManager.CheckForDuplicateDevice` now matches with Core's transport-independent `DeviceIdentity` instead of its own serial-only comparison. Core ported this app's implementation as its reference and then extended it, so this is a straight adoption of the superset.

Stages 2 and 3 of the issue stay open with their blockers — see below.

## What changes

| | Before | After |
|---|---|---|
| Blank serial number | Duplicate check skipped entirely | Falls back to MAC address |
| MAC separators | n/a | `AA-BB-CC-DD-EE-FF` == `aa:bb:cc:dd:ee:ff` |
| Serial mismatch | Not a duplicate | Still not a duplicate — decisive, so a weaker discriminator can never re-merge two different units |
| No discriminator at all | Never matches | Never matches (guarantee kept) |

The blank-serial case is the real bug fix: the WiFi path knows a device's MAC before its serial number arrives with the first status message, so **the same physical unit reached over USB and over WiFi could previously be connected twice**.

`DuplicateDeviceCheckResult` and `DuplicateDeviceAction` are unchanged — they carry the `"USB"`/`"WiFi"` display strings the connection dialog renders, and `ConnectionDialogViewModel` still wires `HandleDuplicateDevice` into them.

Two small things came along with it:

- `DuplicateDeviceHandler` is now declared nullable, matching the null check that was already there and letting tests reset it.
- The duplicate-detected log line now includes the identity's diagnostic string, so support logs show *which* discriminator matched.

## Testing

`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` — 668 passed, 0 failed.

The four existing `DuplicateDeviceDetectionTests` pass **unchanged** (Core ported these cases, so behavior must not drift). Three added:

- blank serial + matching MAC in different separator styles → duplicate detected (this fails against the old implementation)
- different serials + identical MAC → both connect, serial mismatch is decisive
- two devices with no discriminator at all → both connect, unidentifiable devices never match each other

`Setup` now also resets the singleton's `DuplicateDeviceHandler` so handler state cannot leak between tests.

## Not in this PR

- **Stage 2** — swapping `ConnectedDevices` for `DaqifiDeviceRegistry`. Blocked: the registry is typed on Core's `DaqifiDevice`, while `AbstractStreamingDevice` *wraps* a Core device rather than extending one, so registering the inner device would require exactly the side-map the registry exists to delete. Unblocks on daqifi-core#333 or a registry typed on an interface.
- **Stage 3** — deleting the `Win32_DeviceChangeEvent` WMI watcher. Blocked on daqifi-core#382; Core cannot report a serial unplug today because `SerialStreamTransport.IsConnected` is the OS handle's `IsOpen`, which stays true after the cable is pulled.

Aggregate `ConnectionStatus`, `LastDisconnectReason`/`NotifyConnection`, the `LoggingManager.Unsubscribe` teardown, `DeviceBeingUpdated` suppression, and `AppLogger` device context all remain app-level policy with no Core equivalent, as recorded in #708.

Refs #752 (Stages 2 and 3 keep it open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
