### PR TITLE
fix(summary): report the real per-channel Min/Max/Average

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
@@ -29,7 +29,10 @@ public class SummaryLoggerTests
     /// Feeds one stream frame: the frame's device message followed by its channel samples,
     /// matching the production dispatch order described on the class.
     /// </summary>
-    private static void PumpFrame(SummaryLogger logger, long timestampTicks, params (string Channel, double Value)[] samples)
+    private static void PumpFrame(
+        SummaryLogger logger,
+        long timestampTicks,
+        params (string Channel, double Value)[] samples)
     {
         logger.Log(new DeviceMessage
         {
@@ -72,6 +75,32 @@ public class SummaryLoggerTests
         {
             PumpFrame(logger, ticks);
             ticks += 10_000;
+        }
+    }
+
+    /// <summary>
+    /// Feeds one complete window for a single channel whose samples are spaced by
+    /// <paramref name="intervalTicks"/>, then pads the window out to <c>SampleSize</c> device
+    /// messages so it swaps in. A run of N intervals produces N + 1 samples on the channel, and the
+    /// padding frames carry no samples, so they add no intervals of their own.
+    /// </summary>
+    private static void PumpIntervalWindow(SummaryLogger logger, string channelName, params long[] intervalTicks)
+    {
+        var ticks = 1_000_000L;
+        PumpFrame(logger, ticks, (channelName, 1.0));
+
+        var frames = 1;
+        foreach (var interval in intervalTicks)
+        {
+            ticks += interval;
+            PumpFrame(logger, ticks, (channelName, 1.0));
+            frames++;
+        }
+
+        for (; frames < logger.SampleSize; frames++)
+        {
+            ticks += 10_000;
+            PumpFrame(logger, ticks);
         }
     }
 
@@ -178,6 +207,44 @@ public class SummaryLoggerTests
             SummaryFor(large, "AI0").AverageValue,
             1e-9,
             "The reported mean must not scale with SampleSize.");
+    }
+
+    [TestMethod]
+    public void Log_AverageDelta_IsMeanOfTheChannelsOwnIntervals()
+    {
+        // Arrange: four samples on one channel, spaced unevenly, so the three intervals average
+        // 20,000 ticks. Dividing their sum by (SampleSize - 1) = 4 instead reports 15,000 — the
+        // same message-window-vs-per-channel-count mismatch that skewed AverageValue.
+        var logger = new SummaryLogger(sampleSize: 5);
+
+        // Act
+        PumpIntervalWindow(logger, "AI0", 10_000, 30_000, 20_000);
+
+        // Assert
+        var summary = SummaryFor(logger, "AI0");
+        Assert.AreEqual(4, summary.SampleCount, "The completed window should hold four samples.");
+        Assert.AreEqual(20_000.0, summary.AverageDelta, 1e-9,
+            "AverageDelta must be the mean of the intervals between the channel's own samples.");
+    }
+
+    [TestMethod]
+    public void Log_AverageDelta_IsIndependentOfSampleSize()
+    {
+        // Arrange: identical sample spacing read back through two window sizes. How many device
+        // messages bound the window cannot change how far apart a channel's samples were.
+        var small = new SummaryLogger(sampleSize: 5);
+        var large = new SummaryLogger(sampleSize: 16);
+
+        // Act
+        PumpIntervalWindow(small, "AI0", 10_000, 30_000, 20_000);
+        PumpIntervalWindow(large, "AI0", 10_000, 30_000, 20_000);
+
+        // Assert
+        Assert.AreEqual(
+            SummaryFor(small, "AI0").AverageDelta,
+            SummaryFor(large, "AI0").AverageDelta,
+            1e-9,
+            "The reported mean interval must not scale with SampleSize.");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
@@ -61,9 +61,14 @@ public class SummaryLoggerTests
     /// Feeds one complete window: <paramref name="values"/> for a single channel, then enough
     /// sample-less frames to take the window's device-message count up to <c>SampleSize</c>,
     /// which is what swaps the window in and makes it readable through <c>Channels</c>.
+    /// <para>
+    /// Requires <c>values.Length &lt; SampleSize</c> — see <see cref="AssertWindowHasRoomToSwap"/>.
+    /// </para>
     /// </summary>
     private static void PumpWindow(SummaryLogger logger, string channelName, params double[] values)
     {
+        AssertWindowHasRoomToSwap(logger, values.Length);
+
         var ticks = 1_000_000L;
         foreach (var value in values)
         {
@@ -83,9 +88,15 @@ public class SummaryLoggerTests
     /// <paramref name="intervalTicks"/>, then pads the window out to <c>SampleSize</c> device
     /// messages so it swaps in. A run of N intervals produces N + 1 samples on the channel, and the
     /// padding frames carry no samples, so they add no intervals of their own.
+    /// <para>
+    /// Requires <c>intervalTicks.Length + 1 &lt; SampleSize</c> — see
+    /// <see cref="AssertWindowHasRoomToSwap"/>.
+    /// </para>
     /// </summary>
     private static void PumpIntervalWindow(SummaryLogger logger, string channelName, params long[] intervalTicks)
     {
+        AssertWindowHasRoomToSwap(logger, intervalTicks.Length + 1);
+
         var ticks = 1_000_000L;
         PumpFrame(logger, ticks, (channelName, 1.0));
 
@@ -102,6 +113,28 @@ public class SummaryLoggerTests
             ticks += 10_000;
             PumpFrame(logger, ticks);
         }
+    }
+
+    /// <summary>
+    /// Guards the precondition both window helpers depend on: a window must have at least one
+    /// sample-less frame left after its last sample-bearing frame.
+    /// <para>
+    /// The <c>SampleSize</c>-th device message swaps the window in, and it does so <i>before</i>
+    /// that same frame's samples are logged. So a helper asked for <c>SampleSize</c> or more
+    /// sample-bearing frames would swap in a window that silently omits its final sample — and its
+    /// final interval — leaving the caller asserting against data it did not intend. Failing loudly
+    /// here is the point: the helpers deliberately do not paper over it by stretching the window,
+    /// because a test's window size is part of what it is asserting.
+    /// </para>
+    /// </summary>
+    private static void AssertWindowHasRoomToSwap(SummaryLogger logger, int sampleBearingFrames)
+    {
+        Assert.IsTrue(
+            sampleBearingFrames < logger.SampleSize,
+            $"Test-helper misuse: {sampleBearingFrames} sample-bearing frames were requested for a "
+            + $"window of SampleSize {logger.SampleSize}. The SampleSize-th device message swaps the "
+            + "window before its own samples are logged, so the swapped-in window would be missing "
+            + "its last sample. Use a larger SampleSize or fewer samples.");
     }
 
     private static SummaryLogger.ChannelSummary SummaryFor(SummaryLogger logger, string channelName)

--- a/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
@@ -23,7 +23,7 @@ namespace Daqifi.Desktop.Test.Loggers;
 [TestClass]
 public class SummaryLoggerTests
 {
-    private const string DeviceSerial = "SN-1";
+    private const string DEVICE_SERIAL = "SN-1";
 
     /// <summary>
     /// Feeds one stream frame: the frame's device message followed by its channel samples,
@@ -37,7 +37,7 @@ public class SummaryLoggerTests
         logger.Log(new DeviceMessage
         {
             DeviceName = "Nq1",
-            DeviceSerialNo = DeviceSerial,
+            DeviceSerialNo = DEVICE_SERIAL,
             TimestampTicks = timestampTicks,
             AppTicks = timestampTicks
         });
@@ -47,7 +47,7 @@ public class SummaryLoggerTests
             logger.Log(new DataSample
             {
                 DeviceName = "Nq1",
-                DeviceSerialNo = DeviceSerial,
+                DeviceSerialNo = DEVICE_SERIAL,
                 ChannelName = channel,
                 Type = ChannelType.Analog,
                 Color = "#FF0000FF",

--- a/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs
@@ -1,0 +1,222 @@
+using System.Linq;
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Logger;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Unit coverage for <see cref="SummaryLogger"/>'s per-channel value statistics — the
+/// Min / Average / Max shown on the Summary flyout's "Value" row (issue #757).
+/// <para>
+/// The tests drive the logger in the same order production does: for each stream frame,
+/// <c>AbstractStreamingDevice.ProcessStreamMessage</c> dispatches the frame's
+/// <see cref="DeviceMessage"/> and Core then raises that frame's channel samples immediately
+/// afterwards, so the message is always logged before its samples. Because
+/// <see cref="SummaryLogger.Log(DeviceMessage)"/> is what swaps the completed window into the
+/// buffer <c>Channels</c> reads from, a window of N per-channel samples takes N+1 frames: the
+/// (N+1)-th message triggers the swap before its own samples are logged, and those samples
+/// start the next window.
+/// </para>
+/// </summary>
+[TestClass]
+public class SummaryLoggerTests
+{
+    private const string DeviceSerial = "SN-1";
+
+    /// <summary>
+    /// Feeds one stream frame: the frame's device message followed by its channel samples,
+    /// matching the production dispatch order described on the class.
+    /// </summary>
+    private static void PumpFrame(SummaryLogger logger, long timestampTicks, params (string Channel, double Value)[] samples)
+    {
+        logger.Log(new DeviceMessage
+        {
+            DeviceName = "Nq1",
+            DeviceSerialNo = DeviceSerial,
+            TimestampTicks = timestampTicks,
+            AppTicks = timestampTicks
+        });
+
+        foreach (var (channel, value) in samples)
+        {
+            logger.Log(new DataSample
+            {
+                DeviceName = "Nq1",
+                DeviceSerialNo = DeviceSerial,
+                ChannelName = channel,
+                Type = ChannelType.Analog,
+                Color = "#FF0000FF",
+                Value = value,
+                TimestampTicks = timestampTicks
+            });
+        }
+    }
+
+    /// <summary>
+    /// Feeds one complete window: <paramref name="values"/> for a single channel, then enough
+    /// sample-less frames to take the window's device-message count up to <c>SampleSize</c>,
+    /// which is what swaps the window in and makes it readable through <c>Channels</c>.
+    /// </summary>
+    private static void PumpWindow(SummaryLogger logger, string channelName, params double[] values)
+    {
+        var ticks = 1_000_000L;
+        foreach (var value in values)
+        {
+            PumpFrame(logger, ticks, (channelName, value));
+            ticks += 10_000;
+        }
+
+        for (var i = values.Length; i < logger.SampleSize; i++)
+        {
+            PumpFrame(logger, ticks);
+            ticks += 10_000;
+        }
+    }
+
+    private static SummaryLogger.ChannelSummary SummaryFor(SummaryLogger logger, string channelName)
+        => logger.Channels.Single(c => c.Name == channelName);
+
+    [TestMethod]
+    public void Log_PositiveOnlyChannel_ReportsSmallestSampleAsMinValue()
+    {
+        // Arrange: a window whose samples never reach zero. Every value is a valid minimum
+        // candidate, so an unseeded running minimum shows up as a hard 0.
+        var logger = new SummaryLogger(sampleSize: 4);
+
+        // Act
+        PumpWindow(logger, "AI0", 2.5, 4.0, 3.25);
+
+        // Assert
+        Assert.AreEqual(2.5, SummaryFor(logger, "AI0").MinValue, 1e-9,
+            "MinValue must be the smallest sample in the window, not the 0 the buffer starts at.");
+    }
+
+    [TestMethod]
+    public void Log_NegativeOnlyChannel_ReportsLargestSampleAsMaxValue()
+    {
+        // Arrange: the mirror case — every sample is below zero, so an unseeded running
+        // maximum stays pinned at 0.
+        var logger = new SummaryLogger(sampleSize: 4);
+
+        // Act
+        PumpWindow(logger, "AI0", -5.0, -1.5, -3.0);
+
+        // Assert
+        Assert.AreEqual(-1.5, SummaryFor(logger, "AI0").MaxValue, 1e-9,
+            "MaxValue must be the largest sample in the window, not the 0 the buffer starts at.");
+    }
+
+    [TestMethod]
+    public void Log_SingleSampleWindow_ReportsThatSampleAsBothMinAndMax()
+    {
+        // Arrange: with exactly one sample the seeding branch is the only one that runs, so
+        // this isolates it from the Math.Min/Math.Max accumulation path entirely.
+        var logger = new SummaryLogger(sampleSize: 2);
+
+        // Act
+        PumpWindow(logger, "AI0", 4.2);
+
+        // Assert
+        var summary = SummaryFor(logger, "AI0");
+        Assert.AreEqual(1, summary.SampleCount, "The completed window should hold exactly one sample.");
+        Assert.AreEqual(4.2, summary.MinValue, 1e-9, "A one-sample window's minimum is that sample.");
+        Assert.AreEqual(4.2, summary.MaxValue, 1e-9, "A one-sample window's maximum is that sample.");
+    }
+
+    [TestMethod]
+    public void Log_MinAndMax_SpanEverySampleIncludingTheFirst()
+    {
+        // Arrange: the extremes are deliberately placed on the first and last samples, so a
+        // window that skipped its first sample would report 3.0 as the minimum.
+        var logger = new SummaryLogger(sampleSize: 5);
+
+        // Act
+        PumpWindow(logger, "AI0", 1.0, 3.0, 5.0, 9.0);
+
+        // Assert
+        var summary = SummaryFor(logger, "AI0");
+        Assert.AreEqual(1.0, summary.MinValue, 1e-9, "The first sample must participate in the minimum.");
+        Assert.AreEqual(9.0, summary.MaxValue, 1e-9, "The last sample must participate in the maximum.");
+    }
+
+    [TestMethod]
+    public void Log_AverageValue_IsMeanOfTheSamplesTheChannelReceived()
+    {
+        // Arrange: SampleSize counts device messages, and a channel's window is swapped out one
+        // sample short of it, so an average divided by SampleSize reads low (here 9/4 = 2.25
+        // instead of 3.0).
+        var logger = new SummaryLogger(sampleSize: 4);
+
+        // Act
+        PumpWindow(logger, "AI0", 1.0, 2.0, 6.0);
+
+        // Assert
+        var summary = SummaryFor(logger, "AI0");
+        Assert.AreEqual(3, summary.SampleCount, "The completed window should hold three samples.");
+        Assert.AreEqual(3.0, summary.AverageValue, 1e-9,
+            "AverageValue must be the mean of the samples the channel actually received.");
+    }
+
+    [TestMethod]
+    public void Log_AverageValue_IsIndependentOfSampleSize()
+    {
+        // Arrange: the same three samples, read back through two different window sizes. The
+        // mean of a channel's samples cannot depend on how many device messages bound the
+        // window — SampleSize is a live, user-editable field on the flyout.
+        var small = new SummaryLogger(sampleSize: 4);
+        var large = new SummaryLogger(sampleSize: 16);
+
+        // Act
+        PumpWindow(small, "AI0", 1.0, 2.0, 6.0);
+        PumpWindow(large, "AI0", 1.0, 2.0, 6.0);
+
+        // Assert
+        Assert.AreEqual(
+            SummaryFor(small, "AI0").AverageValue,
+            SummaryFor(large, "AI0").AverageValue,
+            1e-9,
+            "The reported mean must not scale with SampleSize.");
+    }
+
+    [TestMethod]
+    public void Log_MultipleChannels_TrackMinAndMaxIndependently()
+    {
+        // Arrange: one all-positive channel and one all-negative channel in the same window —
+        // the two failure directions of an unseeded extreme, side by side.
+        var logger = new SummaryLogger(sampleSize: 3);
+        var ticks = 1_000_000L;
+
+        // Act
+        PumpFrame(logger, ticks, ("AI0", 2.0), ("AI1", -4.0));
+        PumpFrame(logger, ticks + 10_000, ("AI0", 3.0), ("AI1", -2.0));
+        PumpFrame(logger, ticks + 20_000);
+
+        // Assert
+        var analogZero = SummaryFor(logger, "AI0");
+        var analogOne = SummaryFor(logger, "AI1");
+        Assert.AreEqual(2.0, analogZero.MinValue, 1e-9, "AI0's minimum is its own smallest sample.");
+        Assert.AreEqual(3.0, analogZero.MaxValue, 1e-9, "AI0's maximum is its own largest sample.");
+        Assert.AreEqual(-4.0, analogOne.MinValue, 1e-9, "AI1's minimum is its own smallest sample.");
+        Assert.AreEqual(-2.0, analogOne.MaxValue, 1e-9, "AI1's maximum is its own largest sample.");
+    }
+
+    [TestMethod]
+    public void Log_SecondWindow_ReseedsMinAndMaxFromItsOwnFirstSample()
+    {
+        // Arrange: buffers are recycled across swaps (ChannelBuffer.Reset zeroes the extremes
+        // but the channel entry survives), so a later window must re-seed rather than inherit
+        // either the previous window's extremes or the reset 0.
+        var logger = new SummaryLogger(sampleSize: 3);
+
+        // Act
+        PumpWindow(logger, "AI0", 10.0, 11.0);
+        PumpWindow(logger, "AI0", 2.0, 3.0);
+
+        // Assert
+        var summary = SummaryFor(logger, "AI0");
+        Assert.AreEqual(2.0, summary.MinValue, 1e-9, "The second window's minimum comes from its own samples.");
+        Assert.AreEqual(3.0, summary.MaxValue, 1e-9, "The second window's maximum comes from its own samples.");
+    }
+}

--- a/Daqifi.Desktop/Loggers/SummaryLogger.cs
+++ b/Daqifi.Desktop/Loggers/SummaryLogger.cs
@@ -426,7 +426,15 @@ public partial class SummaryLogger : ObservableObject, ILogger
                     buffer.MinDeltaTicks = Math.Min(buffer.MinDeltaTicks, elapsed);
                     buffer.MaxDeltaTicks = Math.Max(buffer.MaxDeltaTicks, elapsed);
                 }
-                buffer.AverageDeltaTicks += elapsed / (double)(SampleSize - 1);
+                // Mean over the intervals this channel actually saw, for the same reason
+                // AverageValue above is: SampleSize bounds the window in device *messages*, so it
+                // is neither the channel's sample count nor its interval count. At the k-th
+                // interval SampleCount is exactly k, so this form self-seeds on the first interval,
+                // stays exact for every window length, and cannot divide by zero when SampleSize
+                // is 1. (The device-level accumulator below keeps (SampleSize - 1): that buffer
+                // does count messages, so a completed window really does hold SampleSize - 1
+                // intervals.)
+                buffer.AverageDeltaTicks += (elapsed - buffer.AverageDeltaTicks) / buffer.SampleCount;
             }
             buffer.LastSampleTicks = dataSample.TimestampTicks;
 

--- a/Daqifi.Desktop/Loggers/SummaryLogger.cs
+++ b/Daqifi.Desktop/Loggers/SummaryLogger.cs
@@ -68,17 +68,17 @@ public partial class SummaryLogger : ObservableObject, ILogger
         public double MinDelta => _current.MinDeltaTicks;
 
         /// <summary>
-        /// The maximum time between samples
+        /// The largest sample value seen on this channel
         /// </summary>
         public double MaxValue => _current.MaxValue;
 
         /// <summary>
-        /// The minimum time between samples
+        /// The smallest sample value seen on this channel
         /// </summary>
         public double MinValue => _current.MinValue;
 
         /// <summary>
-        /// The minimum time between samples
+        /// The mean of the sample values seen on this channel
         /// </summary>
         public double AverageValue => _current.AverageValue;
     }
@@ -116,17 +116,17 @@ public partial class SummaryLogger : ObservableObject, ILogger
         public long MinDeltaTicks { get; set; }
 
         /// <summary>
-        /// The average value of these samples
+        /// The running mean of these samples
         /// </summary>
         public double AverageValue { get; set; }
 
         /// <summary>
-        /// The minimum value of these samples
+        /// The maximum value of these samples
         /// </summary>
         public double MaxValue { get; set; }
 
         /// <summary>
-        /// The maximum value of these samples
+        /// The minimum value of these samples
         /// </summary>
         public double MinValue { get; set; }
 
@@ -390,8 +390,13 @@ public partial class SummaryLogger : ObservableObject, ILogger
             if (buffer.SampleCount == 0)
             {
                 buffer.FirstSampleTicks = dataSample.TimestampTicks;
-                buffer.MinValue = buffer.MinValue;
-                buffer.MaxValue = buffer.MaxValue;
+
+                // Seed the running extremes from the first sample of the window, the same way
+                // the delta and latency accumulators below seed themselves. ChannelBuffer starts
+                // (and Reset()s) at 0, so without this the extremes stay anchored at 0 and
+                // Math.Min/Math.Max report 0 for any channel that never crosses zero.
+                buffer.MinValue = dataSample.Value;
+                buffer.MaxValue = dataSample.Value;
             }
             else
             {
@@ -399,7 +404,14 @@ public partial class SummaryLogger : ObservableObject, ILogger
                 buffer.MaxValue = Math.Max(dataSample.Value, buffer.MaxValue);
             }
 
-            buffer.AverageValue += dataSample.Value / SampleSize;
+            // Accumulate the mean incrementally over the samples this channel actually received.
+            // SampleSize counts device *messages*, not per-channel samples, and the two differ:
+            // a frame's DeviceMessage is dispatched before that frame's channel samples, and the
+            // buffer swap fires from Log(DeviceMessage), so a completed window holds one fewer
+            // sample per channel than SampleSize. SampleSize is also a live, user-editable field
+            // on the Summary flyout, so dividing by it rescaled an in-progress average. This form
+            // is exact for every window length and independent of SampleSize.
+            buffer.AverageValue += (dataSample.Value - buffer.AverageValue) / (buffer.SampleCount + 1);
 
             if (buffer.SampleCount > 0)
             {


### PR DESCRIPTION
Closes #757

**Not merging — this is for your review.**

The Summary flyout's per-channel **Value** row (Min / Average / Max) was wrong on every channel. Two independent defects, both in `SummaryLogger.Log(DataSample)`.

## 1. Min/Max were never seeded

```csharp
if (buffer.SampleCount == 0)
{
    buffer.FirstSampleTicks = dataSample.TimestampTicks;
    buffer.MinValue = buffer.MinValue;   // no-op
    buffer.MaxValue = buffer.MaxValue;   // no-op
}
```

`ChannelBuffer` starts at `0.0` and `Reset()` zeroes both on every buffer swap, so the running extremes stayed anchored at 0 — `Math.Min(x, 0.0)` / `Math.Max(x, 0.0)` — and the window's first sample was excluded from the aggregate even when it was the extremum.

| Channel signal | Was | Now |
|---|---|---|
| 2.4 V rail (2.39–2.41) | Min **0**, Max 2.41 | Min 2.39, Max 2.41 |
| all-negative (−5.0…−1.5) | Min −5.0, Max **0** | Min −5.0, Max −1.5 |

The intent is unambiguous because the two sibling accumulators in the same method already get this right: `MinDeltaTicks`/`MaxDeltaTicks` seed from the first delta and `MinLatencyTicks`/`MaxLatencyTicks` from the first latency. The value pair was simply missed.

## 2. Average divided by `SampleSize`, which is the wrong denominator

`SampleSize` counts **device messages**, not per-channel samples, and the two differ at swap time. `AbstractStreamingDevice.ProcessStreamMessage` dispatches the frame's `DeviceMessage` *before* Core raises that frame's channel samples, and the buffer swap fires from `Log(DeviceMessage)` — so a completed window holds `SampleSize - 1` samples per channel, each of which had been divided by `SampleSize`. The mean always read low by `(n-1)/n`: 0.1 % at the default 1000, 50 % at `SampleSize = 2`.

`SampleSize` is also a live two-way-bound `NumericUpDown` on the flyout (`Minimum="1"`), so editing it mid-window rescaled the in-progress average by an arbitrary factor.

Replaced with an incremental (Welford) mean over the samples the channel actually received:

```csharp
buffer.AverageValue += (dataSample.Value - buffer.AverageValue) / (buffer.SampleCount + 1);
```

Exact for every window length, numerically stable, and independent of `SampleSize` — so a mid-window `SampleSize` edit can no longer corrupt it. No change to `ChannelBuffer.Reset()` or `ChannelSummary`, which keep reading a finished mean.

## Also

Corrected the XML docs on the value properties in `ChannelSummary` and `ChannelBuffer` — they were copy-pasted from the timing properties ("The minimum time between samples" on `MaxValue`) and had `MinValue`/`MaxValue` described the wrong way round. That copy-paste is plausibly how the self-assignment survived review in the first place.

## 3. AverageDelta had the same wrong denominator (added in review round 1)

Qodo flagged the per-channel interval mean a few lines below, and it is the same defect as #2 — `SampleSize` bounds the window in device *messages*, so it is neither the channel's sample count nor its interval count:

```csharp
buffer.AverageDeltaTicks += elapsed / (double)(SampleSize - 1);
```

A channel present in every frame lands `SampleSize - 2` intervals in a completed window but divided by `SampleSize - 1`, so the reported mean read **low** (measured: three intervals of 10,000 / 30,000 / 20,000 ticks reported 15,000 instead of 20,000); a channel present in only some frames got an arbitrary denominator; and a mid-window `SampleSize` edit rescaled it. Now the same Welford form, which also removes the division by zero at `SampleSize = 1`.

The **device-level** accumulator in `Log(DeviceMessage)` deliberately keeps `(SampleSize - 1)`: that buffer really does count messages, so a completed window really does hold `SampleSize - 1` intervals. A comment at the fix site records why the two differ.

## Tests

`Daqifi.Desktop.Test/Loggers/SummaryLoggerTests.cs` — 10 new tests. `SummaryLogger` had **zero** coverage (0.0 % in the CI report), and **all 10 fail against the previous code**.

They drive the logger in production's real dispatch order (a frame's `DeviceMessage`, then that frame's channel samples) and read results back through the public `Channels` surface the flyout binds to — no seam, no mocks, no hardware, no `App.ServiceProvider`, no database. Covered: an all-positive channel's minimum, an all-negative channel's maximum, a one-sample window (isolates the seeding branch), extremes landing on the first and last samples, the mean over the samples actually received, the mean's independence from `SampleSize`, two channels tracked independently, a second window re-seeding from its own first sample rather than inheriting the previous window's extremes or the reset 0, the interval mean over the channel's own uneven intervals, and that interval mean's independence from `SampleSize`.

## Scope

`SummaryLogger` is display-only — it feeds the Summary flyout and nothing else, and is not part of the logging, export or plot data paths. The change is confined to `Log(DataSample)`; no signature, caller, schema or persisted-data change.

Adjacent defects **deliberately left alone**, since each needs its own decision:

- channel buffers are keyed by `ChannelName` alone, so two devices both exposing `AI0` merge into one summary row (fixing it changes the flyout's displayed channel identity) — documented in #757
- the swap tests `SampleCount == SampleSize` exactly, so lowering `SampleSize` below the in-progress count freezes the readout permanently — documented in #757
- the **device-level** `AverageLatencyTicks` sums `SampleSize` values but divides by `SampleSize - 1` (it has no first-message guard), so it reads high by `SampleSize / (SampleSize - 1)` and is `Infinity` at `SampleSize = 1` — a different mechanism on a different statistic, filed separately as **#760**

## Verification

Every commit was taken through the full gate set: round 1 (`9a76279`), round 2 (`04cbc18`, the Qodo fixes) and round 3 (`938db29`, a test-constant rename). Round 2 numbers, which cover the last change to production code:

| Gate | Result |
|---|---|
| `dotnet build` | 0 errors; no warning in either changed file |
| Unit gate (`TestCategory!=Ui`) | **699 passed**, 0 failed (689 on `main` + 10 new) |
| App-launch smoke (`Launch_MainWindowAppears_AndIsResponsive`) | **PASS**, 10 s |
| Device bench (`StartLoggingSession_RendersLivePlot_RunsStopsAndDeletesSession`, `RequiresDevice`) | **PASS**, 1 m 16 s, real board on COM3 |

Both new tests were confirmed **failing against the pre-fix code** before the fix was written (15,000 vs 20,000 ticks; and 15,000 vs 4,000 across `SampleSize` 5 and 16).

