### PR TITLE
fix(logging): unsubscribe the channel that was matched, not the first same-named one

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
@@ -2,11 +2,13 @@ using System.ComponentModel;
 using System.Diagnostics;
 using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Configuration;
+using Daqifi.Desktop.Device;
 using Daqifi.Desktop.Logger;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using ChannelDirection = Daqifi.Core.Channel.ChannelDirection;
 using ChannelType = Daqifi.Core.Channel.ChannelType;
+using CoreAnalogChannel = Daqifi.Core.Channel.AnalogChannel;
 
 namespace Daqifi.Desktop.Test.Loggers;
 
@@ -47,6 +49,40 @@ public class LoggingManagerSubscribedChannelsTests
     private static FakeChannel NewChannel(string name, string deviceSerial = DEVICE_SERIAL)
     {
         return new FakeChannel { Name = name, DeviceSerialNo = deviceSerial };
+    }
+
+    /// <summary>
+    /// Builds a real <see cref="AnalogChannel"/> — the production type — owned by a mocked device
+    /// reporting <paramref name="deviceSerial"/>.
+    /// <para>
+    /// The multi-device tests below deliberately do <em>not</em> use <see cref="FakeChannel"/>.
+    /// <c>FakeChannel</c> does not override <c>Equals</c>, so every collection operation on it falls
+    /// back to reference equality — which is the behaviour under test. Using it would restate the
+    /// expected outcome instead of exercising the name-only <see cref="AbstractChannel.Equals"/>
+    /// that the production channel types actually carry.
+    /// </para>
+    /// </summary>
+    /// <param name="name">The channel name, e.g. <c>AI0</c>. Devices name channels by index, so
+    /// two different units both expose the same names.</param>
+    /// <param name="deviceSerial">Serial number the owning device reports.</param>
+    private static AnalogChannel NewAnalogChannel(string name, string deviceSerial)
+    {
+        var owner = new Mock<IStreamingDevice>();
+        owner.SetupGet(d => d.DeviceSerialNo).Returns(deviceSerial);
+        owner.SetupGet(d => d.DevicePartNumber).Returns("Nq3");
+
+        var coreChannel = new CoreAnalogChannel(0, 4096)
+        {
+            Name = name,
+            Direction = ChannelDirection.Input,
+            CalibrationB = 0,
+            CalibrationM = 1,
+            InternalScaleM = 1,
+            PortRange = 5
+        };
+
+        // The AnalogChannel constructor copies DeviceSerialNo off the owner.
+        return new AnalogChannel(owner.Object, coreChannel);
     }
     #endregion
 
@@ -282,6 +318,112 @@ public class LoggingManagerSubscribedChannelsTests
         Assert.AreEqual(0, manager.SubscribedChannels.Count);
         Assert.IsFalse(first.IsActive);
         Assert.IsFalse(second.IsActive);
+    }
+    #endregion
+
+    #region Same-named channels across two devices (issue #773)
+    /// <summary>
+    /// Two connected devices both expose <c>AI0</c>, and <see cref="AbstractChannel.Equals"/> compares
+    /// <c>Name</c> only. <c>Unsubscribe</c> resolves the target with a device-qualified predicate, but
+    /// used to drop it with a value-based <c>List.Remove</c> — which re-matched by name and removed
+    /// whichever same-named channel sat earliest in the list. Unsubscribing the second device's
+    /// channel therefore deactivated the right one and removed the wrong one, leaving the other
+    /// device's channel logging while invisible to the UI.
+    /// <para>
+    /// Note the assertions use <see cref="Assert.AreSame"/>, never <c>CollectionAssert.AreEqual</c>:
+    /// the latter would compare with the very name-only equality under test and pass on either channel.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void Unsubscribe_RemovesTheTargetedChannel_WhenASameNamedChannelWasSubscribedFirst()
+    {
+        // Arrange - device A subscribes AI0 first, so it occupies the index a name-only
+        // removal would land on.
+        var manager = NewManager();
+        var deviceA = NewAnalogChannel("AI0", DEVICE_SERIAL);
+        var deviceB = NewAnalogChannel("AI0", OTHER_DEVICE_SERIAL);
+        manager.Subscribe(deviceA);
+        manager.Subscribe(deviceB);
+
+        // Act - tear down the second device's channel.
+        manager.Unsubscribe(deviceB);
+
+        // Assert - A must be the survivor, and must still be streaming.
+        Assert.AreEqual(1, manager.SubscribedChannels.Count);
+        Assert.AreSame(deviceA, manager.SubscribedChannels[0],
+            "Unsubscribing device B's AI0 must not remove device A's AI0.");
+        Assert.IsTrue(deviceA.IsActive, "The other device's channel must keep streaming.");
+        Assert.IsFalse(deviceB.IsActive, "The unsubscribed channel must be deactivated.");
+    }
+
+    /// <summary>
+    /// The mirror ordering. This case was already correct before the fix — the targeted channel was
+    /// also the first name-match — so it is a preservation control rather than a second catch: it
+    /// proves the reference-based removal did not break the ordinary path.
+    /// </summary>
+    [TestMethod]
+    public void Unsubscribe_RemovesTheTargetedChannel_WhenItIsItselfTheFirstSameNamedChannel()
+    {
+        // Arrange
+        var manager = NewManager();
+        var deviceA = NewAnalogChannel("AI0", DEVICE_SERIAL);
+        var deviceB = NewAnalogChannel("AI0", OTHER_DEVICE_SERIAL);
+        manager.Subscribe(deviceA);
+        manager.Subscribe(deviceB);
+
+        // Act
+        manager.Unsubscribe(deviceA);
+
+        // Assert
+        Assert.AreEqual(1, manager.SubscribedChannels.Count);
+        Assert.AreSame(deviceB, manager.SubscribedChannels[0]);
+        Assert.IsTrue(deviceB.IsActive);
+        Assert.IsFalse(deviceA.IsActive);
+    }
+
+    /// <summary>
+    /// The stuck-entry consequence of the wrong removal. Once the wrong channel has been dropped, the
+    /// deactivated one that stayed behind can never be removed: <c>Unsubscribe</c> filters on
+    /// <c>IsActive</c>, so every later attempt early-returns and the entry survives until
+    /// <c>ClearChannelList</c> or an app restart — the legend keeps showing a dead channel.
+    /// </summary>
+    [TestMethod]
+    public void Unsubscribe_EmptiesTheList_WhenBothDevicesSameNamedChannelsAreUnsubscribed()
+    {
+        // Arrange
+        var manager = NewManager();
+        var deviceA = NewAnalogChannel("AI0", DEVICE_SERIAL);
+        var deviceB = NewAnalogChannel("AI0", OTHER_DEVICE_SERIAL);
+        manager.Subscribe(deviceA);
+        manager.Subscribe(deviceB);
+
+        // Act - tear both down, second device first (the disconnect-loop order).
+        manager.Unsubscribe(deviceB);
+        manager.Unsubscribe(deviceA);
+
+        // Assert
+        Assert.AreEqual(0, manager.SubscribedChannels.Count,
+            "Both channels were unsubscribed, so neither may be left stranded in the list.");
+        Assert.IsFalse(deviceA.IsActive);
+        Assert.IsFalse(deviceB.IsActive);
+    }
+
+    /// <summary>
+    /// Guards the premise the other tests rest on: the production channel type really does compare by
+    /// name alone, so a value-based removal on this list is genuinely ambiguous. If channel equality is
+    /// ever made device-aware, this test fails and points at <c>Unsubscribe</c>'s removal comment.
+    /// </summary>
+    [TestMethod]
+    public void AnalogChannel_ComparesEqual_WhenOnlyTheNameMatchesAcrossDevices()
+    {
+        // Arrange
+        var deviceA = NewAnalogChannel("AI0", DEVICE_SERIAL);
+        var deviceB = NewAnalogChannel("AI0", OTHER_DEVICE_SERIAL);
+
+        // Assert
+        Assert.AreNotEqual(deviceA.DeviceSerialNo, deviceB.DeviceSerialNo);
+        Assert.IsTrue(deviceA.Equals(deviceB),
+            "Premise of issue #773: channel equality is name-only, so removal must go by reference.");
     }
     #endregion
 

--- a/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/LoggingManagerSubscribedChannelsTests.cs
@@ -416,13 +416,18 @@ public class LoggingManagerSubscribedChannelsTests
     [TestMethod]
     public void AnalogChannel_ComparesEqual_WhenOnlyTheNameMatchesAcrossDevices()
     {
-        // Arrange
+        // Arrange - two channels that share a name but genuinely belong to different devices, so any
+        // equality between them can only come from the name.
         var deviceA = NewAnalogChannel("AI0", DEVICE_SERIAL);
         var deviceB = NewAnalogChannel("AI0", OTHER_DEVICE_SERIAL);
+        Assert.AreNotEqual(deviceA.DeviceSerialNo, deviceB.DeviceSerialNo,
+            "Precondition: the two channels must report different device serials.");
+
+        // Act
+        var comparesEqual = deviceA.Equals(deviceB);
 
         // Assert
-        Assert.AreNotEqual(deviceA.DeviceSerialNo, deviceB.DeviceSerialNo);
-        Assert.IsTrue(deviceA.Equals(deviceB),
+        Assert.IsTrue(comparesEqual,
             "Premise of issue #773: channel equality is name-only, so removal must go by reference.");
     }
     #endregion

--- a/Daqifi.Desktop/Loggers/LoggingManager.cs
+++ b/Daqifi.Desktop/Loggers/LoggingManager.cs
@@ -709,8 +709,14 @@ public partial class LoggingManager : ObservableObject
             subscribedChannel.OnChannelUpdated -= HandleChannelUpdate;
 
             // Copy-on-write — see SubscribedChannels' remarks.
+            //
+            // Remove by reference, not by value. The lookup above already resolved the exact
+            // instance to drop, and List.Remove would re-match it with the default comparer —
+            // which lands on AbstractChannel.Equals, and that compares Name only. Two devices
+            // both expose "AI0", so a value-based removal drops whichever same-named channel
+            // sits earliest in the list rather than the one that was just deactivated.
             var updated = new List<IChannel>(current);
-            updated.Remove(subscribedChannel);
+            updated.RemoveAll(x => ReferenceEquals(x, subscribedChannel));
             Volatile.Write(ref _subscribedChannels, updated);
         }
 


### PR DESCRIPTION
Closes #773

## The bug

`LoggingManager.Unsubscribe` resolved its target correctly but removed the wrong object.

```csharp
var subscribedChannel = current.FirstOrDefault(
    x => x.DeviceSerialNo == channel.DeviceSerialNo && x.Name == channel.Name && x.IsActive);  // device-qualified

...
var updated = new List<IChannel>(current);
updated.Remove(subscribedChannel);      // NOT device-qualified
```

`List<T>.Remove` re-matches through `EqualityComparer<IChannel>.Default`. `IChannel` does not implement `IEquatable<IChannel>`, so that lands on `AbstractChannel.Equals`, which compares `Name` only:

```csharp
public override bool Equals(object? obj)
{
    if (obj is not AbstractChannel channel) { return false; }
    return channel.Name == Name;      // device identity does not participate
}
```

Devices name channels by index, so two connected units both expose `AI0`. With `[A.AI0, B.AI0]`, unsubscribing **B** deactivated B and removed **A**.

It is order-dependent, not a guaranteed failure — it goes wrong whenever the target is not the first name-match, which is exactly the case when tearing down the second-connected device. Every caller is a per-device loop that hits that ordering (`ConnectionManager.cs:111/411/492`, `DaqifiViewModel.cs:847/1266/1551`, `ProfilesPaneViewModel.cs:341`, `ChannelsPaneViewModel.cs:298`).

**Fallout:** A's channel left `SubscribedChannels` while still `IsActive` with `HandleChannelUpdate` attached, so it kept logging while invisible to the UI; B's entry stayed in the list where `Unsubscribe`'s `IsActive` filter made it permanently unremovable; and re-subscribing A attached the handler a second time, logging every sample twice.

## The fix

One line — remove by reference, since the lookup already resolved the exact instance:

```csharp
updated.RemoveAll(x => ReferenceEquals(x, subscribedChannel));
```

**Deliberately *not* fixed by making `AbstractChannel.Equals` device-aware.** `DeviceSerialNo` is assigned after construction and re-assigned on every Core resync (`AbstractStreamingDevice.cs:1562-1563`, `1572-1573`); folding a mutable field into `GetHashCode` would strand entries in `AbstractStreamingDevice._channelSampleHandlers` (`:119`, default comparer) and turn a wrong-removal bug into a handler leak. It would also change `AddChannel`/`RemoveChannel` semantics. Far wider blast radius, no extra benefit here.

Identity-based removal is precedent-consistent: `ChannelsPaneViewModel` hit the same hazard and fixed it with the repo's own `Helpers/ReferenceComparer.cs`, whose doc says to use identity "so entries stay reachable even when a stored object mutates fields that participate in its value hash."

**Scope check:** line 713 was the only value-equality removal on the subscribed-channel list. `ClearChannelList` replaces the list wholesale and is unaffected; the `AbstractStreamingDevice` sites are scoped to one device's `DataChannels`, where names are unique, so they are correct as-is.

## Tests

+4 methods in `LoggingManagerSubscribedChannelsTests` (17 in the fixture, **756 in the suite**, up from 752).

They use **real `AnalogChannel` instances, not the fixture's `FakeChannel`** — this is load-bearing. `FakeChannel` does not override `Equals`, so every collection operation on it falls back to reference equality, which is the behaviour under test; using it would have restated the expected outcome instead of exercising production equality. That is precisely why the existing fixture missed this bug despite already setting up the two-serial scenario.

Assertions use `Assert.AreSame`, never `CollectionAssert.AreEqual` — the latter would compare with the very name-only equality under test and pass on either channel.

| Test | Catches the bug? |
| --- | --- |
| `Unsubscribe_RemovesTheTargetedChannel_WhenASameNamedChannelWasSubscribedFirst` | **Yes** |
| `Unsubscribe_EmptiesTheList_WhenBothDevicesSameNamedChannelsAreUnsubscribed` (the stuck-ghost consequence) | **Yes** |
| `Unsubscribe_RemovesTheTargetedChannel_WhenItIsItselfTheFirstSameNamedChannel` | No — preservation control, passes on both sides by design |
| `AnalogChannel_ComparesEqual_WhenOnlyTheNameMatchesAcrossDevices` | No — premise guard; fails loudly if channel equality is ever made device-aware |

**Non-vacuity proven by revert:** `git checkout origin/main -- Daqifi.Desktop/Loggers/LoggingManager.cs`, rebuild, run the fixture → **2 failed / 15 passed**, failing on exactly the two assertions above (`Assert.AreSame(deviceA, manager.SubscribedChannels[0])` and `Assert.AreEqual(0, manager.SubscribedChannels.Count)`), then restored → 17/17. The two controls are labelled as such in the table rather than counted as catches.

---

**Not merging — opened for your review.**
