### PR TITLE
fix(connect): classify Core's typed SCPI-init error so it stops reaching Sentry

### DIFF
--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -17,6 +17,13 @@ namespace Daqifi.Desktop.Test.Device;
 /// asserted "did not throw", which is true of every switch arm, so they stayed green while the SCPI
 /// arm was unreachable (issue #775) and the condition was silently reaching Sentry.
 /// </para>
+/// <para>
+/// Each case verifies BOTH <see cref="IAppLogger.Error(Exception, string)"/> and
+/// <see cref="IAppLogger.Error(string)"/>, because both capture to Sentry — the exception overload
+/// via <c>SentrySdk.CaptureException(ex, ...)</c> and the message-only overload via a synthesized
+/// <c>AppLogErrorException</c>. Guarding only the exception overload would leave a live Sentry path
+/// a regression could take with these tests still green.
+/// </para>
 /// </summary>
 [TestClass]
 public class SerialStreamingDeviceLogConnectFailureTests
@@ -87,6 +94,7 @@ public class SerialStreamingDeviceLogConnectFailureTests
         // Error path (which is what captures to Sentry). Regression guard for #775.
         logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
         logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
@@ -104,6 +112,7 @@ public class SerialStreamingDeviceLogConnectFailureTests
         // Assert
         logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
         logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
@@ -122,6 +131,7 @@ public class SerialStreamingDeviceLogConnectFailureTests
         // Assert
         logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
         logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
@@ -139,6 +149,10 @@ public class SerialStreamingDeviceLogConnectFailureTests
         // Assert
         logger.Verify(l => l.Error(ex, It.IsAny<string>()), Times.Once);
         logger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+
+        // ...and via the exception-carrying overload specifically: the message-only Error(string)
+        // synthesizes an AppLogErrorException, which would strand the real stack trace out of Sentry.
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     /// <summary>

--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -1,82 +1,38 @@
+using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device.SerialDevice;
+using Moq;
+using ScpiInitializationErrorException = Daqifi.Core.Device.ScpiInitializationErrorException;
 
 namespace Daqifi.Desktop.Test.Device;
 
 /// <summary>
-/// Tests for <see cref="SerialStreamingDevice"/>'s connect-failure classification. Certain
-/// InvalidOperationExceptions raised during connect are device/environmental conditions, not app
-/// bugs, so they must be downgraded to a Warning (no Sentry capture) rather than the default Error
-/// path: Core's SCPI-error-during-initialization message (issue #589) and the serial transport
-/// reporting the COM port closed mid-initialization (issue #588).
+/// Tests for <see cref="SerialStreamingDevice"/>'s connect-failure classification. Certain failures
+/// raised during connect are device/environmental conditions, not app bugs, so they must be
+/// downgraded to a Warning (which does NOT capture to Sentry) rather than the default Error path:
+/// Core's SCPI-error-during-initialization (issues #589/#775) and the serial transport reporting the
+/// COM port closed mid-initialization (issue #588).
+/// <para>
+/// The <c>LogConnectFailure_*</c> cases assert the log level actually used, via an injected
+/// <see cref="IAppLogger"/>. That is the whole point: the earlier versions of these tests only
+/// asserted "did not throw", which is true of every switch arm, so they stayed green while the SCPI
+/// arm was unreachable (issue #775) and the condition was silently reaching Sentry.
+/// </para>
 /// </summary>
 [TestClass]
 public class SerialStreamingDeviceLogConnectFailureTests
 {
-    // Exact wording Daqifi.Core 1.1.1 throws from DaqifiStreamingDevice.InitializeAsync()
-    // (verified against the NuGet package's DLL strings) when any command in its init sequence
-    // gets back a SCPI -200 execution error — e.g. "SYSTem:STReam:INTerface 0" (setting the
-    // stream interface to USB) rejected because firmware persisted WiFi as the last interface.
+    // Exact wording Daqifi.Core throws from DaqifiStreamingDevice.InitializeAsync() when any command
+    // in its init sequence gets back a SCPI -200 execution error — e.g. "SYSTem:STReam:INTerface 0"
+    // (setting the stream interface to USB) rejected because firmware persisted WiFi as the last
+    // interface.
     private const string CORE_SCPI_INIT_ERROR_MESSAGE =
         "Device returned a SCPI error during initialization: -200,\"Execution error\"";
 
     // The exact message Core throws from DaqifiStreamingDevice.OnDeviceInitializingAsync when the
     // "SYSTem:STReam:INTerface 0" (stream-interface -> USB) switch is rejected. This is the message
-    // issue #589 and its Sentry alert DAQIFI-DESKTOP-Y are filed for; the original #589 fix only
-    // matched CORE_SCPI_INIT_ERROR_MESSAGE, so this variant was still hitting the Error path.
+    // issue #589 and its Sentry alert DAQIFI-DESKTOP-Y are filed for.
     private const string CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE =
         "Device returned a SCPI error while setting stream interface to USB.";
-
-    [TestMethod]
-    public void IsScpiInitializationError_MatchesCoresInitializationErrorMessage()
-    {
-        var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
-
-        Assert.IsTrue(SerialStreamingDevice.IsScpiInitializationError(ex));
-    }
-
-    [TestMethod]
-    public void IsScpiInitializationError_MatchesCoresStreamInterfaceErrorMessage()
-    {
-        // Arrange — regression guard for #589: the actual reported message (Sentry
-        // DAQIFI-DESKTOP-Y) must be classified as the environmental SCPI-init error, not fall
-        // through to the Error path.
-        var ex = new InvalidOperationException(CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE);
-
-        // Act
-        var isScpiInitError = SerialStreamingDevice.IsScpiInitializationError(ex);
-
-        // Assert
-        Assert.IsTrue(isScpiInitError);
-    }
-
-    [TestMethod]
-    public void IsScpiInitializationError_IsCaseInsensitive()
-    {
-        var ex = new InvalidOperationException("device returned a scpi error during initialization: whatever");
-
-        Assert.IsTrue(SerialStreamingDevice.IsScpiInitializationError(ex));
-    }
-
-    [TestMethod]
-    public void IsScpiInitializationError_DoesNotMatchUnrelatedInvalidOperationException()
-    {
-        // Regression guard: an unrelated InvalidOperationException bug must still hit the
-        // default Error path instead of being silently downgraded.
-        var ex = new InvalidOperationException("Transport exploded.");
-
-        Assert.IsFalse(SerialStreamingDevice.IsScpiInitializationError(ex));
-    }
-
-    [TestMethod]
-    public void IsScpiInitializationError_DoesNotMatchUnrelatedScpiErrorMention()
-    {
-        // Regression guard: the predicate matches Core's full known prefix, not the bare
-        // substring "SCPI error" — an unrelated failure that happens to mention a SCPI error in
-        // some other context must not be misclassified as the initialization error.
-        var ex = new InvalidOperationException("SCPI error while doing something unrelated to initialization.");
-
-        Assert.IsFalse(SerialStreamingDevice.IsScpiInitializationError(ex));
-    }
 
     [TestMethod]
     public void IsTransportClosedError_MatchesDotNetBaseStreamMessage()
@@ -116,72 +72,92 @@ public class SerialStreamingDeviceLogConnectFailureTests
     }
 
     [TestMethod]
-    public void LogConnectFailure_WithTransportClosedError_DoesNotThrow()
+    public void LogConnectFailure_WithScpiInitializationError_LogsWarningAndNotError()
     {
-        var device = new TestableSerialStreamingDevice("COM_TEST_588");
+        // Arrange — Core 1.3.0 throws its typed ScpiInitializationErrorException (daqifi-core#317)
+        // from InitializeAsync, NOT an InvalidOperationException.
+        var logger = new Mock<IAppLogger>();
+        var device = new TestableSerialStreamingDevice("COM_TEST_589", logger.Object);
+        var ex = CreateScpiInitializationError(CORE_SCPI_INIT_ERROR_MESSAGE);
+
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert — environmental condition: Warning carrying the exception detail, and never the
+        // Error path (which is what captures to Sentry). Regression guard for #775.
+        logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithScpiStreamInterfaceError_LogsWarningAndNotError()
+    {
+        // Arrange — the stream-interface variant (Sentry DAQIFI-DESKTOP-Y) is the same typed
+        // exception, thrown from Core's OnDeviceInitializingAsync.
+        var logger = new Mock<IAppLogger>();
+        var device = new TestableSerialStreamingDevice("COM_TEST_589", logger.Object);
+        var ex = CreateScpiInitializationError(CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE);
+
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert
+        logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithTransportClosedError_LogsWarningAndNotError()
+    {
+        // Arrange — the COM port closing mid-initialization (issue #588) stays a Warning. Core's
+        // TransportNotConnectedException does derive from InvalidOperationException, so this arm
+        // was never affected by #775; asserted here so the two classifications can't drift.
+        var logger = new Mock<IAppLogger>();
+        var device = new TestableSerialStreamingDevice("COM_TEST_588", logger.Object);
         var ex = new InvalidOperationException("The BaseStream is only available when the port is open.");
 
-        try
-        {
-            device.ExposedLogConnectFailure(ex);
-        }
-        catch (Exception caught)
-        {
-            Assert.Fail($"LogConnectFailure must not throw for the transport-closed case, but threw: {caught}");
-        }
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert
+        logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
-    public void LogConnectFailure_WithScpiInitializationError_DoesNotThrow()
+    public void LogConnectFailure_WithUnrelatedException_LogsError()
     {
-        var device = new TestableSerialStreamingDevice("COM_TEST_589");
-        var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
+        // Arrange — the guard in the other direction: a genuine app bug must still reach the Error
+        // (Sentry) path. Without this, "always log a Warning" would pass every other case here.
+        var logger = new Mock<IAppLogger>();
+        var device = new TestableSerialStreamingDevice("COM_TEST_589", logger.Object);
+        var ex = new InvalidOperationException("Transport exploded.");
 
-        try
-        {
-            device.ExposedLogConnectFailure(ex);
-        }
-        catch (Exception caught)
-        {
-            Assert.Fail($"LogConnectFailure must not throw for the SCPI-init-error case, but threw: {caught}");
-        }
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert
+        logger.Verify(l => l.Error(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
     }
 
-    [TestMethod]
-    public void LogConnectFailure_WithScpiStreamInterfaceError_DoesNotThrow()
+    /// <summary>
+    /// Builds the exception Core 1.3.0 actually throws for a SCPI initialization failure: the typed
+    /// <c>ScpiInitializationErrorException</c> (daqifi-core#317), which carries the raw device reply
+    /// and the parsed SCPI error alongside the message. It derives from <see cref="Exception"/>, not
+    /// <see cref="InvalidOperationException"/> — the whole reason issue #775 existed.
+    /// </summary>
+    private static ScpiInitializationErrorException CreateScpiInitializationError(string message) =>
+        new(message, ["-200,\"Execution error\""], "-200,\"Execution error\"");
+
+    private sealed class TestableSerialStreamingDevice : SerialStreamingDevice
     {
-        // Arrange
-        var device = new TestableSerialStreamingDevice("COM_TEST_589");
-        var ex = new InvalidOperationException(CORE_SCPI_STREAM_INTERFACE_ERROR_MESSAGE);
-
-        // Act & Assert — classifying + logging the stream-interface variant must not throw.
-        try
+        public TestableSerialStreamingDevice(string portName, IAppLogger appLogger)
+            : base(portName)
         {
-            device.ExposedLogConnectFailure(ex);
+            AppLogger = appLogger;
         }
-        catch (Exception caught)
-        {
-            Assert.Fail($"LogConnectFailure must not throw for the SCPI stream-interface case, but threw: {caught}");
-        }
-    }
 
-    [TestMethod]
-    public void LogConnectFailure_WithUnrelatedException_DoesNotThrow()
-    {
-        var device = new TestableSerialStreamingDevice("COM_TEST_589");
-
-        try
-        {
-            device.ExposedLogConnectFailure(new InvalidOperationException("Transport exploded."));
-        }
-        catch (Exception caught)
-        {
-            Assert.Fail($"LogConnectFailure must not throw for the default case, but threw: {caught}");
-        }
-    }
-
-    private sealed class TestableSerialStreamingDevice(string portName) : SerialStreamingDevice(portName)
-    {
         public void ExposedLogConnectFailure(Exception ex) => LogConnectFailure(ex);
     }
 }

--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
@@ -18,6 +18,13 @@ namespace Daqifi.Desktop.Test.Device.WiFiDevice;
 /// <see cref="IAppLogger"/> — the earlier "did not throw" assertions were true of every switch arm,
 /// so they stayed green while the SCPI arm was unreachable (issue #775).
 /// </para>
+/// <para>
+/// Each case verifies BOTH <see cref="IAppLogger.Error(Exception, string)"/> and
+/// <see cref="IAppLogger.Error(string)"/>, because both capture to Sentry — the exception overload
+/// via <c>SentrySdk.CaptureException(ex, ...)</c> and the message-only overload via a synthesized
+/// <c>AppLogErrorException</c>. Guarding only the exception overload would leave a live Sentry path
+/// a regression could take with these tests still green.
+/// </para>
 /// </summary>
 [TestClass]
 public class DaqifiStreamingDeviceLogConnectFailureTests
@@ -86,6 +93,7 @@ public class DaqifiStreamingDeviceLogConnectFailureTests
         // (Sentry) path. Regression guard for #775.
         logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
         logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
@@ -102,6 +110,7 @@ public class DaqifiStreamingDeviceLogConnectFailureTests
         // Assert
         logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
         logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
@@ -119,6 +128,10 @@ public class DaqifiStreamingDeviceLogConnectFailureTests
         // Assert
         logger.Verify(l => l.Error(ex, It.IsAny<string>()), Times.Once);
         logger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+
+        // ...and via the exception-carrying overload specifically: the message-only Error(string)
+        // synthesizes an AppLogErrorException, which would strand the real stack trace out of Sentry.
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     /// <summary>

--- a/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/WiFiDevice/DaqifiStreamingDeviceLogConnectFailureTests.cs
@@ -1,15 +1,23 @@
+using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device.WiFiDevice;
+using Moq;
 using System.Net;
+using ScpiInitializationErrorException = Daqifi.Core.Device.ScpiInitializationErrorException;
 
 namespace Daqifi.Desktop.Test.Device.WiFiDevice;
 
 /// <summary>
 /// Tests for <see cref="DaqifiStreamingDevice"/>'s connect-failure classification. The shared Connect
-/// template runs Core's InitializeAsync after ConnectTcp, so device/environmental InvalidOperation
-/// exceptions raised during connect must be downgraded to a Warning (no Sentry capture) rather than
-/// the default Error path — mirroring the serial classification: Core's SCPI-error-during-init
-/// message (issue #732, #589, #709) and Core's transport reporting the connection dropped
-/// mid-initialization ("Transport is not connected.", issue #740; serial equivalent #588).
+/// template runs Core's InitializeAsync after ConnectTcp, so device/environmental failures raised
+/// during connect must be downgraded to a Warning (no Sentry capture) rather than the default Error
+/// path — mirroring the serial classification: Core's SCPI-error-during-init (issues #732, #589,
+/// #709, #775) and Core's transport reporting the connection dropped mid-initialization
+/// ("Transport is not connected.", issue #740; serial equivalent #588).
+/// <para>
+/// The <c>LogConnectFailure_*</c> cases assert the log level actually used, via an injected
+/// <see cref="IAppLogger"/> — the earlier "did not throw" assertions were true of every switch arm,
+/// so they stayed green while the SCPI arm was unreachable (issue #775).
+/// </para>
 /// </summary>
 [TestClass]
 public class DaqifiStreamingDeviceLogConnectFailureTests
@@ -19,49 +27,6 @@ public class DaqifiStreamingDeviceLogConnectFailureTests
     // init sequence runs over TCP (WiFi) and serial.
     private const string CORE_SCPI_INIT_ERROR_MESSAGE =
         "Device returned a SCPI error during initialization: -200,\"Execution error\"";
-
-    [TestMethod]
-    public void IsScpiInitializationError_MatchesCoresWiFiInitializationErrorMessage()
-    {
-        // Arrange
-        var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
-
-        // Act
-        var isEnvironmental = DaqifiStreamingDevice.IsScpiInitializationError(ex);
-
-        // Assert — proves the WiFi-surfaced message classifies as environmental (Warning, not
-        // the default Error/Sentry path); guards against a regression that drops the downgrade.
-        Assert.IsTrue(isEnvironmental);
-    }
-
-    [TestMethod]
-    public void IsScpiInitializationError_DoesNotMatchWiFiAppBugInvalidOperationException()
-    {
-        // Arrange — WiFi's own app-bug InvalidOperationException must NOT be downgraded.
-        var ex = new InvalidOperationException("Connected Core device does not support streaming operations.");
-
-        // Act
-        var isEnvironmental = DaqifiStreamingDevice.IsScpiInitializationError(ex);
-
-        // Assert
-        Assert.IsFalse(isEnvironmental);
-    }
-
-    [TestMethod]
-    public void LogConnectFailure_WithScpiInitializationError_DoesNotThrow()
-    {
-        var device = CreateTestableDevice();
-        var ex = new InvalidOperationException(CORE_SCPI_INIT_ERROR_MESSAGE);
-
-        try
-        {
-            device.ExposedLogConnectFailure(ex);
-        }
-        catch (Exception caught)
-        {
-            Assert.Fail($"LogConnectFailure must not throw for the SCPI-init-error case, but threw: {caught}");
-        }
-    }
 
     [TestMethod]
     public void IsTransportDisconnectedError_MatchesCoreTransportNotConnectedMessage()
@@ -106,48 +71,76 @@ public class DaqifiStreamingDeviceLogConnectFailureTests
     }
 
     [TestMethod]
-    public void LogConnectFailure_WithTransportDisconnectedError_DoesNotThrow()
+    public void LogConnectFailure_WithScpiInitializationError_LogsWarningAndNotError()
     {
-        // Arrange
-        var device = CreateTestableDevice();
-        var ex = new InvalidOperationException("Transport is not connected.");
+        // Arrange — Core 1.3.0 throws its typed ScpiInitializationErrorException (daqifi-core#317),
+        // which derives from Exception rather than InvalidOperationException.
+        var logger = new Mock<IAppLogger>();
+        var device = CreateTestableDevice(logger.Object);
+        var ex = CreateScpiInitializationError(CORE_SCPI_INIT_ERROR_MESSAGE);
 
-        // Act & Assert — the transport-disconnect case must be classified and logged without throwing.
-        try
-        {
-            device.ExposedLogConnectFailure(ex);
-        }
-        catch (Exception caught)
-        {
-            Assert.Fail($"LogConnectFailure must not throw for the transport-disconnect case, but threw: {caught}");
-        }
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert — environmental condition: Warning carrying the exception detail, never the Error
+        // (Sentry) path. Regression guard for #775.
+        logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
-    public void LogConnectFailure_WithUnrelatedInvalidOperationException_DoesNotThrow()
+    public void LogConnectFailure_WithTransportDisconnectedError_LogsWarningAndNotError()
     {
-        // Regression guard: WiFi's own app-bug InvalidOperationException
-        // ("Connected Core device does not support streaming operations.") must still hit the
-        // default Error path, not be silently downgraded — the SCPI-init predicate must not match it.
-        var device = CreateTestableDevice();
+        // Arrange — the connection dropping mid-initialization (issue #740) stays a Warning.
+        var logger = new Mock<IAppLogger>();
+        var device = CreateTestableDevice(logger.Object);
+        var ex = new InvalidOperationException("Transport is not connected.");
 
-        try
-        {
-            device.ExposedLogConnectFailure(
-                new InvalidOperationException("Connected Core device does not support streaming operations."));
-        }
-        catch (Exception caught)
-        {
-            Assert.Fail($"LogConnectFailure must not throw for the default case, but threw: {caught}");
-        }
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert
+        logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
     }
 
-    private static TestableDaqifiStreamingDevice CreateTestableDevice() =>
-        new(IPAddress.Parse("192.168.1.100"), 9760, "Test Device");
-
-    private sealed class TestableDaqifiStreamingDevice(IPAddress ipAddress, int port, string name)
-        : DaqifiStreamingDevice(ipAddress, port, name)
+    [TestMethod]
+    public void LogConnectFailure_WithUnrelatedInvalidOperationException_LogsError()
     {
+        // Arrange — guard in the other direction: WiFi's own app-bug InvalidOperationException must
+        // still reach the Error (Sentry) path, not be silently downgraded.
+        var logger = new Mock<IAppLogger>();
+        var device = CreateTestableDevice(logger.Object);
+        var ex = new InvalidOperationException("Connected Core device does not support streaming operations.");
+
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert
+        logger.Verify(l => l.Error(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Builds the exception Core 1.3.0 actually throws for a SCPI initialization failure: the typed
+    /// <c>ScpiInitializationErrorException</c> (daqifi-core#317), which carries the raw device reply
+    /// and the parsed SCPI error alongside the message. It derives from <see cref="Exception"/>, not
+    /// <see cref="InvalidOperationException"/> — the whole reason issue #775 existed.
+    /// </summary>
+    private static ScpiInitializationErrorException CreateScpiInitializationError(string message) =>
+        new(message, ["-200,\"Execution error\""], "-200,\"Execution error\"");
+
+    private static TestableDaqifiStreamingDevice CreateTestableDevice(IAppLogger appLogger) =>
+        new(IPAddress.Parse("192.168.1.100"), 9760, "Test Device", appLogger);
+
+    private sealed class TestableDaqifiStreamingDevice : DaqifiStreamingDevice
+    {
+        public TestableDaqifiStreamingDevice(IPAddress ipAddress, int port, string name, IAppLogger appLogger)
+            : base(ipAddress, port, name)
+        {
+            AppLogger = appLogger;
+        }
+
         public void ExposedLogConnectFailure(Exception ex) => LogConnectFailure(ex);
     }
 }

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -169,7 +169,15 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
     #region Properties
 
-    protected AppLogger AppLogger { get; } = AppLogger.Instance;
+    /// <summary>
+    /// Application logger for this device's diagnostics. Defaults to the process-wide
+    /// <see cref="Common.Loggers.AppLogger.Instance"/>. Typed as <see cref="IAppLogger"/> and
+    /// <c>init</c>-only so a derived test double can substitute a fake in its own constructor —
+    /// which is what makes the connect-failure classification in <see cref="LogConnectFailure"/>
+    /// assertable by log level (Warning vs Error) instead of only "did not throw". Production code
+    /// still cannot swap it after construction.
+    /// </summary>
+    protected IAppLogger AppLogger { get; init; } = Common.Loggers.AppLogger.Instance;
 
     /// <summary>
     /// Gets the device metadata from Core library
@@ -457,26 +465,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     {
         AppLogger.Error(ex, $"Problem connecting to DAQiFi device {DisplayIdentifier}");
     }
-
-    /// <summary>
-    /// True when <paramref name="ex"/> is one of Core's SCPI-error-during-initialization
-    /// <see cref="InvalidOperationException"/>s (issue #589, Sentry DAQIFI-DESKTOP-Y). Core's
-    /// <c>InitializeAsync()</c> throws these from the shared <see cref="Connect"/> template
-    /// regardless of transport, so both serial and WiFi devices classify them here as a
-    /// device/environmental condition (a Warning, not a Sentry-captured bug). Two sibling sites throw
-    /// with distinct wording: <c>"...SCPI error during initialization..."</c> (a command in the init
-    /// sequence returned -200) and <c>"...SCPI error while setting stream interface to USB..."</c>
-    /// (the stream-interface switch specifically — the exact message #589/DAQIFI-DESKTOP-Y is filed
-    /// for). Matched on each site's full distinctive phrase (via
-    /// <see cref="string.Contains(string, StringComparison)"/>, not a prefix/<c>StartsWith</c> — Core
-    /// embeds the phrase mid-message) rather than the bare substring "SCPI error" so an unrelated
-    /// <see cref="InvalidOperationException"/> that merely mentions a SCPI error elsewhere isn't
-    /// misclassified. Extracted as a pure predicate so the classification is unit-testable without
-    /// exercising the logger.
-    /// </summary>
-    internal static bool IsScpiInitializationError(Exception ex) =>
-        ex.Message.Contains("SCPI error during initialization", StringComparison.OrdinalIgnoreCase) ||
-        ex.Message.Contains("SCPI error while setting stream interface to USB", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// True when <paramref name="ex"/> is Core's transport reporting that the connection closed

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -121,8 +121,8 @@ public partial class SerialStreamingDevice : AbstractStreamingDevice, ILanChipIn
                 // #517, #632).
                 AppLogger.Warning(ex, $"Device on {PortName} did not respond within the connection timeout");
                 break;
-            case InvalidOperationException when IsScpiInitializationError(ex):
-                // Core's init sequence throws a bare InvalidOperationException when a command gets
+            case ScpiInitializationErrorException:
+                // Core's init sequence throws ScpiInitializationErrorException when a command gets
                 // a SCPI -200 execution error back, from two sibling sites with distinct wording:
                 //   * "Device returned a SCPI error during initialization: ..." (a command in the
                 //     echo/stop/power/stream-format/sysinfo sequence), and
@@ -133,9 +133,12 @@ public partial class SerialStreamingDevice : AbstractStreamingDevice, ILanChipIn
                 // Firmware persists the last stream interface across sessions, so a device
                 // previously left streaming over WiFi is a common trigger on the very next USB
                 // connect, but any command in the sequence can hit this transient/timing condition.
-                // Matched by message substring (Core doesn't yet throw a typed exception for this —
-                // daqifi-core issue tracks that) so other InvalidOperationException bugs still hit
-                // Error. Device/environmental condition, not an app bug (issue #589).
+                // Matched on Core's typed exception (added in daqifi-core#317, shipped in Core
+                // 1.3.0) rather than a message substring. It derives from Exception, NOT from
+                // InvalidOperationException, so the previous `case InvalidOperationException when
+                // IsScpiInitializationError(ex)` arm could never match and this condition was still
+                // reaching the default Error/Sentry path (issue #775). Device/environmental
+                // condition, not an app bug (issues #589, #709).
                 AppLogger.Warning(ex,
                     $"Device on {PortName} returned a SCPI error during initialization " +
                     "(including stream-interface setup)");

--- a/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/WiFiDevice/DaqifiStreamingDevice.cs
@@ -132,8 +132,8 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
                 // Connection refused / host unreachable. Same classification as above.
                 AppLogger.Warning(ex, $"Cannot reach device at {IpAddress}:{Port}: {socketEx.SocketErrorCode}");
                 break;
-            case InvalidOperationException when IsScpiInitializationError(ex):
-                // Core's InitializeAsync throws a bare InvalidOperationException, message
+            case ScpiInitializationErrorException:
+                // Core's InitializeAsync throws ScpiInitializationErrorException, message
                 // "Device returned a SCPI error during initialization: ...", when any command in
                 // its init sequence gets a SCPI -200 execution error back. The WiFi transport runs
                 // the identical Core init sequence as serial (the shared Connect template calls
@@ -141,6 +141,10 @@ public class DaqifiStreamingDevice : AbstractStreamingDevice
                 // = false), so a device left in a bad state is the same device/environmental
                 // condition here, not an app bug — downgrade to a Warning instead of the default
                 // Error/Sentry path, mirroring the serial classification (issues #589, #709).
+                // Core's typed exception (daqifi-core#317, Core 1.3.0) derives from Exception, not
+                // InvalidOperationException, so the previous `case InvalidOperationException when
+                // IsScpiInitializationError(ex)` arm never matched and this kept hitting the
+                // default Error/Sentry path (issue #775).
                 AppLogger.Warning(ex, $"Device at {IpAddress}:{Port} returned a SCPI error during initialization");
                 break;
             case InvalidOperationException when IsTransportDisconnectedError(ex):


### PR DESCRIPTION
Closes #775.

**Not merging — opened for your review.**

## The bug

Both connect paths downgrade a SCPI-error-during-initialization to a Warning (so it does *not* capture to Sentry) with:

```csharp
case InvalidOperationException when IsScpiInitializationError(ex):
```

Against the pinned `Daqifi.Core` **1.3.0**, that arm is unreachable. Core throws its **typed** `ScpiInitializationErrorException` (daqifi-core#317) from both sites, and that type derives from `Exception`, **not** `InvalidOperationException`. A C# type pattern tests the type *before* the `when` guard runs, so the guard was never evaluated, control fell through to `default:`, and the environmental "device answered but rejected an init command" case kept hitting `AppLogger.Error` → `SentrySdk.CaptureException` — the exact outcome #589/#709/#726/#733 were meant to prevent.

Invisible to a green build: a runtime type-pattern miss, not a compile error.

## Verified against the pinned assembly, not assumed

I checked the actual `Daqifi.Core` 1.3.0 DLL rather than trusting the report:

| Check | Result |
| --- | --- |
| `ScpiInitializationErrorException` base chain | `Exception -> Object` — **not** an `InvalidOperationException` |
| `TransportNotConnectedException` base chain | `InvalidOperationException -> SystemException -> Exception` — so the transport arms (#724/#741/#588/#740) were **never** affected |
| Which ctor receives each SCPI message (IL scan) | `InitializeAsync`: `IL_0273 ldstr → IL_0283 newobj ScpiInitializationErrorException`<br>`OnDeviceInitializingAsync`: `IL_018D ldstr → IL_0195 newobj ScpiInitializationErrorException` |

The IL scan also confirms those are the **only** two methods in Core carrying a "SCPI error" string, so nothing else can still throw an `InvalidOperationException` with that wording — which is what makes deleting the message predicate safe rather than merely tidy.

## The fix

- Match `case ScpiInitializationErrorException:` in `SerialStreamingDevice.LogConnectFailure` and `DaqifiStreamingDevice.LogConnectFailure`.
- Delete the now-unreachable `AbstractStreamingDevice.IsScpiInitializationError` message predicate.

No behavior changes for any other arm.

## The tests were the real hole

The previous tests asserted the message predicate in isolation, plus `LogConnectFailure ... _DoesNotThrow`. Not throwing is true of *every* switch arm, so those tests stayed green the entire time the arm was dead — they could never have caught this.

So this PR also makes the classification observable:

- `AbstractStreamingDevice.AppLogger` becomes an **`init`-only `IAppLogger`** (was a get-only concrete `AppLogger`). A derived test double can inject a fake in its own constructor; production code still cannot swap it after construction. `Mock<IAppLogger>` is already the established pattern in this repo (`BootloaderWatcherTests`, `SessionDataRepositoryTests`), and `FirewallManager` already types its logger field as `IAppLogger`.
- Every `LogConnectFailure_*` case now asserts the **log level actually used**: `Warning` carrying the exception, and `Error` *never* called — plus the reverse guard that a genuine app bug (`InvalidOperationException("Transport exploded.")` / `"Connected Core device does not support streaming operations."`) still *does* reach `Error`, so "always warn" cannot pass either.
- The 7 message-predicate tests for the deleted predicate are removed; the `IsTransportClosedError` / `IsTransportDisconnectedError` predicate tests are untouched.

### Non-vacuity proved

Reverted the two arms to the pre-fix form and re-ran the fixtures: **3 failed / 11 passed**, failing exactly on the SCPI cases with

```
Expected invocation on the mock once, but was 0 times: l => l.Warning(ScpiInitializationErrorException: ..., It.IsAny<string>())
      IAppLogger.Error(ScpiInitializationErrorException: Device returned a SCPI error during initialization: -200,"Execution error", "Failed to connect on COM_TEST_589")
```

That `IAppLogger.Error(...)` line is the Sentry path, reproduced at runtime. Restoring the fix returns **14/14**.

## Gates

- `dotnet build` — 0 errors, **0 warnings**
- Unit gate (`TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests`) — **745 passed / 0 failed**
- App-launch smoke (`Launch_MainWindowAppears_AndIsResponsive`) — **PASS**, 15 s
- Device bench — **skipped, no board attached** (details in the BENCH RESULTS comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
