### PR TITLE
chore(device): subscribe Core's classified message events

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -26,20 +26,17 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
-    public void RouteInboundMessage_StatusMessageWithFriendlyDeviceName_UpdatesFriendlyName()
+    public void StatusMessageWithFriendlyDeviceName_UpdatesFriendlyName()
     {
         // Arrange
         var device = new TestStreamingDevice();
-        device.InitializeDeviceState(); // wires the protocol handler that classifies/routes inbound messages
 
         // Act — firmware's fast streaming-frame encoder (Nanopb_EncodeStreamingFast) hardcodes
         // only msg_time_stamp/analog_in_data/digital_data/digital_port_dir; friendly_device_name
         // is only ever populated on "info" responses like SYSTem:SYSInfoPB? (Core sends this once
-        // during InitializeAsync). Core's ProtobufProtocolHandler classifies a message with no
-        // analog/digital sample data but a nonzero port-count field as "Status", routed to
-        // OnStatusMessageReceived — not OnStreamMessageReceived (see ProtobufProtocolHandler.
-        // IsStatusMessage/IsStreamMessage).
-        device.RouteInboundMessage(new DaqifiOutMessage
+        // during InitializeAsync). Core classifies a message with no analog/digital sample data but
+        // a nonzero port-count field as Status and raises StatusMessageReceived for it.
+        device.RouteStatusMessage(new DaqifiOutMessage
         {
             AnalogInPortNum = 1,
             DeviceSn = 12345,
@@ -52,16 +49,15 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
-    public void RouteInboundMessage_StreamMessageWithFriendlyDeviceName_UpdatesFriendlyName()
+    public void StreamMessageWithFriendlyDeviceName_UpdatesFriendlyName()
     {
         // Arrange — belt-and-suspenders: a real Stream-classified frame never carries this field
         // (see the Status-message test above), but the desktop code captures it there too in
         // case firmware's streaming field set ever changes.
         var device = new TestStreamingDevice();
-        device.InitializeDeviceState();
 
         // Act
-        device.RouteInboundMessage(new DaqifiOutMessage
+        device.RouteStreamMessage(new DaqifiOutMessage
         {
             MsgTimeStamp = 1000,
             DeviceSn = 12345,
@@ -74,15 +70,17 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
-    public void RouteInboundMessage_StatusMessageWithoutFriendlyDeviceName_ClearsStaleFriendlyName()
+    public void StatusMessageWithoutFriendlyDeviceName_ClearsStaleFriendlyName()
     {
         // Arrange — e.g. SerialStreamingDevice instances are reused across reconnects on the same
         // COM port (ConnectionDialogViewModel dedups discovery by port), so a name captured from a
         // previously connected device must not leak onto a different/renamed device that reports
         // no name (issue #83 Qodo review: "stale friendlyname leaks").
+        //
+        // This is also why FriendlyName is not folded into Core's Metadata.FriendlyName: Core's
+        // UpdateFromProtobuf assigns the name only when non-empty, so it can never clear.
         var device = new TestStreamingDevice();
-        device.InitializeDeviceState();
-        device.RouteInboundMessage(new DaqifiOutMessage
+        device.RouteStatusMessage(new DaqifiOutMessage
         {
             AnalogInPortNum = 1,
             DeviceSn = 12345,
@@ -92,7 +90,7 @@ public class AbstractStreamingDeviceTests
 
         // Act — a fresh connect's status response with no name (firmware always includes the
         // field, empty when unset) is authoritative and must clear the stale value.
-        device.RouteInboundMessage(new DaqifiOutMessage
+        device.RouteStatusMessage(new DaqifiOutMessage
         {
             AnalogInPortNum = 1,
             DeviceSn = 67890
@@ -103,14 +101,13 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
-    public void RouteInboundMessage_StreamMessageWithoutFriendlyDeviceName_LeavesFriendlyNameUnchanged()
+    public void StreamMessageWithoutFriendlyDeviceName_LeavesFriendlyNameUnchanged()
     {
         // Arrange — a Stream-classified frame never carries this field at all (firmware's fast
         // streaming encoder omits it), so it must not clobber the value the status response
         // already captured — unlike the status-message case above, which is authoritative.
         var device = new TestStreamingDevice();
-        device.InitializeDeviceState();
-        device.RouteInboundMessage(new DaqifiOutMessage
+        device.RouteStatusMessage(new DaqifiOutMessage
         {
             AnalogInPortNum = 1,
             DeviceSn = 12345,
@@ -118,7 +115,7 @@ public class AbstractStreamingDeviceTests
         });
 
         // Act
-        device.RouteInboundMessage(new DaqifiOutMessage
+        device.RouteStreamMessage(new DaqifiOutMessage
         {
             MsgTimeStamp = 1000,
             DeviceSn = 12345,
@@ -137,8 +134,7 @@ public class AbstractStreamingDeviceTests
         {
             DeviceSerialNo = "12345"
         };
-        device.InitializeDeviceState();
-        device.RouteInboundMessage(new DaqifiOutMessage
+        device.RouteStatusMessage(new DaqifiOutMessage
         {
             AnalogInPortNum = 1,
             DeviceSn = 12345,
@@ -819,7 +815,7 @@ public class AbstractStreamingDeviceTests
     }
 
     [TestMethod]
-    public void HandleInboundMessage_WhenInLogToDevice_IgnoresStreamingSamples()
+    public void StreamMessage_WhenInLogToDevice_IgnoresStreamingSamples()
     {
         var device = new TestStreamingDevice();
         var coreChannel = new Daqifi.Core.Channel.AnalogChannel(0, 4096)
@@ -838,11 +834,10 @@ public class AbstractStreamingDeviceTests
         };
 
         device.DataChannels.Add(channel);
-        device.InitializeDeviceState();
         device.SwitchMode(DeviceMode.LogToDevice);
         device.IsStreaming = true;
 
-        device.RouteInboundMessage(new DaqifiOutMessage
+        device.RouteStreamMessage(new DaqifiOutMessage
         {
             MsgTimeStamp = 1000,
             DeviceSn = 12345,
@@ -902,12 +897,19 @@ public class AbstractStreamingDeviceTests
             SentCommands.Add(message.Data);
         }
 
-        public void RouteInboundMessage(DaqifiOutMessage message)
-        {
-            HandleInboundMessage(
-                new MessageReceivedEventArgs(
-                    new GenericInboundMessage<object>(message)));
-        }
+        /// <summary>
+        /// Invokes the handler Core calls when it classifies a frame as a status message and raises
+        /// <c>StatusMessageReceived</c> (daqifi-core#308). The desktop no longer classifies frames
+        /// itself, so which handler a given frame reaches is Core's decision and these tests state
+        /// it explicitly rather than re-deriving it.
+        /// </summary>
+        public void RouteStatusMessage(DaqifiOutMessage message) => OnStatusMessageReceived(message);
+
+        /// <summary>
+        /// Invokes the handler Core calls when it classifies a frame as a streaming data message and
+        /// raises <c>StreamMessageReceived</c>. Core's own decode step is not driven here.
+        /// </summary>
+        public void RouteStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
 
         /// <summary>
         /// Fakes a connected Core device (transport-less, mirrors <see cref="RecordingCoreStreamingDevice"/>)

--- a/Daqifi.Desktop.Test/Device/ChannelDataMappingTests.cs
+++ b/Daqifi.Desktop.Test/Device/ChannelDataMappingTests.cs
@@ -12,11 +12,10 @@ namespace Daqifi.Desktop.Test.Device;
 /// Verifies analog stream decode maps device data to the correct channel regardless of which
 /// subset of channels is active (issue #663 predecessor coverage). Channel decoding itself is
 /// delegated to Core's <c>DaqifiStreamingDevice</c> (issue #613), so these tests route frames
-/// through both halves of the real production pipeline: the desktop's own gating/dispatch
-/// (<c>HandleInboundMessage</c>) and Core's decode step
-/// (<see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>) — in that synchronous order, exactly
-/// as Core's actual <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in
-/// production.
+/// through Core's real <c>OnStreamMessageReceived</c>
+/// (<see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>): it raises the classified
+/// <c>StreamMessageReceived</c> event the desktop's gating/dispatch subscribes to, then runs Core's
+/// decode step — the same synchronous order production uses.
 /// </summary>
 [TestClass]
 public class ChannelDataMappingTests : IDisposable
@@ -283,7 +282,10 @@ public class ChannelDataMappingTests : IDisposable
             // (including the SampleReceived subscription installed by SyncChannelsFromCore).
             SyncFromCoreDevice(_coreDevice);
 
-            InitializeDeviceState();
+            // Subscribes the wrapper to Core's classified Status/StreamMessageReceived events, which
+            // is what Connect() does in production. Deliberately after PopulateChannelsFromStatus
+            // above so the ChannelsPopulated subscription doesn't re-run the sync mid-setup.
+            SubscribeCoreDeviceEvents(_coreDevice);
 
             _coreDevice.StreamingFrequency = 1;
             _coreDevice.StartStreaming();
@@ -310,17 +312,19 @@ public class ChannelDataMappingTests : IDisposable
         }
 
         /// <summary>
-        /// Routes a raw frame through both halves of the real production pipeline: the desktop's
-        /// own gating/dispatch (<c>HandleInboundMessage</c>) and Core's decode step
-        /// (<see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>) — in that order, exactly as
-        /// Core's actual <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in
-        /// production (base call raises <c>MessageReceived</c> before Core decodes).
+        /// Routes a raw frame through the real production pipeline by calling Core's own
+        /// <c>OnStreamMessageReceived</c>: it raises the classified <c>StreamMessageReceived</c>
+        /// event the desktop subscribes to, then decodes the same frame into per-channel samples —
+        /// in that order, which is what makes the desktop's accept-samples gate work.
         /// </summary>
+        /// <remarks>
+        /// Previously this had to drive both halves by hand (<c>HandleInboundMessage</c> then
+        /// <c>SimulateStreamFrame</c>) because the desktop re-classified the frame itself. Now that
+        /// it subscribes to Core's classified event (daqifi-core#308), one call covers both and the
+        /// ordering is Core's rather than something the test has to reproduce correctly.
+        /// </remarks>
         public void RouteStreamFrame(DaqifiOutMessage message)
         {
-            HandleInboundMessage(
-                new MessageReceivedEventArgs(
-                    new GenericInboundMessage<object>(message)));
             _coreDevice.SimulateStreamFrame(message);
         }
     }

--- a/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
+++ b/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
@@ -322,12 +322,14 @@ public class CoreConnectionTemplateTests
         /// Runs Core's status-message path for <paramref name="message"/>, which raises the
         /// classified <c>StatusMessageReceived</c> event the wrapper subscribes to.
         /// </summary>
+        /// <param name="message">The frame Core has classified as a status message.</param>
         public void SimulateStatusMessage(DaqifiOutMessage message) => OnStatusMessageReceived(message);
 
         /// <summary>
         /// Runs Core's stream-message path for <paramref name="message"/>, which raises the
         /// classified <c>StreamMessageReceived</c> event the wrapper subscribes to.
         /// </summary>
+        /// <param name="message">The frame Core has classified as a streaming frame.</param>
         public void SimulateStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
     }
 }

--- a/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
+++ b/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
@@ -155,6 +155,41 @@ public class CoreConnectionTemplateTests
     }
 
     [TestMethod]
+    public void Disconnect_UnsubscribesCoresClassifiedMessageEvents()
+    {
+        // Arrange — a connected device receiving Core's classified frames. Core classifies each
+        // inbound frame once and raises StatusMessageReceived/StreamMessageReceived (daqifi-core#308);
+        // the wrapper subscribes to both in SubscribeCoreDeviceEvents.
+        var device = new TemplateTestDevice();
+        device.Connect();
+        var coreDevice = device.CreatedCoreDevice!;
+        coreDevice.SimulateStatusMessage(BuildStatusMessage(friendlyDeviceName: "Bench NQ1"));
+        Assert.AreEqual("Bench NQ1", device.FriendlyName,
+            "Precondition: Core's classified status event must reach the wrapper while connected.");
+
+        // Act
+        device.Disconnect();
+
+        // Assert — the Core device outlives the wrapper's connection (Disconnect only drops the
+        // wrapper's reference), so every classified subscription must have a matching removal or a
+        // late frame would keep mutating the disconnected device's bound state. Covers both events
+        // added when the desktop stopped running its own ProtobufProtocolHandler pass.
+        coreDevice.SimulateStatusMessage(BuildStatusMessage(friendlyDeviceName: "A different device"));
+        Assert.AreEqual("Bench NQ1", device.FriendlyName,
+            "StatusMessageReceived must be unsubscribed on disconnect.");
+
+        coreDevice.SimulateStreamMessage(new DaqifiOutMessage
+        {
+            MsgTimeStamp = 1000,
+            DeviceSn = 12345,
+            FriendlyDeviceName = "A different device",
+            AnalogInDataFloat = { 1.25f }
+        });
+        Assert.AreEqual("Bench NQ1", device.FriendlyName,
+            "StreamMessageReceived must be unsubscribed on disconnect.");
+    }
+
+    [TestMethod]
     public void Connect_WhenNotOverridden_ReturnsFalse()
     {
         // Arrange — a device that does not provide a Core device factory
@@ -165,13 +200,14 @@ public class CoreConnectionTemplateTests
             "The default template must fail safely when CreateCoreDevice is not overridden.");
     }
 
-    private static DaqifiOutMessage BuildStatusMessage()
+    private static DaqifiOutMessage BuildStatusMessage(string? friendlyDeviceName = null)
     {
         return new DaqifiOutMessage
         {
             DevicePn = "Nq1",
             DeviceSn = 12345,
             DeviceFwRev = "1.2.3",
+            FriendlyDeviceName = friendlyDeviceName ?? string.Empty,
             AnalogInPortNum = 1,
             AnalogInRes = 4095,
             DigitalPortNum = 1,
@@ -281,5 +317,17 @@ public class CoreConnectionTemplateTests
         public override void Send<T>(IOutboundMessage<T> message)
         {
         }
+
+        /// <summary>
+        /// Runs Core's status-message path for <paramref name="message"/>, which raises the
+        /// classified <c>StatusMessageReceived</c> event the wrapper subscribes to.
+        /// </summary>
+        public void SimulateStatusMessage(DaqifiOutMessage message) => OnStatusMessageReceived(message);
+
+        /// <summary>
+        /// Runs Core's stream-message path for <paramref name="message"/>, which raises the
+        /// classified <c>StreamMessageReceived</c> event the wrapper subscribes to.
+        /// </summary>
+        public void SimulateStreamMessage(DaqifiOutMessage message) => OnStreamMessageReceived(message);
     }
 }

--- a/Daqifi.Desktop.Test/Device/DigitalChannelStreamDecodeTests.cs
+++ b/Daqifi.Desktop.Test/Device/DigitalChannelStreamDecodeTests.cs
@@ -16,10 +16,10 @@ namespace Daqifi.Desktop.Test.Device;
 /// pin-state snapshot — bit N is pin N regardless of which channels are enabled — so
 /// enabling a subset of digital channels must still read the correct pins.
 /// Channel decoding itself is delegated to Core's <c>DaqifiStreamingDevice</c> (issue #613), so
-/// these tests route frames through both the real desktop gating pipeline
-/// (<see cref="DecodeTestDevice.RouteStreamFrame"/> calls <c>HandleInboundMessage</c>) and Core's
-/// real decode step (via <see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>), exactly
-/// mirroring the synchronous order Core's actual message pump uses in production.
+/// these tests route frames through Core's real <c>OnStreamMessageReceived</c>
+/// (<see cref="DecodeTestDevice.RouteStreamFrame"/> → <see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>),
+/// which raises the classified event the desktop gates on and then runs Core's decode — the same
+/// synchronous order Core's actual message pump uses in production.
 /// </summary>
 [TestClass]
 public class DigitalChannelStreamDecodeTests : IDisposable
@@ -192,7 +192,10 @@ public class DigitalChannelStreamDecodeTests : IDisposable
             // (including the SampleReceived subscription installed by SyncChannelsFromCore).
             SyncFromCoreDevice(_coreDevice);
 
-            InitializeDeviceState();
+            // Subscribes the wrapper to Core's classified Status/StreamMessageReceived events, which
+            // is what Connect() does in production. Deliberately after PopulateChannelsFromStatus
+            // above so the ChannelsPopulated subscription doesn't re-run the sync mid-setup.
+            SubscribeCoreDeviceEvents(_coreDevice);
 
             _coreDevice.StreamingFrequency = 1;
             _coreDevice.StartStreaming();
@@ -219,17 +222,12 @@ public class DigitalChannelStreamDecodeTests : IDisposable
         }
 
         /// <summary>
-        /// Routes a raw frame through both halves of the real production pipeline: the desktop's
-        /// own gating/dispatch (<c>HandleInboundMessage</c>) and Core's decode step
-        /// (<see cref="TestCoreStreamingDevice.SimulateStreamFrame"/>) — in that order, exactly as
-        /// Core's actual <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in
-        /// production (base call raises <c>MessageReceived</c> before Core decodes).
+        /// Routes a raw frame through the real production pipeline by calling Core's own
+        /// <c>OnStreamMessageReceived</c>: it raises the classified <c>StreamMessageReceived</c>
+        /// event the desktop subscribes to, then decodes the same frame into per-channel samples.
         /// </summary>
         public void RouteStreamFrame(DaqifiOutMessage message)
         {
-            HandleInboundMessage(
-                new MessageReceivedEventArgs(
-                    new GenericInboundMessage<object>(message)));
             _coreDevice.SimulateStreamFrame(message);
         }
     }

--- a/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
+++ b/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
@@ -234,7 +234,6 @@ public class FrameTimestampSourceTests : IDisposable
             DispatchedMessages.Add(deviceMessage);
         }
 
-        /// <summary>Routes a frame through the desktop's inbound path and then Core's decode.</summary>
         /// <summary>
         /// Routes a frame the way production does: Core's own <c>OnStreamMessageReceived</c> raises
         /// the classified <c>StreamMessageReceived</c> event this device is subscribed to, then runs

--- a/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
+++ b/Daqifi.Desktop.Test/Device/FrameTimestampSourceTests.cs
@@ -146,13 +146,15 @@ public class FrameTimestampSourceTests : IDisposable
         _device.RouteStreamFrame(1_000_000_000 + SAMPLE_PERIOD_TICKS);
         var dispatchedBefore = _device.DispatchedMessages.Count;
 
-        // Act - only the desktop half of the pipeline, which is all Core's MessageReceived event
-        // does before Core goes on to decode that same frame into per-channel samples
+        // Act - only the desktop half of the pipeline: the handler Core invokes when it raises the
+        // classified StreamMessageReceived event, before going on to decode that same frame into
+        // per-channel samples
         _device.RouteStreamFrameToDesktopOnly(1_000_000_000 + 2 * SAMPLE_PERIOD_TICKS);
 
-        // Assert - the desktop hands the frame to Core's ProtobufProtocolHandler and discards the
-        // returned task, so the per-frame state Core's decode then reads (sample gate, timestamp,
-        // firmware delta) only belongs to the right frame while that handler stays synchronous
+        // Assert - Core decodes the frame immediately after this handler returns, and that decode
+        // reads per-frame state the handler leaves behind (sample gate, timestamp, firmware delta).
+        // That state only belongs to the right frame if the handler completes synchronously, so an
+        // await introduced inside it would silently let Core decode against the previous frame's state.
         Assert.AreEqual(dispatchedBefore + 1, _device.DispatchedMessages.Count,
             "Routing a frame must finish processing it before returning, since Core decodes the same "
             + "frame immediately afterwards and reads the per-frame state left behind.");
@@ -161,9 +163,9 @@ public class FrameTimestampSourceTests : IDisposable
 
     #region Test Doubles
     /// <summary>
-    /// Routes frames through both halves of the real production pipeline — the desktop's gating and
-    /// dispatch (<c>HandleInboundMessage</c>) and Core's decode step — in that order, exactly as
-    /// Core's <c>DaqifiStreamingDevice.OnStreamMessageReceived</c> sequences them in production.
+    /// Routes frames through Core's real <c>OnStreamMessageReceived</c>, which raises the classified
+    /// <c>StreamMessageReceived</c> event the desktop's gating/dispatch subscribes to and then runs
+    /// Core's decode step — in that order, exactly as production sequences them.
     /// </summary>
     private sealed class FrameTimestampTestDevice : AbstractStreamingDevice, IDisposable
     {
@@ -201,7 +203,10 @@ public class FrameTimestampSourceTests : IDisposable
             // the SampleReceived subscription installed by SyncChannelsFromCore.
             SyncFromCoreDevice(_coreDevice);
 
-            InitializeDeviceState();
+            // Subscribes the wrapper to Core's classified Status/StreamMessageReceived events, which
+            // is what Connect() does in production. Deliberately after PopulateChannelsFromStatus
+            // above so the ChannelsPopulated subscription doesn't re-run the sync mid-setup.
+            SubscribeCoreDeviceEvents(_coreDevice);
         }
 
         public List<DeviceMessage> DispatchedMessages { get; } = [];
@@ -230,11 +235,15 @@ public class FrameTimestampSourceTests : IDisposable
         }
 
         /// <summary>Routes a frame through the desktop's inbound path and then Core's decode.</summary>
+        /// <summary>
+        /// Routes a frame the way production does: Core's own <c>OnStreamMessageReceived</c> raises
+        /// the classified <c>StreamMessageReceived</c> event this device is subscribed to, then runs
+        /// Core's decode step. The desktop handler must not also be invoked directly here — it is
+        /// already reached through that subscription, and calling both would process every frame twice.
+        /// </summary>
         public void RouteStreamFrame(uint deviceTimestamp)
         {
-            var message = BuildStreamFrame(deviceTimestamp);
-            RouteToDesktop(message);
-            _coreDevice.SimulateStreamFrame(message);
+            _coreDevice.SimulateStreamFrame(BuildStreamFrame(deviceTimestamp));
         }
 
         /// <summary>
@@ -248,9 +257,9 @@ public class FrameTimestampSourceTests : IDisposable
 
         private void RouteToDesktop(DaqifiOutMessage message)
         {
-            HandleInboundMessage(
-                new MessageReceivedEventArgs(
-                    new GenericInboundMessage<object>(message)));
+            // Exactly what Core invokes when it raises the classified StreamMessageReceived event,
+            // with Core's own decode step left out.
+            OnStreamMessageReceived(message);
         }
 
         private static DaqifiOutMessage BuildStreamFrame(uint deviceTimestamp) => new()

--- a/Daqifi.Desktop.Test/Device/StreamStartLeftoverFrameTests.cs
+++ b/Daqifi.Desktop.Test/Device/StreamStartLeftoverFrameTests.cs
@@ -36,7 +36,6 @@ public class StreamStartLeftoverFrameTests : IDisposable
             IsActive = true
         };
         _device.DataChannels.Add(_channel);
-        _device.InitializeDeviceState();
     }
 
     // MSTest disposes the test-class instance after each test, releasing the device's Core
@@ -358,9 +357,10 @@ public class StreamStartLeftoverFrameTests : IDisposable
                 AnalogInDataFloat = { 1.25f }
             };
 
-            HandleInboundMessage(
-                new MessageReceivedEventArgs(
-                    new GenericInboundMessage<object>(message)));
+            // The handler Core invokes when it raises the classified StreamMessageReceived event.
+            // These tests exercise the desktop's leftover-frame gating only, so Core's decode step
+            // is deliberately not driven here.
+            OnStreamMessageReceived(message);
         }
     }
 

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -12,7 +12,6 @@ using ScpiMessageProducer = Daqifi.Core.Communication.Producers.ScpiMessageProdu
 using System.Runtime.InteropServices; // Added for P/Invoke
 using CommunityToolkit.Mvvm.ComponentModel; // Added using
 using Daqifi.Core.Device; // Added for DeviceType, DeviceTypeDetector, DeviceMetadata, DeviceCapabilities, DeviceState
-using Daqifi.Core.Device.Protocol; // Added for ProtobufProtocolHandler
 using Daqifi.Core.Communication.Messages; // Added for IInboundMessage
 using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
 using Daqifi.Core.Device.SdCard;
@@ -104,9 +103,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     // frame's counter delta validates the pair as same-session data.
     private volatile bool _pendingFirstFrameValidation;
     private DaqifiOutMessage? _heldFirstFrame;
-
-    // Protocol handler for automatic message routing
-    private ProtobufProtocolHandler? _protocolHandler;
 
     /// <summary>
     /// Per-channel subscriptions onto Core's decode pipeline (issue #613). Core's
@@ -374,11 +370,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
             CoreDevice = coreDevice;
 
-            coreDevice.ChannelsPopulated += OnCoreChannelsPopulated;
-            coreDevice.MessageReceived += OnCoreMessageReceived;
-            coreDevice.StatusChanged += OnCoreStatusChanged;
-
-            InitializeDeviceState();
+            SubscribeCoreDeviceEvents(coreDevice);
 
             // Blocking on Core's async initialization is safe because Connect() is invoked
             // from Task.Run by ConnectionManager (see remarks).
@@ -519,21 +511,37 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         CoreDevice = null;
     }
 
+    /// <summary>
+    /// Subscribes the wrapper to the Core device events it mirrors. Core classifies each inbound
+    /// protobuf frame once and raises <see cref="DaqifiDevice.StatusMessageReceived"/> /
+    /// <see cref="DaqifiDevice.StreamMessageReceived"/> accordingly (daqifi-core#308), so the
+    /// desktop no longer runs its own <c>ProtobufProtocolHandler</c> pass over the same frame.
+    /// </summary>
+    /// <remarks>
+    /// Ordering matters for <see cref="_acceptChannelSamples"/>. Core raises the classified event
+    /// synchronously from inside <c>DaqifiStreamingDevice.OnStreamMessageReceived</c>, before that
+    /// method's own <c>DecodeStreamFrame</c> step — so <see cref="ProcessStreamMessage"/> still runs
+    /// to completion, and the gate is still set, before Core decodes the same frame into per-channel
+    /// samples. The previous route (Core's undifferentiated <c>MessageReceived</c> into a
+    /// fire-and-forget <c>HandleAsync</c>) depended on that task happening to complete inline.
+    /// </remarks>
+    /// <param name="coreDevice">The Core device to subscribe to.</param>
+    protected void SubscribeCoreDeviceEvents(CoreStreamingDevice coreDevice)
+    {
+        ArgumentNullException.ThrowIfNull(coreDevice);
+
+        coreDevice.ChannelsPopulated += OnCoreChannelsPopulated;
+        coreDevice.StatusMessageReceived += OnStatusMessageReceived;
+        coreDevice.StreamMessageReceived += OnStreamMessageReceived;
+        coreDevice.StatusChanged += OnCoreStatusChanged;
+    }
+
     private void UnsubscribeCoreDeviceEvents(CoreStreamingDevice coreDevice)
     {
         coreDevice.ChannelsPopulated -= OnCoreChannelsPopulated;
-        coreDevice.MessageReceived -= OnCoreMessageReceived;
+        coreDevice.StatusMessageReceived -= OnStatusMessageReceived;
+        coreDevice.StreamMessageReceived -= OnStreamMessageReceived;
         coreDevice.StatusChanged -= OnCoreStatusChanged;
-    }
-
-    /// <summary>
-    /// Handles non-status messages received from Core's DaqifiDevice and routes them
-    /// to the protocol handler for streaming data processing.
-    /// Status messages are handled via <see cref="OnCoreChannelsPopulated"/>.
-    /// </summary>
-    private void OnCoreMessageReceived(object? sender, MessageReceivedEventArgs e)
-    {
-        HandleInboundMessage(e);
     }
 
     /// <summary>
@@ -575,41 +583,9 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
 
     #region Message Handlers
     /// <summary>
-    /// Initializes the protocol handler for automatic message routing.
-    /// Uses Core's ProtobufProtocolHandler to route streaming protobuf messages while Core
-    /// itself owns status parsing and channel population.
-    /// </summary>
-    private void InitializeProtocolHandler()
-    {
-        _protocolHandler = new ProtobufProtocolHandler(
-            statusMessageHandler: OnStatusMessageReceived,
-            streamMessageHandler: OnStreamMessageReceived,
-            sdCardMessageHandler: _ => { } // SD card messages are text-based, handled separately; empty handler prevents NullReferenceException
-        );
-
-        AppLogger.Information("Protocol handler initialized with automatic message routing");
-    }
-
-    /// <summary>
-    /// Routes incoming messages through the protocol handler.
-    /// This method is called by the message consumer for each received message.
-    /// </summary>
-    private void OnInboundMessageReceived(object sender, MessageReceivedEventArgs e)
-    {
-        var inboundMessage = e.Message;
-
-        // Route through protocol handler if available and it can handle this message
-        if (_protocolHandler != null && _protocolHandler.CanHandle(inboundMessage))
-        {
-            // Fire and forget - we don't need to wait for the handler to complete
-            _ = _protocolHandler.HandleAsync(inboundMessage);
-        }
-    }
-
-    /// <summary>
     /// Handles status/info messages received from the device (e.g. the <c>SYSTem:SYSInfoPB?</c>
-    /// response Core sends during <c>InitializeAsync</c>). Called automatically by
-    /// ProtobufProtocolHandler when a status-shaped message is detected.
+    /// response Core sends during <c>InitializeAsync</c>). Invoked by Core's classified
+    /// <see cref="DaqifiDevice.StatusMessageReceived"/> event; Core does the classification.
     /// </summary>
     /// <remarks>
     /// Firmware always includes <c>friendly_device_name</c> in this response — empty when unset —
@@ -620,7 +596,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// never be cleared, since firmware's fast streaming-frame encoder never re-sends the field at
     /// all (see <see cref="CaptureFriendlyDeviceNameIfPresent"/>).
     /// </remarks>
-    private void OnStatusMessageReceived(DaqifiOutMessage message)
+    protected void OnStatusMessageReceived(DaqifiOutMessage message)
     {
         FriendlyName = message.FriendlyDeviceName ?? string.Empty;
     }
@@ -644,10 +620,11 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     }
 
     /// <summary>
-    /// Handles streaming messages received from the device.
-    /// Called automatically by ProtobufProtocolHandler when a streaming message is detected.
+    /// Handles streaming messages received from the device. Invoked by Core's classified
+    /// <see cref="DaqifiDevice.StreamMessageReceived"/> event, synchronously and before Core decodes
+    /// the same frame into per-channel samples — see <see cref="SubscribeCoreDeviceEvents"/>.
     /// </summary>
-    private void OnStreamMessageReceived(DaqifiOutMessage message)
+    protected void OnStreamMessageReceived(DaqifiOutMessage message)
     {
         // Closed by default for every frame; only ProcessStreamMessage (reached below when this
         // frame is accepted) opens it for Core's immediately-following decode of this same frame.
@@ -920,15 +897,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         ProcessStreamMessage(message);
     }
 
-    /// <summary>
-    /// Routes a message through the protocol handler for processing.
-    /// Called by derived classes (e.g., WiFi devices) that receive messages directly from Core's DaqifiDevice.
-    /// </summary>
-    /// <param name="e">The message event args containing the protobuf message.</param>
-    protected void HandleInboundMessage(MessageReceivedEventArgs e)
-    {
-        OnInboundMessageReceived(this, e);
-    }
     #endregion
 
     #region Streaming Methods
@@ -1731,12 +1699,6 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     }
 
     #endregion
-
-    public void InitializeDeviceState()
-    {
-        // Initialize protocol handler for automatic message routing
-        InitializeProtocolHandler();
-    }
 
     public async Task UpdateNetworkConfiguration()
     {

--- a/Daqifi.Desktop/Device/IStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/IStreamingDevice.cs
@@ -126,11 +126,6 @@ public interface IStreamingDevice : IDevice
     void StopStreaming();
 
     /// <summary>
-    /// Sends a command to get any initialization data from the streamingDevice that might be needed
-    /// </summary>
-    void InitializeDeviceState();
-
-    /// <summary>
     /// Sends a command to activate a channel on the streamingDevice
     /// </summary>
     void AddChannel(IChannel channelToAdd);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,8 +86,11 @@ sequenceDiagram
     Core->>Core: Decode protobuf → DaqifiOutMessage
     Core->>Core: Classify frame (ProtobufProtocolHandler)
     Core->>Dev: StreamMessageReceived event (classified)
-    Dev->>Dev: OnStreamMessageReceived(DaqifiOutMessage)
-    Note over Dev: For each active analog channel:<br/>scale raw ADC (WiFi) or<br/>use pre-scaled float (USB)
+    Dev->>Dev: OnStreamMessageReceived → ProcessStreamMessage
+    Note over Dev: Reconstructs this frame's timestamp and opens<br/>the _acceptChannelSamples gate — synchronously,<br/>before Core decodes the same frame
+    Core->>Core: DecodeStreamFrame (same frame, once the event returns)
+    Note over Core: For each active analog channel:<br/>scale raw ADC (WiFi) or use<br/>pre-scaled float (USB); unpack digital bits
+    Core->>Dev: IChannel.SampleReceived (per channel)
     Dev->>Ch: channel.ActiveSample = new DataSample(...)
     Ch->>Ch: Apply NCalc scale expression (if set)
     Ch->>LM: OnChannelUpdated event
@@ -99,7 +102,8 @@ sequenceDiagram
 
 ### Notes on the flow
 
-- **WiFi vs USB scaling.** WiFi firmware sends raw ADC counts; USB firmware sends pre-scaled floats already in volts. `OnStreamMessageReceived` branches on this — see `AnalogInData` vs `AnalogInDataFloat` in [AbstractStreamingDevice.cs](../Daqifi.Desktop/Device/AbstractStreamingDevice.cs).
+- **WiFi vs USB scaling.** WiFi firmware sends raw ADC counts; USB firmware sends pre-scaled floats already in volts. Channel decoding — including that `AnalogInData` vs `AnalogInDataFloat` branch — belongs to Core's `DaqifiStreamingDevice.DecodeStreamFrame` since issue #613. The desktop only stamps each decoded value with the frame's own timestamp, in `OnCoreChannelSampleReceived` — see [AbstractStreamingDevice.cs](../Daqifi.Desktop/Device/AbstractStreamingDevice.cs).
+- **One frame, one timestamp.** Core raises the classified `StreamMessageReceived` *before* its own decode of that same frame, so `ProcessStreamMessage` has already computed `_currentFrameTimestamp` and opened `_acceptChannelSamples` by the time the per-channel samples arrive. Frames the desktop rejects (a leftover frame from the previous streaming session) are still decoded by Core — it has no notion of that heuristic — and are dropped by that gate instead.
 - **Two parallel paths per protobuf message.** The same `DaqifiOutMessage` produces per-channel `DataSample`s (the path above) *and* a single `DeviceMessage` carrying device-level state (battery, status, target frequency). The latter is dispatched via `LoggingManager.HandleDeviceMessage`.
 - **Loggers are a list, not a single class.** `LoggingManager.Loggers` is an `ILogger` collection. `DatabaseLogger` is the persistent one, but `PlotLogger` and `SummaryLogger` also subscribe.
 - **Backpressure.** `DatabaseLogger` uses a `BlockingCollection<DataSample>` producer/consumer split so the UI/device threads never wait on disk. The consumer drains in ~100 ms ticks and bulk-inserts via `EFCore.BulkExtensions.Sqlite`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ flowchart TB
 
     user -- "Uses" --> ui
     ui -- "Commands &amp;<br/>observable state" --> domain
-    domain -- "SCPI out,<br/>MessageReceived in" --> core
+    domain -- "SCPI out,<br/>classified message<br/>events in" --> core
     core -- "Wire protocol" --> nyquist
     domain -- "Bulk inserts" --> sqlite
     ui -- "Reads / writes" --> config
@@ -84,8 +84,8 @@ sequenceDiagram
 
     HW->>Core: Bytes (TCP or USB-Serial)
     Core->>Core: Decode protobuf → DaqifiOutMessage
-    Core->>Dev: MessageReceived event
-    Dev->>Dev: HandleInboundMessage → ProtobufProtocolHandler.HandleAsync
+    Core->>Core: Classify frame (ProtobufProtocolHandler)
+    Core->>Dev: StreamMessageReceived event (classified)
     Dev->>Dev: OnStreamMessageReceived(DaqifiOutMessage)
     Note over Dev: For each active analog channel:<br/>scale raw ADC (WiFi) or<br/>use pre-scaled float (USB)
     Dev->>Ch: channel.ActiveSample = new DataSample(...)


### PR DESCRIPTION
Row 5 of the [#708](https://github.com/daqifi/daqifi-desktop/issues/708) deletion backlog. daqifi-core#308 shipped in Core **1.2.0**; we're on **1.3.0**.

Core already classifies every inbound protobuf frame — that's how it decides whether to update metadata and populate channels. The desktop was subscribing to the undifferentiated `MessageReceived` and running a **second** `ProtobufProtocolHandler` pass over the same frame to re-derive the answer Core had just computed. At streaming rates, on every frame.

**Deleted:** the `_protocolHandler` field, `InitializeProtocolHandler`, `OnInboundMessageReceived`, `OnCoreMessageReceived`, `HandleInboundMessage`. `InitializeDeviceState` existed only to build that handler, so it goes from `AbstractStreamingDevice` and from `IStreamingDevice` (sole implementer). Subscription is now a `SubscribeCoreDeviceEvents` mirroring the `UnsubscribeCoreDeviceEvents` that already existed.

## This also fixes a latent correctness hazard

`_acceptChannelSamples` gates which decoded samples reach desktop channels. It's set at the end of `ProcessStreamMessage` and must still be set when Core decodes *that same frame*.

- **Before:** the desktop was reached via `MessageReceived` → `_ = _protocolHandler.HandleAsync(...)` — **fire-and-forget**. It worked only because that task happened to complete inline. An `await` introduced anywhere inside that path would have silently decoupled the gate from the frame it guards, and the symptom would have been wrong samples on the wrong frame, not a crash.
- **After:** Core raises the classified event *synchronously* from inside `DaqifiStreamingDevice.OnStreamMessageReceived`, immediately before its own `DecodeStreamFrame`. The ordering is now structural.

As a bonus, Core wraps classified-event subscribers in `RaiseClassifiedEvent`, which catches and logs a throwing subscriber. Previously an exception on this path vanished into the discarded task.

`OnStatusMessageReceived`/`OnStreamMessageReceived` become `protected` — they replace `HandleInboundMessage` as the test seam and name what they actually are: the handlers Core invokes for an already-classified frame.

## Testing

`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → **768/768 pass**.

Test fixtures that previously drove both halves by hand (`HandleInboundMessage` *then* `SimulateStreamFrame`) now make one call to Core's own `OnStreamMessageReceived`, which raises the classified event and then decodes. That's closer to production than the two-step simulation it replaces — the ordering is Core's rather than something each fixture has to reproduce correctly.

Tests named for the classification (`RouteInboundMessage_StatusMessage…`) now call the specific handler, since which handler a frame reaches is Core's decision, not ours — consistent with #707's "don't test Core here". The recorded knowledge about which frame shapes classify which way is preserved in the comments rather than dropped.

One thing worth a reviewer's eye: while converting the fixtures I hit a real double-dispatch — a fixture that both invoked the desktop handler directly *and* was subscribed to Core processed every frame twice. Caught by `FrameTimestampSourceTests`. Worth confirming I didn't leave a similar one anywhere.

⚠️ **Streaming hot path** — the unit suite covers the gating logic well, but a smoke test against real hardware (stream, check samples land on the right channels with sane timestamps) would be worth it before merge.

Independent of #783/#784/#785.

Refs #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
