### PR TITLE
fix(summary): average device latency over the messages the window holds

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/SummaryLoggerLatencyTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SummaryLoggerLatencyTests.cs
@@ -79,11 +79,13 @@ public class SummaryLoggerLatencyTests
     [TestMethod]
     public void Log_AverageLatency_IsTheMeanOfTheWindowsLatencies()
     {
+        // Arrange
         var logger = new SummaryLogger(5);
 
+        // Act
         PumpWindow(logger, 100, 200, 300, 400, 500);
 
-        // (100 + 200 + 300 + 400 + 500) / 5. Dividing the same sum by SampleSize - 1 gives 375.
+        // Assert - (100 + 200 + 300 + 400 + 500) / 5. Dividing that sum by SampleSize - 1 gives 375.
         Assert.AreEqual(300.0, logger.AverageLatency, 1e-9);
     }
 
@@ -96,12 +98,15 @@ public class SummaryLoggerLatencyTests
     [TestMethod]
     public void Log_AverageLatency_IsIndependentOfSampleSize()
     {
+        // Arrange
         var small = new SummaryLogger(5);
         var large = new SummaryLogger(16);
 
+        // Act - the same latency, measured through two different window bounds.
         PumpWindow(small, Repeated(1000, small.SampleSize));
         PumpWindow(large, Repeated(1000, large.SampleSize));
 
+        // Assert
         Assert.AreEqual(1000.0, small.AverageLatency, 1e-9);
         Assert.AreEqual(1000.0, large.AverageLatency, 1e-9);
         Assert.AreEqual(small.AverageLatency, large.AverageLatency, 1e-9);
@@ -115,10 +120,13 @@ public class SummaryLoggerLatencyTests
     [TestMethod]
     public void Log_AverageLatency_IsFinite_WhenSampleSizeIsOne()
     {
+        // Arrange
         var logger = new SummaryLogger(1);
 
+        // Act
         PumpWindow(logger, 700);
 
+        // Assert
         Assert.IsFalse(double.IsInfinity(logger.AverageLatency), "Average latency must stay finite.");
         Assert.IsFalse(double.IsNaN(logger.AverageLatency), "Average latency must stay a number.");
         Assert.AreEqual(700.0, logger.AverageLatency, 1e-9);
@@ -131,12 +139,21 @@ public class SummaryLoggerLatencyTests
     [TestMethod]
     public void Log_AverageLatency_DoesNotCarryAcrossWindows()
     {
+        // Arrange - complete one window whose mean is a known, non-zero value, so that anything
+        // carried into the next window would show up rather than hide behind a zero. The check on
+        // it is a precondition, not the assertion under test.
         var logger = new SummaryLogger(3);
-
         PumpWindow(logger, 100, 100, 100);
-        Assert.AreEqual(100.0, logger.AverageLatency, 1e-9);
+        Assert.AreEqual(
+            100.0,
+            logger.AverageLatency,
+            1e-9,
+            "Precondition: the first window must report its own mean before carry-over can be judged.");
 
+        // Act - the single window under test.
         PumpWindow(logger, 400, 400, 400);
+
+        // Assert
         Assert.AreEqual(400.0, logger.AverageLatency, 1e-9);
     }
 
@@ -148,10 +165,14 @@ public class SummaryLoggerLatencyTests
     [TestMethod]
     public void Log_MinAndMaxLatency_SpanEveryMessageInTheWindow()
     {
+        // Arrange
         var logger = new SummaryLogger(4);
 
+        // Act - the smallest and largest latencies sit in the middle of the window, so neither can
+        // be reported by accident from the first or last message alone.
         PumpWindow(logger, 300, 100, 900, 500);
 
+        // Assert
         Assert.AreEqual(100.0, logger.MinLatency, 1e-9);
         Assert.AreEqual(900.0, logger.MaxLatency, 1e-9);
     }
@@ -165,10 +186,11 @@ public class SummaryLoggerLatencyTests
     [TestMethod]
     public void Log_AverageDelta_StillAveragesOverSampleSizeMinusOneIntervals()
     {
+        // Arrange
         var logger = new SummaryLogger(5);
-
-        // Four intervals of 10, 20, 30 and 40 ticks between five messages: mean 25.
         var appTicks = FIRST_APP_TICKS;
+
+        // Act - four intervals of 10, 20, 30 and 40 ticks between five messages: mean 25.
         PumpMessage(logger, appTicks, 1);
         foreach (var interval in new long[] { 10, 20, 30, 40 })
         {
@@ -176,6 +198,7 @@ public class SummaryLoggerLatencyTests
             PumpMessage(logger, appTicks, 1);
         }
 
+        // Assert
         Assert.AreEqual(25.0, logger.AverageDelta, 1e-9);
         Assert.AreEqual(10.0, logger.MinDelta, 1e-9);
         Assert.AreEqual(40.0, logger.MaxDelta, 1e-9);
@@ -188,10 +211,13 @@ public class SummaryLoggerLatencyTests
     [TestMethod]
     public void Log_AverageDelta_IsZero_WhenSampleSizeIsOne()
     {
+        // Arrange
         var logger = new SummaryLogger(1);
 
+        // Act
         PumpWindow(logger, 700);
 
+        // Assert
         Assert.AreEqual(0.0, logger.AverageDelta, 1e-9);
     }
 }

--- a/Daqifi.Desktop.Test/Loggers/SummaryLoggerLatencyTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SummaryLoggerLatencyTests.cs
@@ -1,0 +1,197 @@
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Logger;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Unit coverage for <see cref="SummaryLogger"/>'s device-level latency statistics — the
+/// Min / Average / Max shown on the Summary flyout's "Latency" row (issue #760).
+/// <para>
+/// Latency is <c>AppTicks - TimestampTicks</c>: the gap between the instant the board stamped a
+/// stream frame and the instant the app consumed it. A window is exactly <c>SampleSize</c> device
+/// messages — <see cref="SummaryLogger.Log(DeviceMessage)"/> swaps the completed window in when its
+/// message count reaches <c>SampleSize</c> — and the statistics are only readable through the public
+/// properties once that swap has happened, so every test here pumps a whole number of windows.
+/// </para>
+/// <para>
+/// These tests live in their own file rather than in <c>SummaryLoggerTests.cs</c> because that file
+/// is added by the still-open PR #758; keeping them separate avoids an add/add merge conflict. They
+/// can be folded together once both land.
+/// </para>
+/// </summary>
+[TestClass]
+public class SummaryLoggerLatencyTests
+{
+    private const string DEVICE_NAME = "Nq1";
+    private const string DEVICE_SERIAL = "SN-1";
+
+    /// <summary>
+    /// The app-tick value the first message of a window is stamped with. Arbitrary, but large enough
+    /// that a latency can be subtracted from it without going negative.
+    /// </summary>
+    private const long FIRST_APP_TICKS = 1_000_000L;
+
+    /// <summary>
+    /// Feeds one device message whose latency is exactly <paramref name="latencyTicks"/>, by stamping
+    /// the device timestamp that far behind the app timestamp.
+    /// </summary>
+    private static void PumpMessage(SummaryLogger logger, long appTicks, long latencyTicks)
+    {
+        logger.Log(new DeviceMessage
+        {
+            DeviceName = DEVICE_NAME,
+            DeviceSerialNo = DEVICE_SERIAL,
+            AppTicks = appTicks,
+            TimestampTicks = appTicks - latencyTicks
+        });
+    }
+
+    /// <summary>
+    /// Feeds one complete window of <c>SampleSize</c> messages carrying <paramref name="latencies"/>.
+    /// The messages are spaced evenly in app time, which keeps the delta statistics uniform and lets
+    /// each test vary latency alone.
+    /// </summary>
+    private static void PumpWindow(SummaryLogger logger, params long[] latencies)
+    {
+        Assert.AreEqual(
+            logger.SampleSize,
+            latencies.Length,
+            "A window is exactly SampleSize messages; supply one latency per message.");
+
+        var appTicks = FIRST_APP_TICKS;
+        foreach (var latency in latencies)
+        {
+            PumpMessage(logger, appTicks, latency);
+            appTicks += 10_000;
+        }
+    }
+
+    /// <summary>
+    /// Builds an array of <paramref name="count"/> copies of <paramref name="latency"/>.
+    /// </summary>
+    private static long[] Repeated(long latency, int count)
+    {
+        var values = new long[count];
+        Array.Fill(values, latency);
+        return values;
+    }
+
+    [TestMethod]
+    public void Log_AverageLatency_IsTheMeanOfTheWindowsLatencies()
+    {
+        var logger = new SummaryLogger(5);
+
+        PumpWindow(logger, 100, 200, 300, 400, 500);
+
+        // (100 + 200 + 300 + 400 + 500) / 5. Dividing the same sum by SampleSize - 1 gives 375.
+        Assert.AreEqual(300.0, logger.AverageLatency, 1e-9);
+    }
+
+    /// <summary>
+    /// The window bound must not scale the mean. Every message in both windows carries the same
+    /// latency, so a correct mean is that latency at any <c>SampleSize</c>; a mean denominated by
+    /// <c>SampleSize - 1</c> instead reads high by <c>SampleSize / (SampleSize - 1)</c>, which is a
+    /// different number for each window size.
+    /// </summary>
+    [TestMethod]
+    public void Log_AverageLatency_IsIndependentOfSampleSize()
+    {
+        var small = new SummaryLogger(5);
+        var large = new SummaryLogger(16);
+
+        PumpWindow(small, Repeated(1000, small.SampleSize));
+        PumpWindow(large, Repeated(1000, large.SampleSize));
+
+        Assert.AreEqual(1000.0, small.AverageLatency, 1e-9);
+        Assert.AreEqual(1000.0, large.AverageLatency, 1e-9);
+        Assert.AreEqual(small.AverageLatency, large.AverageLatency, 1e-9);
+    }
+
+    /// <summary>
+    /// A single-message window is reachable from the UI — the Summary flyout's sample-size control is
+    /// <c>&lt;controls:NumericUpDown ... Minimum="1" /&gt;</c> — and dividing that one latency by
+    /// <c>SampleSize - 1</c> divides by zero, so the flyout displayed an infinity.
+    /// </summary>
+    [TestMethod]
+    public void Log_AverageLatency_IsFinite_WhenSampleSizeIsOne()
+    {
+        var logger = new SummaryLogger(1);
+
+        PumpWindow(logger, 700);
+
+        Assert.IsFalse(double.IsInfinity(logger.AverageLatency), "Average latency must stay finite.");
+        Assert.IsFalse(double.IsNaN(logger.AverageLatency), "Average latency must stay a number.");
+        Assert.AreEqual(700.0, logger.AverageLatency, 1e-9);
+    }
+
+    /// <summary>
+    /// Each window is scored on its own messages. <c>SummaryBuffer.Reset()</c> zeroes the accumulator
+    /// on every swap, so a second window must not inherit any part of the first window's mean.
+    /// </summary>
+    [TestMethod]
+    public void Log_AverageLatency_DoesNotCarryAcrossWindows()
+    {
+        var logger = new SummaryLogger(3);
+
+        PumpWindow(logger, 100, 100, 100);
+        Assert.AreEqual(100.0, logger.AverageLatency, 1e-9);
+
+        PumpWindow(logger, 400, 400, 400);
+        Assert.AreEqual(400.0, logger.AverageLatency, 1e-9);
+    }
+
+    /// <summary>
+    /// The extremes are seeded from the first message of the window rather than from the zeroed
+    /// buffer, so a window whose latencies never reach zero still reports its own smallest and
+    /// largest. This guards the seeding that the average accumulator was missing.
+    /// </summary>
+    [TestMethod]
+    public void Log_MinAndMaxLatency_SpanEveryMessageInTheWindow()
+    {
+        var logger = new SummaryLogger(4);
+
+        PumpWindow(logger, 300, 100, 900, 500);
+
+        Assert.AreEqual(100.0, logger.MinLatency, 1e-9);
+        Assert.AreEqual(900.0, logger.MaxLatency, 1e-9);
+    }
+
+    /// <summary>
+    /// Regression guard for the accumulator this fix deliberately leaves alone. The device-level
+    /// <c>AverageDelta</c> is guarded by <c>SampleCount &gt; 0</c>, so a window of <c>SampleSize</c>
+    /// messages really does contribute <c>SampleSize - 1</c> intervals and its <c>SampleSize - 1</c>
+    /// denominator is correct.
+    /// </summary>
+    [TestMethod]
+    public void Log_AverageDelta_StillAveragesOverSampleSizeMinusOneIntervals()
+    {
+        var logger = new SummaryLogger(5);
+
+        // Four intervals of 10, 20, 30 and 40 ticks between five messages: mean 25.
+        var appTicks = FIRST_APP_TICKS;
+        PumpMessage(logger, appTicks, 1);
+        foreach (var interval in new long[] { 10, 20, 30, 40 })
+        {
+            appTicks += interval;
+            PumpMessage(logger, appTicks, 1);
+        }
+
+        Assert.AreEqual(25.0, logger.AverageDelta, 1e-9);
+        Assert.AreEqual(10.0, logger.MinDelta, 1e-9);
+        Assert.AreEqual(40.0, logger.MaxDelta, 1e-9);
+    }
+
+    /// <summary>
+    /// A single-message window has no intervals at all, so the delta accumulator must never run and
+    /// must not divide by its own zero denominator either.
+    /// </summary>
+    [TestMethod]
+    public void Log_AverageDelta_IsZero_WhenSampleSizeIsOne()
+    {
+        var logger = new SummaryLogger(1);
+
+        PumpWindow(logger, 700);
+
+        Assert.AreEqual(0.0, logger.AverageDelta, 1e-9);
+    }
+}

--- a/Daqifi.Desktop/Loggers/SummaryLogger.cs
+++ b/Daqifi.Desktop/Loggers/SummaryLogger.cs
@@ -187,17 +187,18 @@ public partial class SummaryLogger : ObservableObject, ILogger
         public long MinDeltaTicks { get; set; }
 
         /// <summary>
-        /// The maximum time between when the board reported a message and when the app recieved it
+        /// The longest time between when the board reported a message and when the app received it
         /// </summary>
         public long MaxLatencyTicks { get; set; }
 
         /// <summary>
-        /// The inimum time between when the board reported a message and when the app recieved it
+        /// The shortest time between when the board reported a message and when the app received it
         /// </summary>
         public long MinLatencyTicks { get; set; }
 
         /// <summary>
-        /// The minimum time between when the board reported a message and when the app recieved it
+        /// The running mean time between when the board reported a message and when the app
+        /// received it
         /// </summary>
         public double AverageLatencyTicks { get; set; }
 
@@ -292,17 +293,17 @@ public partial class SummaryLogger : ObservableObject, ILogger
     public double AverageDelta => _current.AverageDeltaTicks;
 
     /// <summary>
-    /// The maximum time between samples
+    /// The longest message latency in the sample set
     /// </summary>
     public double MaxLatency => _current.MaxLatencyTicks;
 
     /// <summary>
-    /// The minimum time between samples
+    /// The shortest message latency in the sample set
     /// </summary>
     public double MinLatency => _current.MinLatencyTicks;
 
     /// <summary>
-    /// The minimum time between samples
+    /// The mean message latency of the sample set
     /// </summary>
     public double AverageLatency => _current.AverageLatencyTicks;
 
@@ -450,7 +451,14 @@ public partial class SummaryLogger : ObservableObject, ILogger
                 _buffer.MinLatencyTicks = Math.Min(latency, _buffer.MinLatencyTicks);
                 _buffer.MaxLatencyTicks = Math.Max(latency, _buffer.MaxLatencyTicks);
             }
-            _buffer.AverageLatencyTicks += latency / (double)(SampleSize - 1);
+            // Mean over the messages this window actually holds. Unlike the delta accumulator
+            // below, this one has no first-message guard, so it runs for all SampleSize messages
+            // of a completed window -- one more than the (SampleSize - 1) it used to divide by,
+            // which read the average high by SampleSize / (SampleSize - 1) and produced Infinity
+            // at the SampleSize of 1 the Summary flyout's NumericUpDown permits. SampleCount is
+            // still the pre-increment count here, so this incremental form divides the first
+            // value by 1 (seeding exactly) and the n-th by n, for any window length.
+            _buffer.AverageLatencyTicks += (latency - _buffer.AverageLatencyTicks) / (_buffer.SampleCount + 1);
 
             if (_buffer.SampleCount > 0)
             {
@@ -466,6 +474,11 @@ public partial class SummaryLogger : ObservableObject, ILogger
                     _buffer.MaxDeltaTicks = Math.Max(_buffer.MaxDeltaTicks, elapsed);
                 }
 
+                // Deliberately keeps the (SampleSize - 1) denominator: this branch IS guarded by
+                // SampleCount > 0, so a completed window of SampleSize messages contributes
+                // exactly SampleSize - 1 intervals. It also cannot divide by zero, because at a
+                // SampleSize of 1 the window swaps after the first message and the guard never
+                // opens.
                 _buffer.AverageDeltaTicks += elapsed / (double)(SampleSize - 1);
             }
             _buffer.LastSampleTicks = dataSample.AppTicks;


### PR DESCRIPTION
Closes #760.

> **Not merging — this is for your review.**

## The bug

`SummaryLogger.Log(DeviceMessage)` accumulated the device-level average latency like this:

```csharp
var latency = dataSample.AppTicks - dataSample.TimestampTicks;
if (_buffer.SampleCount == 0) { /* seed Min/MaxLatencyTicks */ }
else                          { /* Math.Min / Math.Max      */ }
_buffer.AverageLatencyTicks += latency / (double)(SampleSize - 1);   // <-- no first-message guard
```

Unlike the delta accumulator a few lines below, this expression sits **outside** any
`SampleCount > 0` guard, so it runs for every message of the window. A completed window is exactly
`SampleSize` messages — the swap fires at `_buffer.SampleCount == SampleSize` — so `SampleSize`
values were summed and divided by `SampleSize - 1`.

Two consequences, both visible on the Summary flyout's **Average Latency** field:

1. **Reads high by `SampleSize / (SampleSize - 1)`.** At the default sample size of 1000 that is
   +0.1% and cosmetic. At a small window it is not: a sample size of 4 overstates latency by 33%.
2. **A sample size of 1 divides by zero and displays an infinity.** That is reachable from the UI —
   the flyout's control is `<controls:NumericUpDown ... Minimum="1" />`
   (`Daqifi.Desktop/View/Flyouts/SummaryFlyout.xaml:44`).

## The fix

The same incremental (Welford) mean already used for the per-channel statistics:

```csharp
_buffer.AverageLatencyTicks += (latency - _buffer.AverageLatencyTicks) / (_buffer.SampleCount + 1);
```

`_buffer.SampleCount` is still the pre-increment count at that point (`++_buffer.SampleCount` is
further down), so the first message divides by 1 — seeding the mean exactly — and the n-th by n.
Exact for every window length, and independent of `SampleSize`, which matters because `SampleSize`
is a live user-editable field. `SummaryBuffer.Reset()` already zeroes `AverageLatencyTicks` on every
swap, so nothing else had to change.

## Deliberately *not* changed

`_buffer.AverageDeltaTicks += elapsed / (double)(SampleSize - 1)`, in the same method. That one **is**
correct: it is guarded by `if (_buffer.SampleCount > 0)`, so a window of `SampleSize` messages
contributes exactly `SampleSize - 1` intervals, and it cannot divide by zero either — at a sample
size of 1 the window swaps after the first message and the guard never opens. Since the two
expressions now look different, I added a comment explaining why, plus a regression test
(`Log_AverageDelta_StillAveragesOverSampleSizeMinusOneIntervals`) pinning the behaviour.

The per-channel accumulators in `Log(DataSample)` are the subject of #758 and are untouched here.

## Also in this PR

The XML docs on the six latency members were copy-pasted from the delta statistics and described the
wrong quantity — `AverageLatency` was documented as *"The minimum time between samples"*, and
`AverageLatencyTicks` as *"The minimum time between when the board reported a message…"*. Corrected,
along with an `inimum`/`recieved` typo in the same block. Plausibly how the wrong denominator
survived review.

## Tests

New file `Daqifi.Desktop.Test/Loggers/SummaryLoggerLatencyTests.cs`, **7 tests**.

**Why a new file rather than adding to `SummaryLoggerTests.cs`:** that file is *added* by the
still-open #758, so putting these tests there would produce an add/add merge conflict between the
two PRs. Keeping them separate makes the two independently mergeable in either order — they touch
different methods of `SummaryLogger.cs`, so that file merges cleanly. They can be folded together
once both land.

**4 of the 7 were verified failing against the unfixed code** before the fix was written:

| Test | Pre-fix | Post-fix |
|---|---|---|
| `Log_AverageLatency_IsTheMeanOfTheWindowsLatencies` | 375 | 300 |
| `Log_AverageLatency_IsIndependentOfSampleSize` | 1250 at SampleSize 5 vs 1066.7 at 16 | 1000 at both |
| `Log_AverageLatency_IsFinite_WhenSampleSizeIsOne` | `Infinity` | 700 |
| `Log_AverageLatency_DoesNotCarryAcrossWindows` | 150 | 100 |

The other 3 are controls that pass both before and after —
`Log_MinAndMaxLatency_SpanEveryMessageInTheWindow` (the extremes were already seeded correctly; this
pins the seeding the average was missing), `Log_AverageDelta_StillAveragesOverSampleSizeMinusOneIntervals`,
and `Log_AverageDelta_IsZero_WhenSampleSizeIsOne`.

## Gates

| Gate | Result |
|---|---|
| `dotnet build --no-incremental` | 0 errors, **887 warnings — byte-identical to the `main` baseline** captured before any edit |
| Unit gate (`TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests`) | **696 passed / 0 failed** (689 `main` baseline + 7 new) |
| App-launch smoke (`Launch_MainWindowAppears_AndIsResponsive`) | **PASS**, 12s |
| Device bench — `LoggingSessionTests.StartLoggingSession_RendersLivePlot_RunsStopsAndDeletesSession` | **PASS**, 1m16s, on the board at COM3 (`USB\VID_04D8&PID_F794`) |

Line-length note: the only >120-char line in `SummaryLogger.cs` is `ElapsedTime` at line 261
(124 chars), which is pre-existing — `git blame` puts it at `51aaaab`, 2022 — and is untouched by
this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
