### PR TITLE
fix(logging): publish SubscribedChannels copy-on-write

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
@@ -111,9 +111,10 @@ public class LoggingManagerSubscribedChannelsTests
     /// decode thread.
     /// </summary>
     /// <remarks>
-    /// The reader signals that it is genuinely inside the enumeration loop before the mutations
-    /// start, so the two really do overlap — a stress test whose threads never run at the same time
-    /// passes against broken code.
+    /// The reader signals from inside the <c>foreach</c> body, so when the mutation loop starts the
+    /// reader is provably mid-enumeration rather than merely alive — a stress test whose threads
+    /// never run at the same time passes against broken code. It then keeps enumerating for the
+    /// whole budget, so the overlap is sustained rather than a single lucky instant.
     /// </remarks>
     [TestMethod]
     public void SubscribedChannels_IsSafeToEnumerate_WhileAnotherThreadSubscribesAndUnsubscribes()
@@ -138,9 +139,15 @@ public class LoggingManagerSubscribedChannelsTests
                     foreach (var channel in manager.SubscribedChannels)
                     {
                         _ = channel.Name;
-                    }
 
-                    readerIsEnumerating.Set();
+                        // Signalled from *inside* the enumeration, not after it: the waiter's
+                        // guarantee has to be "the reader is mid-enumeration right now", not merely
+                        // "the reader has run at least once".
+                        if (!readerIsEnumerating.IsSet)
+                        {
+                            readerIsEnumerating.Set();
+                        }
+                    }
                 }
             }
             catch (Exception ex)
@@ -193,7 +200,7 @@ public class LoggingManagerSubscribedChannelsTests
         manager.Subscribe(channel);
 
         // Assert
-        CollectionAssert.AreEqual(new[] { channel }, manager.SubscribedChannels);
+        CollectionAssert.AreEqual(new[] { channel }, manager.SubscribedChannels.ToList());
         Assert.IsTrue(channel.IsActive);
     }
 
@@ -312,21 +319,27 @@ public class LoggingManagerSubscribedChannelsTests
         CollectionAssert.Contains(raised, nameof(LoggingManager.SubscribedChannels));
     }
 
+    /// <summary>
+    /// Reading the property must hand back the same published snapshot every time until something
+    /// actually changes. A getter that materialized a fresh copy per read would also be safe, but
+    /// it would allocate on the transport thread for every series creation and would silently break
+    /// the reference comparisons the copy-on-write tests above rely on.
+    /// </summary>
     [TestMethod]
-    public void SubscribedChannelsSetter_RaisesPropertyChanged_AndCoercesNullToAnEmptyList()
+    public void SubscribedChannels_ReturnsTheSameSnapshot_UntilSomethingChanges()
     {
         // Arrange
         var manager = NewManager();
-        var raised = new List<string?>();
-        manager.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        manager.Subscribe(NewChannel("AI0"));
 
         // Act
-        manager.SubscribedChannels = null!;
+        var first = manager.SubscribedChannels;
+        var second = manager.SubscribedChannels;
 
         // Assert
-        Assert.IsNotNull(manager.SubscribedChannels);
-        Assert.AreEqual(0, manager.SubscribedChannels.Count);
-        CollectionAssert.Contains(raised, nameof(LoggingManager.SubscribedChannels));
+        Assert.AreSame(first, second);
+        manager.Subscribe(NewChannel("AI1"));
+        Assert.AreNotSame(first, manager.SubscribedChannels);
     }
     #endregion
 

--- a/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
@@ -320,13 +320,15 @@ public class LoggingManagerSubscribedChannelsTests
     }
 
     /// <summary>
-    /// Reading the property must hand back the same published snapshot every time until something
-    /// actually changes. A getter that materialized a fresh copy per read would also be safe, but
-    /// it would allocate on the transport thread for every series creation and would silently break
-    /// the reference comparisons the copy-on-write tests above rely on.
+    /// Reading the property must hand back the same published snapshot every time while nothing
+    /// changes. A getter that materialized a fresh copy per read would also be safe, but it would
+    /// allocate on the transport thread for every series creation and would silently break the
+    /// reference comparisons the copy-on-write tests above rely on. The other half of the contract
+    /// — that a mutation publishes a <em>different</em> instance — is asserted by the
+    /// <c>PublishesANewList</c> tests.
     /// </summary>
     [TestMethod]
-    public void SubscribedChannels_ReturnsTheSameSnapshot_UntilSomethingChanges()
+    public void SubscribedChannels_ReturnsTheSameSnapshot_WhileNothingChanges()
     {
         // Arrange
         var manager = NewManager();
@@ -338,8 +340,6 @@ public class LoggingManagerSubscribedChannelsTests
 
         // Assert
         Assert.AreSame(first, second);
-        manager.Subscribe(NewChannel("AI1"));
-        Assert.AreNotSame(first, manager.SubscribedChannels);
     }
     #endregion
 

--- a/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
@@ -1,0 +1,374 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Configuration;
+using Daqifi.Desktop.Logger;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.Loggers;
+
+/// <summary>
+/// Covers <see cref="LoggingManager.SubscribedChannels"/> and its mutators.
+/// <para>
+/// The point of these tests is the copy-on-write contract: <c>SubscribedChannels</c> is read from
+/// the device transport thread (<c>PlotLogger</c> resolves series visibility there) while the UI
+/// thread subscribes and unsubscribes, so a mutator must publish a new list rather than change the
+/// one a reader may be enumerating.
+/// </para>
+/// </summary>
+[TestClass]
+public class LoggingManagerSubscribedChannelsTests
+{
+    #region Constants
+    private const string DEVICE_SERIAL = "SN-0001";
+    private const string OTHER_DEVICE_SERIAL = "SN-0002";
+
+    /// <summary>
+    /// Wall-clock budget for the mutation loop in the concurrency test. Against the unfixed code
+    /// the reader faulted in single-digit milliseconds, so this is generous.
+    /// </summary>
+    private const int MUTATION_BUDGET_MS = 300;
+
+    /// <summary>Ceiling for any wait that only a broken build should ever exhaust.</summary>
+    private const int THREAD_WAIT_TIMEOUT_MS = 10_000;
+    #endregion
+
+    #region Setup
+    private static LoggingManager NewManager()
+    {
+        // The parameterless constructor resolves its context factory from App.ServiceProvider,
+        // which does not exist in the test host. The internal constructor is the seam.
+        return new LoggingManager(new Mock<IDbContextFactory<LoggingContext>>().Object);
+    }
+
+    private static FakeChannel NewChannel(string name, string deviceSerial = DEVICE_SERIAL)
+    {
+        return new FakeChannel { Name = name, DeviceSerialNo = deviceSerial };
+    }
+    #endregion
+
+    #region Copy-on-write contract
+    [TestMethod]
+    public void Subscribe_PublishesANewList_LeavingAnAlreadyHandedOutSnapshotUntouched()
+    {
+        // Arrange
+        var manager = NewManager();
+        var snapshotTakenByAReader = manager.SubscribedChannels;
+
+        // Act
+        manager.Subscribe(NewChannel("AI0"));
+
+        // Assert - the reader's list must not have grown under it, and the property must now
+        // hand out a different list containing the new channel.
+        Assert.AreEqual(0, snapshotTakenByAReader.Count);
+        Assert.AreNotSame(snapshotTakenByAReader, manager.SubscribedChannels);
+        Assert.AreEqual(1, manager.SubscribedChannels.Count);
+    }
+
+    [TestMethod]
+    public void Unsubscribe_PublishesANewList_LeavingAnAlreadyHandedOutSnapshotUntouched()
+    {
+        // Arrange
+        var manager = NewManager();
+        var channel = NewChannel("AI0");
+        manager.Subscribe(channel);
+        var snapshotTakenByAReader = manager.SubscribedChannels;
+
+        // Act
+        manager.Unsubscribe(channel);
+
+        // Assert
+        Assert.AreEqual(1, snapshotTakenByAReader.Count);
+        Assert.AreNotSame(snapshotTakenByAReader, manager.SubscribedChannels);
+        Assert.AreEqual(0, manager.SubscribedChannels.Count);
+    }
+
+    [TestMethod]
+    public void ClearChannelList_PublishesANewList_LeavingAnAlreadyHandedOutSnapshotUntouched()
+    {
+        // Arrange
+        var manager = NewManager();
+        manager.Subscribe(NewChannel("AI0"));
+        manager.Subscribe(NewChannel("AI1"));
+        var snapshotTakenByAReader = manager.SubscribedChannels;
+
+        // Act
+        manager.ClearChannelList();
+
+        // Assert
+        Assert.AreEqual(2, snapshotTakenByAReader.Count);
+        Assert.AreEqual(0, manager.SubscribedChannels.Count);
+    }
+
+    /// <summary>
+    /// The regression this file exists for. A reader enumerating <c>SubscribedChannels</c> off the
+    /// UI thread must never see the list mutate mid-enumeration. Against the unfixed code the
+    /// reader throws <see cref="InvalidOperationException"/> ("Collection was modified") almost
+    /// immediately; nothing in the real transport call chain catches it, so it escapes onto Core's
+    /// decode thread.
+    /// </summary>
+    /// <remarks>
+    /// The reader signals that it is genuinely inside the enumeration loop before the mutations
+    /// start, so the two really do overlap — a stress test whose threads never run at the same time
+    /// passes against broken code.
+    /// </remarks>
+    [TestMethod]
+    public void SubscribedChannels_IsSafeToEnumerate_WhileAnotherThreadSubscribesAndUnsubscribes()
+    {
+        // Arrange - seed enough entries that an enumeration spans a meaningful window.
+        var manager = NewManager();
+        for (var i = 0; i < 8; i++)
+        {
+            manager.Subscribe(NewChannel($"AI{i}"));
+        }
+
+        Exception? escaped = null;
+        var stop = 0;
+        var readerIsEnumerating = new ManualResetEventSlim(false);
+
+        var reader = new Thread(() =>
+        {
+            try
+            {
+                while (Volatile.Read(ref stop) == 0)
+                {
+                    foreach (var channel in manager.SubscribedChannels)
+                    {
+                        _ = channel.Name;
+                    }
+
+                    readerIsEnumerating.Set();
+                }
+            }
+            catch (Exception ex)
+            {
+                Volatile.Write(ref escaped, ex);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "SubscribedChannels reader"
+        };
+
+        reader.Start();
+        Assert.IsTrue(
+            readerIsEnumerating.Wait(THREAD_WAIT_TIMEOUT_MS),
+            "The reader thread never started enumerating, so the test would not have overlapped anything.");
+
+        // Act - churn the collection for a fixed budget while the reader keeps enumerating.
+        var churn = NewChannel("AI-churn", OTHER_DEVICE_SERIAL);
+        var elapsed = Stopwatch.StartNew();
+        var mutations = 0;
+        while (elapsed.ElapsedMilliseconds < MUTATION_BUDGET_MS && Volatile.Read(ref escaped) == null)
+        {
+            manager.Subscribe(churn);
+            manager.Unsubscribe(churn);
+            mutations++;
+        }
+
+        Volatile.Write(ref stop, 1);
+        Assert.IsTrue(reader.Join(THREAD_WAIT_TIMEOUT_MS), "The reader thread did not finish.");
+
+        // Assert
+        Assert.IsNull(
+            Volatile.Read(ref escaped),
+            $"A reader on another thread faulted after {mutations} subscribe/unsubscribe cycles: " +
+            $"{Volatile.Read(ref escaped)}");
+        Assert.IsTrue(mutations > 0, "The mutation loop never ran.");
+    }
+    #endregion
+
+    #region Subscribe / Unsubscribe behaviour
+    [TestMethod]
+    public void Subscribe_AddsTheChannel_AndActivatesIt()
+    {
+        // Arrange
+        var manager = NewManager();
+        var channel = NewChannel("AI0");
+
+        // Act
+        manager.Subscribe(channel);
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { channel }, manager.SubscribedChannels);
+        Assert.IsTrue(channel.IsActive);
+    }
+
+    [TestMethod]
+    public void Subscribe_IsANoOp_WhenTheSameDeviceAndChannelIsAlreadySubscribed()
+    {
+        // Arrange
+        var manager = NewManager();
+        manager.Subscribe(NewChannel("AI0"));
+        var duplicate = NewChannel("AI0");
+
+        // Act
+        manager.Subscribe(duplicate);
+
+        // Assert
+        Assert.AreEqual(1, manager.SubscribedChannels.Count);
+        Assert.IsFalse(duplicate.IsActive, "The rejected duplicate must not have been activated.");
+    }
+
+    [TestMethod]
+    public void Subscribe_AddsBothChannels_WhenTheNameMatchesButTheDeviceDoesNot()
+    {
+        // Arrange
+        var manager = NewManager();
+        manager.Subscribe(NewChannel("AI0"));
+
+        // Act
+        manager.Subscribe(NewChannel("AI0", OTHER_DEVICE_SERIAL));
+
+        // Assert
+        Assert.AreEqual(2, manager.SubscribedChannels.Count);
+    }
+
+    [TestMethod]
+    public void Unsubscribe_RemovesTheChannel_AndDeactivatesIt()
+    {
+        // Arrange
+        var manager = NewManager();
+        var channel = NewChannel("AI0");
+        manager.Subscribe(channel);
+
+        // Act - matched by serial and name, so a distinct instance still resolves.
+        manager.Unsubscribe(NewChannel("AI0"));
+
+        // Assert
+        Assert.AreEqual(0, manager.SubscribedChannels.Count);
+        Assert.IsFalse(channel.IsActive);
+    }
+
+    [TestMethod]
+    public void Unsubscribe_IsANoOp_WhenTheChannelWasNeverSubscribed()
+    {
+        // Arrange
+        var manager = NewManager();
+        var subscribed = manager.SubscribedChannels;
+
+        // Act
+        manager.Unsubscribe(NewChannel("AI0"));
+
+        // Assert
+        Assert.AreEqual(0, manager.SubscribedChannels.Count);
+        Assert.AreSame(subscribed, manager.SubscribedChannels, "A no-op must not publish a new list.");
+    }
+
+    [TestMethod]
+    public void ClearChannelList_DeactivatesEveryChannel_AndEmptiesTheList()
+    {
+        // Arrange
+        var manager = NewManager();
+        var first = NewChannel("AI0");
+        var second = NewChannel("AI1");
+        manager.Subscribe(first);
+        manager.Subscribe(second);
+
+        // Act
+        manager.ClearChannelList();
+
+        // Assert
+        Assert.AreEqual(0, manager.SubscribedChannels.Count);
+        Assert.IsFalse(first.IsActive);
+        Assert.IsFalse(second.IsActive);
+    }
+    #endregion
+
+    #region Change notification
+    [TestMethod]
+    public void Subscribe_RaisesPropertyChanged_ForSubscribedChannels()
+    {
+        // Arrange
+        var manager = NewManager();
+        var raised = new List<string?>();
+        manager.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        // Act
+        manager.Subscribe(NewChannel("AI0"));
+
+        // Assert
+        CollectionAssert.Contains(raised, nameof(LoggingManager.SubscribedChannels));
+    }
+
+    [TestMethod]
+    public void Unsubscribe_RaisesPropertyChanged_ForSubscribedChannels()
+    {
+        // Arrange
+        var manager = NewManager();
+        var channel = NewChannel("AI0");
+        manager.Subscribe(channel);
+
+        var raised = new List<string?>();
+        manager.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        // Act
+        manager.Unsubscribe(channel);
+
+        // Assert
+        CollectionAssert.Contains(raised, nameof(LoggingManager.SubscribedChannels));
+    }
+
+    [TestMethod]
+    public void SubscribedChannelsSetter_RaisesPropertyChanged_AndCoercesNullToAnEmptyList()
+    {
+        // Arrange
+        var manager = NewManager();
+        var raised = new List<string?>();
+        manager.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        // Act
+        manager.SubscribedChannels = null!;
+
+        // Assert
+        Assert.IsNotNull(manager.SubscribedChannels);
+        Assert.AreEqual(0, manager.SubscribedChannels.Count);
+        CollectionAssert.Contains(raised, nameof(LoggingManager.SubscribedChannels));
+    }
+    #endregion
+
+    #region Helper Types
+    /// <summary>
+    /// A hand-rolled <see cref="IChannel"/> so the concurrency test exercises the collection under
+    /// test rather than a mocking framework's own internal state, which is not documented as safe
+    /// to touch from two threads at once.
+    /// </summary>
+    private sealed class FakeChannel : IChannel
+    {
+        public int ID { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string DeviceName { get; set; } = string.Empty;
+        public string DeviceSerialNo { get; set; } = string.Empty;
+        public int Index => 0;
+        public double OutputValue { get; set; }
+        public ChannelType Type => ChannelType.Analog;
+        public ChannelDirection Direction { get; set; }
+        public string TypeString => Type.ToString();
+        public string ScaleExpression { get; set; } = string.Empty;
+        public System.Windows.Media.Brush ChannelColorBrush { get; set; } = System.Windows.Media.Brushes.Transparent;
+        public bool IsBidirectional { get; set; }
+        public bool IsOutput { get; set; }
+        public bool HasAdc { get; set; }
+        public bool IsActive { get; set; }
+        public bool IsDigital => false;
+        public bool IsAnalog => true;
+        public bool IsDigitalOn { get; set; }
+        public bool IsPwmCapable => false;
+        public bool IsPwmEnabled { get; set; }
+        public int PwmDutyCyclePercent { get; set; }
+        public bool IsScalingActive { get; set; }
+        public bool HasValidExpression { get; set; }
+        public DataSample ActiveSample { get; set; } = null!;
+        public bool IsVisible { get; set; } = true;
+
+        public event OnChannelUpdatedHandler OnChannelUpdated = null!;
+
+        public void NotifyChannelUpdated(object sender, DataSample e) => OnChannelUpdated?.Invoke(sender, e);
+
+        public void SetColor(System.Windows.Media.Brush color) => ChannelColorBrush = color;
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -40,16 +40,19 @@ public partial class LoggingManager : ObservableObject
     private List<IChannel> _subscribedChannels = [];
 
     /// <summary>
-    /// Gets or sets the channels currently subscribed for logging.
+    /// Gets the channels currently subscribed for logging.
     /// </summary>
     /// <remarks>
-    /// The returned list is <b>immutable by contract</b>: callers must not mutate it, and every
-    /// mutation inside this class publishes a brand-new list instead of changing this one in place
-    /// (copy-on-write). That is what makes the property safe to read from a non-UI thread —
-    /// <see cref="PlotLogger"/> resolves channel visibility from the device transport thread while
-    /// the UI thread subscribes and unsubscribes, and <see cref="List{T}"/> does not tolerate a
-    /// read that overlaps an <c>Add</c>/<c>Remove</c>/<c>Clear</c> (it throws
-    /// <see cref="InvalidOperationException"/> mid-enumeration, or observes a torn state).
+    /// The returned list is a <b>snapshot that is never mutated</b>: every change goes through
+    /// <see cref="Subscribe"/>, <see cref="Unsubscribe"/> or <see cref="ClearChannelList"/>, each of
+    /// which publishes a brand-new list rather than changing this one in place (copy-on-write). That
+    /// is what makes the property safe to read from a non-UI thread — <see cref="PlotLogger"/>
+    /// resolves channel visibility from the device transport thread while the UI thread subscribes
+    /// and unsubscribes, and <see cref="List{T}"/> does not tolerate a read that overlaps an
+    /// <c>Add</c>/<c>Remove</c>/<c>Clear</c> (it throws <see cref="InvalidOperationException"/>
+    /// mid-enumeration, or observes a torn state). It is exposed as
+    /// <see cref="IReadOnlyList{T}"/>, and those three methods are the only way in, so the guarantee
+    /// is a property of the API rather than of caller discipline.
     /// <para>
     /// Written under <see cref="_subscribedChannelsSync"/> and published with
     /// <see cref="Volatile"/> so a reader on another core cannot observe a partially constructed
@@ -57,24 +60,7 @@ public partial class LoggingManager : ObservableObject
     /// that reason — the generated accessors do a plain field read/write.
     /// </para>
     /// </remarks>
-    public List<IChannel> SubscribedChannels
-    {
-        get => Volatile.Read(ref _subscribedChannels);
-        set
-        {
-            lock (_subscribedChannelsSync)
-            {
-                if (ReferenceEquals(_subscribedChannels, value))
-                {
-                    return;
-                }
-
-                Volatile.Write(ref _subscribedChannels, value ?? []);
-            }
-
-            OnPropertyChanged();
-        }
-    }
+    public IReadOnlyList<IChannel> SubscribedChannels => Volatile.Read(ref _subscribedChannels);
 
     [ObservableProperty]
     private bool _active;
@@ -251,10 +237,12 @@ public partial class LoggingManager : ObservableObject
     internal LoggingManager(IDbContextFactory<LoggingContext> loggingContext)
     {
         Loggers = [];
-        SubscribedChannels = [];
         _loggingContext = loggingContext;
     }
 
+    /// <summary>
+    /// Gets the process-wide logging manager. Created on first access.
+    /// </summary>
     public static LoggingManager Instance => _instance.Value;
 
     #endregion
@@ -530,8 +518,8 @@ public partial class LoggingManager : ObservableObject
         {
             var current = _subscribedChannels;
 
-            var subscribedChannel = current
-                .FirstOrDefault(x => x.DeviceSerialNo == channel.DeviceSerialNo && x.Name == channel.Name && x.IsActive);
+            var subscribedChannel = current.FirstOrDefault(
+                x => x.DeviceSerialNo == channel.DeviceSerialNo && x.Name == channel.Name && x.IsActive);
 
             if (subscribedChannel == null)
             {

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -22,6 +22,14 @@ public partial class LoggingManager : ObservableObject
     private static string ProfileAppDirectory = Daqifi.Desktop.Common.AppDataPaths.DataDirectory;
     private static readonly string ProfileSettingsXmlPath = ProfileAppDirectory + "\\DAQifiProfilesConfiguration.xml";
     private readonly IDbContextFactory<LoggingContext> _loggingContext;
+
+    /// <summary>
+    /// Serializes writers of <see cref="SubscribedChannels"/>. Readers never take it — they read a
+    /// published snapshot — so it is never held while calling into a logger or raising a
+    /// notification, and it cannot nest inside any other lock.
+    /// </summary>
+    private readonly object _subscribedChannelsSync = new();
+
     private bool _hasActiveApplicationSession;
     private bool _hasActiveApplicationSamples;
     #endregion
@@ -29,8 +37,44 @@ public partial class LoggingManager : ObservableObject
     #region Properties
     public List<ILogger> Loggers { get; }
 
-    [ObservableProperty]
     private List<IChannel> _subscribedChannels = [];
+
+    /// <summary>
+    /// Gets or sets the channels currently subscribed for logging.
+    /// </summary>
+    /// <remarks>
+    /// The returned list is <b>immutable by contract</b>: callers must not mutate it, and every
+    /// mutation inside this class publishes a brand-new list instead of changing this one in place
+    /// (copy-on-write). That is what makes the property safe to read from a non-UI thread —
+    /// <see cref="PlotLogger"/> resolves channel visibility from the device transport thread while
+    /// the UI thread subscribes and unsubscribes, and <see cref="List{T}"/> does not tolerate a
+    /// read that overlaps an <c>Add</c>/<c>Remove</c>/<c>Clear</c> (it throws
+    /// <see cref="InvalidOperationException"/> mid-enumeration, or observes a torn state).
+    /// <para>
+    /// Written under <see cref="_subscribedChannelsSync"/> and published with
+    /// <see cref="Volatile"/> so a reader on another core cannot observe a partially constructed
+    /// list. Written as an explicit property rather than <c>[ObservableProperty]</c> for exactly
+    /// that reason — the generated accessors do a plain field read/write.
+    /// </para>
+    /// </remarks>
+    public List<IChannel> SubscribedChannels
+    {
+        get => Volatile.Read(ref _subscribedChannels);
+        set
+        {
+            lock (_subscribedChannelsSync)
+            {
+                if (ReferenceEquals(_subscribedChannels, value))
+                {
+                    return;
+                }
+
+                Volatile.Write(ref _subscribedChannels, value ?? []);
+            }
+
+            OnPropertyChanged();
+        }
+    }
 
     [ObservableProperty]
     private bool _active;
@@ -185,16 +229,33 @@ public partial class LoggingManager : ObservableObject
     }
 
     #region Singleton Constructor / Initalization
-    private static readonly LoggingManager instance = new();
+    // Deferred rather than an eager static field initializer: the parameterless constructor resolves
+    // from App.ServiceProvider, which is null outside the running app. An eager initializer can run
+    // as soon as the type is touched — and a failed static initializer is permanent for the whole
+    // process — so that turned any use of this type outside the app into a hard failure. Deferring
+    // it to the first Instance access keeps the type usable from unit tests, which build their own
+    // instance through the internal constructor below.
+    private static readonly Lazy<LoggingManager> _instance = new(() => new LoggingManager());
 
     private LoggingManager()
+        : this(App.ServiceProvider.GetRequiredService<IDbContextFactory<LoggingContext>>())
+    {
+    }
+
+    /// <summary>
+    /// Test seam: builds an instance with an explicitly supplied database context factory rather
+    /// than resolving one from <see cref="App.ServiceProvider"/>, which only exists while the
+    /// application is running.
+    /// </summary>
+    /// <param name="loggingContext">Factory used to open <see cref="LoggingContext"/> sessions.</param>
+    internal LoggingManager(IDbContextFactory<LoggingContext> loggingContext)
     {
         Loggers = [];
         SubscribedChannels = [];
-        _loggingContext = App.ServiceProvider.GetRequiredService<IDbContextFactory<LoggingContext>>();
+        _loggingContext = loggingContext;
     }
 
-    public static LoggingManager Instance => instance;
+    public static LoggingManager Instance => _instance.Value;
 
     #endregion
 
@@ -425,41 +486,70 @@ public partial class LoggingManager : ObservableObject
     #endregion
 
     #region Channel Subscription
+    /// <summary>
+    /// Adds <paramref name="channel"/> to <see cref="SubscribedChannels"/> and activates it.
+    /// Subscribing an already-subscribed channel is a no-op.
+    /// </summary>
+    /// <param name="channel">The channel to subscribe.</param>
     public void Subscribe(IChannel channel)
     {
-        if (SubscribedChannels.Any(x => x.DeviceSerialNo == channel.DeviceSerialNo && x.Name == channel.Name))
+        lock (_subscribedChannelsSync)
         {
-            return;
+            var current = _subscribedChannels;
+
+            if (current.Any(x => x.DeviceSerialNo == channel.DeviceSerialNo && x.Name == channel.Name))
+            {
+                return;
+            }
+
+            channel.IsActive = true;
+
+            // Only attach streaming handlers if in Stream mode
+            if (CurrentMode == LoggingMode.Stream)
+            {
+                channel.OnChannelUpdated += HandleChannelUpdate;
+            }
+
+            // Copy-on-write: publish a new list instead of Add-ing to the one a reader on the
+            // transport thread may be enumerating right now. See SubscribedChannels' remarks.
+            Volatile.Write(ref _subscribedChannels, [.. current, channel]);
         }
 
-        channel.IsActive = true;
-
-        // Only attach streaming handlers if in Stream mode
-        if (CurrentMode == LoggingMode.Stream)
-        {
-            channel.OnChannelUpdated += HandleChannelUpdate;
-        }
-
-        SubscribedChannels.Add(channel);
+        // Raised outside the lock so a binding handler can never re-enter under it.
         OnPropertyChanged(nameof(SubscribedChannels));
     }
 
+    /// <summary>
+    /// Removes <paramref name="channel"/> from <see cref="SubscribedChannels"/> and deactivates it.
+    /// Unsubscribing a channel that is not subscribed (or is already inactive) is a no-op.
+    /// </summary>
+    /// <param name="channel">The channel to unsubscribe. Matched by device serial number and name.</param>
     public void Unsubscribe(IChannel channel)
     {
-        var subscribedChannel = SubscribedChannels
-            .FirstOrDefault(x => x.DeviceSerialNo == channel.DeviceSerialNo && x.Name == channel.Name && x.IsActive);
-
-        if (subscribedChannel == null)
+        lock (_subscribedChannelsSync)
         {
-            return;
+            var current = _subscribedChannels;
+
+            var subscribedChannel = current
+                .FirstOrDefault(x => x.DeviceSerialNo == channel.DeviceSerialNo && x.Name == channel.Name && x.IsActive);
+
+            if (subscribedChannel == null)
+            {
+                return;
+            }
+
+            subscribedChannel.IsActive = false;
+
+            // Remove event handler if it's attached
+            subscribedChannel.OnChannelUpdated -= HandleChannelUpdate;
+
+            // Copy-on-write — see SubscribedChannels' remarks.
+            var updated = new List<IChannel>(current);
+            updated.Remove(subscribedChannel);
+            Volatile.Write(ref _subscribedChannels, updated);
         }
 
-        subscribedChannel.IsActive = false;
-
-        // Remove event handler if it's attached
-        subscribedChannel.OnChannelUpdated -= HandleChannelUpdate;
-
-        SubscribedChannels.Remove(subscribedChannel);
+        // Raised outside the lock so a binding handler can never re-enter under it.
         OnPropertyChanged(nameof(SubscribedChannels));
     }
     #endregion
@@ -810,14 +900,30 @@ public partial class LoggingManager : ObservableObject
         }
     }
 
-    private void ClearChannelList()
+    /// <summary>
+    /// Deactivates and unsubscribes every channel in <see cref="SubscribedChannels"/>.
+    /// </summary>
+    /// <remarks>
+    /// Internal rather than private so it can be covered directly: its only production caller,
+    /// <see cref="UnsubscribeProfile"/>, writes the profiles XML first and swallows any failure,
+    /// so driving this through it would touch the user's real data directory.
+    /// </remarks>
+    internal void ClearChannelList()
     {
-        foreach (var channel in SubscribedChannels)
+        lock (_subscribedChannelsSync)
         {
-            channel.IsActive = false;
-            channel.OnChannelUpdated -= HandleChannelUpdate;
+            foreach (var channel in _subscribedChannels)
+            {
+                channel.IsActive = false;
+                channel.OnChannelUpdated -= HandleChannelUpdate;
+            }
+
+            // Copy-on-write — see SubscribedChannels' remarks. Clear() would empty the very list a
+            // reader on the transport thread may be enumerating.
+            Volatile.Write(ref _subscribedChannels, []);
         }
-        SubscribedChannels.Clear();
+
+        // Raised outside the lock so a binding handler can never re-enter under it.
         OnPropertyChanged(nameof(SubscribedChannels));
     }
 }


### PR DESCRIPTION
Closes #762.

**Not merging — this is for your review.**

## The bug

`LoggingManager.SubscribedChannels` is a plain `List<IChannel>` that is **read from the device transport thread and written from the UI thread**, with nothing synchronizing the two.

- **Reader (transport thread):** `PlotLogger.Log(DataSample)` → `AddChannelSeries` → `SubscribedChannels.FirstOrDefault(...)` when a channel's series is first created (`PlotLogger.cs:276`). The chain is `AbstractStreamingDevice.OnCoreChannelSampleReceived` → `AbstractChannel.ActiveSample` → `NotifyChannelUpdated` → `LoggingManager.HandleChannelUpdate` → `logger.Log(sample)`.
- **Writers (UI thread):** `Subscribe` (`.Add`), `Unsubscribe` (`.Remove`), `ClearChannelList` (`.Clear()`).

`List<T>` does not tolerate a read that overlaps a structural mutation — the enumeration throws `InvalidOperationException: Collection was modified`. Nothing in the transport call chain catches it (`AbstractChannel.ActiveSample`'s `catch` only wraps NCalc evaluation), so it escapes onto Core's decode thread — the same escape path as #759.

The window is narrow but real: subscribing or unsubscribing a channel while a stream is running, at the moment a *new* channel's series is created.

## The fix

Make the list **immutable by contract**. Every mutator publishes a brand-new list instead of changing the one a reader may be holding, so a reader always enumerates a stable snapshot:

```csharp
public List<IChannel> SubscribedChannels
{
    get => Volatile.Read(ref _subscribedChannels);
    ...
}
```

- `Volatile.Write`/`Volatile.Read` for **safe publication** — an ordinary reference write is not guaranteed to have release semantics on a weakly-ordered CPU, so a reader on another core could otherwise observe a partially constructed list.
- A small private lock serializes writers. **Readers never take it**, so it is never held while calling into a logger and it cannot nest inside any other lock. The only thing done outside it is `OnPropertyChanged`, so a binding handler can never re-enter under the lock.
- Written out longhand instead of `[ObservableProperty]` because the generated accessors do a plain field read/write, which is exactly what must not happen here. Everything else in the class keeps the attribute.

### Why not the lock-based shape sketched in the issue

#762 proposed giving `LoggingManager` a lock plus a thread-safe read API and pointing `PlotLogger` at it. Copy-on-write is better here:

- **No reader changes at all.** Both `PlotLogger` sites, `DaqifiViewModel`'s two reads, and `LoggingManager`'s own are fixed without being touched.
- **No new lock-ordering edge.** `PlotLogger.CompositionTargetRendering` already enumerates this list *inside* `PlotModel.SyncRoot`. A lock the reader had to take would nest a second lock under `SyncRoot`; copy-on-write avoids that entirely.
- **Cost is nil.** `SubscribedChannels` holds one entry per enabled channel and only changes on user action, so the copy is trivial next to the per-sample work already done under `SyncRoot`.

`channel.IsActive = true` and the handler attach stay inside the lock so the check-and-publish is atomic. That is safe: `AnalogChannel`/`DigitalChannel.IsActive` only set a Core flag and raise `OnPropertyChanged` — no device I/O, nothing blocking — and since readers never take this lock, a handler could only ever contend with another writer.

## Test seam

`LoggingManager` was **not unit-testable at all**: its constructor resolves from `App.ServiceProvider`, which is null outside the running app, and it was created by an eager `static readonly` initializer — so merely touching the type could throw `TypeInitializationException`, permanently, for the whole process.

Two minimal changes fix that, matching the seam pattern already used in this repo:
- The singleton is now `Lazy<LoggingManager>`, so touching the type no longer runs that constructor.
- An `internal` constructor takes the `IDbContextFactory<LoggingContext>` directly. `InternalsVisibleTo("Daqifi.Desktop.Test")` already exists.

`ClearChannelList` went `private` → `internal` so it can be covered directly; its only production caller (`UnsubscribeProfile`) writes the profiles XML first and swallows failures, so driving it through that would touch the user's real data directory.

## Tests

New `Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs` — 13 tests. **Five verified failing first** against the pre-fix mutators:

| Test | Pre-fix failure |
|---|---|
| `Subscribe_PublishesANewList_LeavingAnAlreadyHandedOutSnapshotUntouched` | `Assert.AreEqual(0, snapshotTakenByAReader.Count)` — the reader's list grew under it |
| `Unsubscribe_…` | `Assert.AreEqual(1, …)` |
| `ClearChannelList_…` | `Assert.AreEqual(2, …)` |
| `SubscribedChannels_IsSafeToEnumerate_WhileAnotherThreadSubscribesAndUnsubscribes` | `InvalidOperationException: Collection was modified; enumeration operation may not execute.` at `List<T>.Enumerator.MoveNext()`, within 4 ms of a 300 ms budget |
| `SubscribedChannels_ReturnsTheSameSnapshot_UntilSomethingChanges` | `Assert.AreNotSame` — in-place mutation keeps handing back the same instance |

The other eight pin existing behaviour (add/activate, duplicate rejection, same-name-different-device, remove/deactivate, no-op paths, `PropertyChanged`, null coercion) and pass on both sides of the fix.

Two details worth calling out:
- The concurrency test waits on a `ManualResetEventSlim` the reader sets from **inside** its enumeration loop before the mutations begin, so the threads genuinely overlap — a stress test whose threads never run at the same time passes against broken code.
- `IChannel` is hand-rolled as a small `FakeChannel` rather than mocked, so the concurrency test exercises the collection under test rather than a mocking framework's own internal state, which isn't documented as safe to touch from two threads.

## Merge-conflict check

Both files this branch touches are also touched by open PRs, so I checked the regions:

- **`LoggingManager.cs`** — #749's hunks stop at line 406 and resume at 540; the channel-subscription region (428-464) and `ClearChannelList` (813) are untouched by it.
- **`PlotLogger.cs`** — **not modified here at all**, which is what keeps this clear of #761 (that PR rewrites exactly the region containing both reader sites).
- The new test file name does not collide with the files added by #749, #758 or #763.

## Out of scope

- The copy-on-write contract is now enforced by the type — `SubscribedChannels` is an `IReadOnlyList<IChannel>` with no setter (Qodo round 1, finding 4). An earlier revision of this section deferred that, claiming it was a breaking signature change for the reader sites; that was untested and wrong — every consumer only enumerates or runs LINQ over it, so it compiled with zero call-site edits.
- Writer-writer safety now has a lock behind it, but every production caller still marshals to the UI thread first (`ConnectionManager`'s three sites all go through `UiThreadHelper.InvokeOnUiThread`/`Dispatcher.Invoke`), so nothing depends on it today.

