### PR TITLE
chore(test): match FakeChannel's nullability to IChannel

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
@@ -374,10 +374,10 @@ public class LoggingManagerSubscribedChannelsTests
         public int PwmDutyCyclePercent { get; set; }
         public bool IsScalingActive { get; set; }
         public bool HasValidExpression { get; set; }
-        public DataSample ActiveSample { get; set; } = null!;
+        public DataSample? ActiveSample { get; set; }
         public bool IsVisible { get; set; } = true;
 
-        public event OnChannelUpdatedHandler OnChannelUpdated = null!;
+        public event OnChannelUpdatedHandler? OnChannelUpdated;
 
         public void NotifyChannelUpdated(object sender, DataSample e) => OnChannelUpdated?.Invoke(sender, e);
 


### PR DESCRIPTION
Closes #766.

## Problem

`main` no longer builds warning-free. #749 ("take the build from 1,764 warning lines to zero") landed
that invariant and it has already regressed — `main` at `3e8d275` builds with **2 warnings**, both on
the `FakeChannel` test double in `Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs`:

```
(377,47): warning CS8767: Nullability of reference types in type of parameter 'value' of
  'void FakeChannel.ActiveSample.set' doesn't match implicitly implemented member
  'void IChannel.ActiveSample.set'
(380,46): warning CS8612: Nullability of reference types in type of
  'event OnChannelUpdatedHandler FakeChannel.OnChannelUpdated' doesn't match implicitly
  implemented member 'event OnChannelUpdatedHandler? IChannel.OnChannelUpdated'
```

Verified by building `origin/main` standalone in a clean worktree, not inferred from a feature branch.

## Root cause — a cross-PR interaction, not a mistake in either PR

- **#749** made `IChannel`'s members nullable: `DataSample? ActiveSample { get; set; }`
  (`IChannel.cs:56`) and `event OnChannelUpdatedHandler? OnChannelUpdated` (`:61`).
- **#764** was branched from `c6489d4` — *before* #749 merged — so its `FakeChannel` was written
  against the old, non-nullable `IChannel`: `public DataSample ActiveSample { get; set; } = null!;`
  and `public event OnChannelUpdatedHandler OnChannelUpdated = null!;`.

Each PR was green in CI against a `main` that did not yet contain the other, and
`TreatWarningsAsErrors` is `false` (`Directory.Build.props`), so the merged combination produced
warnings nobody's build had seen. Textually the merge was clean — this is a semantic conflict.

## The fix

Declare the two members the way the **production** implementation already does. `AbstractChannel` uses
`DataSample? ActiveSample` (`AbstractChannel.cs:178`) and
`event OnChannelUpdatedHandler? OnChannelUpdated` (`:272`), so `FakeChannel` was the lone outlier:

```diff
-        public DataSample ActiveSample { get; set; } = null!;
+        public DataSample? ActiveSample { get; set; }
         public bool IsVisible { get; set; } = true;

-        public event OnChannelUpdatedHandler OnChannelUpdated = null!;
+        public event OnChannelUpdatedHandler? OnChannelUpdated;
```

The `= null!` initialisers become unnecessary once the declarations are nullable.

## Why it is safe

- **Test-only.** `FakeChannel` is a private test double in one test file; no production code
  references it.
- **No behavioural change.** `null!` already asserted "this really is null, trust me" — the fix just
  stops lying to the compiler about it. The single consumer,
  `NotifyChannelUpdated(...) => OnChannelUpdated?.Invoke(sender, e)`, is already null-conditional.
- Lines 377/380/382 are the *only* occurrences of these members in the file (grepped); nothing asserts
  on them.

## Why no new test

The regression is a compiler diagnostic, and the assertion that catches it is the build itself — a
unit test cannot observe a nullability annotation mismatch. Whether this *class* of regression should
be caught automatically (flip `TreatWarningsAsErrors`, or add a CI warning-count check) is a real
question, but a larger and more opinionated one; I deliberately left it out rather than bundling a
policy change into a 2-line fix. Noted in #766 as a possible follow-up.

## Validation

| Gate | Result |
| --- | --- |
| `dotnet build "DAQiFi Desktop.sln" --no-incremental` | **0 warnings / 0 errors** — invariant restored (was 2 warnings on `main`) |
| Unit gate (`TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests`) | **735 passed / 0 failed** |
| App-launch smoke `Launch_MainWindowAppears_AndIsResponsive` | **PASS** (12s) |
| Device bench | **Skipped — not device-observable.** Zero production code touched; the diff is 2 lines in one test file |

**Not merging — for review.**
