### PR TITLE
fix(sd-import): report timestamp quality from Core's exact per-entry flag

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
@@ -17,18 +17,18 @@ namespace Daqifi.Desktop.Test.Loggers;
 [TestClass]
 public class ImportTimestampQualityTests
 {
-    private static readonly DateTime BaseTime = new(2026, 6, 23, 14, 32, 17, DateTimeKind.Utc);
-    private static readonly TimeSpan SampleStep = TimeSpan.FromMilliseconds(100);
+    private static readonly DateTime BASE_TIME = new(2026, 6, 23, 14, 32, 17, DateTimeKind.Utc);
+    private static readonly TimeSpan SAMPLE_STEP = TimeSpan.FromMilliseconds(100);
 
     /// <summary>An entry Core reconstructed a real device timestamp for.</summary>
     private static SdCardLogEntry EntryWithDeviceTimestamp(int index) =>
-        new(BaseTime + index * SampleStep, [1.25], 0, null);
+        new(BASE_TIME + index * SAMPLE_STEP, [1.25], 0, null);
 
     /// <summary>
     /// An entry Core had no usable device timestamp for, so it substituted the session base time.
     /// </summary>
     private static SdCardLogEntry EntryWithoutDeviceTimestamp() =>
-        new(BaseTime, [1.25], 0, null) { HasDeviceTimestamp = false };
+        new(BASE_TIME, [1.25], 0, null) { HasDeviceTimestamp = false };
 
     [TestMethod]
     public void Observe_AllEntriesCarryDeviceTimestamps_IsHealthy()
@@ -123,7 +123,8 @@ public class ImportTimestampQualityTests
         var warning = quality.BuildUserWarning();
         Assert.IsNotNull(warning);
         StringAssert.Contains(warning, "30");
-        StringAssert.Contains(warning, "%");
+        StringAssert.Contains(warning, "(30.0%)",
+            "The percentage always carries one decimal so small shares cannot render as a bare 0.");
     }
 
     /// <summary>
@@ -152,8 +153,40 @@ public class ImportTimestampQualityTests
 
         var warning = quality.BuildUserWarning();
         Assert.IsNotNull(warning);
-        StringAssert.Contains(warning, "0.1%",
+        StringAssert.Contains(warning, "(0.1%)",
             "A sub-1% share must not round to 0% and read as though nothing was substituted.");
+    }
+
+    /// <summary>
+    /// A substitution rate too small to survive the displayed precision (1 in 5,000 is 0.02%) must
+    /// still not render as "0%" — the same sentence states a non-zero substituted count, so a zero
+    /// percentage beside it would contradict the very thing the warning exists to report.
+    /// </summary>
+    [TestMethod]
+    [DataRow(5000)]
+    [DataRow(10000)]
+    public void Observe_SubstitutionRateBelowDisplayedPrecision_IsNotReportedAsZeroPercent(int totalEntries)
+    {
+        // Arrange
+        var quality = new ImportTimestampQuality();
+
+        // Act — exactly one substituted sample in an otherwise healthy file
+        for (var i = 0; i < totalEntries - 1; i++)
+        {
+            quality.Observe(EntryWithDeviceTimestamp(i));
+        }
+        quality.Observe(EntryWithoutDeviceTimestamp());
+
+        // Assert
+        Assert.AreEqual(totalEntries, quality.TotalEntries);
+        Assert.AreEqual(1, quality.EntriesWithoutDeviceTimestamp);
+
+        var warning = quality.BuildUserWarning();
+        Assert.IsNotNull(warning);
+        StringAssert.Contains(warning, "(<0.1%)",
+            "A share below the displayed precision must read as a small one, not as none at all.");
+        Assert.IsFalse(warning.Contains("0%", StringComparison.Ordinal),
+            $"A substituted sample must never be reported at 0%. Warning was: {warning}");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Daqifi.Core.Device.SdCard;
 using Daqifi.Desktop.Loggers;
 
@@ -19,6 +20,25 @@ public class ImportTimestampQualityTests
 {
     private static readonly DateTime BASE_TIME = new(2026, 6, 23, 14, 32, 17, DateTimeKind.Utc);
     private static readonly TimeSpan SAMPLE_STEP = TimeSpan.FromMilliseconds(100);
+
+    private CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+
+    /// <summary>
+    /// The warning is formatted for the user's locale, so the fixture pins a known culture rather
+    /// than inheriting the build agent's. The comma-decimal test overrides it deliberately.
+    /// </summary>
+    [TestInitialize]
+    public void PinCulture()
+    {
+        _originalCulture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    [TestCleanup]
+    public void RestoreCulture()
+    {
+        Thread.CurrentThread.CurrentCulture = _originalCulture;
+    }
 
     /// <summary>An entry Core reconstructed a real device timestamp for.</summary>
     private static SdCardLogEntry EntryWithDeviceTimestamp(int index) =>
@@ -187,6 +207,46 @@ public class ImportTimestampQualityTests
             "A share below the displayed precision must read as a small one, not as none at all.");
         Assert.IsFalse(warning.Contains("0%", StringComparison.Ordinal),
             $"A substituted sample must never be reported at 0%. Warning was: {warning}");
+    }
+
+    /// <summary>
+    /// The sample count in this sentence is formatted for the user's locale, so the percentage
+    /// beside it must be too — one sentence carrying two decimal conventions reads as a bug. The
+    /// below-resolution marker is built from the same culture rather than a hardcoded "&lt;0.1".
+    /// </summary>
+    [TestMethod]
+    public void BuildUserWarning_CommaDecimalCulture_FormatsPercentInThatCulture()
+    {
+        // Arrange
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+        var mixed = new ImportTimestampQuality();
+        var tiny = new ImportTimestampQuality();
+
+        // Act
+        for (var i = 0; i < 70; i++)
+        {
+            mixed.Observe(EntryWithDeviceTimestamp(i));
+        }
+        for (var i = 0; i < 30; i++)
+        {
+            mixed.Observe(EntryWithoutDeviceTimestamp());
+        }
+
+        for (var i = 0; i < 4999; i++)
+        {
+            tiny.Observe(EntryWithDeviceTimestamp(i));
+        }
+        tiny.Observe(EntryWithoutDeviceTimestamp());
+
+        // Assert
+        var mixedWarning = mixed.BuildUserWarning();
+        var tinyWarning = tiny.BuildUserWarning();
+        Assert.IsNotNull(mixedWarning);
+        Assert.IsNotNull(tinyWarning);
+        StringAssert.Contains(mixedWarning, "(30,0%)",
+            "The percentage must use the same decimal separator as the count beside it.");
+        StringAssert.Contains(tinyWarning, "(<0,1%)",
+            "The below-resolution marker is a formatted number too, not a hardcoded string.");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
@@ -215,38 +215,30 @@ public class ImportTimestampQualityTests
     /// below-resolution marker is built from the same culture rather than a hardcoded "&lt;0.1".
     /// </summary>
     [TestMethod]
-    public void BuildUserWarning_CommaDecimalCulture_FormatsPercentInThatCulture()
+    [DataRow(30, 100, "(30,0%)")]
+    [DataRow(1, 5000, "(<0,1%)")]
+    public void BuildUserWarning_CommaDecimalCulture_FormatsPercentInThatCulture(
+        int substituted, int totalEntries, string expectedPercent)
     {
         // Arrange
         Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
-        var mixed = new ImportTimestampQuality();
-        var tiny = new ImportTimestampQuality();
+        var quality = new ImportTimestampQuality();
+        for (var i = 0; i < totalEntries - substituted; i++)
+        {
+            quality.Observe(EntryWithDeviceTimestamp(i));
+        }
+        for (var i = 0; i < substituted; i++)
+        {
+            quality.Observe(EntryWithoutDeviceTimestamp());
+        }
 
         // Act
-        for (var i = 0; i < 70; i++)
-        {
-            mixed.Observe(EntryWithDeviceTimestamp(i));
-        }
-        for (var i = 0; i < 30; i++)
-        {
-            mixed.Observe(EntryWithoutDeviceTimestamp());
-        }
-
-        for (var i = 0; i < 4999; i++)
-        {
-            tiny.Observe(EntryWithDeviceTimestamp(i));
-        }
-        tiny.Observe(EntryWithoutDeviceTimestamp());
+        var warning = quality.BuildUserWarning();
 
         // Assert
-        var mixedWarning = mixed.BuildUserWarning();
-        var tinyWarning = tiny.BuildUserWarning();
-        Assert.IsNotNull(mixedWarning);
-        Assert.IsNotNull(tinyWarning);
-        StringAssert.Contains(mixedWarning, "(30,0%)",
-            "The percentage must use the same decimal separator as the count beside it.");
-        StringAssert.Contains(tinyWarning, "(<0,1%)",
-            "The below-resolution marker is a formatted number too, not a hardcoded string.");
+        Assert.IsNotNull(warning);
+        StringAssert.Contains(warning, expectedPercent,
+            "The percentage — marker included — must use the same separators as the count beside it.");
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
@@ -210,15 +210,17 @@ public class ImportTimestampQualityTests
     }
 
     /// <summary>
-    /// The sample count in this sentence is formatted for the user's locale, so the percentage
-    /// beside it must be too — one sentence carrying two decimal conventions reads as a bug. The
+    /// The count and the percentage in this sentence come from separate formatting paths, so both
+    /// are pinned here: a warning reading "1.500 of the samples ... (30.0%)" mixes two conventions
+    /// in one breath. The 1,500 row is the one with a culture-dependent grouping separator, and the
     /// below-resolution marker is built from the same culture rather than a hardcoded "&lt;0.1".
     /// </summary>
     [TestMethod]
-    [DataRow(30, 100, "(30,0%)")]
-    [DataRow(1, 5000, "(<0,1%)")]
-    public void BuildUserWarning_CommaDecimalCulture_FormatsPercentInThatCulture(
-        int substituted, int totalEntries, string expectedPercent)
+    [DataRow(30, 100, "30", "(30,0%)")]
+    [DataRow(1, 5000, "1", "(<0,1%)")]
+    [DataRow(1500, 5000, "1.500", "(30,0%)")]
+    public void BuildUserWarning_CommaDecimalCulture_FormatsCountAndPercentInThatCulture(
+        int substituted, int totalEntries, string expectedCount, string expectedPercent)
     {
         // Arrange
         Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
@@ -237,6 +239,8 @@ public class ImportTimestampQualityTests
 
         // Assert
         Assert.IsNotNull(warning);
+        StringAssert.Contains(warning, $"{expectedCount} of the samples",
+            "The sample count must carry the culture's grouping separator.");
         StringAssert.Contains(warning, expectedPercent,
             "The percentage — marker included — must use the same separators as the count beside it.");
     }

--- a/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/ImportTimestampQualityTests.cs
@@ -1,19 +1,37 @@
-﻿using Daqifi.Desktop.Loggers;
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Desktop.Loggers;
 
 namespace Daqifi.Desktop.Test.Loggers;
 
 /// <summary>
-/// Covers the timestamp-quality classification used to warn when an SD card
-/// file's time axis could not be reconstructed (issue #572 follow-up).
+/// Covers the timestamp-quality classification used to warn when an SD card file's time axis could
+/// not be reconstructed (issue #572 follow-up).
 /// </summary>
+/// <remarks>
+/// Since daqifi-core#303 this reads Core's per-entry <see cref="SdCardLogEntry.HasDeviceTimestamp"/>
+/// instead of inferring substitution from timestamps that collapsed onto one tick. The tests
+/// changed shape accordingly: entries now state whether they carried a device timestamp rather than
+/// encoding it in the tick values, and the old 20%-threshold cases are gone — with an exact signal
+/// there is no inference error left for a margin to absorb.
+/// </remarks>
 [TestClass]
 public class ImportTimestampQualityTests
 {
-    private const long BASE_TICKS = 638_000_000_000_000_000;
-    private const long TICK_STEP = 1_000_000; // 100 ms
+    private static readonly DateTime BaseTime = new(2026, 6, 23, 14, 32, 17, DateTimeKind.Utc);
+    private static readonly TimeSpan SampleStep = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>An entry Core reconstructed a real device timestamp for.</summary>
+    private static SdCardLogEntry EntryWithDeviceTimestamp(int index) =>
+        new(BaseTime + index * SampleStep, [1.25], 0, null);
+
+    /// <summary>
+    /// An entry Core had no usable device timestamp for, so it substituted the session base time.
+    /// </summary>
+    private static SdCardLogEntry EntryWithoutDeviceTimestamp() =>
+        new(BaseTime, [1.25], 0, null) { HasDeviceTimestamp = false };
 
     [TestMethod]
-    public void Observe_AdvancingTimestamps_IsHealthy()
+    public void Observe_AllEntriesCarryDeviceTimestamps_IsHealthy()
     {
         // Arrange
         var quality = new ImportTimestampQuality();
@@ -21,33 +39,58 @@ public class ImportTimestampQualityTests
         // Act
         for (var i = 0; i < 100; i++)
         {
-            quality.Observe(BASE_TICKS + i * TICK_STEP);
+            quality.Observe(EntryWithDeviceTimestamp(i));
         }
 
         // Assert
         Assert.AreEqual(100, quality.TotalEntries);
-        Assert.AreEqual(1, quality.EntriesAtFirstTimestamp);
+        Assert.AreEqual(0, quality.EntriesWithoutDeviceTimestamp);
         Assert.IsFalse(quality.HasFlatTimeAxis);
         Assert.IsFalse(quality.HasDegenerateTimeAxis);
         Assert.IsNull(quality.BuildUserWarning());
     }
 
+    /// <summary>
+    /// The case the old inference could not tell apart from a substituted run: real samples whose
+    /// device timestamps genuinely repeat. Firmware does emit duplicate ticks, so counting entries
+    /// that shared the first tick used to flag a perfectly good file once enough of them repeated.
+    /// Core's flag makes these unambiguously healthy.
+    /// </summary>
     [TestMethod]
-    public void Observe_AllIdenticalTimestamps_IsFlatAndDegenerate()
+    public void Observe_RepeatedDeviceTimestamps_IsStillHealthy()
     {
-        // Arrange - the issue #572 collapse shape: every entry at base time
+        // Arrange
+        var quality = new ImportTimestampQuality();
+
+        // Act — every entry lands on the same tick, but each is a real device timestamp
+        for (var i = 0; i < 100; i++)
+        {
+            quality.Observe(EntryWithDeviceTimestamp(0));
+        }
+
+        // Assert
+        Assert.AreEqual(100, quality.TotalEntries);
+        Assert.IsFalse(quality.HasDegenerateTimeAxis,
+            "Duplicate device timestamps are real samples, not substituted ones.");
+        Assert.IsNull(quality.BuildUserWarning());
+    }
+
+    [TestMethod]
+    public void Observe_NoEntryCarriesADeviceTimestamp_IsFlatAndDegenerate()
+    {
+        // Arrange - the issue #572 collapse shape: every entry at the session base time
         var quality = new ImportTimestampQuality();
 
         // Act
         for (var i = 0; i < 50; i++)
         {
-            quality.Observe(BASE_TICKS);
+            quality.Observe(EntryWithoutDeviceTimestamp());
         }
 
         // Assert
         Assert.IsTrue(quality.HasFlatTimeAxis);
         Assert.IsTrue(quality.HasDegenerateTimeAxis);
-        Assert.AreEqual(1.0, quality.CollapsedFraction);
+        Assert.AreEqual(1.0, quality.SubstitutedFraction);
 
         var warning = quality.BuildUserWarning();
         Assert.IsNotNull(warning);
@@ -55,88 +98,92 @@ public class ImportTimestampQualityTests
     }
 
     [TestMethod]
-    public void Observe_PartialCollapseAboveThreshold_IsDegenerateButNotFlat()
+    public void Observe_SomeEntriesSubstituted_IsDegenerateButNotFlat()
     {
-        // Arrange - 100 entries: the first plus 30 more collapsed onto its
-        // timestamp, interleaved with 69 advancing entries (mixed file where
-        // only some messages carry msg_time_stamp)
+        // Arrange - a mixed file where only some messages carried msg_time_stamp
         var quality = new ImportTimestampQuality();
-        quality.Observe(BASE_TICKS);
-        for (var i = 1; i < 70; i++)
+
+        // Act
+        for (var i = 0; i < 70; i++)
         {
-            quality.Observe(BASE_TICKS + i * TICK_STEP);
+            quality.Observe(EntryWithDeviceTimestamp(i));
         }
         for (var i = 0; i < 30; i++)
         {
-            quality.Observe(BASE_TICKS);
+            quality.Observe(EntryWithoutDeviceTimestamp());
         }
 
-        // Assert - 30 of 99 follow-on entries collapsed (~30%)
+        // Assert
         Assert.AreEqual(100, quality.TotalEntries);
-        Assert.AreEqual(31, quality.EntriesAtFirstTimestamp);
+        Assert.AreEqual(30, quality.EntriesWithoutDeviceTimestamp);
+        Assert.AreEqual(0.3, quality.SubstitutedFraction, 1e-12);
         Assert.IsFalse(quality.HasFlatTimeAxis);
         Assert.IsTrue(quality.HasDegenerateTimeAxis);
 
         var warning = quality.BuildUserWarning();
         Assert.IsNotNull(warning);
+        StringAssert.Contains(warning, "30");
         StringAssert.Contains(warning, "%");
     }
 
+    /// <summary>
+    /// A single substituted entry is now reported. The old 20% margin existed to absorb the
+    /// inference's false positives; with an exact per-entry answer, every substituted sample is a
+    /// confirmed hole in the time axis rather than a guess.
+    /// </summary>
     [TestMethod]
-    public void Observe_PartialCollapseBelowThreshold_IsHealthy()
-    {
-        // Arrange - 10 of 99 follow-on entries collapsed (~10%, below the 20% threshold)
-        var quality = new ImportTimestampQuality();
-        quality.Observe(BASE_TICKS);
-        for (var i = 1; i < 90; i++)
-        {
-            quality.Observe(BASE_TICKS + i * TICK_STEP);
-        }
-        for (var i = 0; i < 10; i++)
-        {
-            quality.Observe(BASE_TICKS);
-        }
-
-        // Assert
-        Assert.AreEqual(100, quality.TotalEntries);
-        Assert.IsFalse(quality.HasDegenerateTimeAxis);
-        Assert.IsNull(quality.BuildUserWarning());
-    }
-
-    [TestMethod]
-    public void Observe_CollapseExactlyAtThreshold_IsDegenerate()
-    {
-        // Arrange - 101 entries, 20 of 100 follow-on entries collapsed (exactly 20%)
-        var quality = new ImportTimestampQuality();
-        quality.Observe(BASE_TICKS);
-        for (var i = 1; i <= 80; i++)
-        {
-            quality.Observe(BASE_TICKS + i * TICK_STEP);
-        }
-        for (var i = 0; i < 20; i++)
-        {
-            quality.Observe(BASE_TICKS);
-        }
-
-        // Assert
-        Assert.AreEqual(101, quality.TotalEntries);
-        Assert.AreEqual(0.2, quality.CollapsedFraction, 1e-12);
-        Assert.IsTrue(quality.HasDegenerateTimeAxis);
-    }
-
-    [TestMethod]
-    public void Observe_SingleEntry_IsHealthy()
+    public void Observe_OneSubstitutedEntryAmongMany_IsReported()
     {
         // Arrange
         var quality = new ImportTimestampQuality();
 
         // Act
-        quality.Observe(BASE_TICKS);
+        for (var i = 0; i < 999; i++)
+        {
+            quality.Observe(EntryWithDeviceTimestamp(i));
+        }
+        quality.Observe(EntryWithoutDeviceTimestamp());
 
-        // Assert - one sample has no meaningful time axis either way; no warning
+        // Assert
+        Assert.AreEqual(1000, quality.TotalEntries);
+        Assert.AreEqual(1, quality.EntriesWithoutDeviceTimestamp);
+        Assert.IsTrue(quality.HasDegenerateTimeAxis);
+        Assert.IsFalse(quality.HasFlatTimeAxis);
+
+        var warning = quality.BuildUserWarning();
+        Assert.IsNotNull(warning);
+        StringAssert.Contains(warning, "0.1%",
+            "A sub-1% share must not round to 0% and read as though nothing was substituted.");
+    }
+
+    [TestMethod]
+    public void Observe_SingleEntryWithDeviceTimestamp_IsHealthy()
+    {
+        // Arrange
+        var quality = new ImportTimestampQuality();
+
+        // Act
+        quality.Observe(EntryWithDeviceTimestamp(0));
+
+        // Assert
         Assert.IsFalse(quality.HasFlatTimeAxis);
         Assert.IsFalse(quality.HasDegenerateTimeAxis);
         Assert.IsNull(quality.BuildUserWarning());
+    }
+
+    [TestMethod]
+    public void Observe_SingleSubstitutedEntry_IsFlat()
+    {
+        // Arrange
+        var quality = new ImportTimestampQuality();
+
+        // Act
+        quality.Observe(EntryWithoutDeviceTimestamp());
+
+        // Assert — one sample has no meaningful time axis, and Core told us so outright
+        Assert.IsTrue(quality.HasFlatTimeAxis);
+        Assert.IsTrue(quality.HasDegenerateTimeAxis);
+        Assert.IsNotNull(quality.BuildUserWarning());
     }
 
     [TestMethod]
@@ -147,8 +194,17 @@ public class ImportTimestampQualityTests
 
         // Assert
         Assert.AreEqual(0, quality.TotalEntries);
-        Assert.AreEqual(0.0, quality.CollapsedFraction);
+        Assert.AreEqual(0.0, quality.SubstitutedFraction);
+        Assert.IsFalse(quality.HasFlatTimeAxis, "An empty import has no axis to call flat.");
         Assert.IsFalse(quality.HasDegenerateTimeAxis);
         Assert.IsNull(quality.BuildUserWarning());
+    }
+
+    [TestMethod]
+    public void Observe_NullEntry_Throws()
+    {
+        var quality = new ImportTimestampQuality();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() => quality.Observe(null!));
     }
 }

--- a/Daqifi.Desktop.Test/Loggers/SdCardSessionImporterTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardSessionImporterTests.cs
@@ -72,12 +72,17 @@ public class SdCardSessionImporterTests : IDisposable
     [TestMethod]
     public async Task ImportSessionAsync_CollapsedTimestamps_ImportsAndFlagsDegenerateTimeAxis()
     {
-        // Arrange - the issue #572 shape: every entry shares one timestamp
-        // (messages without msg_time_stamp collapse onto the parser's base time)
+        // Arrange - the issue #572 shape: no entry carries a device timestamp, so Core substitutes
+        // the session base time into all of them. HasDeviceTimestamp is what says so
+        // (daqifi-core#303); sharing a timestamp is the symptom, not the signal — real samples can
+        // legitimately repeat a tick, which is why the old inference needed a tolerance margin.
         var entries = new List<SdCardLogEntry>();
         for (var i = 0; i < 50; i++)
         {
-            entries.Add(new SdCardLogEntry(BaseTime, [1.0 + i, 2.0 + i], 0u, null));
+            entries.Add(new SdCardLogEntry(BaseTime, [1.0 + i, 2.0 + i], 0u, null)
+            {
+                HasDeviceTimestamp = false
+            });
         }
 
         var logSession = new SdCardLogSession("log_20260609_120000.bin", BaseTime, null, AsAsync(entries));

--- a/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
+++ b/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
@@ -22,6 +22,21 @@ namespace Daqifi.Desktop.Loggers;
 /// </remarks>
 public sealed class ImportTimestampQuality
 {
+    #region Constants
+    /// <summary>
+    /// Format for the substituted-sample percentage. Always renders one decimal, so a small
+    /// non-zero share can never collapse to a bare "0".
+    /// </summary>
+    private const string PERCENT_FORMAT = "0.0";
+
+    /// <summary>
+    /// Stands in for a percentage too small to survive <see cref="PERCENT_FORMAT"/>'s precision.
+    /// Substitutions did happen, so rendering "0.0%" would state the opposite of the sentence it
+    /// sits in.
+    /// </summary>
+    private const string BELOW_PERCENT_RESOLUTION = "<0.1";
+    #endregion
+
     #region Public Properties
     /// <summary>
     /// Total number of entries observed.
@@ -90,11 +105,29 @@ public sealed class ImportTimestampQuality
                    "Older device firmware may not record timestamps in SD card logs.";
         }
 
-        var percent = (SubstitutedFraction * 100).ToString("0.#", CultureInfo.InvariantCulture);
+        var percent = FormatSubstitutedPercent();
         var count = EntriesWithoutDeviceTimestamp.ToString("N0", CultureInfo.CurrentCulture);
         return $"{count} of the samples in this file ({percent}%) have no usable timestamp and " +
                "were placed at the session start time, so time spacing for those samples is not " +
                "meaningful. Older device firmware may not record timestamps in SD card logs.";
+    }
+    #endregion
+
+    #region Private Methods
+    /// <summary>
+    /// Renders <see cref="SubstitutedFraction"/> as a percentage that can never read as zero while
+    /// entries were in fact substituted: a rate below the format's resolution (1 in 5,000, say)
+    /// reports as <c>&lt;0.1</c> rather than rounding down to nothing.
+    /// </summary>
+    private string FormatSubstitutedPercent()
+    {
+        // Round first and format the rounded value, so the "did this collapse to zero" test and
+        // the text the user actually reads can never disagree.
+        var percent = Math.Round(SubstitutedFraction * 100, 1, MidpointRounding.AwayFromZero);
+
+        return percent > 0.0
+            ? percent.ToString(PERCENT_FORMAT, CultureInfo.InvariantCulture)
+            : BELOW_PERCENT_RESOLUTION;
     }
     #endregion
 }

--- a/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
+++ b/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Daqifi.Core.Device.SdCard;
 
 namespace Daqifi.Desktop.Loggers;
 
@@ -7,33 +8,20 @@ namespace Daqifi.Desktop.Loggers;
 /// classifies whether the file's time axis could be reconstructed.
 /// </summary>
 /// <remarks>
-/// Core's SD card parsers assign the session base time to any entry whose
-/// message carries no usable timestamp (e.g. <c>msg_time_stamp == 0</c>, or a
-/// CSV row without a timestamp column), so such entries collapse onto one
-/// identical tick. A healthy parse produces strictly advancing timestamps with
-/// only the anchor entry at the base time, which is what makes the collapse
-/// detectable here with O(1) memory: count entries that share the first
-/// entry's tick. See issue #572 for the full background.
+/// Core's SD card parsers assign the session base time to any entry whose message carries no
+/// usable timestamp (e.g. <c>msg_time_stamp == 0</c>, an unknown tick rate, or a CSV row without a
+/// timestamp column) and report that per entry via
+/// <see cref="SdCardLogEntry.HasDeviceTimestamp"/> (daqifi-core#303). Counting those flags is an
+/// exact answer to "how much of this file has a real time axis".
+///
+/// <para>Before Core exposed the flag this had to be inferred: substituted entries all collapse
+/// onto one identical tick, so the old implementation counted entries sharing the first entry's
+/// tick and called the axis degenerate past a 20% margin. That inference had false positives the
+/// margin existed to absorb — the hardware genuinely emits duplicate ticks on occasion, and those
+/// are real samples, not substituted ones. See issue #572 for the original background.</para>
 /// </remarks>
 public sealed class ImportTimestampQuality
 {
-    #region Constants
-    /// <summary>
-    /// Fraction of entries (beyond the first) collapsed onto the first
-    /// timestamp above which the time axis is reported as degenerate. A
-    /// healthy file sits at ~0; a file whose messages all lack timestamps
-    /// sits at 1.0. The margin tolerates occasional firmware stragglers
-    /// without missing mostly-collapsed files.
-    /// </summary>
-    private const double DEGENERATE_COLLAPSED_FRACTION = 0.2;
-    #endregion
-
-    #region Private Fields
-    private long _firstTicks;
-    private long _minTicks = long.MaxValue;
-    private long _maxTicks = long.MinValue;
-    #endregion
-
     #region Public Properties
     /// <summary>
     /// Total number of entries observed.
@@ -41,60 +29,46 @@ public sealed class ImportTimestampQuality
     public long TotalEntries { get; private set; }
 
     /// <summary>
-    /// Number of entries (including the first) whose timestamp equals the
-    /// first entry's timestamp.
+    /// Number of entries Core could not reconstruct a device timestamp for, and substituted the
+    /// session base time into.
     /// </summary>
-    public long EntriesAtFirstTimestamp { get; private set; }
+    public long EntriesWithoutDeviceTimestamp { get; private set; }
 
     /// <summary>
-    /// Fraction of entries beyond the first that collapsed onto the first
-    /// entry's timestamp. Zero for an empty or single-entry import.
+    /// Fraction of entries carrying no device timestamp. Zero for an empty import.
     /// </summary>
-    public double CollapsedFraction => TotalEntries > 1
-        ? (EntriesAtFirstTimestamp - 1) / (double)(TotalEntries - 1)
+    public double SubstitutedFraction => TotalEntries > 0
+        ? EntriesWithoutDeviceTimestamp / (double)TotalEntries
         : 0.0;
 
     /// <summary>
-    /// True when every observed entry shares one identical timestamp.
+    /// True when no entry in the file carried a device timestamp, so every sample sits at the
+    /// session base time and the time axis is entirely flat.
     /// </summary>
-    public bool HasFlatTimeAxis => TotalEntries > 1 && _minTicks == _maxTicks;
+    public bool HasFlatTimeAxis => TotalEntries > 0 && EntriesWithoutDeviceTimestamp == TotalEntries;
 
     /// <summary>
-    /// True when the time axis is unusable for analysis: either fully flat,
-    /// or a meaningful fraction of entries collapsed onto the first timestamp.
+    /// True when any part of the time axis is not real: at least one entry's timestamp was
+    /// substituted rather than reconstructed from the device.
     /// </summary>
-    public bool HasDegenerateTimeAxis =>
-        HasFlatTimeAxis || (TotalEntries > 1 && CollapsedFraction >= DEGENERATE_COLLAPSED_FRACTION);
+    public bool HasDegenerateTimeAxis => EntriesWithoutDeviceTimestamp > 0;
     #endregion
 
     #region Public Methods
     /// <summary>
-    /// Records one parsed entry's timestamp.
+    /// Records one parsed entry.
     /// </summary>
-    /// <param name="timestampTicks">The entry's reconstructed timestamp, in ticks.</param>
-    public void Observe(long timestampTicks)
+    /// <param name="entry">The entry Core produced for this sample.</param>
+    public void Observe(SdCardLogEntry entry)
     {
-        if (TotalEntries == 0)
-        {
-            _firstTicks = timestampTicks;
-        }
-
-        if (timestampTicks == _firstTicks)
-        {
-            EntriesAtFirstTimestamp++;
-        }
-
-        if (timestampTicks < _minTicks)
-        {
-            _minTicks = timestampTicks;
-        }
-
-        if (timestampTicks > _maxTicks)
-        {
-            _maxTicks = timestampTicks;
-        }
+        ArgumentNullException.ThrowIfNull(entry);
 
         TotalEntries++;
+
+        if (!entry.HasDeviceTimestamp)
+        {
+            EntriesWithoutDeviceTimestamp++;
+        }
     }
 
     /// <summary>
@@ -116,9 +90,10 @@ public sealed class ImportTimestampQuality
                    "Older device firmware may not record timestamps in SD card logs.";
         }
 
-        var percent = (CollapsedFraction * 100).ToString("0", CultureInfo.InvariantCulture);
-        return $"About {percent}% of the samples in this file have no usable timestamp and were " +
-               "collapsed onto the session start time, so time spacing for those samples is not " +
+        var percent = (SubstitutedFraction * 100).ToString("0.#", CultureInfo.InvariantCulture);
+        var count = EntriesWithoutDeviceTimestamp.ToString("N0", CultureInfo.CurrentCulture);
+        return $"{count} of the samples in this file ({percent}%) have no usable timestamp and " +
+               "were placed at the session start time, so time spacing for those samples is not " +
                "meaningful. Older device firmware may not record timestamps in SD card logs.";
     }
     #endregion

--- a/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
+++ b/Daqifi.Desktop/Loggers/ImportTimestampQuality.cs
@@ -30,11 +30,17 @@ public sealed class ImportTimestampQuality
     private const string PERCENT_FORMAT = "0.0";
 
     /// <summary>
-    /// Stands in for a percentage too small to survive <see cref="PERCENT_FORMAT"/>'s precision.
-    /// Substitutions did happen, so rendering "0.0%" would state the opposite of the sentence it
-    /// sits in.
+    /// Decimal places <see cref="PERCENT_FORMAT"/> shows. Rounding uses the same count, so the
+    /// value tested for zero is the value the user ends up reading.
     /// </summary>
-    private const string BELOW_PERCENT_RESOLUTION = "<0.1";
+    private const int PERCENT_DECIMALS = 1;
+
+    /// <summary>
+    /// Smallest share <see cref="PERCENT_FORMAT"/> can express. A non-zero count landing below it
+    /// reports as "less than this": rendering "0.0%" would state the opposite of the count sitting
+    /// in the same sentence.
+    /// </summary>
+    private const double SMALLEST_SHOWN_PERCENT = 0.1;
     #endregion
 
     #region Public Properties
@@ -121,13 +127,17 @@ public sealed class ImportTimestampQuality
     /// </summary>
     private string FormatSubstitutedPercent()
     {
+        // The sample count beside it is formatted for the user's locale, so the percentage is too.
+        // One sentence carrying two decimal conventions reads as a formatting bug.
+        var culture = CultureInfo.CurrentCulture;
+
         // Round first and format the rounded value, so the "did this collapse to zero" test and
         // the text the user actually reads can never disagree.
-        var percent = Math.Round(SubstitutedFraction * 100, 1, MidpointRounding.AwayFromZero);
+        var percent = Math.Round(SubstitutedFraction * 100, PERCENT_DECIMALS, MidpointRounding.AwayFromZero);
 
         return percent > 0.0
-            ? percent.ToString(PERCENT_FORMAT, CultureInfo.InvariantCulture)
-            : BELOW_PERCENT_RESOLUTION;
+            ? percent.ToString(PERCENT_FORMAT, culture)
+            : $"<{SMALLEST_SHOWN_PERCENT.ToString(PERCENT_FORMAT, culture)}";
     }
     #endregion
 }

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -324,7 +324,7 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             }
 
             sampleIndex++;
-            timestampQuality.Observe(entry.Timestamp.Ticks);
+            timestampQuality.Observe(entry);
 
             // If we didn't have config, discover channel count from first entry
             if (analogPortCount == 0 && entry.AnalogValues.Count > 0)
@@ -401,8 +401,9 @@ public class SdCardSessionImporter : ISdCardSessionImporter
         {
             _logger.Warning(
                 $"Imported session '{session.Name}' (ID={session.ID}) has a degenerate time axis: " +
-                $"{timestampQuality.EntriesAtFirstTimestamp:N0} of {timestampQuality.TotalEntries:N0} " +
-                "entries share the first timestamp. The source file likely lacks per-sample timestamps.");
+                $"{timestampQuality.EntriesWithoutDeviceTimestamp:N0} of {timestampQuality.TotalEntries:N0} " +
+                "entries carried no device timestamp and were placed at the session base time. " +
+                "The source file likely lacks per-sample timestamps.");
         }
 
         // Record the sample count on the session so the list view can show it


### PR DESCRIPTION
Row 4 of the [#708](https://github.com/daqifi/daqifi-desktop/issues/708) deletion backlog. daqifi-core#303 shipped in Core **1.2.0**; we're on **1.3.0**.

Core now reports per entry whether a timestamp was reconstructed from a real device tick (`SdCardLogEntry.HasDeviceTimestamp`) or substituted from the session base time. The desktop was inferring that: counting entries whose timestamp equalled the first entry's, and calling the axis degenerate past a 20% margin.

**Titled `fix:` rather than `chore:`** — #708 lists it as a deletion, but the inference was wrong in both directions and this changes what users see.

## Why the inference was wrong

The margin existed to absorb the inference's own error. **The hardware genuinely emits duplicate ticks** — a known bench behavior — and those are *real samples*. A file with enough legitimately repeated timestamps got warned about; the margin traded that against silently missing partially-substituted files below 20%. With an exact per-entry answer, both errors disappear and there is nothing left for a threshold to absorb.

## User-visible changes

- A file whose device timestamps merely repeat is **no longer warned about at all**.
- Substitution is reported **whenever it occurs**, not above 20%. Every substituted sample is now a confirmed hole in the time axis rather than a guess.
- The partial message leads with the exact count — "1,234 of the samples in this file (2.5%)" — instead of "About 30%", and formats to one decimal so a sub-1% share no longer renders as "About 0%".

⚠️ **One judgment call for you.** Dropping to zero-tolerance is what the exact signal justifies, but it's a product decision I made rather than found. If firmware emits occasional zero-timestamp frames often enough that this gets noisy on real cards, reintroducing a threshold is a one-line change to `HasDegenerateTimeAxis`. Happy to put it back if your bench data says so — I just didn't want to carry a margin whose only justification was measurement error that no longer exists.

## API changes

`CollapsedFraction` → `SubstitutedFraction`, `EntriesAtFirstTimestamp` → `EntriesWithoutDeviceTimestamp`, and `Observe` takes the entry rather than its ticks. `DEGENERATE_COLLAPSED_FRACTION` and the min/max tick bookkeeping are deleted.

## Testing

`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → **770/770 pass**.

The threshold cases are gone — there's nothing left to threshold. Added the case the old inference got wrong: 100 entries sharing one tick, all flagged as real device timestamps, now correctly healthy. That test would have failed before this change. Also added a single-substituted-entry-in-1000 case asserting the percentage doesn't round to `0%`.

The importer's collapsed-timestamp test now sets `HasDeviceTimestamp = false` to state the condition it models, rather than relying on duplicate ticks to imply it.

Independent of #783/#784/#785/#786/#787.

Refs #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
