### PR TITLE
fix(channels): close the channel settings drawer when its device disconnects

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/ChannelsPaneViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ChannelsPaneViewModelTests.cs
@@ -1,0 +1,268 @@
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Configuration;
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Covers <see cref="ChannelsPaneViewModel"/>'s settings-drawer lifetime across a rebuild
+/// (issue #765). The pane rebuilds every tile whenever
+/// <see cref="ConnectionManager.ConnectedDevices"/> changes; the drawer is a top-level overlay
+/// gated on <c>IsSettingsOpen</c> alone, so nothing about an emptied tile list hides it. It must
+/// therefore close itself when the device that owns the channel it is showing goes away, and
+/// stay put otherwise.
+/// </summary>
+[TestClass]
+public class ChannelsPaneViewModelTests : IDisposable
+{
+    #region Setup
+    private ChannelsPaneViewModel _viewModel = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Other tests Connect() devices onto the process-wide singleton, so reset it here to keep
+        // this class order-independent.
+        SetConnectedDevices();
+
+        // The parameterless constructor reads LoggingManager.Instance, which resolves its context
+        // factory from App.ServiceProvider — absent in the test host. The internal constructor is
+        // the seam.
+        _viewModel = new ChannelsPaneViewModel(
+            new LoggingManager(new Mock<IDbContextFactory<LoggingContext>>().Object));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        // Leave the shared singleton clean for whatever test runs next.
+        SetConnectedDevices();
+    }
+
+    // MSTest disposes the test-class instance after each test, releasing the view-model's refresh
+    // timer and singleton subscriptions instead of leaking one per test (CA1001).
+    public void Dispose()
+    {
+        _viewModel.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Publishes a new connected-device list. Assigning the property is what raises
+    /// <c>PropertyChanged("ConnectedDevices")</c> — the notification the pane rebuilds on, and the
+    /// one <see cref="ConnectionManager.Connect"/> / <see cref="ConnectionManager.Disconnect"/>
+    /// raise in production.
+    /// </summary>
+    private static void SetConnectedDevices(params IStreamingDevice[] devices)
+    {
+        ConnectionManager.Instance.ConnectedDevices = [.. devices];
+    }
+
+    private static PaneTestDevice NewDevice(string name, string serial, params string[] channelNames)
+    {
+        var device = new PaneTestDevice { Name = name, DeviceSerialNo = serial };
+        foreach (var channelName in channelNames)
+        {
+            device.DataChannels.Add(new FakeChannel { Name = channelName, DeviceSerialNo = serial });
+        }
+        return device;
+    }
+
+    /// <summary>Opens the drawer through the real command path, on the tile for a given channel.</summary>
+    private void OpenDrawerOn(IChannel channel)
+    {
+        var tile = _viewModel.AnalogInputs.FirstOrDefault(t => ReferenceEquals(t.Channel, channel));
+        Assert.IsNotNull(tile, "The pane did not build a tile for the channel under test.");
+        _viewModel.OpenSettingsCommand.Execute(tile);
+        Assert.IsTrue(_viewModel.IsSettingsOpen, "Arrange failed: the drawer did not open.");
+    }
+    #endregion
+
+    #region Drawer lifetime across a rebuild
+    [TestMethod]
+    public void OwningDeviceDisconnects_ClosesTheDrawer()
+    {
+        // Arrange
+        var device = NewDevice("Nq1", "SN-0001", "AI0");
+        SetConnectedDevices(device);
+        OpenDrawerOn(device.DataChannels[0]);
+
+        // Act — the device disappears from the connected list, as Disconnect() makes it.
+        SetConnectedDevices();
+
+        // Assert — the drawer cannot be left over an empty pane pointing at removed hardware.
+        Assert.IsFalse(_viewModel.IsSettingsOpen);
+        Assert.IsNull(_viewModel.SelectedChannel);
+        Assert.IsNull(_viewModel.SelectedDevice);
+    }
+
+    [TestMethod]
+    public void UnrelatedDeviceDisconnects_LeavesTheDrawerOpen()
+    {
+        // Arrange
+        var kept = NewDevice("Nq1", "SN-0001", "AI0");
+        var removed = NewDevice("Nq3", "SN-0002", "AI0");
+        SetConnectedDevices(kept, removed);
+        var openChannel = kept.DataChannels[0];
+        OpenDrawerOn(openChannel);
+
+        // Act
+        SetConnectedDevices(kept);
+
+        // Assert — a rebuild triggered by someone else's disconnect must not close a drawer the
+        // user is working in.
+        Assert.IsTrue(_viewModel.IsSettingsOpen);
+        Assert.AreSame(openChannel, _viewModel.SelectedChannel);
+        Assert.AreSame(kept, _viewModel.SelectedDevice);
+    }
+
+    [TestMethod]
+    public void AnotherDeviceConnects_LeavesTheDrawerOpen()
+    {
+        // Arrange
+        var first = NewDevice("Nq1", "SN-0001", "AI0");
+        SetConnectedDevices(first);
+        var openChannel = first.DataChannels[0];
+        OpenDrawerOn(openChannel);
+
+        // Act
+        SetConnectedDevices(first, NewDevice("Nq3", "SN-0002", "AI0"));
+
+        // Assert
+        Assert.IsTrue(_viewModel.IsSettingsOpen);
+        Assert.AreSame(openChannel, _viewModel.SelectedChannel);
+        Assert.AreSame(first, _viewModel.SelectedDevice);
+    }
+
+    [TestMethod]
+    public void ClosedDrawer_StaysClosedAcrossARebuild()
+    {
+        // Arrange
+        var device = NewDevice("Nq1", "SN-0001", "AI0");
+        SetConnectedDevices(device);
+
+        // Act
+        SetConnectedDevices();
+
+        // Assert — the rebuild must not touch drawer state when nothing is open.
+        Assert.IsFalse(_viewModel.IsSettingsOpen);
+        Assert.IsNull(_viewModel.SelectedChannel);
+        Assert.IsNull(_viewModel.SelectedDevice);
+    }
+
+    /// <summary>
+    /// The pane must still tear the drawer down when the device is dropped by a path that also
+    /// empties its channel list — the shape <c>AbstractStreamingDevice.Disconnect</c> leaves behind
+    /// (it clears <c>DataChannels</c> to avoid ghost channels on reconnect).
+    /// </summary>
+    [TestMethod]
+    public void OwningDeviceDisconnectsAndClearsItsChannels_ClosesTheDrawer()
+    {
+        // Arrange
+        var kept = NewDevice("Nq1", "SN-0001", "AI0");
+        var removed = NewDevice("Nq3", "SN-0002", "AI1");
+        SetConnectedDevices(kept, removed);
+        OpenDrawerOn(removed.DataChannels[0]);
+
+        // Act
+        removed.DataChannels.Clear();
+        SetConnectedDevices(kept);
+
+        // Assert
+        Assert.IsFalse(_viewModel.IsSettingsOpen);
+        Assert.IsNull(_viewModel.SelectedChannel);
+        Assert.IsNull(_viewModel.SelectedDevice);
+    }
+    #endregion
+
+    #region Ownership resolution
+    /// <summary>
+    /// Ownership is resolved by object identity, not by <see cref="IChannel.DeviceSerialNo"/>.
+    /// A blank serial is a real state in this codebase, and matching on it resolves every
+    /// blank-serial channel to whichever blank-serial device happens to come first.
+    /// </summary>
+    [TestMethod]
+    public void BlankSerials_ResolveTheDrawerToTheDeviceThatActuallyOwnsTheChannel()
+    {
+        // Arrange — two devices, neither reporting a serial.
+        var first = NewDevice("Nq1", string.Empty, "AI0");
+        var second = NewDevice("Nq3", string.Empty, "AI1");
+        SetConnectedDevices(first, second);
+        var openChannel = second.DataChannels[0];
+        OpenDrawerOn(openChannel);
+
+        // Act — a rebuild that changes nothing about either device.
+        SetConnectedDevices(first, second);
+
+        // Assert — the drawer's device-scoped half (the device-wide PWM frequency) must point at
+        // the real owner, not at the first device with a matching serial string.
+        Assert.IsTrue(_viewModel.IsSettingsOpen);
+        Assert.AreSame(openChannel, _viewModel.SelectedChannel);
+        Assert.AreSame(second, _viewModel.SelectedDevice);
+    }
+    #endregion
+
+    #region Helper Types
+    /// <summary>A no-op streaming device whose channel list the tests own outright.</summary>
+    private sealed class PaneTestDevice : AbstractStreamingDevice
+    {
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        public override bool Connect() => true;
+
+        public override bool Disconnect() => true;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A hand-rolled analog <see cref="IChannel"/>. The pane only reads presentation state off it,
+    /// and a hand-rolled instance keeps reference identity — the thing under test here — obvious.
+    /// </summary>
+    private sealed class FakeChannel : IChannel
+    {
+        public int ID { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string DeviceName { get; set; } = string.Empty;
+        public string DeviceSerialNo { get; set; } = string.Empty;
+        public int Index => 0;
+        public double OutputValue { get; set; }
+        public ChannelType Type => ChannelType.Analog;
+        public ChannelDirection Direction { get; set; } = ChannelDirection.Input;
+        public string TypeString => Type.ToString();
+        public string ScaleExpression { get; set; } = string.Empty;
+        public System.Windows.Media.Brush ChannelColorBrush { get; set; } = System.Windows.Media.Brushes.Transparent;
+        public bool IsBidirectional { get; set; }
+        public bool IsOutput { get; set; }
+        public bool HasAdc { get; set; }
+        public bool IsActive { get; set; }
+        public bool IsDigital => false;
+        public bool IsAnalog => true;
+        public bool IsDigitalOn { get; set; }
+        public bool IsPwmCapable => false;
+        public bool IsPwmEnabled { get; set; }
+        public int PwmDutyCyclePercent { get; set; }
+        public bool IsScalingActive { get; set; }
+        public bool HasValidExpression { get; set; }
+        public DataSample? ActiveSample { get; set; }
+        public bool IsVisible { get; set; } = true;
+
+        public event OnChannelUpdatedHandler? OnChannelUpdated;
+
+        public void NotifyChannelUpdated(object sender, DataSample e) => OnChannelUpdated?.Invoke(sender, e);
+
+        public void SetColor(System.Windows.Media.Brush color) => ChannelColorBrush = color;
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/ViewModels/ChannelsPaneViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ChannelsPaneViewModel.cs
@@ -23,6 +23,17 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
     private bool _disposed;
 
     /// <summary>
+    /// Channel → owning device, captured while <see cref="Rebuild"/> walks each connected device's
+    /// channels. Owner lookups read this map instead of re-scanning
+    /// <see cref="Daqifi.Desktop.Device.IStreamingDevice.DataChannels"/>, which the device mutates
+    /// off the UI thread (<c>AbstractStreamingDevice.SyncChannelsFromCore</c> clears and repopulates
+    /// it from Core's channels-populated callback). The map is keyed by reference identity, so it
+    /// stays correct even when a channel mutates fields that participate in its value hash.
+    /// </summary>
+    private readonly Dictionary<IChannel, Daqifi.Desktop.Device.IStreamingDevice> _channelOwners =
+        new(ReferenceComparer<IChannel>.Instance);
+
+    /// <summary>
     /// Fires at the refresh cadence so tiles can re-read their live value
     /// without each tile owning its own timer.
     /// </summary>
@@ -181,6 +192,7 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         DisposeTiles(DigitalInputs);
         DisposeTiles(DigitalOutputs);
         ConnectedDeviceNames.Clear();
+        _channelOwners.Clear();
 
         var devices = ConnectionManager.Instance.ConnectedDevices.ToList();
         HasConnectedDevice = devices.Count > 0;
@@ -196,6 +208,7 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         {
             foreach (var channel in device.DataChannels.NaturalOrderBy(c => c.Name))
             {
+                _channelOwners[channel] = device;
                 var tile = new ChannelTileViewModel(channel, this, device.Name, HasMultipleDevices);
                 if (channel.IsAnalog && channel.Direction == ChannelDirection.Input)
                 {
@@ -219,7 +232,7 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
             }
         }
         RecomputeCounts();
-        SyncSettingsDrawer(devices);
+        SyncSettingsDrawer();
     }
 
     /// <summary>
@@ -235,13 +248,14 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
     /// is open. Identity is stable for as long as the channel is: a metadata re-sync keeps the
     /// existing desktop channel instance for every channel that is still present
     /// (<c>AbstractStreamingDevice.SyncChannelsFromCore</c>), and disconnecting empties
-    /// <see cref="Daqifi.Desktop.Device.IStreamingDevice.DataChannels"/> outright.
+    /// <see cref="Daqifi.Desktop.Device.IStreamingDevice.DataChannels"/> outright. A channel absent
+    /// from <see cref="_channelOwners"/> after a rebuild is therefore one no connected device owns.
     /// </remarks>
-    private void SyncSettingsDrawer(List<Daqifi.Desktop.Device.IStreamingDevice> devices)
+    private void SyncSettingsDrawer()
     {
         if (!IsSettingsOpen) return;
 
-        var owner = SelectedChannel == null ? null : FindOwningDevice(SelectedChannel, devices);
+        var owner = SelectedChannel == null ? null : FindOwningDevice(SelectedChannel);
         if (owner == null)
         {
             CloseSettings();
@@ -332,24 +346,14 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
     }
 
     /// <summary>
-    /// Resolves the connected device that owns <paramref name="channel"/>. Enumerates a
-    /// snapshot of the connected-device list (like <see cref="Rebuild"/>) because the
-    /// list mutates during connect/disconnect flows.
+    /// Resolves the connected device that owns <paramref name="channel"/>, from the map
+    /// <see cref="Rebuild"/> captured. Returns null once the owning device has left
+    /// <see cref="ConnectionManager.ConnectedDevices"/>. See <see cref="SyncSettingsDrawer"/> for
+    /// why ownership is keyed by identity rather than by <see cref="IChannel.DeviceSerialNo"/>.
     /// </summary>
-    private static Daqifi.Desktop.Device.IStreamingDevice? FindOwningDevice(IChannel channel)
+    private Daqifi.Desktop.Device.IStreamingDevice? FindOwningDevice(IChannel channel)
     {
-        return FindOwningDevice(channel, ConnectionManager.Instance.ConnectedDevices.ToList());
-    }
-
-    /// <summary>
-    /// Resolves the owner of <paramref name="channel"/> within an already-materialized
-    /// <paramref name="devices"/> snapshot, by object identity. See <see cref="SyncSettingsDrawer"/>
-    /// for why identity beats a <see cref="IChannel.DeviceSerialNo"/> match here.
-    /// </summary>
-    private static Daqifi.Desktop.Device.IStreamingDevice? FindOwningDevice(
-        IChannel channel, List<Daqifi.Desktop.Device.IStreamingDevice> devices)
-    {
-        return devices.FirstOrDefault(d => d.DataChannels.Any(c => ReferenceEquals(c, channel)));
+        return _channelOwners.GetValueOrDefault(channel);
     }
 
     /// <summary>Closes the inline settings drawer.</summary>
@@ -386,6 +390,7 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         DisposeTiles(AnalogInputs);
         DisposeTiles(DigitalInputs);
         DisposeTiles(DigitalOutputs);
+        _channelOwners.Clear();
 
         GC.SuppressFinalize(this);
     }

--- a/Daqifi.Desktop/ViewModels/ChannelsPaneViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ChannelsPaneViewModel.cs
@@ -19,6 +19,7 @@ namespace Daqifi.Desktop.ViewModels;
 public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
 {
     private readonly DispatcherTimer _valueRefreshTimer;
+    private readonly LoggingManager _loggingManager;
     private bool _disposed;
 
     /// <summary>
@@ -102,15 +103,27 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
     }
 
     /// <summary>Creates the view-model and begins watching for connected devices.</summary>
-    public ChannelsPaneViewModel()
+    public ChannelsPaneViewModel() : this(LoggingManager.Instance)
     {
+    }
+
+    /// <summary>
+    /// Test seam. <see cref="LoggingManager.Instance"/> resolves its context factory from
+    /// <c>App.ServiceProvider</c>, which does not exist in the test host, so tests hand in a
+    /// manager built through <see cref="LoggingManager"/>'s own internal constructor.
+    /// </summary>
+    /// <param name="loggingManager">Manager supplying the logging-active state this pane mirrors.</param>
+    internal ChannelsPaneViewModel(LoggingManager loggingManager)
+    {
+        _loggingManager = loggingManager;
+
         _valueRefreshTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
         _valueRefreshTimer.Tick += OnValueRefreshTick;
         _valueRefreshTimer.Start();
 
         ConnectionManager.Instance.PropertyChanged += OnConnectionManagerPropertyChanged;
-        LoggingManager.Instance.PropertyChanged += OnLoggingManagerPropertyChanged;
-        IsLoggingActive = LoggingManager.Instance.Active;
+        _loggingManager.PropertyChanged += OnLoggingManagerPropertyChanged;
+        IsLoggingActive = _loggingManager.Active;
         Rebuild();
     }
 
@@ -129,11 +142,11 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
             var dispatcher = _valueRefreshTimer.Dispatcher;
             if (dispatcher.CheckAccess())
             {
-                IsLoggingActive = LoggingManager.Instance.Active;
+                IsLoggingActive = _loggingManager.Active;
             }
             else
             {
-                dispatcher.BeginInvoke(() => IsLoggingActive = LoggingManager.Instance.Active);
+                dispatcher.BeginInvoke(() => IsLoggingActive = _loggingManager.Active);
             }
         }
     }
@@ -179,12 +192,6 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
             ConnectedDeviceNames.Add(device.Name);
         }
 
-        if (devices.Count == 0)
-        {
-            RecomputeCounts();
-            return;
-        }
-
         foreach (var device in devices)
         {
             foreach (var channel in device.DataChannels.NaturalOrderBy(c => c.Name))
@@ -212,6 +219,38 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
             }
         }
         RecomputeCounts();
+        SyncSettingsDrawer(devices);
+    }
+
+    /// <summary>
+    /// Preserves the settings drawer across a rebuild while the channel it is showing is still
+    /// owned by a connected device, and closes it otherwise so it cannot sit over an empty pane
+    /// pointing at hardware that is gone (issue #765). This is the same preserve-or-close rule
+    /// <see cref="DevicesPaneViewModel"/>'s own rebuild already applies to its drawer.
+    /// </summary>
+    /// <remarks>
+    /// Ownership is resolved by <em>object identity</em> rather than by
+    /// <see cref="IChannel.DeviceSerialNo"/>: a blank serial is a real state elsewhere in this
+    /// codebase, so a string match can resolve to the wrong device — or to none — while the drawer
+    /// is open. Identity is stable for as long as the channel is: a metadata re-sync keeps the
+    /// existing desktop channel instance for every channel that is still present
+    /// (<c>AbstractStreamingDevice.SyncChannelsFromCore</c>), and disconnecting empties
+    /// <see cref="Daqifi.Desktop.Device.IStreamingDevice.DataChannels"/> outright.
+    /// </remarks>
+    private void SyncSettingsDrawer(List<Daqifi.Desktop.Device.IStreamingDevice> devices)
+    {
+        if (!IsSettingsOpen) return;
+
+        var owner = SelectedChannel == null ? null : FindOwningDevice(SelectedChannel, devices);
+        if (owner == null)
+        {
+            CloseSettings();
+            return;
+        }
+
+        // The drawer edits device-scoped state too (the device-wide PWM frequency), so point it at
+        // the device that provably owns the channel.
+        SelectedDevice = owner;
     }
 
     private static void DisposeTiles(ObservableCollection<ChannelTileViewModel> tiles)
@@ -242,13 +281,13 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
 
         if (channel.IsActive)
         {
-            LoggingManager.Instance.Unsubscribe(channel);
+            _loggingManager.Unsubscribe(channel);
             device.RemoveChannel(channel);
         }
         else
         {
             device.AddChannel(channel);
-            LoggingManager.Instance.Subscribe(channel);
+            _loggingManager.Subscribe(channel);
         }
         RecomputeCounts();
     }
@@ -299,8 +338,18 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
     /// </summary>
     private static Daqifi.Desktop.Device.IStreamingDevice? FindOwningDevice(IChannel channel)
     {
-        return ConnectionManager.Instance.ConnectedDevices.ToList()
-            .FirstOrDefault(d => d.DeviceSerialNo == channel.DeviceSerialNo);
+        return FindOwningDevice(channel, ConnectionManager.Instance.ConnectedDevices.ToList());
+    }
+
+    /// <summary>
+    /// Resolves the owner of <paramref name="channel"/> within an already-materialized
+    /// <paramref name="devices"/> snapshot, by object identity. See <see cref="SyncSettingsDrawer"/>
+    /// for why identity beats a <see cref="IChannel.DeviceSerialNo"/> match here.
+    /// </summary>
+    private static Daqifi.Desktop.Device.IStreamingDevice? FindOwningDevice(
+        IChannel channel, List<Daqifi.Desktop.Device.IStreamingDevice> devices)
+    {
+        return devices.FirstOrDefault(d => d.DataChannels.Any(c => ReferenceEquals(c, channel)));
     }
 
     /// <summary>Closes the inline settings drawer.</summary>
@@ -332,7 +381,7 @@ public partial class ChannelsPaneViewModel : ObservableObject, IDisposable
         _valueRefreshTimer.Stop();
         _valueRefreshTimer.Tick -= OnValueRefreshTick;
         ConnectionManager.Instance.PropertyChanged -= OnConnectionManagerPropertyChanged;
-        LoggingManager.Instance.PropertyChanged -= OnLoggingManagerPropertyChanged;
+        _loggingManager.PropertyChanged -= OnLoggingManagerPropertyChanged;
 
         DisposeTiles(AnalogInputs);
         DisposeTiles(DigitalInputs);


### PR DESCRIPTION
Closes #765

**Not merging — opened for review.**

## The bug

`ChannelsPaneViewModel.Rebuild()` tears down and re-creates every channel tile whenever
`ConnectionManager.ConnectedDevices` changes, but it never touched the settings-drawer state.
When the device owning the open drawer disappeared, the drawer stayed on screen over an empty
pane, still bound to a channel of a device that is gone.

Nothing else hides it: the drawer is a top-level `Grid` with `Panel.ZIndex="10"` and a full-pane
scrim, gated on `IsSettingsOpen` alone — not a child of the tile list — so an emptied tile list
leaves it exactly where it was.

What the user then gets is a modal-looking drawer whose writes go nowhere. `IsOutput` /
`IsDigitalOn` / `IsPwmEnabled` / `PwmDutyCyclePercent` all reach
`AbstractStreamingDevice.ExecuteDeviceCommand`, which returns early with
`Ignored {operation} for {target}: device is not connected.` — the toggle moves in the UI and
nothing happens on the device, with no visible error. Edits that do "work" (name, plot colour,
scaling expression) land on an orphaned `IChannel` and are silently lost on reconnect, because the
reconnected device is a new object with new channels.

## This was a gap, not a design choice

`DevicesPaneViewModel.Rebuild()` already handles exactly this case, with a comment stating the
intent: *preserve drawer state across a rebuild if the device is still there; otherwise close the
drawer so it doesn't point at a removed device.* The Channels pane was written to the same shape
(rebuild-on-`ConnectedDevices`-changed + inline settings drawer) and was missing the second half.

## The fix

`Rebuild()` now ends with the same preserve-or-close rule:

- the owning device is still connected → the drawer stays open, `SelectedChannel` untouched, so an
  unrelated device connecting or disconnecting cannot close a drawer the user is working in;
- the owning device is gone → `CloseSettings()`, the existing already-exercised teardown path that
  the close button and the scrim both invoke.

**Ownership is resolved by object identity, not by `DeviceSerialNo`.** A blank serial is a real
state this codebase accounts for elsewhere (`DeviceDisplayName`'s `IsNullOrWhiteSpace` fallback,
PR #756's blank-serial handling), so a string match can resolve to the wrong device — or to none —
while the drawer is open. `ProfilesPaneViewModel` makes the same argument for its own matching.
Identity is stable for as long as the channel is, and I verified both halves before relying on it:

- `AbstractStreamingDevice.SyncChannelsFromCore` **reuses the existing desktop channel instance**
  for every channel still present (it swaps only the inner Core channel via `ReplaceCoreChannel`),
  so a metadata re-sync does not spuriously orphan an open drawer;
- `Disconnect()` **clears `DataChannels` outright** (the issue-#29 ghost-channel guard), so a
  disconnected device cannot claim ownership even if a stale reference to it lingered.

`FindOwningDevice` is now identity-based for `OpenSettings` and `ToggleChannel` too, so the drawer
opens against the right device in the first place rather than being corrected on the next rebuild.

Two smaller things fall out:

- **`Rebuild()`'s `devices.Count == 0` early return is removed.** It was redundant — the tile loop
  is already a no-op on an empty list, and `RecomputeCounts()` ran on both paths — and removing it
  gives the new guard a single exit to hang off so it cannot be skipped on the very path (all
  devices gone) that matters most.
- **`SelectedDevice` is re-pointed to the proven owner** while the drawer stays open. The drawer
  edits device-scoped state too — the device-wide PWM frequency field binds
  `SelectedDevice.PwmFrequencyHz` — so it should track the device that actually owns the channel.

## Tests

`ChannelsPaneViewModel` had **no unit tests**, so this also closes a coverage gap on a 341-line
view model. Six tests, driven through the real notification path (`ConnectedDevices` is an
`[ObservableProperty]`, so publishing a new list raises the same `PropertyChanged("ConnectedDevices")`
that `Connect`/`Disconnect` raise) and the real `OpenSettingsCommand`.

Each test earns its place — I verified this by reverting the production change in two steps:

| Test | Fails against |
| --- | --- |
| `OwningDeviceDisconnects_ClosesTheDrawer` | unguarded `Rebuild()` |
| `OwningDeviceDisconnectsAndClearsItsChannels_ClosesTheDrawer` | unguarded `Rebuild()` |
| `BlankSerials_ResolveTheDrawerToTheDeviceThatActuallyOwnsTheChannel` | serial-based ownership |
| `UnrelatedDeviceDisconnects_LeavesTheDrawerOpen` | *(pins the preserve case)* |
| `AnotherDeviceConnects_LeavesTheDrawerOpen` | *(pins the preserve case)* |
| `ClosedDrawer_StaysClosedAcrossARebuild` | *(pins the no-op case)* |

The last three are the guard-rails: the worst case for an over-eager guard is a drawer that closes
when it should not, and nothing else in the suite would catch that.

`ChannelsPaneViewModel` gains an **internal constructor seam** taking a `LoggingManager`, because
`LoggingManager.Instance` resolves its context factory from `App.ServiceProvider`, which does not
exist in the test host. This is the same seam `LoggingManager` itself already exposes for the same
reason, and it matches that convention (no null guard — the public constructor passes the
non-null singleton).

## Validation

- `dotnet build` — 0 errors, and **0 new warnings** (the 2 warnings on this branch are main's
  pre-existing `FakeChannel` nullability drift, which PR #767 fixes).
- Unit gate `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` —
  **741 passed / 0 failed** (735 main baseline + the 6 added here).
- App-launch smoke `Launch_MainWindowAppears_AndIsResponsive` — **PASS**.
- **Device bench, run against the physically attached board** — see the BENCH RESULTS comment.
