### PR TITLE
fix(plot): take PlotModel.SyncRoot for every PlotLogger collection mutation

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/PlotLoggerConcurrencyTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/PlotLoggerConcurrencyTests.cs
@@ -41,6 +41,14 @@ public class PlotLoggerConcurrencyTests
     /// <summary>How long the thread state must stay <c>WaitSleepJoin</c> to count as parked on the lock.</summary>
     private const int BLOCK_SETTLE_MS = 100;
 
+    /// <summary>
+    /// Budget for observing the background thread park on the lock. Deliberately far larger than
+    /// <see cref="BLOCK_WAIT_TIMEOUT_MS"/> because it is only ever spent on a genuine failure: the poll
+    /// returns the instant the park is seen, so a passing run never waits anywhere near this long.
+    /// A loaded CI agent can take a while to schedule the thread and JIT its way to the lock.
+    /// </summary>
+    private const int PARK_WAIT_TIMEOUT_MS = 30000;
+
     /// <summary>Wall-clock budget for the stress test. Bounded so the unit gate stays fast.</summary>
     private const int STRESS_DURATION_MS = 300;
 
@@ -78,13 +86,36 @@ public class PlotLoggerConcurrencyTests
     }
 
     /// <summary>
-    /// Blocks until <paramref name="thread"/> has been parked in <see cref="ThreadState.WaitSleepJoin"/>
-    /// continuously for <see cref="BLOCK_SETTLE_MS"/> — i.e. it is waiting on the monitor rather than
-    /// momentarily inside a runtime lock while starting up.
+    /// Blocks until <paramref name="thread"/> is parked on <c>PlotModel.SyncRoot</c> inside
+    /// <see cref="PlotLogger.Log(DataSample)"/>, in two steps: first a real synchronization primitive
+    /// (<paramref name="reachedLogCall"/>, set by the thread immediately before the call), then a poll
+    /// for <see cref="ThreadState.WaitSleepJoin"/> held continuously for <see cref="BLOCK_SETTLE_MS"/>
+    /// so a transient runtime/JIT lock during start-up is not mistaken for the park.
     /// </summary>
-    private static void WaitUntilParkedOnLock(Thread thread)
+    /// <remarks>
+    /// The state poll is a heuristic, so it is worth being precise about what rests on it.
+    /// <list type="bullet">
+    /// <item>It is <b>not</b> what makes the interleaving safe. The caller holds the lock across this
+    /// wait and across its <c>ClearPlot()</c>, so a correctly locked <c>Log</c> physically cannot run
+    /// its body in that window whether or not the park is ever observed.</item>
+    /// <item>What it adds is proof that the thread really is <i>inside</i> <c>Log</c> — which is what
+    /// made this test fail against the pre-fix code, where <c>Log</c> read <c>ContainsKey</c> before
+    /// taking the lock. Parked means that unlocked read has already happened, so the following
+    /// <c>ClearPlot()</c> lands in the exact window that threw <c>KeyNotFoundException</c>.</item>
+    /// <item>A false <i>positive</i> cannot turn a real bug green: it would only clear the lock earlier,
+    /// which the fixed code still handles. A false <i>negative</i> could only turn a passing test red,
+    /// which is why the budget is <see cref="PARK_WAIT_TIMEOUT_MS"/> rather than the usual one — a
+    /// thread blocked on a monitor stays in <c>WaitSleepJoin</c> until released, so the state is stable
+    /// and the poll cannot miss it once it is reached.</item>
+    /// </list>
+    /// </remarks>
+    private static void WaitUntilParkedOnLock(Thread thread, ManualResetEventSlim reachedLogCall)
     {
-        var deadline = Environment.TickCount64 + BLOCK_WAIT_TIMEOUT_MS;
+        Assert.IsTrue(
+            reachedLogCall.Wait(BLOCK_WAIT_TIMEOUT_MS),
+            "The background thread never reached its Log() call.");
+
+        var deadline = Environment.TickCount64 + PARK_WAIT_TIMEOUT_MS;
         while (Environment.TickCount64 < deadline)
         {
             if ((thread.ThreadState & ThreadState.WaitSleepJoin) == 0)
@@ -160,10 +191,14 @@ public class PlotLoggerConcurrencyTests
         plotter.Log(Sample(0, 1.0));
 
         Exception? escaped = null;
+        using var reachedLogCall = new ManualResetEventSlim(false);
         var transport = new Thread(() =>
         {
             try
             {
+                // Signalled from the call site so the wait below starts from a known point: everything
+                // between here and Log's lock acquisition is non-blocking.
+                reachedLogCall.Set();
                 plotter.Log(Sample(1, 2.0));
             }
             catch (Exception ex)
@@ -181,7 +216,7 @@ public class PlotLoggerConcurrencyTests
             transport.Start();
 
             // Park the "transport thread" mid-Log, then let the UI thread's session-start clear land.
-            WaitUntilParkedOnLock(transport);
+            WaitUntilParkedOnLock(transport, reachedLogCall);
             plotter.ClearPlot();
         }
 

--- a/Daqifi.Desktop.Test/Loggers/PlotLoggerConcurrencyTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/PlotLoggerConcurrencyTests.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Logger;
+using OxyPlot;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Unit coverage for <see cref="PlotLogger"/>'s shared-state locking (issue #759).
+/// <para>
+/// <see cref="PlotLogger.Log(DataSample)"/> runs on the device transport thread while
+/// <see cref="PlotLogger.ClearPlot"/> runs on the UI thread at session start, so every structural
+/// mutation of the per-channel collections must happen under <c>PlotModel.SyncRoot</c>. These tests
+/// pin that contract down deterministically — a test thread holds the lock to force the exact
+/// interleaving rather than relying on a timing race — plus the behaviour the locking must not
+/// change (clearing, the <c>FirstTime</c> re-seed, colour updates and initial series visibility).
+/// </para>
+/// </summary>
+[TestClass]
+public class PlotLoggerConcurrencyTests
+{
+    #region Constants
+    private const string DEVICE_SERIAL = "SN-0001";
+    private const string CHANNEL_NAME = "AI0";
+    private const string OTHER_CHANNEL_NAME = "AI1";
+    private const string RED_ARGB = "#FFFF0000";
+    private const string GREEN_ARGB = "#FF00FF00";
+
+    /// <summary>Upper bound on any wait for a background thread; only reached when a test fails.</summary>
+    private const int BLOCK_WAIT_TIMEOUT_MS = 5000;
+
+    /// <summary>
+    /// How long a lock-blocked operation is given to (wrongly) complete before we conclude it really
+    /// is blocked. Long enough that an unlocked <c>ClearPlot</c> always finishes inside it.
+    /// </summary>
+    private const int LOCK_HELD_OBSERVATION_MS = 250;
+
+    /// <summary>How long the thread state must stay <c>WaitSleepJoin</c> to count as parked on the lock.</summary>
+    private const int BLOCK_SETTLE_MS = 100;
+
+    /// <summary>Wall-clock budget for the stress test. Bounded so the unit gate stays fast.</summary>
+    private const int STRESS_DURATION_MS = 300;
+
+    private static readonly long BASE_TICKS = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+
+    private static readonly string EMPTY_SUMMARY =
+        "series=0;points=0;nonfinite=0;last=NaN;min=NaN;max=NaN;firstx=NaN;lastx=NaN";
+    #endregion
+
+    #region Helpers
+    /// <summary>
+    /// Builds a <see cref="PlotLogger"/> with the channel-visibility lookup stubbed out. A unit test
+    /// must never let it reach <c>LoggingManager.Instance</c>: that singleton's constructor resolves
+    /// services from <c>App.ServiceProvider</c>, which is null outside the running application, so
+    /// touching it throws a <see cref="TypeInitializationException"/> that then sticks for the whole
+    /// test process.
+    /// </summary>
+    private static PlotLogger CreatePlotter()
+    {
+        return new PlotLogger { ChannelVisibilityLookup = _ => null };
+    }
+
+    private static DataSample Sample(
+        long elapsedMs, double value, string color = RED_ARGB, string channelName = CHANNEL_NAME)
+    {
+        return new DataSample
+        {
+            DeviceSerialNo = DEVICE_SERIAL,
+            ChannelName = channelName,
+            Color = color,
+            Type = ChannelType.Analog,
+            Value = value,
+            TimestampTicks = BASE_TICKS + (elapsedMs * TimeSpan.TicksPerMillisecond)
+        };
+    }
+
+    /// <summary>
+    /// Blocks until <paramref name="thread"/> has been parked in <see cref="ThreadState.WaitSleepJoin"/>
+    /// continuously for <see cref="BLOCK_SETTLE_MS"/> — i.e. it is waiting on the monitor rather than
+    /// momentarily inside a runtime lock while starting up.
+    /// </summary>
+    private static void WaitUntilParkedOnLock(Thread thread)
+    {
+        var deadline = Environment.TickCount64 + BLOCK_WAIT_TIMEOUT_MS;
+        while (Environment.TickCount64 < deadline)
+        {
+            if ((thread.ThreadState & ThreadState.WaitSleepJoin) == 0)
+            {
+                Thread.Sleep(5);
+                continue;
+            }
+
+            var settleUntil = Environment.TickCount64 + BLOCK_SETTLE_MS;
+            var stayedParked = true;
+            while (Environment.TickCount64 < settleUntil)
+            {
+                if ((thread.ThreadState & ThreadState.WaitSleepJoin) == 0)
+                {
+                    stayedParked = false;
+                    break;
+                }
+
+                Thread.Sleep(5);
+            }
+
+            if (stayedParked)
+            {
+                return;
+            }
+        }
+
+        Assert.Fail("The background thread never parked on PlotModel.SyncRoot.");
+    }
+    #endregion
+
+    #region ClearPlot takes the lock
+    [TestMethod]
+    public void ClearPlot_DoesNotComplete_WhileThePlotLockIsHeld()
+    {
+        var plotter = CreatePlotter();
+        plotter.Log(Sample(0, 1.0));
+
+        var entered = new ManualResetEventSlim(false);
+        Task clear;
+
+        lock (plotter.PlotModel.SyncRoot)
+        {
+            clear = Task.Run(() =>
+            {
+                entered.Set();
+                plotter.ClearPlot();
+            });
+
+            Assert.IsTrue(entered.Wait(BLOCK_WAIT_TIMEOUT_MS), "The clearing task never started.");
+            Assert.IsFalse(
+                clear.Wait(LOCK_HELD_OBSERVATION_MS),
+                "ClearPlot() ran to completion while PlotModel.SyncRoot was held, so it never took the "
+                + "lock that guards the collections it empties.");
+        }
+
+        Assert.IsTrue(clear.Wait(BLOCK_WAIT_TIMEOUT_MS), "ClearPlot() did not complete once the lock was released.");
+        Assert.AreEqual(0, plotter.LoggedPoints.Count, "ClearPlot() should still have emptied the plot.");
+    }
+    #endregion
+
+    #region Log survives a concurrent clear
+    /// <summary>
+    /// The reported failure mode: <c>Log</c> decided the channel was already known, then a session-start
+    /// <c>ClearPlot</c> emptied the dictionaries before <c>Log</c> reached its indexed access. With the
+    /// membership check outside the lock this threw <see cref="System.Collections.Generic.KeyNotFoundException"/>
+    /// on the device transport thread, where nothing catches it.
+    /// </summary>
+    [TestMethod]
+    public void Log_DoesNotThrow_WhenClearPlotEmptiesTheChannelsWhileItWaitsForTheLock()
+    {
+        var plotter = CreatePlotter();
+        plotter.Log(Sample(0, 1.0));
+
+        Exception? escaped = null;
+        var transport = new Thread(() =>
+        {
+            try
+            {
+                plotter.Log(Sample(1, 2.0));
+            }
+            catch (Exception ex)
+            {
+                escaped = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "fake-transport"
+        };
+
+        lock (plotter.PlotModel.SyncRoot)
+        {
+            transport.Start();
+
+            // Park the "transport thread" mid-Log, then let the UI thread's session-start clear land.
+            WaitUntilParkedOnLock(transport);
+            plotter.ClearPlot();
+        }
+
+        Assert.IsTrue(transport.Join(BLOCK_WAIT_TIMEOUT_MS), "The logging thread never finished.");
+        Assert.IsNull(escaped, $"Log() let {escaped?.GetType().Name} escape onto the transport thread: {escaped}");
+        Assert.AreEqual(
+            1,
+            plotter.LoggedPoints.Count,
+            "Log() should have re-created the series ClearPlot() removed rather than dropping the sample.");
+    }
+
+    /// <summary>
+    /// Secondary, non-deterministic guard covering the failure modes the interleaved test cannot force:
+    /// <c>Dictionary</c>/<c>HashSet</c> corruption from a concurrent structural <c>Clear</c>, which can
+    /// spin or return garbage rather than throw. The producer is started and given a moment to reach
+    /// steady state so the two threads genuinely overlap.
+    /// </summary>
+    [TestMethod]
+    public void LogAndClearPlot_FromTwoThreads_DoNotThrow()
+    {
+        var plotter = CreatePlotter();
+        using var stop = new CancellationTokenSource();
+        var running = new ManualResetEventSlim(false);
+        Exception? escaped = null;
+
+        var transport = new Thread(() =>
+        {
+            try
+            {
+                long elapsedMs = 0;
+                while (!stop.IsCancellationRequested)
+                {
+                    plotter.Log(Sample(elapsedMs++, 1.0));
+                    running.Set();
+                }
+            }
+            catch (Exception ex)
+            {
+                escaped = ex;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "fake-transport"
+        };
+
+        transport.Start();
+        try
+        {
+            Assert.IsTrue(running.Wait(BLOCK_WAIT_TIMEOUT_MS), "The logging thread never produced a sample.");
+
+            var deadline = Environment.TickCount64 + STRESS_DURATION_MS;
+            while (Environment.TickCount64 < deadline)
+            {
+                plotter.ClearPlot();
+            }
+        }
+        finally
+        {
+            stop.Cancel();
+        }
+
+        Assert.IsTrue(transport.Join(BLOCK_WAIT_TIMEOUT_MS), "The logging thread never finished.");
+        Assert.IsNull(escaped, $"A concurrent Log()/ClearPlot() threw {escaped?.GetType().Name}: {escaped}");
+    }
+    #endregion
+
+    #region Behaviour the locking must preserve
+    [TestMethod]
+    public void ClearPlot_ResetsEveryPlotCollectionAndTheStatsSummary()
+    {
+        var plotter = CreatePlotter();
+        plotter.Log(Sample(0, 1.0));
+        plotter.Log(Sample(1, 2.0, channelName: OTHER_CHANNEL_NAME));
+
+        Assert.AreEqual(2, plotter.LoggedChannels.Count, "Arrange failed: both channels should have a series.");
+        Assert.AreEqual(2, plotter.PlotModel.Series.Count, "Arrange failed: both series should be on the model.");
+        Assert.IsNotNull(plotter.FirstTime, "Arrange failed: the first sample should have seeded FirstTime.");
+
+        plotter.ClearPlot();
+
+        Assert.AreEqual(0, plotter.LoggedChannels.Count);
+        Assert.AreEqual(0, plotter.LoggedPoints.Count);
+        Assert.AreEqual(0, plotter.PlotModel.Series.Count);
+        Assert.IsNull(plotter.FirstTime, "ClearPlot() must drop the time-axis anchor so the next session re-seeds it.");
+        Assert.AreEqual(EMPTY_SUMMARY, plotter.PlotStatsSummary);
+    }
+
+    [TestMethod]
+    public void Log_ReSeedsFirstTime_AfterClearPlot()
+    {
+        var plotter = CreatePlotter();
+        plotter.Log(Sample(0, 1.0));
+        plotter.Log(Sample(5, 2.0));
+
+        Assert.AreEqual(
+            5.0,
+            plotter.LoggedPoints[(DEVICE_SERIAL, CHANNEL_NAME)][1].X,
+            "Arrange failed: X is elapsed ms measured from the first sample.");
+
+        plotter.ClearPlot();
+        plotter.Log(Sample(100, 3.0));
+
+        var points = plotter.LoggedPoints[(DEVICE_SERIAL, CHANNEL_NAME)];
+        Assert.AreEqual(1, points.Count);
+        Assert.AreEqual(
+            0.0,
+            points[0].X,
+            "The first sample after a clear becomes the new time-axis anchor, so it plots at X = 0.");
+    }
+
+    [TestMethod]
+    public void Log_UpdatesTheSeriesColour_WithoutCreatingASecondSeries()
+    {
+        var plotter = CreatePlotter();
+        plotter.Log(Sample(0, 1.0, RED_ARGB));
+        plotter.Log(Sample(1, 2.0, GREEN_ARGB));
+
+        Assert.AreEqual(1, plotter.PlotModel.Series.Count, "A colour change must not add a second series.");
+        Assert.AreEqual(
+            OxyColor.FromArgb(0xFF, 0x00, 0xFF, 0x00),
+            plotter.LoggedChannels[(DEVICE_SERIAL, CHANNEL_NAME)].Color,
+            "The series should track the channel's current colour.");
+        Assert.AreEqual(2, plotter.LoggedPoints[(DEVICE_SERIAL, CHANNEL_NAME)].Count);
+    }
+
+    [TestMethod]
+    public void Log_AppliesTheChannelVisibilityLookup_ToANewSeries()
+    {
+        var plotter = new PlotLogger
+        {
+            ChannelVisibilityLookup = key => key.channelName == CHANNEL_NAME ? false : null
+        };
+
+        plotter.Log(Sample(0, 1.0));
+        plotter.Log(Sample(1, 2.0, channelName: OTHER_CHANNEL_NAME));
+
+        Assert.IsFalse(
+            plotter.LoggedChannels[(DEVICE_SERIAL, CHANNEL_NAME)].IsVisible,
+            "A hidden subscribed channel's series should start hidden.");
+        Assert.IsTrue(
+            plotter.LoggedChannels[(DEVICE_SERIAL, OTHER_CHANNEL_NAME)].IsVisible,
+            "An unsubscribed channel has no recorded visibility, so its series keeps OxyPlot's default.");
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Loggers/PlotLogger.cs
+++ b/Daqifi.Desktop/Loggers/PlotLogger.cs
@@ -127,6 +127,30 @@ public partial class PlotLogger : ObservableObject, ILogger
     }
     #endregion
 
+    #region Channel visibility lookup
+    /// <summary>
+    /// Resolves a subscribed channel's current visibility so a newly created series starts out
+    /// matching the channel's <c>IsVisible</c> state. Returns <see langword="null"/> when the
+    /// channel is not subscribed, in which case the series keeps OxyPlot's default (visible).
+    /// </summary>
+    /// <remarks>
+    /// Settable purely as a unit-test seam. The default implementation reads the
+    /// <see cref="LoggingManager"/> singleton, whose constructor resolves services from
+    /// <c>App.ServiceProvider</c> and therefore throws a <see cref="TypeInitializationException"/>
+    /// outside a running application — which would otherwise make <see cref="Log(DataSample)"/>
+    /// untestable.
+    /// </remarks>
+    internal Func<(string deviceSerial, string channelName), bool?> ChannelVisibilityLookup { get; set; }
+        = LookUpSubscribedChannelVisibility;
+
+    private static bool? LookUpSubscribedChannelVisibility((string deviceSerial, string channelName) key)
+    {
+        return LoggingManager.Instance?.SubscribedChannels
+            .FirstOrDefault(ch => ch.DeviceSerialNo == key.deviceSerial && ch.Name == key.channelName)
+            ?.IsVisible;
+    }
+    #endregion
+
     #region Constructor
     public PlotLogger()
     {
@@ -201,44 +225,68 @@ public partial class PlotLogger : ObservableObject, ILogger
     }
     #endregion
 
+    /// <summary>
+    /// Buffers a sample for the live plot, creating the channel's series on first sight.
+    /// </summary>
+    /// <remarks>
+    /// Runs on the device transport thread, so the whole read-then-mutate sequence is held under
+    /// <c>PlotModel.SyncRoot</c> — the lock <see cref="ClearPlot"/> and the render tick also take.
+    /// The membership check and the <see cref="FirstTime"/> seed used to sit outside it, which left
+    /// two windows for a session-start <see cref="ClearPlot"/> on the UI thread: the key could be
+    /// present for <c>ContainsKey</c> and gone by the indexed access below
+    /// (<see cref="KeyNotFoundException"/> on a thread with no handler), and <see cref="FirstTime"/>
+    /// could be nulled between the null check and the <c>.Value</c> dereference. See issue #759.
+    /// </remarks>
     public void Log(DataSample dataSample)
     {
         var key = (dataSample.DeviceSerialNo, dataSample.ChannelName);
-
-        if (!LoggedChannels.ContainsKey(key))
-        {
-            AddChannelSeries(dataSample.ChannelName,dataSample.DeviceSerialNo, dataSample.Type, dataSample.Color);
-        }
-        else
-        {
-            //Check for a change in color
-            if (LoggedChannels[key].Color.ToString().ToLower() != dataSample.Color.ToLower())
-            {
-                LoggedChannels[key].Color = OxyColor.Parse(dataSample.Color.ToLower());
-            }
-        }
-
-        if (FirstTime == null) { FirstTime = new DateTime(dataSample.TimestampTicks); }
-
-        var deltaTime = (dataSample.TimestampTicks - FirstTime.Value.Ticks) / 10000.0; //Ticks is 100 nanoseconds
-        var scaledSampleValue = dataSample.Value;
+        var addedSeries = false;
 
         lock (PlotModel.SyncRoot)
         {
+            if (!LoggedChannels.TryGetValue(key, out var series))
+            {
+                // The series may be absent because this is a new channel, or because ClearPlot()
+                // removed it while this call waited for the lock. Either way it is re-created here
+                // rather than dropping the sample.
+                AddChannelSeries(
+                    dataSample.ChannelName, dataSample.DeviceSerialNo, dataSample.Type, dataSample.Color);
+                addedSeries = true;
+            }
+            else if (series.Color.ToString().ToLower() != dataSample.Color.ToLower())
+            {
+                // Check for a change in color
+                series.Color = OxyColor.Parse(dataSample.Color.ToLower());
+            }
+
+            FirstTime ??= new DateTime(dataSample.TimestampTicks);
+
+            // Ticks is 100 nanoseconds
+            var deltaTime = (dataSample.TimestampTicks - FirstTime.Value.Ticks) / 10000.0;
+            var scaledSampleValue = dataSample.Value;
+            var points = LoggedPoints[key];
+
             if (_gapDetector.IsGap(key, dataSample.FirmwareDeltaMs))
             {
-                LoggedPoints[key].Add(DataPoint.Undefined);
-                if (LoggedPoints[key].Count >= 5000)
+                points.Add(DataPoint.Undefined);
+                if (points.Count >= 5000)
                 {
-                    LoggedPoints[key].RemoveAt(0);
+                    points.RemoveAt(0);
                 }
             }
 
-            LoggedPoints[key].Add(new DataPoint(deltaTime, scaledSampleValue));
-            if (LoggedPoints[key].Count >= 5000)
+            points.Add(new DataPoint(deltaTime, scaledSampleValue));
+            if (points.Count >= 5000)
             {
-                LoggedPoints[key].RemoveAt(0);
+                points.RemoveAt(0);
             }
+        }
+
+        // Change notifications are raised outside the lock so a binding handler can never re-enter
+        // the logger while it is held. AddChannelSeries used to raise the PlotModel one itself.
+        if (addedSeries)
+        {
+            OnPropertyChanged(nameof(PlotModel));
         }
 
         OnPropertyChanged(nameof(LoggedPoints));
@@ -253,6 +301,16 @@ public partial class PlotLogger : ObservableObject, ILogger
         // No-op
     }
 
+    /// <summary>
+    /// Creates a channel's line series and point buffer and registers both with the plot.
+    /// </summary>
+    /// <remarks>
+    /// The caller must hold <c>PlotModel.SyncRoot</c>. These structural Adds race the render tick's
+    /// enumeration (<see cref="CompositionTargetRendering"/>, <see cref="UpdatePlotStatsSummary"/>)
+    /// and <see cref="ClearPlot"/>'s removals, so without the lock a concurrent OxyPlot render or
+    /// stats recompute could observe a half-updated dictionary/series list. The caller also raises
+    /// the <c>PlotModel</c> change notification, which must not be raised while the lock is held.
+    /// </remarks>
     private void AddChannelSeries(string channelName, string DeviceSerialNo, ChannelType channelType, string newColor)
     {
         var key = (DeviceSerialNo, channelName);
@@ -270,18 +328,12 @@ public partial class PlotLogger : ObservableObject, ILogger
             TrackerFormatString = $"{channelName} ({serialSuffix})\n{{1}}: {{2:0.###}}\n{{3}}: {{4:0.######}}"
         };
 
-        // Synchronize IsVisible with the IChannel
-        if (LoggingManager.Instance != null)
+        // Synchronize IsVisible with the IChannel. When the channel is not subscribed the lookup
+        // returns null and the series keeps OxyPlot's default IsVisible (true).
+        var subscribedVisibility = ChannelVisibilityLookup(key);
+        if (subscribedVisibility.HasValue)
         {
-            var subscribedChannel = LoggingManager.Instance.SubscribedChannels
-                .FirstOrDefault(ch => ch.DeviceSerialNo == DeviceSerialNo && ch.Name == channelName);
-
-            if (subscribedChannel != null)
-            {
-                newLineSeries.IsVisible = subscribedChannel.IsVisible;
-            }
-            // Optional: else, default to true or log a warning if channel not found
-            // For now, if not found, it will use the default LineSeries.IsVisible (which is true)
+            newLineSeries.IsVisible = subscribedVisibility.Value;
         }
 
         newLineSeries.YAxisKey = channelType switch
@@ -291,18 +343,9 @@ public partial class PlotLogger : ObservableObject, ILogger
             _ => newLineSeries.YAxisKey
         };
 
-        // Mutate the shared collections under PlotModel.SyncRoot — the same lock held by Log()'s
-        // point-append and by the render tick (InvalidatePlot + plot-stats recompute). Without it
-        // these structural Adds raced the render-tick enumeration, so a concurrent OxyPlot render
-        // or stats recompute could observe a half-updated dictionary/series list.
-        lock (PlotModel.SyncRoot)
-        {
-            LoggedPoints.Add(key, newDataPoints);
-            LoggedChannels.Add(key, newLineSeries);
-            PlotModel.Series.Add(newLineSeries);
-        }
-
-        OnPropertyChanged(nameof(PlotModel));
+        LoggedPoints.Add(key, newDataPoints);
+        LoggedChannels.Add(key, newLineSeries);
+        PlotModel.Series.Add(newLineSeries);
     }
 
     private void CompositionTargetRendering(object sender, EventArgs e)
@@ -336,9 +379,10 @@ public partial class PlotLogger : ObservableObject, ILogger
     /// <summary>
     /// Recomputes <see cref="PlotStatsSummary"/> from the currently buffered points. Called on the
     /// once-a-second render tick while holding <c>PlotModel.SyncRoot</c>. Every mutation of the
-    /// per-channel collections — <see cref="Log(DataSample)"/>'s point-append and
-    /// <see cref="AddChannelSeries"/>'s series creation — takes that same lock, so enumerating the
-    /// point lists here is consistent (no torn reads, no structural-modification race).
+    /// per-channel collections — <see cref="Log(DataSample)"/>'s point-append,
+    /// <see cref="AddChannelSeries"/>'s series creation and <see cref="ClearPlot"/>'s removals —
+    /// takes that same lock, so enumerating the point lists here is consistent (no torn reads, no
+    /// structural-modification race).
     /// Gap markers are inserted as <c>DataPoint.Undefined</c> (NaN X); a real sample always has a
     /// finite X (elapsed ms), so an NaN X distinguishes a gap from data and lets a genuinely
     /// non-finite sample VALUE still be counted (nonfinite) rather than hidden.
@@ -426,14 +470,33 @@ public partial class PlotLogger : ObservableObject, ILogger
             firstX, double.IsNegativeInfinity(lastX) ? double.NaN : lastX);
     }
 
+    /// <summary>
+    /// Drops every buffered point, series and gap-detector entry, returning the plot to its empty
+    /// state and releasing the time-axis anchor so the next session re-seeds it.
+    /// </summary>
+    /// <remarks>
+    /// Runs on the UI thread (<c>LoggingManager.OnActiveChanged</c> at session start) while
+    /// <see cref="Log(DataSample)"/> runs on the device transport thread, so these removals take
+    /// <c>PlotModel.SyncRoot</c> for exactly the reason the additions do. Unsubscribing the channel
+    /// handlers just before this call narrows the window but cannot close it — an invocation already
+    /// in flight still completes, because C# snapshots a delegate's invocation list before invoking.
+    /// See issue #759.
+    /// </remarks>
     public void ClearPlot()
     {
-        LoggedChannels.Clear();
-        LoggedPoints.Clear();
-        _gapDetector.Clear();
-        PlotModel.Series.Clear();
-        PlotModel.InvalidatePlot(true);
-        FirstTime = null;
+        lock (PlotModel.SyncRoot)
+        {
+            LoggedChannels.Clear();
+            LoggedPoints.Clear();
+            _gapDetector.Clear();
+            PlotModel.Series.Clear();
+            PlotModel.InvalidatePlot(true);
+            FirstTime = null;
+        }
+
+        // Outside the lock, like every other change notification here: no binding handler may run
+        // while the plot lock is held. PlotStatsSummary is derived state that the render tick
+        // recomputes about once a second, so publishing it a moment later is harmless.
         PlotStatsSummary = EMPTY_PLOT_STATS_SUMMARY;
         OnPropertyChanged(nameof(LoggedChannels));
         OnPropertyChanged(nameof(LoggedPoints));


### PR DESCRIPTION
Closes #759

> **Not merging — opened for review.**

## The problem

`PlotLogger` documents an invariant it then violates. `AddChannelSeries` mutates the shared per-channel collections under `PlotModel.SyncRoot` and explains exactly why:

> Mutate the shared collections under `PlotModel.SyncRoot` — the same lock held by `Log()`'s point-append and by the render tick... Without it these structural `Add`s raced the render-tick enumeration...

But the matching structural **removals** in `ClearPlot()` took no lock at all, and `Log()`'s membership check and `FirstTime` seed sat **outside** its own lock:

```csharp
public void Log(DataSample dataSample)
{
    if (!LoggedChannels.ContainsKey(key)) { AddChannelSeries(...); }   // unlocked read
    ...
    if (FirstTime == null) { FirstTime = new DateTime(...); }          // unlocked
    var deltaTime = (dataSample.TimestampTicks - FirstTime.Value.Ticks) / 10000.0;   // unlocked deref

    lock (PlotModel.SyncRoot)
    {
        LoggedPoints[key].Add(...);   // indexes a dictionary the check above vouched for
```

### The two threads

- **`Log(DataSample)` — device transport thread.** `AbstractStreamingDevice.OnCoreChannelSampleReceived` → `AbstractChannel.ActiveSample` → `NotifyChannelUpdated` → `LoggingManager.HandleChannelUpdate` → `logger.Log(sample)`.
- **`ClearPlot()` — UI thread.** `LoggingManager.OnActiveChanged` when a session starts.

`OnActiveChanged` unsubscribes `HandleChannelUpdate` from every channel immediately before clearing, which narrows the window but does not close it: unsubscribing cannot stop an invocation already in flight, because C# snapshots a delegate's invocation list before invoking. `Active` is already `true` by then, so `HandleChannelUpdate`'s `!Active` early-return does not guard this path either.

The window is narrow but real — at session start the device has not been told to stream yet, so it needs a leftover/in-flight frame from the previous session to land at that moment. That is a documented state: #573 exists because the device holds the stopped session's final frame in its transmit path.

### Failure modes

1. **`KeyNotFoundException` on the transport thread** — `ContainsKey` says yes, `ClearPlot` empties `LoggedPoints`, `LoggedPoints[key]` throws. Nothing in that call chain catches it (`AbstractChannel.ActiveSample`'s `catch` only wraps NCalc evaluation), so it escapes onto Core's decode thread.
2. **`Nullable object must have a value`** — `FirstTime` nulled between the check and the `.Value` deref.
3. **`Dictionary`/`HashSet` corruption** — `Dictionary<,>` is explicitly unsafe for concurrent read+write; an unlocked `Clear()` racing locked writers can corrupt the bucket array rather than merely throw. `TimestampGapDetector` has the same shape (`IsGap` called under the lock, `Clear()` called unlocked).
4. **`PlotModel.Series.Clear()`** unlocked racing the render tick's enumeration under the same lock.

## The fix

- **`ClearPlot()`** wraps its mutations — including `_gapDetector.Clear()` and the `FirstTime` reset — in `lock (PlotModel.SyncRoot)`.
- **`Log()`** takes the lock once around a single `TryGetValue`, so the membership decision, the `FirstTime` seed and the point append are one atomic step. When the series is gone it is **re-created rather than dropping the sample**.
- **`AddChannelSeries()`** now requires the caller to hold the lock (documented in its `<remarks>`); its inner `lock` is gone and its `PlotModel` change notification moves up to `Log`, so **no change notification is ever raised while the lock is held** — a binding handler can never re-enter the logger. `PlotStatsSummary` is set outside the lock for the same reason; it is derived state the render tick recomputes about once a second.

No API change and no happy-path behaviour change: this only serializes mutations the class already declares must be serialized. `PlotLogger` is constructed once per app run, `ClearPlot` runs on the UI thread, and `Log`'s critical section is microseconds, so the added contention is not user-visible. Note `DatabaseLogger.ClearPlot` solves the same problem differently — it marshals its whole body through `Dispatcher.Invoke`; `PlotLogger` has no such confinement, which is why it needs the lock.

### One test seam

`Log` was **not unit-testable at all** before this PR: `AddChannelSeries` read `LoggingManager.Instance`, whose private constructor resolves services from `App.ServiceProvider` (null outside the running app), so any `Log` call on a new channel threw `TypeInitializationException` — and that failure is sticky for the whole test process. The inline lookup is replaced by an `internal ChannelVisibilityLookup` delegate defaulting to the identical `LoggingManager` query. Behaviour is unchanged: a null result still leaves OxyPlot's default visibility. `InternalsVisibleTo(Daqifi.Desktop.Test)` already exists, and this matches the seam pattern already used elsewhere in the repo (e.g. `LoggingManager.ParseProfiles`).

## Tests

7 new tests in `Daqifi.Desktop.Test/Loggers/PlotLoggerConcurrencyTests.cs`, on a type with no prior direct coverage. The two interleaving tests are **deterministic** — a test thread holds `PlotModel.SyncRoot` to force the exact interleaving instead of relying on a timing race.

| Test | What it pins |
|---|---|
| `ClearPlot_DoesNotComplete_WhileThePlotLockIsHeld` | ClearPlot actually takes the lock (completes only after release) |
| `Log_DoesNotThrow_WhenClearPlotEmptiesTheChannelsWhileItWaitsForTheLock` | Failure mode 1, forced: the sample is re-plotted, not lost |
| `LogAndClearPlot_FromTwoThreads_DoNotThrow` | Secondary guard for failure mode 3 (corruption can spin rather than throw) |
| `ClearPlot_ResetsEveryPlotCollectionAndTheStatsSummary` | The clear still clears |
| `Log_ReSeedsFirstTime_AfterClearPlot` | The time-axis anchor resets, so the next session plots from X = 0 (#573) |
| `Log_UpdatesTheSeriesColour_WithoutCreatingASecondSeries` | The `TryGetValue` restructure preserved the colour-change branch |
| `Log_AppliesTheChannelVisibilityLookup_ToANewSeries` | The visibility seam behaves like the code it replaced, both ways |

**All three concurrency tests were verified failing against the pre-fix code**, before the fix was written — the interleaving one reproducing the reported stack exactly:

```
Log() let KeyNotFoundException escape onto the transport thread:
System.Collections.Generic.KeyNotFoundException: The given key '(SN-0001, AI0)' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Daqifi.Desktop.Logger.PlotLogger.Log(DataSample dataSample) in PlotLogger.cs:line 261
```

## Deliberately out of scope

- ~~**`CompositionTargetRendering` and `AddChannelSeries` enumerate `LoggingManager.Instance.SubscribedChannels` (a plain `List`) from the transport thread.** That is a pre-existing, separate race — the render tick already does it under this same lock on `main` — so this PR neither introduces nor widens it, and no new lock-ordering edge is created. **Now tracked as #762** (raised by Qodo on this PR); the `ChannelVisibilityLookup` seam added here is what makes it unit-testable.~~ **RESOLVED on `main`** by #764, which is now merged into this branch: `SubscribedChannels` is published copy-on-write as an `IReadOnlyList<IChannel>` read through `Volatile.Read`, so both readers here (`LookUpSubscribedChannelVisibility` and the render tick) now enumerate an immutable snapshot. No change was needed on this branch.
- **`PlotLogger` never unsubscribes from `CompositionTarget.Rendering`.** Harmless today (one instance per app run), unrelated to this fix.

## Merged with `main` (conflict resolved)

`main` moved while this PR was open — #749, #758, #763 and #764 all landed. Two merge commits bring
this branch up to date; #749 was the only textual conflict, in `PlotLogger.cs`.

**The conflict:** #749's zero-warning cleanup rewrote the hex-colour comparison inside `Log()`, and
this PR restructured that same region so the whole read-then-mutate sequence sits under one
`PlotModel.SyncRoot`. **Both sides' intent is kept** — the single-lock restructure from here, and
#749's culture-safe comparison (ordinal case-insensitive `string.Equals` + `ToLowerInvariant()`
instead of the current-culture `ToLower()`) applied to the locked local:

```csharp
else if (!string.Equals(series.Color.ToString(), dataSample.Color, StringComparison.OrdinalIgnoreCase))
{
    series.Color = OxyColor.Parse(dataSample.Color.ToLowerInvariant());
}
```

Nothing else conflicted; #763/#764 merged clean. The build stays **0 warnings / 0 errors** for every
file this PR touches, so #749's zero-warning invariant is preserved here.


