### PR TITLE
fix(streaming): give one frame one timestamp, scaled by the device's own clock

### DIFF
--- a/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
+++ b/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
@@ -1,0 +1,220 @@
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Device;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using ChannelType = Daqifi.Core.Channel.ChannelType;
+using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
+
+namespace Daqifi.Desktop.Test.Device;
+
+/// <summary>
+/// Tests that one stream frame yields exactly one timestamp (issue #769): the reconstruction
+/// <c>ProcessStreamMessage</c> computes for a frame is what both the dispatched
+/// <see cref="DeviceMessage"/> and every channel sample decoded from that frame carry, and that it
+/// is scaled by the device's own clock frequency rather than the 50 MHz fallback.
+/// <para>
+/// This needs a fixture no existing one provides: desktop channels wired onto Core's real decode
+/// pipeline (so <c>ActiveSample</c> is populated, as in <c>ChannelDataMappingTests</c>),
+/// <em>plus</em> captured <see cref="DeviceMessage"/>s (as in <c>StreamStartLeftoverFrameTests</c>),
+/// <em>plus</em> the real <c>InitializeStreaming</c>/<c>StopStreaming</c> session lifecycle, which is
+/// what resets the desktop's timestamp baseline.
+/// </para>
+/// </summary>
+[TestClass]
+public class FrameTimestampSourceTests : IDisposable
+{
+    /// <summary>
+    /// Clock frequency the fixture's device reports, matching the bench hardware: an Nq1 on
+    /// firmware 3.7.2 reports 42 MHz (84 MHz PBCLK, 1:2 prescale), not the 50 MHz that Core's
+    /// <c>TimestampProcessor</c> falls back to when no frequency is applied.
+    /// </summary>
+    private const uint DEVICE_TIMESTAMP_FREQUENCY = 42_000_000;
+
+    /// <summary>One 100 Hz sample period, in device counter ticks at the frequency above.</summary>
+    private const uint SAMPLE_PERIOD_TICKS = DEVICE_TIMESTAMP_FREQUENCY / 100;
+
+    /// <summary>A 13 s stop-to-start gap, in device counter ticks.</summary>
+    private const uint THIRTEEN_SECOND_GAP_TICKS = DEVICE_TIMESTAMP_FREQUENCY * 13;
+
+    private FrameTimestampTestDevice _device = null!;
+    private AnalogChannel _channel = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _device = new FrameTimestampTestDevice();
+        _channel = (AnalogChannel)_device.DataChannels.Single(
+            c => c.Type == ChannelType.Analog && c.Index == 0);
+        _channel.IsActive = true;
+    }
+
+    // MSTest disposes the test-class instance after each test, releasing the device's Core
+    // connection instead of leaking one per test (CA1001).
+    public void Dispose()
+    {
+        _device.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [TestMethod]
+    public void SingleSession_ChannelSampleCarriesTheTimestampOfItsOwnFrame()
+    {
+        // Arrange / Act - a fresh connection holds the first frame until its successor validates
+        // the pair, so three frames leave the third as the most recent on both paths
+        _device.InitializeStreaming();
+        _device.RouteStreamFrame(1_000_000_000);
+        _device.RouteStreamFrame(1_000_000_000 + SAMPLE_PERIOD_TICKS);
+        _device.RouteStreamFrame(1_000_000_000 + 2 * SAMPLE_PERIOD_TICKS);
+
+        // Assert - the sample stored for the frame and the message dispatched for it are the
+        // same frame, so they must not carry two independently reconstructed timestamps
+        Assert.IsNotNull(_channel.ActiveSample, "The last accepted frame should produce a channel sample.");
+        var dispatched = _device.DispatchedMessages[^1];
+        Assert.AreEqual(dispatched.TimestampTicks, _channel.ActiveSample.TimestampTicks,
+            "The channel sample and the DeviceMessage dispatched for the same frame should share one timestamp.");
+    }
+
+    [TestMethod]
+    public void StreamRestart_ChannelSampleDoesNotCarryTheStopToStartGap()
+    {
+        // Arrange - a session runs and stops, establishing a counter reference
+        _device.InitializeStreaming();
+        _device.RouteStreamFrame(1_000_000_000);
+        _device.RouteStreamFrame(1_000_000_000 + SAMPLE_PERIOD_TICKS);
+        _device.StopStreaming();
+
+        // Act - on restart the device emits the held prior-session frame first (discarded by the
+        // desktop, still decoded by Core), then genuine frames a 13 s gap later
+        _device.InitializeStreaming();
+        var leftoverTimestamp = 1_000_000_000 + 2 * SAMPLE_PERIOD_TICKS;
+        _device.RouteStreamFrame(leftoverTimestamp);
+        _device.RouteStreamFrame(leftoverTimestamp + THIRTEEN_SECOND_GAP_TICKS);
+        _device.RouteStreamFrame(leftoverTimestamp + THIRTEEN_SECOND_GAP_TICKS + SAMPLE_PERIOD_TICKS);
+
+        // Assert - a baseline anchored on the discarded leftover frame would push every sample of
+        // the new session 13 s into the future, and DataSample is what gets persisted (issue #573)
+        Assert.IsNotNull(_channel.ActiveSample, "Genuine frames after a restart should produce channel samples.");
+        var dispatched = _device.DispatchedMessages[^1];
+        var driftSeconds = (_channel.ActiveSample.TimestampTicks - dispatched.TimestampTicks)
+            / (double)TimeSpan.TicksPerSecond;
+        Assert.AreEqual(dispatched.TimestampTicks, _channel.ActiveSample.TimestampTicks,
+            $"Restarted-session samples should not be shifted by the stop-to-start gap (drift {driftSeconds:F4}s).");
+    }
+
+    [TestMethod]
+    public void DeviceReportedClockFrequency_ScalesTheReconstructedTimeline()
+    {
+        // Arrange / Act - two frames exactly one device-second apart at the reported frequency
+        _device.InitializeStreaming();
+        _device.RouteStreamFrame(500_000_000);
+        _device.RouteStreamFrame(500_000_000 + DEVICE_TIMESTAMP_FREQUENCY);
+
+        // Assert - reconstructed against the 50 MHz fallback this pair reads 0.84 s apart, and the
+        // error compounds, because each timestamp is the previous one plus elapsed ticks
+        Assert.AreEqual(2, _device.DispatchedMessages.Count,
+            "The held first frame and its successor should both be dispatched.");
+        var deltaSeconds = (_device.DispatchedMessages[1].TimestampTicks - _device.DispatchedMessages[0].TimestampTicks)
+            / (double)TimeSpan.TicksPerSecond;
+        Assert.AreEqual(1.0, deltaSeconds, 1e-6,
+            "One device-second of counter ticks should reconstruct to one second.");
+
+        Assert.IsNotNull(_channel.ActiveSample);
+        Assert.IsNotNull(_channel.ActiveSample.FirmwareDeltaMs);
+        Assert.AreEqual(1000.0, _channel.ActiveSample.FirmwareDeltaMs.Value, 1e-3,
+            "The firmware-measured delta should be scaled by the device's own clock frequency.");
+    }
+
+    /// <summary>
+    /// Routes frames through both halves of the real production pipeline — the desktop's gating and
+    /// dispatch (<c>HandleInboundMessage</c>) and Core's decode step — in that order, exactly as
+    /// Core's <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in production.
+    /// </summary>
+    private sealed class FrameTimestampTestDevice : AbstractStreamingDevice, IDisposable
+    {
+        private const int ANALOG_PORT_COUNT = 2;
+
+        private readonly FrameTimestampCoreDevice _coreDevice;
+
+        public FrameTimestampTestDevice()
+        {
+            _coreDevice = new FrameTimestampCoreDevice();
+            _coreDevice.Connect();
+
+            var statusMessage = new DaqifiOutMessage
+            {
+                DevicePn = "Nq1",
+                DeviceSn = 12345,
+                DeviceFwRev = "1.0.0",
+                AnalogInPortNum = ANALOG_PORT_COUNT,
+                AnalogInRes = 4095,
+                TimestampFreq = DEVICE_TIMESTAMP_FREQUENCY,
+            };
+            for (var i = 0; i < ANALOG_PORT_COUNT; i++)
+            {
+                statusMessage.AnalogInCalM.Add(1.0f);
+                statusMessage.AnalogInCalB.Add(0.0f);
+                statusMessage.AnalogInIntScaleM.Add(1.0f);
+                statusMessage.AnalogInPortRange.Add(5.0f);
+            }
+
+            _coreDevice.Metadata.UpdateFromProtobuf(statusMessage);
+            _coreDevice.PopulateChannelsFromStatus(statusMessage);
+
+            // Wires the desktop channel wrappers around Core's actual channel instances, including
+            // the SampleReceived subscription installed by SyncChannelsFromCore.
+            SyncFromCoreDevice(_coreDevice);
+
+            InitializeDeviceState();
+        }
+
+        public List<DeviceMessage> DispatchedMessages { get; } = [];
+
+        // The Core device connected in the constructor is owned by this fixture; disposing it keeps
+        // the suite from leaking one connected device per test (CA1001).
+        public void Dispose() => _coreDevice.Dispose();
+
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        protected override CoreStreamingDevice? CoreDeviceForStreaming => _coreDevice;
+
+        public override bool Connect() => true;
+
+        public override bool Disconnect() => true;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+
+        protected override void DispatchDeviceMessage(DeviceMessage deviceMessage)
+        {
+            DispatchedMessages.Add(deviceMessage);
+        }
+
+        public void RouteStreamFrame(uint deviceTimestamp)
+        {
+            var message = new DaqifiOutMessage
+            {
+                MsgTimeStamp = deviceTimestamp,
+                DeviceSn = 12345,
+                DeviceFwRev = "1.0.0",
+                AnalogInDataFloat = { 1.25f }
+            };
+
+            HandleInboundMessage(
+                new MessageReceivedEventArgs(
+                    new GenericInboundMessage<object>(message)));
+            _coreDevice.SimulateStreamFrame(message);
+        }
+    }
+
+    private sealed class FrameTimestampCoreDevice() : CoreStreamingDevice("TestDevice")
+    {
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+
+        public void SimulateStreamFrame(DaqifiOutMessage message) => OnStreamMessageReceived(message);
+    }
+}

--- a/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
+++ b/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
@@ -23,6 +23,7 @@ namespace Daqifi.Desktop.Test.Device;
 [TestClass]
 public class FrameTimestampSourceTests : IDisposable
 {
+    #region Constants
     /// <summary>
     /// Clock frequency the fixture's device reports, matching the bench hardware: an Nq1 on
     /// firmware 3.7.2 reports 42 MHz (84 MHz PBCLK, 1:2 prescale), not the 50 MHz that Core's
@@ -35,10 +36,14 @@ public class FrameTimestampSourceTests : IDisposable
 
     /// <summary>A 13 s stop-to-start gap, in device counter ticks.</summary>
     private const uint THIRTEEN_SECOND_GAP_TICKS = DEVICE_TIMESTAMP_FREQUENCY * 13;
+    #endregion
 
+    #region Fields
     private FrameTimestampTestDevice _device = null!;
     private AnalogChannel _channel = null!;
+    #endregion
 
+    #region Setup and Teardown
     [TestInitialize]
     public void Setup()
     {
@@ -55,13 +60,17 @@ public class FrameTimestampSourceTests : IDisposable
         _device.Dispose();
         GC.SuppressFinalize(this);
     }
+    #endregion
 
+    #region Tests
     [TestMethod]
     public void SingleSession_ChannelSampleCarriesTheTimestampOfItsOwnFrame()
     {
-        // Arrange / Act - a fresh connection holds the first frame until its successor validates
-        // the pair, so three frames leave the third as the most recent on both paths
+        // Arrange - a fresh connection holds the first frame until its successor validates the
+        // pair as same-session data
         _device.InitializeStreaming();
+
+        // Act - three frames therefore leave the third as the most recent one on both paths
         _device.RouteStreamFrame(1_000_000_000);
         _device.RouteStreamFrame(1_000_000_000 + SAMPLE_PERIOD_TICKS);
         _device.RouteStreamFrame(1_000_000_000 + 2 * SAMPLE_PERIOD_TICKS);
@@ -104,8 +113,10 @@ public class FrameTimestampSourceTests : IDisposable
     [TestMethod]
     public void DeviceReportedClockFrequency_ScalesTheReconstructedTimeline()
     {
-        // Arrange / Act - two frames exactly one device-second apart at the reported frequency
+        // Arrange - a session on a device that reports its own 42 MHz streaming clock
         _device.InitializeStreaming();
+
+        // Act - two frames exactly one device-second apart at that reported frequency
         _device.RouteStreamFrame(500_000_000);
         _device.RouteStreamFrame(500_000_000 + DEVICE_TIMESTAMP_FREQUENCY);
 
@@ -113,8 +124,9 @@ public class FrameTimestampSourceTests : IDisposable
         // error compounds, because each timestamp is the previous one plus elapsed ticks
         Assert.AreEqual(2, _device.DispatchedMessages.Count,
             "The held first frame and its successor should both be dispatched.");
-        var deltaSeconds = (_device.DispatchedMessages[1].TimestampTicks - _device.DispatchedMessages[0].TimestampTicks)
-            / (double)TimeSpan.TicksPerSecond;
+        var deltaTicks = _device.DispatchedMessages[1].TimestampTicks
+            - _device.DispatchedMessages[0].TimestampTicks;
+        var deltaSeconds = deltaTicks / (double)TimeSpan.TicksPerSecond;
         Assert.AreEqual(1.0, deltaSeconds, 1e-6,
             "One device-second of counter ticks should reconstruct to one second.");
 
@@ -124,6 +136,30 @@ public class FrameTimestampSourceTests : IDisposable
             "The firmware-measured delta should be scaled by the device's own clock frequency.");
     }
 
+    [TestMethod]
+    public void RoutingAFrame_FinishesProcessingIt_BeforeCoreDecodesTheSameFrame()
+    {
+        // Arrange - a session whose first frame has already been validated against its successor,
+        // so the next frame routed is accepted and processed rather than held
+        _device.InitializeStreaming();
+        _device.RouteStreamFrame(1_000_000_000);
+        _device.RouteStreamFrame(1_000_000_000 + SAMPLE_PERIOD_TICKS);
+        var dispatchedBefore = _device.DispatchedMessages.Count;
+
+        // Act - only the desktop half of the pipeline, which is all Core's MessageReceived event
+        // does before Core goes on to decode that same frame into per-channel samples
+        _device.RouteStreamFrameToDesktopOnly(1_000_000_000 + 2 * SAMPLE_PERIOD_TICKS);
+
+        // Assert - the desktop hands the frame to Core's ProtobufProtocolHandler and discards the
+        // returned task, so the per-frame state Core's decode then reads (sample gate, timestamp,
+        // firmware delta) only belongs to the right frame while that handler stays synchronous
+        Assert.AreEqual(dispatchedBefore + 1, _device.DispatchedMessages.Count,
+            "Routing a frame must finish processing it before returning, since Core decodes the same "
+            + "frame immediately afterwards and reads the per-frame state left behind.");
+    }
+    #endregion
+
+    #region Test Doubles
     /// <summary>
     /// Routes frames through both halves of the real production pipeline — the desktop's gating and
     /// dispatch (<c>HandleInboundMessage</c>) and Core's decode step — in that order, exactly as
@@ -132,6 +168,7 @@ public class FrameTimestampSourceTests : IDisposable
     private sealed class FrameTimestampTestDevice : AbstractStreamingDevice, IDisposable
     {
         private const int ANALOG_PORT_COUNT = 2;
+        private const uint DEVICE_SERIAL_NUMBER = 12345;
 
         private readonly FrameTimestampCoreDevice _coreDevice;
 
@@ -143,7 +180,7 @@ public class FrameTimestampSourceTests : IDisposable
             var statusMessage = new DaqifiOutMessage
             {
                 DevicePn = "Nq1",
-                DeviceSn = 12345,
+                DeviceSn = DEVICE_SERIAL_NUMBER,
                 DeviceFwRev = "1.0.0",
                 AnalogInPortNum = ANALOG_PORT_COUNT,
                 AnalogInRes = 4095,
@@ -192,21 +229,37 @@ public class FrameTimestampSourceTests : IDisposable
             DispatchedMessages.Add(deviceMessage);
         }
 
+        /// <summary>Routes a frame through the desktop's inbound path and then Core's decode.</summary>
         public void RouteStreamFrame(uint deviceTimestamp)
         {
-            var message = new DaqifiOutMessage
-            {
-                MsgTimeStamp = deviceTimestamp,
-                DeviceSn = 12345,
-                DeviceFwRev = "1.0.0",
-                AnalogInDataFloat = { 1.25f }
-            };
+            var message = BuildStreamFrame(deviceTimestamp);
+            RouteToDesktop(message);
+            _coreDevice.SimulateStreamFrame(message);
+        }
 
+        /// <summary>
+        /// Routes a frame through the desktop's inbound path only, leaving Core's decode step out,
+        /// so a test can observe what the desktop has finished doing by the time that path returns.
+        /// </summary>
+        public void RouteStreamFrameToDesktopOnly(uint deviceTimestamp)
+        {
+            RouteToDesktop(BuildStreamFrame(deviceTimestamp));
+        }
+
+        private void RouteToDesktop(DaqifiOutMessage message)
+        {
             HandleInboundMessage(
                 new MessageReceivedEventArgs(
                     new GenericInboundMessage<object>(message)));
-            _coreDevice.SimulateStreamFrame(message);
         }
+
+        private static DaqifiOutMessage BuildStreamFrame(uint deviceTimestamp) => new()
+        {
+            MsgTimeStamp = deviceTimestamp,
+            DeviceSn = DEVICE_SERIAL_NUMBER,
+            DeviceFwRev = "1.0.0",
+            AnalogInDataFloat = { 1.25f }
+        };
     }
 
     private sealed class FrameTimestampCoreDevice() : CoreStreamingDevice("TestDevice")
@@ -217,4 +270,5 @@ public class FrameTimestampSourceTests : IDisposable
 
         public void SimulateStreamFrame(DaqifiOutMessage message) => OnStreamMessageReceived(message);
     }
+    #endregion
 }

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -130,7 +130,21 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// this gate keeps them from reaching the desktop's channels.
     /// </summary>
     private bool _acceptChannelSamples;
+
+    /// <summary>
+    /// The timestamp <see cref="ProcessStreamMessage"/> reconstructed for the frame Core is about to
+    /// decode, held so <see cref="OnCoreChannelSampleReceived"/> stamps every channel sample of that
+    /// frame with the very same value the dispatched <see cref="DeviceMessage"/> carries.
+    /// </summary>
+    private DateTime _currentFrameTimestamp;
     private double? _currentFrameFirmwareDeltaMs;
+
+    /// <summary>
+    /// Whether the device-reported clock frequency has been applied to <see cref="_timestampProcessor"/>
+    /// for the current streaming session. Cleared alongside every <c>ResetAll()</c>, which per Core's
+    /// contract also drops per-device frequencies.
+    /// </summary>
+    private bool _timestampFrequencyApplied;
 
     /// <summary>
     /// The Core streaming device created by the shared <see cref="Connect"/> template,
@@ -709,6 +723,19 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         var deviceId = message.DeviceSn.ToString(CultureInfo.InvariantCulture);
 
+        // Without an explicit frequency the processor reconstructs against its 20 ns fallback tick
+        // period (50 MHz) — the legacy clock config. Current firmware runs the streaming timestamp
+        // timer at 42 MHz, which would compress the reconstructed timeline by ~16 % and drift
+        // without bound, since each timestamp is the previous one plus elapsed ticks. Applied here
+        // rather than at session start because this is where the device-id key is known to match
+        // the one ProcessTimestamp uses, and re-applied per session because InitializeStreaming's
+        // ResetAll() drops per-device frequencies along with the baselines.
+        if (!_timestampFrequencyApplied && TimestampFrequency != 0)
+        {
+            _timestampProcessor.SetTimestampFrequency(deviceId, TimestampFrequency);
+            _timestampFrequencyApplied = true;
+        }
+
         // Use Core's TimestampProcessor for rollover handling
         var timestampResult = _timestampProcessor.ProcessTimestamp(deviceId, message.MsgTimeStamp);
         var messageTimestamp = timestampResult.Timestamp;
@@ -720,6 +747,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         // Open the gate for Core's decode of this exact frame, which runs synchronously right
         // after this method returns (see _acceptChannelSamples).
+        _currentFrameTimestamp = messageTimestamp;
         _currentFrameFirmwareDeltaMs = firmwareDeltaMs;
         _acceptChannelSamples = true;
 
@@ -758,10 +786,19 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// immediately after <see cref="ProcessStreamMessage"/> returns, for every enabled channel —
     /// gated by <see cref="_acceptChannelSamples"/> so leftover/held frames (which Core still
     /// decodes, since Core has no notion of the desktop's leftover-frame heuristics) never reach
-    /// desktop channels. Uses <c>coreSample.Timestamp</c> — the same rollover-aware reconstruction
-    /// <see cref="ProcessStreamMessage"/> computed for this frame via <see cref="_timestampProcessor"/> —
-    /// rather than recomputing it, so the two can never diverge.
+    /// desktop channels. Takes only the decoded <c>Value</c> from Core and stamps it with
+    /// <see cref="_currentFrameTimestamp"/> — the reconstruction <see cref="ProcessStreamMessage"/>
+    /// computed for this same frame — so one frame yields exactly one timestamp, shared with the
+    /// <see cref="DeviceMessage"/> dispatched for it.
     /// </summary>
+    /// <remarks>
+    /// <c>coreSample.Timestamp</c> is deliberately not used: Core's <c>DaqifiStreamingDevice</c> owns
+    /// a separate <c>TimestampProcessor</c> whose baseline is anchored on the first frame <em>Core</em>
+    /// decodes. Core has no notion of the desktop's leftover-frame heuristics, so on a stream restart
+    /// that baseline anchors on the discarded leftover frame and shifts every sample of the new
+    /// session into the future by the stop-to-start gap — the artifact issue #573 exists to remove —
+    /// which then lands in the database, since <see cref="DataSample"/> is what gets persisted.
+    /// </remarks>
     private void OnCoreChannelSampleReceived(IChannel desktopChannel, Daqifi.Core.Channel.IDataSample coreSample)
     {
         if (!_acceptChannelSamples)
@@ -770,7 +807,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         }
 
         desktopChannel.ActiveSample = new DataSample(
-            this, desktopChannel, coreSample.Timestamp, coreSample.Value, _currentFrameFirmwareDeltaMs);
+            this, desktopChannel, _currentFrameTimestamp, coreSample.Value, _currentFrameFirmwareDeltaMs);
     }
 
     /// <summary>
@@ -1159,6 +1196,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         // directly; without one (first session after connect — the device's leftover survives a
         // disconnect/reconnect), the first frame is held and validated against its successor.
         _timestampProcessor.ResetAll();
+        _timestampFrequencyApplied = false;
         _discardedLeftoverFrameCount = 0;
         _checkForLeftoverFrames = _hasSeenDeviceTimestamp;
         _pendingFirstFrameValidation = !_hasSeenDeviceTimestamp;
@@ -1191,6 +1229,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
         // Reset timestamp processor state for clean restart
         _timestampProcessor.ResetAll();
+        _timestampFrequencyApplied = false;
 
         foreach (var channel in DataChannels)
         {


### PR DESCRIPTION
Closes #769. **Not merging — opened for review.**

Two coupled defects put the wrong time on streamed data. They have to be fixed together, because
fixing either one alone regresses the other.

## 1. The desktop's `TimestampProcessor` never learned the device's clock frequency

`AbstractStreamingDevice` creates its own `new TimestampProcessor()` and reconstructs each frame's
time with it, but `SetTimestampFrequency` appeared **nowhere in the repo** — so it always used
Core's fallback 20 ns tick period (50 MHz), the *legacy* clock config.

Confirmed on the bench, read-only, with a headless Core probe (serial `DaqifiStreamingDevice` +
`InitializeAsync` over COM3):

```
RESULT TimestampFrequency = 42000000
RESULT PartNumber        = Nq1
RESULT FirmwareVersion   = 3.7.2
```

42 MHz = 84 MHz PBCLK at the streaming timer's 1:2 prescale. Against an assumed 50 MHz the
reconstructed clock advanced **0.84 s per real second** and drifted without bound (each timestamp is
the previous one plus elapsed ticks). Two methods away, the same class *did* use the device-reported
frequency for its leftover-frame windows — so leftover detection was frequency-correct while the
timestamps were not. Visible damage: the Summary flyout's Min/Max/Average device latency
(`AppTicks - TimestampTicks`), plus `DataSample.FirmwareDeltaMs` reading 0.84x true.

## 2. Channel samples were stamped by a *different* processor, so stored data carried the restart gap

Since #715, `OnCoreChannelSampleReceived` used `coreSample.Timestamp`, under a comment claiming it
was "the same rollover-aware reconstruction `ProcessStreamMessage` computed for this frame … so the
two can never diverge". They were two `TimestampProcessor` instances with independent state: the
desktop's is reset per session and only sees frames that pass the #573 leftover-frame gate; Core's
decodes **every** frame, including the leftover the desktop discards. After a restart Core's
baseline anchored on that leftover and shifted the whole new session into the future by the
stop-to-start gap — the exact artifact #573 exists to remove — and `DataSample` is what
`DatabaseLogger` persists and the plot/viewer/CSV export read back.

Measured on the new fixture (before this change): the channel sample was **13.0000 s** later than the
`DeviceMessage` dispatched for the *same frame* after a 13 s stop-to-start gap, and **5.0 ms** off
even inside one uninterrupted session (independent `DateTime.Now` anchors).

## The change

* Apply the device-reported frequency to the desktop's processor once per streaming session, on the
  first frame that reaches `ProcessStreamMessage` — that is where the device-id key is known to match
  the one `ProcessTimestamp` uses, and it must be re-applied per session because `InitializeStreaming`'s
  `ResetAll()` drops per-device frequencies along with the baselines (Core's documented contract).
* Stamp the channel `DataSample` with the reconstruction `ProcessStreamMessage` already computed for
  that frame (what shipped before #715), so one frame yields exactly one timestamp — making the doc
  comment's claim true instead of aspirational. Only the decoded `Value` still comes from Core.

43 added / 4 changed lines in one file. No public API change.

## Tests

New `Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs` (3 tests). It needs a fixture no
existing one provides: desktop channels wired onto Core's real decode pipeline (so `ActiveSample` is
populated, as in `ChannelDataMappingTests`) **plus** captured `DeviceMessage`s (as in
`StreamStartLeftoverFrameTests`) **plus** the real `InitializeStreaming`/`StopStreaming` lifecycle,
which is what resets the baseline. Frames are routed through both halves of the production pipeline
in production order.

Each test was proven to earn its place by reverting the fix in **two separate steps**:

| revert | fails |
|---|---|
| channel sample back to `coreSample.Timestamp` (frequency wiring kept) | `SingleSession_ChannelSampleCarriesTheTimestampOfItsOwnFrame`, `StreamRestart_ChannelSampleDoesNotCarryTheStopToStartGap` |
| frequency wiring removed (timestamp source kept) | `DeviceReportedClockFrequency_ScalesTheReconstructedTimeline` (1.000 s → 0.840 s) |
