### PR TITLE
chore(device): delegate friendly-name SCPI and validation to Core

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -12,10 +12,14 @@ namespace Daqifi.Desktop.Test.Device;
 [TestClass]
 public class AbstractStreamingDeviceTests
 {
+    // First of the two commands Core composes for a friendly-name change; also the injection point
+    // for the mid-sequence failure tests below.
+    private const string SET_FRIENDLY_NAME_COMMAND = "SYSTem:DEVice:NAME \"Bench Rig 3\"";
+
     // "core:" prefixed because Core composes and sends these now (daqifi-core#302); the desktop
     // wrapper no longer builds the SCPI text itself. See RecordingCoreStreamingDevice.
     private static readonly string[] ExpectedFriendlyNameCommands =
-        ["core:SYSTem:DEVice:NAME \"Bench Rig 3\"", "core:SYSTem:DEVice:NAME:SAVE"];
+        [$"core:{SET_FRIENDLY_NAME_COMMAND}", "core:SYSTem:DEVice:NAME:SAVE"];
 
     [TestMethod]
     public void FriendlyName_Property_ShouldDefaultToEmpty()
@@ -253,6 +257,41 @@ public class AbstractStreamingDeviceTests
         // Assert
         Assert.AreEqual(0, device.SentCommands.Count);
         Assert.AreEqual(string.Empty, device.FriendlyName, "A disconnected no-op must not update the local property.");
+    }
+
+    /// <summary>
+    /// The device can drop after the connected check passes — <c>CleanupConnection</c> clears
+    /// <c>CoreDevice</c> from whichever thread notices the disconnect — and Core's own guards throw
+    /// where the pre-delegation send path logged and returned. That no-op has to survive delegation:
+    /// <c>DaqifiViewModel.SetFriendlyName</c> treats <see cref="ArgumentException"/> as the only
+    /// expected failure, so a disconnect race must not escape the UI command as a different type.
+    /// </summary>
+    [TestMethod]
+    public void SetFriendlyName_WhenDeviceDisconnectsMidCall_NoOpsWithoutThrowing()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        device.SetCoreDeviceFailingOn(SET_FRIENDLY_NAME_COMMAND, disconnectOnThrow: true);
+
+        // Act
+        device.SetFriendlyName("Bench Rig 3");
+
+        // Assert
+        Assert.AreEqual(
+            string.Empty, device.FriendlyName, "A send that never reached the device must not update the property.");
+    }
+
+    [TestMethod]
+    public void SetFriendlyName_WhenCoreFailsWhileStillConnected_Propagates()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        device.SetCoreDeviceFailingOn(SET_FRIENDLY_NAME_COMMAND, disconnectOnThrow: false);
+
+        // Act & Assert — a failure that is not a disconnect is a real fault. Swallowing it here
+        // would report success to the user and hide the cause (the masking trap from issue #619).
+        Assert.ThrowsExactly<InvalidOperationException>(() => device.SetFriendlyName("Bench Rig 3"));
+        Assert.AreEqual(string.Empty, device.FriendlyName);
     }
 
     [TestMethod]
@@ -976,6 +1015,23 @@ public class AbstractStreamingDeviceTests
             }
 
             var coreDevice = new RecordingCoreStreamingDevice(SentCommands, throwOnCommandData: null);
+            coreDevice.Connect();
+            CoreDevice = coreDevice;
+        }
+
+        /// <summary>
+        /// Fakes a connected Core device whose send of <paramref name="commandData"/> throws.
+        /// With <paramref name="disconnectOnThrow"/> the Core device drops its connection first,
+        /// reproducing a disconnect that lands between the wrapper's connected check and Core's own
+        /// guard; without it the failure stands for an unrelated Core fault, which must propagate.
+        /// </summary>
+        public void SetCoreDeviceFailingOn(string commandData, bool disconnectOnThrow)
+        {
+            RecordingCoreStreamingDevice? coreDevice = null;
+            coreDevice = new RecordingCoreStreamingDevice(
+                SentCommands,
+                commandData,
+                onThrow: disconnectOnThrow ? () => coreDevice!.Disconnect() : null);
             coreDevice.Connect();
             CoreDevice = coreDevice;
         }

--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -12,8 +12,10 @@ namespace Daqifi.Desktop.Test.Device;
 [TestClass]
 public class AbstractStreamingDeviceTests
 {
+    // "core:" prefixed because Core composes and sends these now (daqifi-core#302); the desktop
+    // wrapper no longer builds the SCPI text itself. See RecordingCoreStreamingDevice.
     private static readonly string[] ExpectedFriendlyNameCommands =
-        ["SYSTem:DEVice:NAME \"Bench Rig 3\"", "SYSTem:DEVice:NAME:SAVE"];
+        ["core:SYSTem:DEVice:NAME \"Bench Rig 3\"", "core:SYSTem:DEVice:NAME:SAVE"];
 
     [TestMethod]
     public void FriendlyName_Property_ShouldDefaultToEmpty()
@@ -195,16 +197,47 @@ public class AbstractStreamingDeviceTests
     [TestMethod]
     public void SetFriendlyName_AtMaxLength_Succeeds()
     {
-        // Arrange
+        // Arrange — length taken from Core so this cannot drift from the bound it is testing.
         var device = new TestStreamingDevice();
         device.SetCoreDeviceConnected(true);
-        var maxLengthName = new string('A', 31);
+        var maxLengthName = new string('A', ScpiMessageProducer.MaxFriendlyNameLength);
 
         // Act
         device.SetFriendlyName(maxLengthName);
 
         // Assert
         Assert.AreEqual(maxLengthName, device.FriendlyName);
+    }
+
+    [TestMethod]
+    public void SetFriendlyName_OneOverMaxLength_ThrowsArgumentException()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        device.SetCoreDeviceConnected(true);
+        var tooLongName = new string('A', ScpiMessageProducer.MaxFriendlyNameLength + 1);
+
+        // Act & Assert
+        Assert.ThrowsExactly<ArgumentException>(() => device.SetFriendlyName(tooLongName));
+        Assert.AreEqual(0, device.SentCommands.Count);
+    }
+
+    /// <summary>
+    /// Validation must run before the connected check, not after. Core's
+    /// <c>SetFriendlyNameAsync</c> validates only after its own connected check and throws when
+    /// disconnected, so leaning on Core's validation alone would let an invalid name pass silently
+    /// whenever no device is attached — the exact case the Devices drawer hits while the user types
+    /// with nothing connected.
+    /// </summary>
+    [TestMethod]
+    public void SetFriendlyName_WithInvalidNameWhileDisconnected_StillThrows()
+    {
+        // Arrange
+        var device = new TestStreamingDevice();
+        device.SetCoreDeviceConnected(false);
+
+        // Act & Assert
+        Assert.ThrowsExactly<ArgumentException>(() => device.SetFriendlyName("Has a \"quote\""));
     }
 
     [TestMethod]
@@ -924,10 +957,16 @@ public class AbstractStreamingDeviceTests
         public void RouteStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
 
         /// <summary>
-        /// Fakes a connected Core device (transport-less, mirrors <see cref="RecordingCoreStreamingDevice"/>)
-        /// so <see cref="IStreamingDevice.IsConnected"/>-gated commands can be exercised without a real
-        /// connect flow. Pass <c>null</c> to simulate a disconnected/missing Core device.
+        /// Fakes a connected Core device (transport-less) so
+        /// <see cref="IStreamingDevice.IsConnected"/>-gated commands can be exercised without a
+        /// real connect flow. Pass <c>false</c> to simulate a disconnected/missing Core device.
         /// </summary>
+        /// <remarks>
+        /// Uses <see cref="RecordingCoreStreamingDevice"/> so commands Core composes on the
+        /// desktop's behalf land in <see cref="SentCommands"/> (prefixed <c>core:</c>) alongside
+        /// the ones the wrapper sends itself (unprefixed, via the <c>SendMessage</c> override).
+        /// Friendly-name commands moved to the Core side in daqifi-core#302.
+        /// </remarks>
         public void SetCoreDeviceConnected(bool connected)
         {
             if (!connected)
@@ -936,7 +975,7 @@ public class AbstractStreamingDeviceTests
                 return;
             }
 
-            var coreDevice = new CoreStreamingDevice("TestDevice");
+            var coreDevice = new RecordingCoreStreamingDevice(SentCommands, throwOnCommandData: null);
             coreDevice.Connect();
             CoreDevice = coreDevice;
         }

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
@@ -13,7 +13,8 @@ namespace Daqifi.Desktop.Test.ViewModels;
 [TestClass]
 public class DaqifiViewModelFriendlyNameTests
 {
-    private const string GENERIC_FAILURE_MESSAGE = "Failed to set the device name. See the application log for details.";
+    private const string GENERIC_FAILURE_MESSAGE =
+        "Failed to set the device name. See the application log for details.";
 
     [TestMethod]
     public async Task SetFriendlyName_WhenDeviceThrowsArgumentException_ShowsValidationMessageVerbatim()
@@ -50,6 +51,55 @@ public class DaqifiViewModelFriendlyNameTests
         // Assert
         Assert.AreEqual(GENERIC_FAILURE_MESSAGE, viewModel.FriendlyNameError);
         Assert.IsFalse(viewModel.FriendlyNameApplied);
+    }
+
+    [TestMethod]
+    public async Task SetFriendlyName_WhenSelectionChangesDuringWrite_LeavesTheNewDrawerAlone()
+    {
+        // Arrange — the write runs off the UI thread, so the user can open another device's drawer
+        // before it returns. FriendlyNameError is shared drawer state that OpenSettings clears on
+        // selection, so a late failure from the previous device must not land on its successor.
+        var successor = CreateConnectedDevice().Object;
+        var device = CreateConnectedDevice();
+        DaqifiViewModel? viewModel = null;
+        device.Setup(d => d.SetFriendlyName(It.IsAny<string>()))
+            .Callback(() =>
+            {
+                viewModel!.SelectedDevice = successor;
+                viewModel.PendingFriendlyName = "Successor Rig";
+            })
+            .Throws(new InvalidOperationException("Device is not connected."));
+        viewModel = CreateViewModel(device.Object);
+
+        // Act
+        await viewModel.SetFriendlyName();
+
+        // Assert
+        Assert.IsNull(viewModel.FriendlyNameError, "A stale failure must not surface on the newly selected device.");
+    }
+
+    [TestMethod]
+    public async Task SetFriendlyName_WhenSelectionChangesDuringWrite_DoesNotSeedTheNewDevicesField()
+    {
+        // Arrange — same race on the success path: seeding would overwrite the successor's NAME
+        // field with the name just written to the device the user navigated away from.
+        var successor = CreateConnectedDevice().Object;
+        var device = CreateConnectedDevice();
+        DaqifiViewModel? viewModel = null;
+        device.Setup(d => d.SetFriendlyName(It.IsAny<string>()))
+            .Callback(() =>
+            {
+                viewModel!.SelectedDevice = successor;
+                viewModel.PendingFriendlyName = "Successor Rig";
+            });
+        viewModel = CreateViewModel(device.Object);
+
+        // Act
+        await viewModel.SetFriendlyName();
+
+        // Assert
+        Assert.AreEqual("Successor Rig", viewModel.PendingFriendlyName);
+        Assert.IsFalse(viewModel.FriendlyNameApplied, "The applied banner belongs to the drawer that is now closed.");
     }
 
     private static Mock<IStreamingDevice> CreateConnectedDevice()

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
@@ -1,0 +1,73 @@
+using Daqifi.Desktop.Device;
+using Daqifi.Desktop.DialogService;
+using Daqifi.Desktop.ViewModels;
+using Moq;
+
+namespace Daqifi.Desktop.Test.ViewModels;
+
+/// <summary>
+/// Covers the failure contract of the Devices drawer's NAME field: which exceptions
+/// <see cref="DaqifiViewModel.SetFriendlyName"/> turns into inline feedback, and which message
+/// the user sees for each.
+/// </summary>
+[TestClass]
+public class DaqifiViewModelFriendlyNameTests
+{
+    private const string GENERIC_FAILURE_MESSAGE = "Failed to set the device name. See the application log for details.";
+
+    [TestMethod]
+    public async Task SetFriendlyName_WhenDeviceThrowsArgumentException_ShowsValidationMessageVerbatim()
+    {
+        // Arrange — validation failures are user-fixable, so the device's own message is shown.
+        var device = CreateConnectedDevice();
+        device.Setup(d => d.SetFriendlyName(It.IsAny<string>()))
+            .Throws(new ArgumentException("Device name must be 1-31 printable ASCII characters.", "name"));
+        var viewModel = CreateViewModel(device.Object);
+
+        // Act
+        await viewModel.SetFriendlyName();
+
+        // Assert
+        StringAssert.StartsWith(
+            viewModel.FriendlyNameError, "Device name must be 1-31 printable ASCII characters.");
+        Assert.IsFalse(viewModel.FriendlyNameApplied);
+    }
+
+    [TestMethod]
+    public async Task SetFriendlyName_WhenDeviceThrowsUnexpectedException_ShowsGenericErrorWithoutEscaping()
+    {
+        // Arrange — anything other than a validation failure (a mid-write transport fault, say)
+        // must not escape the command: an unhandled exception out of an async RelayCommand takes
+        // down the app instead of surfacing in the drawer.
+        var device = CreateConnectedDevice();
+        device.Setup(d => d.SetFriendlyName(It.IsAny<string>()))
+            .Throws(new InvalidOperationException("Device is not connected."));
+        var viewModel = CreateViewModel(device.Object);
+
+        // Act
+        await viewModel.SetFriendlyName();
+
+        // Assert
+        Assert.AreEqual(GENERIC_FAILURE_MESSAGE, viewModel.FriendlyNameError);
+        Assert.IsFalse(viewModel.FriendlyNameApplied);
+    }
+
+    private static Mock<IStreamingDevice> CreateConnectedDevice()
+    {
+        var device = new Mock<IStreamingDevice>();
+        device.SetupGet(d => d.IsConnected).Returns(true);
+        device.SetupGet(d => d.DeviceDisplayName).Returns("12345");
+        return device;
+    }
+
+    private static DaqifiViewModel CreateViewModel(IStreamingDevice device)
+    {
+        var dialogService = new Mock<IDialogService>();
+        var viewModel = new DaqifiViewModel(dialogService.Object)
+        {
+            SelectedDevice = device,
+            PendingFriendlyName = "Bench Rig 3"
+        };
+        return viewModel;
+    }
+}

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -1737,6 +1737,12 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// <c>SYSTem:DEVice:NAME "name"</c> then <c>SYSTem:DEVice:NAME:SAVE</c>. The desktop keeps only
     /// what Core does not provide: the no-op-when-disconnected policy (Core throws instead) and the
     /// WPF-bound <see cref="FriendlyName"/> update.
+    ///
+    /// <para>Disconnecting is never an error here: whether the device is already gone or drops
+    /// between the connected check and the send, the call logs a warning and returns without
+    /// touching <see cref="FriendlyName"/>. <see cref="ArgumentException"/> is therefore the only
+    /// exception this method raises on its own behalf; anything else Core throws is a genuine
+    /// fault and still propagates rather than being masked.</para>
     /// </remarks>
     /// <param name="name">
     /// 1-<see cref="ScpiMessageProducer.MaxFriendlyNameLength"/> printable ASCII characters
@@ -1761,16 +1767,35 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
                 nameof(name));
         }
 
-        if (CoreDevice is not { IsConnected: true })
+        // Read CoreDevice once and use that reference for both the check and the call. The property
+        // is cleared by CleanupConnection() from whichever thread notices the disconnect, so
+        // re-reading it for the call could observe null after the check passed — a
+        // NullReferenceException escaping a UI command that only expects ArgumentException.
+        var coreDevice = CoreDevice;
+        if (coreDevice is not { IsConnected: true })
         {
             AppLogger.Warning($"Ignored SetFriendlyName for device {DeviceDisplayName}: device is not connected.");
             return;
         }
 
-        // Core owns the SCPI composition (SYSTem:DEVice:NAME + :SAVE). The returned task is already
-        // complete once both commands are enqueued — Core does not await on-device application or
-        // NVM persistence, which firmware never acknowledges — so there is nothing to block on here.
-        CoreDevice.SetFriendlyNameAsync(name).GetAwaiter().GetResult();
+        try
+        {
+            // Core owns the SCPI composition (SYSTem:DEVice:NAME + :SAVE). The returned task is already
+            // complete once both commands are enqueued — Core does not await on-device application or
+            // NVM persistence, which firmware never acknowledges — so there is nothing to block on here.
+            coreDevice.SetFriendlyNameAsync(name).GetAwaiter().GetResult();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ObjectDisposedException
+                                   && !coreDevice.IsConnected)
+        {
+            // The device dropped between the check above and Core's own guard. Before delegation the
+            // send simply logged and returned here, and that no-op is what the caller still expects;
+            // the filter keeps it to a confirmed disconnect so an unrelated Core failure is not
+            // swallowed into a silent success (the trap from issue #619).
+            AppLogger.Warning(
+                ex, $"Ignored SetFriendlyName for device {DeviceDisplayName}: device disconnected mid-call.");
+            return;
+        }
 
         // Optimistic local update: the device does not echo the new name back synchronously,
         // and it may not stream another status frame for a while (e.g. StreamToApp is idle).

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -71,12 +71,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     private const string NOT_CONNECTED_MESSAGE = "Device is not connected.";
 
     /// <summary>
-    /// Max length for a friendly device name, matching firmware's
-    /// <c>FRIENDLY_DEVICE_NAME_SIZE</c> (32-byte NVM buffer, NUL-terminated).
-    /// </summary>
-    private const int MAX_FRIENDLY_NAME_LENGTH = 31;
-
-    /// <summary>
     /// Device-wide PWM frequency shown (and commanded on the first enable) before the user picks
     /// one, seeded from Core's <see cref="CoreStreamingDevice.DefaultPwmFrequencyHz"/>. Shadowed
     /// rather than read through to Core's <c>PwmFrequencyHz</c> because the UI binds this before a
@@ -1739,24 +1733,31 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// Sets and persists a user-defined friendly name to the device's NVM.
     /// </summary>
     /// <remarks>
-    /// No producer helper exists in <c>Daqifi.Core.Communication.Producers.ScpiMessageProducer</c>
-    /// for this firmware command yet, so the SCPI text is built directly here (mirrors the
-    /// quoted-string pattern <c>ScpiMessageProducer</c> already uses for SSID/password).
-    /// Commands: <c>SYSTem:DEVice:NAME "name"</c> then <c>SYSTem:DEVice:NAME:SAVE</c>.
+    /// Delegates to Core's <c>DaqifiStreamingDevice.SetFriendlyNameAsync</c>, which composes
+    /// <c>SYSTem:DEVice:NAME "name"</c> then <c>SYSTem:DEVice:NAME:SAVE</c>. The desktop keeps only
+    /// what Core does not provide: the no-op-when-disconnected policy (Core throws instead) and the
+    /// WPF-bound <see cref="FriendlyName"/> update.
     /// </remarks>
     /// <param name="name">
-    /// 1-31 printable ASCII characters (0x20-0x7E); cannot contain <c>"</c> or <c>\</c> — matches
-    /// firmware's <c>daqifi_settings_FriendlyNameIsValid</c> validation exactly, so a name that
-    /// passes here will not be rejected by the device.
+    /// 1-<see cref="ScpiMessageProducer.MaxFriendlyNameLength"/> printable ASCII characters
+    /// (0x20-0x7E); cannot contain <c>"</c> or <c>\</c> — see
+    /// <see cref="ScpiMessageProducer.IsFriendlyNameValid"/>, which mirrors firmware's
+    /// <c>daqifi_settings_FriendlyNameIsValid</c> exactly, so a name that passes will not be
+    /// rejected by the device.
     /// </param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> fails validation.</exception>
     public void SetFriendlyName(string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-        if (!IsFriendlyNameValid(name))
+
+        // Validated here, before the connected check, so an invalid name is rejected whether or not
+        // a device is attached. Core re-validates inside SetFriendlyNameAsync, but only after its
+        // own connected check — which would silently accept an invalid name while disconnected.
+        if (!ScpiMessageProducer.IsFriendlyNameValid(name))
         {
             throw new ArgumentException(
-                "Device name must be 1-31 printable ASCII characters and cannot contain '\"' or '\\'.",
+                $"Device name must be 1-{ScpiMessageProducer.MaxFriendlyNameLength} printable ASCII " +
+                "characters and cannot contain '\"' or '\\'.",
                 nameof(name));
         }
 
@@ -1766,35 +1767,17 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             return;
         }
 
-        SendMessage(new ScpiMessage($"SYSTem:DEVice:NAME \"{name}\""));
-        SendMessage(new ScpiMessage("SYSTem:DEVice:NAME:SAVE"));
+        // Core owns the SCPI composition (SYSTem:DEVice:NAME + :SAVE). The returned task is already
+        // complete once both commands are enqueued — Core does not await on-device application or
+        // NVM persistence, which firmware never acknowledges — so there is nothing to block on here.
+        CoreDevice.SetFriendlyNameAsync(name).GetAwaiter().GetResult();
 
         // Optimistic local update: the device does not echo the new name back synchronously,
         // and it may not stream another status frame for a while (e.g. StreamToApp is idle).
+        // Core makes the same optimistic update to its own Metadata.FriendlyName; this is the
+        // WPF-bound copy, kept separate because the desktop must also be able to clear it (see
+        // OnStatusMessageReceived).
         FriendlyName = name;
-    }
-
-    /// <summary>
-    /// Validates a candidate friendly name against firmware's acceptance rule: printable ASCII
-    /// (0x20-0x7E) only, excluding <c>"</c> and <c>\</c> (which would break the SCPI string
-    /// literal and the JSON info-message encoding), within <see cref="MAX_FRIENDLY_NAME_LENGTH"/>.
-    /// </summary>
-    private static bool IsFriendlyNameValid(string name)
-    {
-        if (name.Length is 0 or > MAX_FRIENDLY_NAME_LENGTH)
-        {
-            return false;
-        }
-
-        foreach (var c in name)
-        {
-            if (c is < (char)0x20 or > (char)0x7E or '"' or '\\')
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     // SD and LAN share one SPI bus and can't both be enabled (hardware limitation).

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -955,8 +955,18 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         }
         catch (ArgumentException ex)
         {
+            // The only exception SetFriendlyName raises on its own behalf, and the one the user can
+            // act on: show the validation message verbatim.
             _appLogger.Warning(ex, $"Rejected friendly name '{name}' for device {device.DeviceDisplayName}");
             FriendlyNameError = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            // Same shape as UpdateNetworkConfiguration: a device write can fail for reasons the user
+            // cannot fix from this field, so log the detail and show a generic message instead of
+            // letting it escape the command as an unhandled exception.
+            _appLogger.Error(ex, $"Failed to set friendly name '{name}' for device {device.DeviceDisplayName}");
+            FriendlyNameError = "Failed to set the device name. See the application log for details.";
         }
     }
 

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -947,18 +947,14 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             // SetFriendlyName sends SCPI commands synchronously (serial/TCP write); run it off
             // the UI thread so a slow or stalled device write cannot freeze the UI.
             await Task.Run(() => device.SetFriendlyName(name));
-
-            // Show the committed value rather than clearing the field — a blank box after a
-            // successful save reads as "it didn't take" even though the device now has the name.
-            SeedPendingFriendlyName(name);
-            _ = ShowFriendlyNameAppliedStatusAsync();
         }
         catch (ArgumentException ex)
         {
             // The only exception SetFriendlyName raises on its own behalf, and the one the user can
             // act on: show the validation message verbatim.
             _appLogger.Warning(ex, $"Rejected friendly name '{name}' for device {device.DeviceDisplayName}");
-            FriendlyNameError = ex.Message;
+            ShowFriendlyNameError(device, ex.Message);
+            return;
         }
         catch (Exception ex)
         {
@@ -966,8 +962,39 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             // cannot fix from this field, so log the detail and show a generic message instead of
             // letting it escape the command as an unhandled exception.
             _appLogger.Error(ex, $"Failed to set friendly name '{name}' for device {device.DeviceDisplayName}");
-            FriendlyNameError = "Failed to set the device name. See the application log for details.";
+            ShowFriendlyNameError(device, "Failed to set the device name. See the application log for details.");
+            return;
         }
+
+        if (SelectedDevice != device)
+        {
+            // The drawer moved to another device while the write was in flight (same guard as
+            // DeviceLogsViewModel.RefreshFilesAsync). Seeding here would overwrite the newly
+            // selected device's NAME field with the name just written to the previous one.
+            return;
+        }
+
+        // Show the committed value rather than clearing the field — a blank box after a
+        // successful save reads as "it didn't take" even though the device now has the name.
+        SeedPendingFriendlyName(name);
+        _ = ShowFriendlyNameAppliedStatusAsync();
+    }
+
+    /// <summary>
+    /// Publishes an inline NAME-field error for <paramref name="device"/>, unless the drawer has
+    /// since moved to another device. <see cref="FriendlyNameError"/> is shared drawer state that
+    /// <c>DevicesPaneViewModel.OpenSettings</c> clears on selection, so a late failure from a
+    /// device the user has already navigated away from must not surface on its successor.
+    /// The failure is logged by the caller either way.
+    /// </summary>
+    private void ShowFriendlyNameError(IStreamingDevice device, string message)
+    {
+        if (SelectedDevice != device)
+        {
+            return;
+        }
+
+        FriendlyNameError = message;
     }
 
     /// <summary>


### PR DESCRIPTION
Row 1 of the [#708](https://github.com/daqifi/daqifi-desktop/issues/708) deletion backlog. daqifi-core#302 shipped in Core **1.2.0**; we're on **1.3.0**.

The desktop was still hand-building `SYSTem:DEVice:NAME "name"` / `:SAVE` and carrying its own copy of firmware's name-validation rule. Core now owns both.

**Deleted:** the two hand-built `ScpiMessage` literals, the 17-line `IsFriendlyNameValid` character loop, and `MAX_FRIENDLY_NAME_LENGTH` — plus the doc comment claiming "no producer helper exists in `ScpiMessageProducer` for this firmware command yet", which Core's own source already flags as stale.

## What I kept, and why

Two behaviors Core does not provide. Both are the kind of thing that looks like leftover duplication until you check:

**1. No-op when disconnected.** Core's `SetFriendlyNameAsync` throws `InvalidOperationException`; the desktop logs a warning and returns. Same trap as #619/#622 — delegating naively flips no-op-when-disconnected into a throw. The connected check stays ahead of the Core call.

**2. Validation ordering.** The desktop validates *before* the connected check, so an invalid name is rejected whether or not a device is attached. Core validates only *after* its own connected check. Leaning on Core's validation alone would silently accept an invalid name whenever nothing is connected — which is exactly the state the Devices drawer is in while the user is typing. Now covered by a test; nothing pinned it before.

**3. `FriendlyName` stays a separate `[ObservableProperty]`** rather than folding into `Metadata.FriendlyName`. Core's `UpdateFromProtobuf` assigns the name only when non-empty, so it can never *clear*. The desktop's `OnStatusMessageReceived` assigns unconditionally, and that's load-bearing: transport instances like `SerialStreamingDevice` are reused across reconnects on the same COM port, so without the unconditional overwrite a name left over from a previously connected device would persist. Folding these together would have been a silent regression.

## Testing

`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → **805/805 pass** (797 before, 8 new), re-run after the rebase onto `main`.

Friendly-name commands now originate in Core rather than the desktop wrapper, so `TestStreamingDevice` installs a `RecordingCoreStreamingDevice` and the expected commands carry the `core:` prefix this file already uses for Core-side sends. The max-length test now derives its length from `ScpiMessageProducer.MaxFriendlyNameLength` so it can't drift from the bound it's testing.

## Note on merge order

**Resolved — #783 has landed and this is now rebased onto `main`.** It was stacked on #783 because both edit adjacent lines in `AbstractStreamingDevice.cs`'s constants block (the friendly-name const this PR deletes sits directly above the PWM comment #783 rewrites). Once #783 squash-merged, the branch still carried its own pre-squash copy of that commit, which is what put the PR into a conflicting state. Dropped that duplicate and rebased the three friendly-name commits onto current `main` — no textual conflicts, and the diff against `main` is exactly this PR's own four files.

Re-verified the two Core-boundary claims above against the newer `main` (#785–#789 also touched device code): `OnStatusMessageReceived` still assigns `FriendlyName` unconditionally after #786's classified-event work, so keeping it a separate `[ObservableProperty]` is still load-bearing, and no new path writes `Metadata.FriendlyName` into the WPF-bound copy.

Refs #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

