### PR TITLE
chore(channels): drop ReplaceCoreChannel now that Core keeps instances stable

### DIFF
--- a/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
+++ b/Daqifi.Desktop.Test/Device/AbstractStreamingDeviceTests.cs
@@ -513,12 +513,12 @@ public class AbstractStreamingDeviceTests
         digitalChannel.CoreChannel.Direction = Daqifi.Core.Channel.ChannelDirection.Output;
         digitalChannel.CoreChannel.OutputValue = true;
 
-        var refreshedCoreDevice = BuildCoreDeviceSnapshot(
-            firmwareVersion: "2.0.0",
-            calibrationM: 2.5f);
+        // A refresh re-populates the same Core device — Core updates its channels in place
+        // (daqifi-core#309) rather than building new instances.
+        RepopulateCoreDevice(initialCoreDevice, firmwareVersion: "2.0.0", calibrationM: 2.5f);
 
         // Act
-        device.ApplyCoreSnapshot(refreshedCoreDevice);
+        device.ApplyCoreSnapshot(initialCoreDevice);
 
         // Assert
         var refreshedAnalogChannel = device.DataChannels.OfType<AnalogChannel>().Single();
@@ -534,10 +534,10 @@ public class AbstractStreamingDeviceTests
         Assert.AreEqual(
             Daqifi.Core.Channel.ChannelDirection.Output,
             refreshedDigitalChannel.Direction,
-            "Channel direction should survive a core-channel replacement.");
+            "Channel direction should survive a channel refresh.");
         Assert.IsTrue(
             refreshedDigitalChannel.CoreChannel.OutputValue,
-            "Commanded output state should survive a core-channel replacement (issue #663).");
+            "Commanded output state should survive a channel refresh (issue #663).");
         Assert.AreEqual(2.5d, refreshedAnalogChannel.CalibrationMValue, 0.001d, "Core calibration data should refresh.");
         Assert.AreEqual("2.0.0", device.DeviceVersion);
         Assert.AreEqual(DeviceType.Nyquist1, device.DeviceType);
@@ -605,9 +605,10 @@ public class AbstractStreamingDeviceTests
         originalAnalog.ScaleExpression = "x * 5";
         originalAnalog.IsScalingActive = true;
 
-        // Act — same-session channel refresh (e.g., re-query device info)
-        var refreshedCoreDevice = BuildCoreDeviceSnapshot(firmwareVersion: "1.0.0", calibrationM: 2.0f);
-        device.SimulateChannelsPopulated(refreshedCoreDevice);
+        // Act — same-session channel refresh (e.g., re-query device info) on the same Core device,
+        // which is the only shape a refresh takes in production
+        RepopulateCoreDevice(coreDevice, firmwareVersion: "1.0.0", calibrationM: 2.0f);
+        device.SimulateChannelsPopulated(coreDevice);
 
         // Assert — wrapper identity preserved, core calibration refreshed
         var refreshedAnalog = device.DataChannels.OfType<AnalogChannel>().Single();
@@ -855,11 +856,22 @@ public class AbstractStreamingDeviceTests
 
     private static DaqifiDevice BuildCoreDeviceSnapshot(string firmwareVersion, float calibrationM)
     {
-        var statusMessage = BuildStatusMessage(firmwareVersion, calibrationM);
         var coreDevice = new DaqifiDevice("Core Test Device");
+        RepopulateCoreDevice(coreDevice, firmwareVersion, calibrationM);
+        return coreDevice;
+    }
+
+    /// <summary>
+    /// Re-runs metadata + channel population on an existing Core device, which is what a routine
+    /// status frame does in production. A same-session refresh always comes from the one Core
+    /// device the wrapper connected — a reconnect builds a new Core device but also clears
+    /// <c>DataChannels</c> first, so a wrapper never survives to meet a different Core instance.
+    /// </summary>
+    private static void RepopulateCoreDevice(DaqifiDevice coreDevice, string firmwareVersion, float calibrationM)
+    {
+        var statusMessage = BuildStatusMessage(firmwareVersion, calibrationM);
         coreDevice.Metadata.UpdateFromProtobuf(statusMessage);
         coreDevice.PopulateChannelsFromStatus(statusMessage);
-        return coreDevice;
     }
 
     private static DaqifiOutMessage BuildStatusMessage(string firmwareVersion, float calibrationM)

--- a/Daqifi.Desktop.Test/Device/ChannelSampleSubscriptionTests.cs
+++ b/Daqifi.Desktop.Test/Device/ChannelSampleSubscriptionTests.cs
@@ -1,0 +1,160 @@
+using Daqifi.Desktop.Channel;
+using Daqifi.Desktop.Device;
+using Daqifi.Core.Communication.Messages;
+using Moq;
+using System.Reflection;
+using CoreChannelDirection = Daqifi.Core.Channel.ChannelDirection;
+using CoreSampleReceivedEventArgs = Daqifi.Core.Channel.SampleReceivedEventArgs;
+
+namespace Daqifi.Desktop.Test.Device;
+
+/// <summary>
+/// Covers the per-channel Core sample subscriptions <see cref="AbstractStreamingDevice"/> tracks
+/// while wiring <c>SampleReceived</c> handlers. <see cref="AbstractChannel"/> overrides equality
+/// and hashing on its mutable <c>Name</c>, so the tracking map has to key on reference identity —
+/// otherwise two wrappers for the same logical channel share a single entry and the bookkeeping
+/// detaches the wrong delegate.
+/// </summary>
+[TestClass]
+public class ChannelSampleSubscriptionTests
+{
+    private const string SHARED_CHANNEL_NAME = "AI0";
+
+    [TestMethod]
+    public void SubscribeChannelSamples_TwoWrappersSharingAName_DetachesEachWrappersOwnHandler()
+    {
+        // Arrange — two wrappers for the same logical channel, which is what SyncChannelsFromCore
+        // produces when Core hands back a different IChannel instance for a key it already has a
+        // wrapper for: the replacement is built and subscribed before the trailing cleanup loop
+        // unsubscribes the outgoing one.
+        var device = new SubscriptionTestDevice();
+        var outgoingCore = CreateCoreChannel(out var outgoingAdded, out var outgoingRemoved);
+        var replacementCore = CreateCoreChannel(out var replacementAdded, out var replacementRemoved);
+        var outgoingWrapper = new AnalogChannel(device, outgoingCore);
+        var replacementWrapper = new AnalogChannel(device, replacementCore);
+
+        Assert.AreNotSame(outgoingWrapper, replacementWrapper);
+        Assert.IsTrue(
+            outgoingWrapper.Equals(replacementWrapper),
+            "Precondition: AbstractChannel equality is Name-based, so these two distinct wrappers " +
+            "collide as keys in any default-equality dictionary.");
+
+        // Act
+        InvokeSubscribeChannelSamples(device, outgoingWrapper, outgoingCore);
+        InvokeSubscribeChannelSamples(device, replacementWrapper, replacementCore);
+        InvokeUnsubscribeChannelSamples(device, outgoingWrapper, outgoingCore);
+        InvokeUnsubscribeChannelSamples(device, replacementWrapper, replacementCore);
+
+        // Assert
+        Assert.AreEqual(1, outgoingAdded.Count, "The outgoing wrapper should be subscribed exactly once.");
+        Assert.AreEqual(1, replacementAdded.Count, "The replacement wrapper should be subscribed exactly once.");
+        CollectionAssert.AreEqual(
+            outgoingAdded,
+            outgoingRemoved,
+            "The outgoing wrapper's own delegate must come off its Core channel. Detaching some " +
+            "other wrapper's delegate is a no-op there and leaves the real subscription attached.");
+        CollectionAssert.AreEqual(
+            replacementAdded,
+            replacementRemoved,
+            "The replacement wrapper's handler must still be tracked after the outgoing wrapper is " +
+            "unsubscribed, so it can be detached in turn instead of leaking.");
+    }
+
+    [TestMethod]
+    public void SubscribeChannelSamples_SameWrapperSubscribedTwice_DetachesThePreviousHandler()
+    {
+        // Arrange
+        var device = new SubscriptionTestDevice();
+        var coreChannel = CreateCoreChannel(out var added, out var removed);
+        var wrapper = new AnalogChannel(device, coreChannel);
+
+        // Act — a second subscribe for the very same wrapper reference
+        InvokeSubscribeChannelSamples(device, wrapper, coreChannel);
+        InvokeSubscribeChannelSamples(device, wrapper, coreChannel);
+
+        // Assert — only one handler can be tracked per wrapper, so the first must be detached
+        // rather than left attached and unreachable, which would route every sample twice.
+        Assert.AreEqual(2, added.Count);
+        CollectionAssert.AreEqual(
+            new[] { added[0] },
+            removed,
+            "Re-subscribing a wrapper must detach the handler it is replacing.");
+    }
+
+    /// <summary>
+    /// Builds a Core analog channel whose <c>SampleReceived</c> accessors record the exact delegates
+    /// handed to them, so a test can tell <em>which</em> handler was attached or detached rather
+    /// than just how many calls were made.
+    /// </summary>
+    private static Daqifi.Core.Channel.IAnalogChannel CreateCoreChannel(
+        out List<EventHandler<CoreSampleReceivedEventArgs>> added,
+        out List<EventHandler<CoreSampleReceivedEventArgs>> removed)
+    {
+        var addedHandlers = new List<EventHandler<CoreSampleReceivedEventArgs>>();
+        var removedHandlers = new List<EventHandler<CoreSampleReceivedEventArgs>>();
+
+        var coreChannel = new Mock<Daqifi.Core.Channel.IAnalogChannel>();
+        coreChannel.SetupGet(channel => channel.Name).Returns(SHARED_CHANNEL_NAME);
+        coreChannel.SetupGet(channel => channel.Direction).Returns(CoreChannelDirection.Input);
+        coreChannel
+            .SetupAdd(channel => channel.SampleReceived += It.IsAny<EventHandler<CoreSampleReceivedEventArgs>>())
+            .Callback<EventHandler<CoreSampleReceivedEventArgs>>(addedHandlers.Add);
+        coreChannel
+            .SetupRemove(channel => channel.SampleReceived -= It.IsAny<EventHandler<CoreSampleReceivedEventArgs>>())
+            .Callback<EventHandler<CoreSampleReceivedEventArgs>>(removedHandlers.Add);
+
+        added = addedHandlers;
+        removed = removedHandlers;
+        return coreChannel.Object;
+    }
+
+    private static void InvokeSubscribeChannelSamples(
+        AbstractStreamingDevice device,
+        IChannel desktopChannel,
+        Daqifi.Core.Channel.IChannel coreChannel)
+    {
+        InvokeChannelSampleMethod(device, "SubscribeChannelSamples", desktopChannel, coreChannel);
+    }
+
+    private static void InvokeUnsubscribeChannelSamples(
+        AbstractStreamingDevice device,
+        IChannel desktopChannel,
+        Daqifi.Core.Channel.IChannel coreChannel)
+    {
+        InvokeChannelSampleMethod(device, "UnsubscribeChannelSamples", desktopChannel, coreChannel);
+    }
+
+    /// <summary>
+    /// Calls one of the device's private subscription helpers. They are deliberately private —
+    /// the production callers are <c>SyncChannelsFromCore</c> and the disconnect teardown — so the
+    /// bookkeeping they share is reached by reflection rather than by widening the device's API.
+    /// </summary>
+    private static void InvokeChannelSampleMethod(
+        AbstractStreamingDevice device,
+        string methodName,
+        IChannel desktopChannel,
+        Daqifi.Core.Channel.IChannel coreChannel)
+    {
+        var method = typeof(AbstractStreamingDevice).GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.IsNotNull(method, $"{methodName} was not found on AbstractStreamingDevice.");
+        method.Invoke(device, [desktopChannel, coreChannel]);
+    }
+
+    private sealed class SubscriptionTestDevice : AbstractStreamingDevice
+    {
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        public override bool Connect() => true;
+
+        public override bool Disconnect() => true;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+    }
+}

--- a/Daqifi.Desktop.Test/Device/ChannelSampleSubscriptionTests.cs
+++ b/Daqifi.Desktop.Test/Device/ChannelSampleSubscriptionTests.cs
@@ -21,64 +21,100 @@ public class ChannelSampleSubscriptionTests
     private const string SHARED_CHANNEL_NAME = "AI0";
 
     [TestMethod]
-    public void SubscribeChannelSamples_TwoWrappersSharingAName_DetachesEachWrappersOwnHandler()
+    public void UnsubscribeChannelSamples_WhenAnotherWrapperSharesItsName_DetachesItsOwnHandler()
     {
-        // Arrange — two wrappers for the same logical channel, which is what SyncChannelsFromCore
-        // produces when Core hands back a different IChannel instance for a key it already has a
-        // wrapper for: the replacement is built and subscribed before the trailing cleanup loop
-        // unsubscribes the outgoing one.
+        // Arrange
+        var scenario = ArrangeCollidingSubscriptions();
+
+        // Act
+        InvokeUnsubscribeChannelSamples(
+            scenario.Device, scenario.OutgoingWrapper, scenario.OutgoingCore.Channel);
+
+        // Assert
+        CollectionAssert.AreEqual(
+            scenario.OutgoingCore.Added,
+            scenario.OutgoingCore.Removed,
+            "The outgoing wrapper's own delegate must come off its own Core channel. Detaching " +
+            "some other wrapper's delegate is a no-op there and leaves the real subscription live " +
+            "on a channel that is no longer in DataChannels.");
+        Assert.AreEqual(
+            0,
+            scenario.ReplacementCore.Removed.Count,
+            "Unsubscribing the outgoing wrapper must not disturb the replacement's subscription.");
+    }
+
+    [TestMethod]
+    public void UnsubscribeChannelSamples_AfterAWrapperSharingItsNameWasRemoved_StillTracksItsHandler()
+    {
+        // Arrange — the outgoing wrapper has already been cleaned up, exactly as the trailing loop
+        // in SyncChannelsFromCore does once the replacement is in place.
+        var scenario = ArrangeCollidingSubscriptions();
+        InvokeUnsubscribeChannelSamples(
+            scenario.Device, scenario.OutgoingWrapper, scenario.OutgoingCore.Channel);
+
+        // Act
+        InvokeUnsubscribeChannelSamples(
+            scenario.Device, scenario.ReplacementWrapper, scenario.ReplacementCore.Channel);
+
+        // Assert
+        CollectionAssert.AreEqual(
+            scenario.ReplacementCore.Added,
+            scenario.ReplacementCore.Removed,
+            "The replacement wrapper's handler must survive the outgoing wrapper's cleanup as a " +
+            "tracked entry, so it can be detached in turn instead of leaking.");
+    }
+
+    [TestMethod]
+    public void SubscribeChannelSamples_WhenTheSameWrapperIsAlreadySubscribed_DetachesThePreviousHandler()
+    {
+        // Arrange
         var device = new SubscriptionTestDevice();
-        var outgoingCore = CreateCoreChannel(out var outgoingAdded, out var outgoingRemoved);
-        var replacementCore = CreateCoreChannel(out var replacementAdded, out var replacementRemoved);
-        var outgoingWrapper = new AnalogChannel(device, outgoingCore);
-        var replacementWrapper = new AnalogChannel(device, replacementCore);
+        var coreChannel = CreateCoreChannel();
+        var wrapper = new AnalogChannel(device, coreChannel.Channel);
+        InvokeSubscribeChannelSamples(device, wrapper, coreChannel.Channel);
+
+        // Act — a second subscribe for the very same wrapper reference
+        InvokeSubscribeChannelSamples(device, wrapper, coreChannel.Channel);
+
+        // Assert — only one handler can be tracked per wrapper, so the first must be detached
+        // rather than left attached and unreachable, which would route every sample twice.
+        Assert.AreEqual(2, coreChannel.Added.Count);
+        CollectionAssert.AreEqual(
+            new[] { coreChannel.Added[0] },
+            coreChannel.Removed,
+            "Re-subscribing a wrapper must detach the handler it is replacing.");
+    }
+
+    /// <summary>
+    /// Builds the state <c>SyncChannelsFromCore</c> reaches when Core hands back a different
+    /// <c>IChannel</c> instance for a key the device already has a wrapper for: the replacement
+    /// wrapper is created and subscribed while the outgoing wrapper is still subscribed. The two
+    /// wrappers are distinct objects that compare equal, because
+    /// <see cref="AbstractChannel"/> equality is <c>Name</c>-based — so they collide as keys in any
+    /// default-equality dictionary.
+    /// </summary>
+    private static CollidingSubscriptions ArrangeCollidingSubscriptions()
+    {
+        var device = new SubscriptionTestDevice();
+        var outgoingCore = CreateCoreChannel();
+        var replacementCore = CreateCoreChannel();
+        var outgoingWrapper = new AnalogChannel(device, outgoingCore.Channel);
+        var replacementWrapper = new AnalogChannel(device, replacementCore.Channel);
 
         Assert.AreNotSame(outgoingWrapper, replacementWrapper);
         Assert.IsTrue(
             outgoingWrapper.Equals(replacementWrapper),
-            "Precondition: AbstractChannel equality is Name-based, so these two distinct wrappers " +
-            "collide as keys in any default-equality dictionary.");
+            "Precondition: the two wrappers must compare equal for this scenario to exercise the " +
+            "key collision at all.");
 
-        // Act
-        InvokeSubscribeChannelSamples(device, outgoingWrapper, outgoingCore);
-        InvokeSubscribeChannelSamples(device, replacementWrapper, replacementCore);
-        InvokeUnsubscribeChannelSamples(device, outgoingWrapper, outgoingCore);
-        InvokeUnsubscribeChannelSamples(device, replacementWrapper, replacementCore);
+        InvokeSubscribeChannelSamples(device, outgoingWrapper, outgoingCore.Channel);
+        InvokeSubscribeChannelSamples(device, replacementWrapper, replacementCore.Channel);
 
-        // Assert
-        Assert.AreEqual(1, outgoingAdded.Count, "The outgoing wrapper should be subscribed exactly once.");
-        Assert.AreEqual(1, replacementAdded.Count, "The replacement wrapper should be subscribed exactly once.");
-        CollectionAssert.AreEqual(
-            outgoingAdded,
-            outgoingRemoved,
-            "The outgoing wrapper's own delegate must come off its Core channel. Detaching some " +
-            "other wrapper's delegate is a no-op there and leaves the real subscription attached.");
-        CollectionAssert.AreEqual(
-            replacementAdded,
-            replacementRemoved,
-            "The replacement wrapper's handler must still be tracked after the outgoing wrapper is " +
-            "unsubscribed, so it can be detached in turn instead of leaking.");
-    }
+        Assert.AreEqual(1, outgoingCore.Added.Count, "The outgoing wrapper should be subscribed once.");
+        Assert.AreEqual(1, replacementCore.Added.Count, "The replacement wrapper should be subscribed once.");
 
-    [TestMethod]
-    public void SubscribeChannelSamples_SameWrapperSubscribedTwice_DetachesThePreviousHandler()
-    {
-        // Arrange
-        var device = new SubscriptionTestDevice();
-        var coreChannel = CreateCoreChannel(out var added, out var removed);
-        var wrapper = new AnalogChannel(device, coreChannel);
-
-        // Act — a second subscribe for the very same wrapper reference
-        InvokeSubscribeChannelSamples(device, wrapper, coreChannel);
-        InvokeSubscribeChannelSamples(device, wrapper, coreChannel);
-
-        // Assert — only one handler can be tracked per wrapper, so the first must be detached
-        // rather than left attached and unreachable, which would route every sample twice.
-        Assert.AreEqual(2, added.Count);
-        CollectionAssert.AreEqual(
-            new[] { added[0] },
-            removed,
-            "Re-subscribing a wrapper must detach the handler it is replacing.");
+        return new CollidingSubscriptions(
+            device, outgoingWrapper, outgoingCore, replacementWrapper, replacementCore);
     }
 
     /// <summary>
@@ -86,26 +122,22 @@ public class ChannelSampleSubscriptionTests
     /// handed to them, so a test can tell <em>which</em> handler was attached or detached rather
     /// than just how many calls were made.
     /// </summary>
-    private static Daqifi.Core.Channel.IAnalogChannel CreateCoreChannel(
-        out List<EventHandler<CoreSampleReceivedEventArgs>> added,
-        out List<EventHandler<CoreSampleReceivedEventArgs>> removed)
+    private static RecordedCoreChannel CreateCoreChannel()
     {
-        var addedHandlers = new List<EventHandler<CoreSampleReceivedEventArgs>>();
-        var removedHandlers = new List<EventHandler<CoreSampleReceivedEventArgs>>();
+        var added = new List<EventHandler<CoreSampleReceivedEventArgs>>();
+        var removed = new List<EventHandler<CoreSampleReceivedEventArgs>>();
 
         var coreChannel = new Mock<Daqifi.Core.Channel.IAnalogChannel>();
         coreChannel.SetupGet(channel => channel.Name).Returns(SHARED_CHANNEL_NAME);
         coreChannel.SetupGet(channel => channel.Direction).Returns(CoreChannelDirection.Input);
         coreChannel
             .SetupAdd(channel => channel.SampleReceived += It.IsAny<EventHandler<CoreSampleReceivedEventArgs>>())
-            .Callback<EventHandler<CoreSampleReceivedEventArgs>>(addedHandlers.Add);
+            .Callback<EventHandler<CoreSampleReceivedEventArgs>>(added.Add);
         coreChannel
             .SetupRemove(channel => channel.SampleReceived -= It.IsAny<EventHandler<CoreSampleReceivedEventArgs>>())
-            .Callback<EventHandler<CoreSampleReceivedEventArgs>>(removedHandlers.Add);
+            .Callback<EventHandler<CoreSampleReceivedEventArgs>>(removed.Add);
 
-        added = addedHandlers;
-        removed = removedHandlers;
-        return coreChannel.Object;
+        return new RecordedCoreChannel(coreChannel.Object, added, removed);
     }
 
     private static void InvokeSubscribeChannelSamples(
@@ -142,6 +174,20 @@ public class ChannelSampleSubscriptionTests
         Assert.IsNotNull(method, $"{methodName} was not found on AbstractStreamingDevice.");
         method.Invoke(device, [desktopChannel, coreChannel]);
     }
+
+    /// <summary>A Core channel paired with the handlers added to and removed from it.</summary>
+    private sealed record RecordedCoreChannel(
+        Daqifi.Core.Channel.IAnalogChannel Channel,
+        List<EventHandler<CoreSampleReceivedEventArgs>> Added,
+        List<EventHandler<CoreSampleReceivedEventArgs>> Removed);
+
+    /// <summary>Two subscribed wrappers for one logical channel, sharing a name.</summary>
+    private sealed record CollidingSubscriptions(
+        AbstractStreamingDevice Device,
+        AnalogChannel OutgoingWrapper,
+        RecordedCoreChannel OutgoingCore,
+        AnalogChannel ReplacementWrapper,
+        RecordedCoreChannel ReplacementCore);
 
     private sealed class SubscriptionTestDevice : AbstractStreamingDevice
     {

--- a/Daqifi.Desktop.Test/Device/DigitalOutputDelegationTests.cs
+++ b/Daqifi.Desktop.Test/Device/DigitalOutputDelegationTests.cs
@@ -207,24 +207,37 @@ public class DigitalOutputDelegationTests : IDisposable
         Assert.AreEqual(0, _coreDevice.SentCommands.Count, "Hydration must not issue device commands");
     }
 
+    /// <summary>
+    /// A status re-population must not disturb a digital output's commanded state, and must not
+    /// re-drive the pin. This used to be the desktop's job — <c>DigitalChannel.ReplaceCoreChannel</c>
+    /// copied the state onto whatever fresh instance Core had built. Since daqifi-core#309 Core
+    /// updates the channel in place, so the wrapper keeps pointing at the same live object.
+    /// </summary>
     [TestMethod]
-    public void ReplaceCoreChannel_KeepsIsDigitalOnInLockstepWithCoreMirror()
+    public void RepopulatingChannels_KeepsIsDigitalOnAndDoesNotRedriveThePin()
     {
-        // Arrange — command HIGH through the normal path, then refresh the core channel
+        // Arrange — command HIGH through the normal path
         var channel = WrapCoreChannel(8);
         channel.Direction = ChannelDirection.Output;
         channel.IsDigitalOn = true;
-        var freshCoreChannel = new Daqifi.Core.Channel.DigitalChannel(8) { Name = "DIO8" };
+        var coreChannelBefore = channel.CoreChannel;
         _coreDevice.SentCommands.Clear();
 
-        // Act
-        channel.ReplaceCoreChannel(freshCoreChannel);
+        // Act — a second status message, exactly what a routine device status frame triggers
+        _coreDevice.PopulateChannelsFromStatus(new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 12345,
+            DeviceFwRev = "1.0.0",
+            DigitalPortNum = 16
+        });
 
-        // Assert — commanded state carried onto the fresh core channel and the desktop
-        // flag stays consistent, with no extra device command
-        Assert.IsTrue(channel.CoreChannel.OutputValue, "Core mirror should carry across the refresh");
-        Assert.IsTrue(channel.IsDigitalOn, "Desktop commanded-state flag should stay in lockstep");
-        Assert.AreEqual(0, _coreDevice.SentCommands.Count, "A core-channel refresh must not drive the pin");
+        // Assert — same instance, state intact, and the pin is not re-driven
+        Assert.AreSame(coreChannelBefore, channel.CoreChannel,
+            "Core must update the channel in place so the wrapper is not left holding a stale instance.");
+        Assert.IsTrue(channel.CoreChannel.OutputValue, "Core's output mirror must survive a re-population");
+        Assert.IsTrue(channel.IsDigitalOn, "Desktop commanded-state flag must stay in lockstep");
+        Assert.AreEqual(0, _coreDevice.SentCommands.Count, "A re-population must not drive the pin");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Device/PwmOutputDelegationTests.cs
+++ b/Daqifi.Desktop.Test/Device/PwmOutputDelegationTests.cs
@@ -318,23 +318,38 @@ public class PwmOutputDelegationTests : IDisposable
         Assert.AreEqual(0, _coreDevice.SentCommands.Count, "Analog channels must not produce PWM commands");
     }
 
+    /// <summary>
+    /// A status re-population must not disturb a channel's PWM state. This used to be the desktop's
+    /// job — <c>DigitalChannel.ReplaceCoreChannel</c> copied the bookkeeping onto whatever fresh
+    /// instance Core had built. Since daqifi-core#309 Core updates the channel in place instead, so
+    /// the wrapper keeps pointing at the same live object and there is nothing to carry across.
+    /// This asserts that guarantee at the level the desktop actually depends on it.
+    /// </summary>
     [TestMethod]
-    public void ReplaceCoreChannel_CarriesPwmBookkeepingAcrossRefresh()
+    public void RepopulatingChannels_KeepsPwmBookkeepingOnTheSameCoreInstance()
     {
-        // Arrange — enable through the normal path, then refresh the core channel
+        // Arrange — enable through the normal path
         var channel = WrapCoreChannel(4);
         channel.PwmDutyCyclePercent = 30;
         channel.IsPwmEnabled = true;
-        var freshCoreChannel = new Daqifi.Core.Channel.DigitalChannel(4, isPwmCapable: true) { Name = "DIO4" };
+        var coreChannelBefore = channel.CoreChannel;
         _coreDevice.SentCommands.Clear();
 
-        // Act
-        channel.ReplaceCoreChannel(freshCoreChannel);
+        // Act — a second status message, exactly what a routine device status frame triggers
+        _coreDevice.PopulateChannelsFromStatus(new DaqifiOutMessage
+        {
+            DevicePn = "Nq1",
+            DeviceSn = 12345,
+            DeviceFwRev = "1.0.0",
+            DigitalPortNum = 16
+        });
 
-        // Assert — PWM state carried onto the fresh core channel with no device command
-        Assert.IsTrue(channel.IsPwmEnabled, "PWM enabled bookkeeping should carry across the refresh");
-        Assert.AreEqual(30, channel.PwmDutyCyclePercent, "Duty bookkeeping should carry across the refresh");
-        Assert.AreEqual(0, _coreDevice.SentCommands.Count, "A core-channel refresh must not command the device");
+        // Assert — same instance, state intact, no device command
+        Assert.AreSame(coreChannelBefore, channel.CoreChannel,
+            "Core must update the channel in place so the wrapper is not left holding a stale instance.");
+        Assert.IsTrue(channel.IsPwmEnabled, "PWM enabled bookkeeping must survive a re-population");
+        Assert.AreEqual(30, channel.PwmDutyCyclePercent, "Duty bookkeeping must survive a re-population");
+        Assert.AreEqual(0, _coreDevice.SentCommands.Count, "A re-population must not command the device");
     }
 
     private sealed class PwmTestDevice : AbstractStreamingDevice

--- a/Daqifi.Desktop/Channel/AnalogChannel.cs
+++ b/Daqifi.Desktop/Channel/AnalogChannel.cs
@@ -10,7 +10,9 @@ public class AnalogChannel : AbstractChannel
     /// <summary>
     /// Core channel implementation handling device communication and scaling
     /// </summary>
-    private Daqifi.Core.Channel.IAnalogChannel _coreChannel;
+    // readonly: Core updates a channel in place across re-population rather than recreating it
+    // (daqifi-core#309), so a wrapper is built around one Core instance for its whole lifetime.
+    private readonly Daqifi.Core.Channel.IAnalogChannel _coreChannel;
     #endregion
 
     #region Properties
@@ -150,27 +152,6 @@ public class AnalogChannel : AbstractChannel
         return _coreChannel.GetScaledValue(rawValue);
     }
 
-    internal void ReplaceCoreChannel(Daqifi.Core.Channel.IAnalogChannel coreChannel)
-    {
-        ArgumentNullException.ThrowIfNull(coreChannel);
-
-        var wasEnabled = _coreChannel.IsEnabled;
-        var direction = _coreChannel.Direction;
-
-        _coreChannel = coreChannel;
-        _coreChannel.IsEnabled = wasEnabled;
-        _coreChannel.Direction = direction;
-
-        OnPropertyChanged(nameof(Name));
-        OnPropertyChanged(nameof(Direction));
-        OnPropertyChanged(nameof(Index));
-        OnPropertyChanged(nameof(IsActive));
-        OnPropertyChanged(nameof(CalibrationBValue));
-        OnPropertyChanged(nameof(CalibrationMValue));
-        OnPropertyChanged(nameof(InternalScaleMValue));
-        OnPropertyChanged(nameof(PortRange));
-        OnPropertyChanged(nameof(Resolution));
-    }
     #endregion
 
     #region Object Overrides

--- a/Daqifi.Desktop/Channel/DigitalChannel.cs
+++ b/Daqifi.Desktop/Channel/DigitalChannel.cs
@@ -15,7 +15,9 @@ public class DigitalChannel : AbstractChannel
     /// <summary>
     /// Core channel implementation handling device communication
     /// </summary>
-    private Daqifi.Core.Channel.IDigitalChannel _coreChannel;
+    // readonly: Core updates a channel in place across re-population rather than recreating it
+    // (daqifi-core#309), so a wrapper is built around one Core instance for its whole lifetime.
+    private readonly Daqifi.Core.Channel.IDigitalChannel _coreChannel;
     #endregion
 
     #region Properties
@@ -179,35 +181,6 @@ public class DigitalChannel : AbstractChannel
         HydrateIsDigitalOn(coreChannel.OutputValue);
     }
 
-    internal void ReplaceCoreChannel(Daqifi.Core.Channel.IDigitalChannel coreChannel)
-    {
-        ArgumentNullException.ThrowIfNull(coreChannel);
-
-        var wasEnabled = _coreChannel.IsEnabled;
-        var direction = _coreChannel.Direction;
-        var outputValue = _coreChannel.OutputValue;
-        var isPwmEnabled = _coreChannel.IsPwmEnabled;
-        var pwmDutyCyclePercent = _coreChannel.PwmDutyCyclePercent;
-
-        _coreChannel = coreChannel;
-        _coreChannel.IsEnabled = wasEnabled;
-        _coreChannel.Direction = direction;
-        _coreChannel.OutputValue = outputValue;
-        _coreChannel.IsPwmEnabled = isPwmEnabled;
-        _coreChannel.PwmDutyCyclePercent = pwmDutyCyclePercent;
-
-        // Keep the desktop commanded-state flag in lockstep with Core's mirror so the
-        // tile/toggle cannot desync after a refresh (no device command is re-issued).
-        HydrateIsDigitalOn(outputValue);
-
-        OnPropertyChanged(nameof(Name));
-        OnPropertyChanged(nameof(Direction));
-        OnPropertyChanged(nameof(Index));
-        OnPropertyChanged(nameof(IsActive));
-        OnPropertyChanged(nameof(IsPwmCapable));
-        OnPropertyChanged(nameof(IsPwmEnabled));
-        OnPropertyChanged(nameof(PwmDutyCyclePercent));
-    }
     #endregion
 
     #region Object Overrides

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -113,8 +113,8 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// <c>DaqifiStreamingDevice</c> decodes every raw stream frame into per-channel samples and
     /// raises <see cref="Daqifi.Core.Channel.IChannel.SampleReceived"/> automatically whenever its
     /// own <c>IsStreaming</c> flag is set — independent of the leftover-frame/first-frame gating
-    /// below. Keyed by the desktop channel wrapper (stable across <c>ReplaceCoreChannel</c> calls)
-    /// so the handler on the previous Core channel instance can be found and removed.
+    /// below. Keyed by the desktop channel wrapper so the handler installed on its Core channel can
+    /// be found and removed when the wrapper leaves <see cref="DataChannels"/>.
     /// </summary>
     private readonly Dictionary<IChannel, EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs>>
         _channelSampleHandlers = new();
@@ -802,8 +802,8 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// Subscribes to a Core channel's <see cref="Daqifi.Core.Channel.IChannel.SampleReceived"/>,
     /// routing decoded samples through <see cref="OnCoreChannelSampleReceived"/> for the given
     /// desktop channel wrapper. Tracks the handler by desktop channel so
-    /// <see cref="UnsubscribeChannelSamples"/> can remove it later even after
-    /// <c>ReplaceCoreChannel</c> has swapped in a different Core channel instance.
+    /// <see cref="UnsubscribeChannelSamples"/> can remove exactly the delegate that was added —
+    /// the handler closes over the wrapper, so it cannot be reconstructed for removal.
     /// </summary>
     private void SubscribeChannelSamples(IChannel desktopChannel, Daqifi.Core.Channel.IChannel coreChannel)
     {
@@ -1577,31 +1577,25 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         {
             var channelKey = GetChannelKey(coreChannel);
 
-            if (existingChannels.TryGetValue(channelKey, out var existingChannel))
+            // Core updates a channel in place when its (type, number) identity is unchanged
+            // (daqifi-core#309), so a re-population hands back the very same IChannel instance the
+            // wrapper is already built around, with its enable/direction/output/PWM state intact.
+            // Reference equality is the check: it is what makes rewiring unnecessary, and it fails
+            // closed — if Core ever hands back a different instance for the same key, the wrapper
+            // is rebuilt below rather than left pointing at a channel the device no longer owns.
+            if (existingChannels.TryGetValue(channelKey, out var existingChannel)
+                && ReferenceEquals(GetCoreChannel(existingChannel), coreChannel))
             {
                 handledExistingKeys.Add(channelKey);
-                switch (existingChannel)
-                {
-                    case AnalogChannel desktopAnalogChannel
-                        when coreChannel is Daqifi.Core.Channel.IAnalogChannel coreAnalogChannel:
-                        UnsubscribeChannelSamples(desktopAnalogChannel, desktopAnalogChannel.CoreChannel);
-                        desktopAnalogChannel.ReplaceCoreChannel(coreAnalogChannel);
-                        desktopAnalogChannel.DeviceName = DevicePartNumber;
-                        desktopAnalogChannel.DeviceSerialNo = DeviceSerialNo;
-                        SubscribeChannelSamples(desktopAnalogChannel, coreAnalogChannel);
-                        updatedChannels.Add(desktopAnalogChannel);
-                        continue;
 
-                    case DigitalChannel desktopDigitalChannel
-                        when coreChannel is Daqifi.Core.Channel.IDigitalChannel coreDigitalChannel:
-                        UnsubscribeChannelSamples(desktopDigitalChannel, desktopDigitalChannel.CoreChannel);
-                        desktopDigitalChannel.ReplaceCoreChannel(coreDigitalChannel);
-                        desktopDigitalChannel.DeviceName = DevicePartNumber;
-                        desktopDigitalChannel.DeviceSerialNo = DeviceSerialNo;
-                        SubscribeChannelSamples(desktopDigitalChannel, coreDigitalChannel);
-                        updatedChannels.Add(desktopDigitalChannel);
-                        continue;
-                }
+                // Metadata can land after the channels do, so these are refreshed every sync.
+                existingChannel.DeviceName = DevicePartNumber;
+                existingChannel.DeviceSerialNo = DeviceSerialNo;
+
+                // The sample subscription is still attached to this same Core instance — tearing it
+                // down and re-adding it would only risk dropping a frame mid-stream.
+                updatedChannels.Add(existingChannel);
+                continue;
             }
 
             var desktopChannel = CreateDesktopChannel(coreChannel);
@@ -1612,9 +1606,10 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             }
         }
 
-        // A channel present before this sync but absent from the new Core snapshot (e.g. a
-        // reconfigured channel count) still holds a subscription onto its old Core channel —
-        // remove it so a stale handler can't fire against a channel no longer in DataChannels.
+        // Any wrapper not carried forward above — dropped from the new Core snapshot (e.g. a
+        // reconfigured channel count), or replaced because Core handed back a different instance
+        // for its key — still holds a subscription onto its old Core channel. Remove it so a stale
+        // handler can't fire against a channel no longer in DataChannels.
         foreach (var (key, oldChannel) in existingChannels)
         {
             if (handledExistingKeys.Contains(key))

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -116,8 +116,17 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// below. Keyed by the desktop channel wrapper so the handler installed on its Core channel can
     /// be found and removed when the wrapper leaves <see cref="DataChannels"/>.
     /// </summary>
+    /// <remarks>
+    /// Keyed by <em>reference identity</em>: <see cref="AbstractChannel"/> overrides equality and
+    /// hashing on its mutable <see cref="IChannel.Name"/>, so under default equality two wrappers
+    /// for the same logical channel would share one entry — a rebuilt wrapper's subscription would
+    /// overwrite the outgoing wrapper's, and the cleanup in <see cref="SyncChannelsFromCore"/> would
+    /// then detach the wrong delegate, leaking the old Core subscription and leaving the new one
+    /// untracked. A rename would likewise strand an entry. <see cref="ReferenceComparer{T}"/> makes
+    /// every wrapper its own key regardless of what its name does.
+    /// </remarks>
     private readonly Dictionary<IChannel, EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs>>
-        _channelSampleHandlers = new();
+        _channelSampleHandlers = new(ReferenceComparer<IChannel>.Instance);
 
     /// <summary>
     /// Gate for <see cref="OnCoreChannelSampleReceived"/>: true only while the raw frame Core is
@@ -807,6 +816,16 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     private void SubscribeChannelSamples(IChannel desktopChannel, Daqifi.Core.Channel.IChannel coreChannel)
     {
+        // Subscribing a wrapper that already has a tracked handler would strand the old delegate:
+        // the map holds one handler per wrapper, so the previous one becomes unreachable and stays
+        // attached, doubling every sample the wrapper routes. Detach it first — a wrapper's Core
+        // channel is readonly, so the delegate found here is necessarily attached to this same
+        // coreChannel.
+        if (_channelSampleHandlers.Remove(desktopChannel, out var previousHandler))
+        {
+            coreChannel.SampleReceived -= previousHandler;
+        }
+
         EventHandler<Daqifi.Core.Channel.SampleReceivedEventArgs> handler =
             (_, e) => OnCoreChannelSampleReceived(desktopChannel, e.Sample);
         coreChannel.SampleReceived += handler;


### PR DESCRIPTION
Row 2 of the [#708](https://github.com/daqifi/daqifi-desktop/issues/708) deletion backlog — the largest single row (~110 lines). daqifi-core#309 shipped in Core **1.2.0**; we're on **1.3.0**.

I verified Core's behavior in source before deleting anything: `PopulateChannelsFromStatus` now indexes existing channels by `(type, number)` and **updates them in place**, with the stated intent that "consumer-held `IChannel` references — and the configuration on them (enable/direction/output/PWM state) — survive a routine status re-population untouched." Before that, Core rebuilt every channel on every status message and the desktop compensated by copying state onto the fresh instance.

**Deleted:** `AnalogChannel.ReplaceCoreChannel`, `DigitalChannel.ReplaceCoreChannel`, and the type-switch in `SyncChannelsFromCore` that drove them. Both `_coreChannel` fields become `readonly`, so *"a wrapper never swaps its Core channel"* is now enforced by the compiler rather than by convention.

## What the reconcile still does

The loop stays — it still handles new channels, dropped channels, and sample-subscription hygiene. What changed is the **match**: a wrapper is carried forward only when Core handed back the very same instance (`ReferenceEquals`).

That choice fails closed. If Core ever returns a *different* instance for a key, the wrapper is rebuilt rather than silently left pointing at a channel the device no longer owns, and the trailing cleanup loop unsubscribes the stale one.

## Two things fixed in passing

1. **A latent subscription leak.** The old code added the key to `handledExistingKeys` *before* the type-switch. A key match with a type mismatch fell through to building a new wrapper, while the old wrapper's sample subscription was skipped by the cleanup loop and left attached to a Core channel no longer in `DataChannels`.
2. **A dropped-sample window.** Same-instance channels were unsubscribed and immediately resubscribed on *every* status frame. That churn is gone.

## Testing

`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → **768/768 pass**.

The two tests that called `ReplaceCoreChannel` directly are replaced by tests of the guarantee that makes it unnecessary: re-populating a Core device keeps the same instance with PWM/output state intact and issues no device command. That's a better test — it pins Core's actual contract instead of a desktop workaround, so a Core regression would fail here.

Two channel-refresh tests were building a whole second `DaqifiDevice` to model a refresh. That shape doesn't occur in production — a same-session refresh re-populates the one connected device, and a reconnect builds a new Core device but clears `DataChannels` first (issue #29's ghost-channel fix), so a wrapper never survives to meet a different Core instance. They now re-populate a single device. All their desktop-state assertions (`ScaleExpression`, `IsVisible`, `ChannelColorBrush`, `IsActive`, direction, output) are unchanged and still pass.

⚠️ **Worth a hardware check** — this is channel-identity plumbing on the streaming path. Suggested smoke test: connect, enable a few channels, set a DIO output high and PWM on another, then let a status refresh land and confirm nothing resets and samples keep flowing to the right channels.

Independent of #783/#784/#785/#786.

Refs #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
