### PR TITLE
fix(tests): stop the exporter tests flaking on load and concurrent runs

### DIFF
--- a/Daqifi.Desktop.Test/Exporter/ExportPerformanceTests.cs
+++ b/Daqifi.Desktop.Test/Exporter/ExportPerformanceTests.cs
@@ -167,10 +167,16 @@ results.MemoryMB, $"Large dataset used {results.MemoryMB}MB - memory usage too h
         Assert.IsFalse(cts.IsCancellationRequested,
             "Export was cancelled by the 90s watchdog — indicates a stall regression (issue #18).");
 
-        // Should complete well under a minute — the original failure was the export appearing
-        // to give up after ~60s. The unconditional stall guards are the 90s watchdog above and
-        // the [Timeout] on the method; this 30s budget is the finer-grained signal and is
-        // reported rather than enforced so machine load cannot fail the run.
+        // The original failure was the export appearing to give up after ~60s, so the stall guard
+        // has to bite below that: the 90s watchdog and the 120s [Timeout] only catch a true hang,
+        // and a 60s export is the regression itself, not a hang. This export measures ~2s, so a
+        // 45s ceiling is ~25x headroom — unreachable by machine load, and still well under the
+        // failure it guards.
+        Assert.IsLessThan(45_000, stopwatch.ElapsedMilliseconds,
+            $"Export took {stopwatch.ElapsedMilliseconds}ms — regression in streaming export path (issue #18).");
+
+        // Finer-grained signal on top of that ceiling: reported every run, enforced only under
+        // DAQIFI_ENFORCE_PERF_ASSERTIONS, so a merely-slow machine reports without failing.
         PerformanceBudget.ExpectElapsedUnder(30_000, stopwatch.ElapsedMilliseconds,
             "Issue #18 DB-path export (100K samples)");
 

--- a/Daqifi.Desktop.Test/Exporter/ExportPerformanceTests.cs
+++ b/Daqifi.Desktop.Test/Exporter/ExportPerformanceTests.cs
@@ -1,21 +1,31 @@
 using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Exporter;
 using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Test.TestSupport;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
 using System.Globalization;
 
 namespace Daqifi.Desktop.Test.Exporter;
 
+/// <summary>
+/// Export performance characterisation. Timing budgets here run through
+/// <see cref="PerformanceBudget"/>: they are reported on every run but only fail the build when
+/// <c>DAQIFI_ENFORCE_PERF_ASSERTIONS=1</c>, because wall-clock numbers track machine load rather
+/// than the exporter. Output correctness, row counts, memory ceilings and the hang guards are
+/// asserted unconditionally.
+/// </summary>
 [TestClass]
 public class ExportPerformanceTests
 {
-    private static readonly string TestDirectoryPath = Path.Combine(Path.GetTempPath(), "DAQiFi", "PerformanceTests");
+    private TempTestDirectory _testDirectory = null!;
+
+    private string TestDirectoryPath => _testDirectory.FullPath;
 
     [TestInitialize]
     public void Initialize()
     {
-        Directory.CreateDirectory(TestDirectoryPath);
+        _testDirectory = new TempTestDirectory("export-perf");
     }
 
     [TestMethod]
@@ -28,7 +38,7 @@ public class ExportPerformanceTests
         Console.WriteLine($"Small Dataset (400 samples): {results.ElapsedMs}ms, {results.MemoryMB}MB");
 
         // Baseline assertions - should pass easily
-        Assert.IsLessThan(1000, results.ElapsedMs, "Small dataset should export in under 1 second");
+        PerformanceBudget.ExpectElapsedUnder(1000, results.ElapsedMs, "Small dataset (400 samples) export");
         Assert.IsLessThan(10, results.MemoryMB, "Small dataset should use under 10MB memory");
     }
 
@@ -42,9 +52,7 @@ public class ExportPerformanceTests
         Console.WriteLine($"Medium Dataset (16K samples): {results.ElapsedMs}ms, {results.MemoryMB}MB");
         Console.WriteLine($"Samples per second: {16000.0 / results.ElapsedMs * 1000:F0}");
 
-        // These will likely fail with current implementation, demonstrating performance issues
-        Assert.IsLessThan(5000,
-results.ElapsedMs, $"Medium dataset took {results.ElapsedMs}ms - should be under 5 seconds");
+        PerformanceBudget.ExpectElapsedUnder(5000, results.ElapsedMs, "Medium dataset (16K samples) export");
         Assert.IsLessThan(50,
 results.MemoryMB, $"Medium dataset used {results.MemoryMB}MB - should be under 50MB");
     }
@@ -61,16 +69,13 @@ results.MemoryMB, $"Medium dataset used {results.MemoryMB}MB - should be under 5
         Console.WriteLine($"Samples per second: {80000.0 / results.ElapsedMs * 1000:F0}");
         Console.WriteLine($"Projected time for 51.8M samples: {results.ElapsedMs * (51800000.0 / 80000) / 1000 / 60:F1} minutes");
 
-        // These assertions will fail with current implementation, proving the performance problem
-        Assert.IsLessThan(10000,
-results.ElapsedMs, $"Large dataset took {results.ElapsedMs}ms - performance issues detected");
+        PerformanceBudget.ExpectElapsedUnder(10000, results.ElapsedMs, "Large dataset (80K samples) export");
         Assert.IsLessThan(100,
 results.MemoryMB, $"Large dataset used {results.MemoryMB}MB - memory usage too high");
 
         // Target performance: should process at least 50K samples/second
         var samplesPerSecond = 80000.0 / results.ElapsedMs * 1000;
-        Assert.IsGreaterThan(50000,
-samplesPerSecond, $"Processing rate {samplesPerSecond:F0} samples/second is too slow");
+        PerformanceBudget.ExpectThroughputOver(50000, samplesPerSecond, "Large dataset (80K samples) throughput");
     }
 
     [TestMethod]
@@ -162,10 +167,12 @@ samplesPerSecond, $"Processing rate {samplesPerSecond:F0} samples/second is too 
         Assert.IsFalse(cts.IsCancellationRequested,
             "Export was cancelled by the 90s watchdog — indicates a stall regression (issue #18).");
 
-        // Must complete well under a minute — the original failure was the export appearing
-        // to give up after ~60s. 30s gives plenty of headroom on slow CI.
-        Assert.IsLessThan(30_000, stopwatch.ElapsedMilliseconds,
-            $"Export took {stopwatch.ElapsedMilliseconds}ms — regression in streaming export path (issue #18).");
+        // Should complete well under a minute — the original failure was the export appearing
+        // to give up after ~60s. The unconditional stall guards are the 90s watchdog above and
+        // the [Timeout] on the method; this 30s budget is the finer-grained signal and is
+        // reported rather than enforced so machine load cannot fail the run.
+        PerformanceBudget.ExpectElapsedUnder(30_000, stopwatch.ElapsedMilliseconds,
+            "Issue #18 DB-path export (100K samples)");
 
         // Streaming export should keep memory roughly flat regardless of sample count.
         Assert.IsLessThan(200, memoryUsedMb,
@@ -290,11 +297,8 @@ samplesPerSecond, $"Processing rate {samplesPerSecond:F0} samples/second is too 
         Assert.IsGreaterThan(1, lines.Length, "Export should contain header and data rows");
 
         // Performance targets for production deployment
-        if (stopwatch.ElapsedMilliseconds > 10) // Only check if measurable
-        {
-            Assert.IsGreaterThan(50000,
-samplesPerSecond, $"Production optimized exporter should process >50K samples/second. Actual: {samplesPerSecond:F0}");
-        }
+        PerformanceBudget.ExpectThroughputOver(50000, samplesPerSecond,
+            "Production optimized exporter (48K samples) throughput");
 
         // Memory should be reasonable for this dataset size
         Assert.IsLessThan(100,
@@ -329,7 +333,7 @@ memoryUsed, $"Production optimized exporter should use <100MB for 48K samples. A
         return samples;
     }
 
-    private static (long ElapsedMs, long MemoryMB) MeasureExportPerformance(List<DataSample> samples, string testName)
+    private (long ElapsedMs, long MemoryMB) MeasureExportPerformance(List<DataSample> samples, string testName)
     {
         var exportFilePath = Path.Combine(TestDirectoryPath, $"{testName}_export.csv");
 
@@ -362,9 +366,6 @@ memoryUsed, $"Production optimized exporter should use <100MB for 48K samples. A
     [TestCleanup]
     public void CleanUp()
     {
-        if (Directory.Exists(TestDirectoryPath))
-        {
-            Directory.Delete(TestDirectoryPath, true);
-        }
+        _testDirectory?.Delete();
     }
 }

--- a/Daqifi.Desktop.Test/Exporter/LoggingSessionExporterTests.cs
+++ b/Daqifi.Desktop.Test/Exporter/LoggingSessionExporterTests.cs
@@ -1,6 +1,7 @@
 using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Exporter;
 using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Test.TestSupport;
 using System.Diagnostics;
 
 namespace Daqifi.Desktop.Test.Exporter;
@@ -8,18 +9,20 @@ namespace Daqifi.Desktop.Test.Exporter;
 [TestClass]
 public class OptimizedLoggingSessionExporterTests
 {
-    private const string ExportFileName = "testExportFile.csv";
-    private static readonly string TestDirectoryPath = Path.Combine(Path.GetTempPath(), "DAQiFi", "Tests");
+    private const string EXPORT_FILE_NAME = "testExportFile.csv";
 
     private readonly DateTime _firstTime = new(2018, 2, 9, 1, 3, 30);
     private readonly DateTime _secondTime = new(2018, 2, 9, 1, 3, 31);
 
+    private TempTestDirectory _testDirectory = null!;
     private List<DataSample> _dataSamples = null!;
+
+    private string TestDirectoryPath => _testDirectory.FullPath;
 
     [TestInitialize]
     public void Initialize()
     {
-        Directory.CreateDirectory(TestDirectoryPath);
+        _testDirectory = new TempTestDirectory("exporter");
 
         _dataSamples =
         [
@@ -66,7 +69,7 @@ public class OptimizedLoggingSessionExporterTests
         };
 
         var exporter = new OptimizedLoggingSessionExporter();
-        var exportFilePath = Path.Combine(TestDirectoryPath, ExportFileName);
+        var exportFilePath = Path.Combine(TestDirectoryPath, EXPORT_FILE_NAME);
         var progress = new Progress<int>();
 
         exporter.ExportLoggingSession(loggingSession, exportFilePath, false, progress, 0, 0, CancellationToken.None);
@@ -93,7 +96,7 @@ public class OptimizedLoggingSessionExporterTests
 
 
         var exporter = new OptimizedLoggingSessionExporter();
-        var exportFilePath = Path.Combine(TestDirectoryPath, ExportFileName);
+        var exportFilePath = Path.Combine(TestDirectoryPath, EXPORT_FILE_NAME);
         var progress = new Progress<int>();
 
         exporter.ExportLoggingSession(loggingSession, exportFilePath, false, progress, 0, 0, CancellationToken.None);
@@ -116,7 +119,7 @@ public class OptimizedLoggingSessionExporterTests
         };
 
         var exporter = new OptimizedLoggingSessionExporter();
-        var exportFilePath = Path.Combine(TestDirectoryPath, ExportFileName);
+        var exportFilePath = Path.Combine(TestDirectoryPath, EXPORT_FILE_NAME);
         var progress = new Progress<int>();
 
         exporter.ExportLoggingSession(loggingSession, exportFilePath, false, progress, 0, 0, CancellationToken.None);
@@ -134,7 +137,7 @@ public class OptimizedLoggingSessionExporterTests
         };
 
         var exporter = new OptimizedLoggingSessionExporter();
-        var exportFilePath = Path.Combine(TestDirectoryPath, "relative_" + ExportFileName);
+        var exportFilePath = Path.Combine(TestDirectoryPath, "relative_" + EXPORT_FILE_NAME);
         var progress = new Progress<int>();
 
         exporter.ExportLoggingSession(loggingSession, exportFilePath, true, progress, 0, 0, CancellationToken.None);
@@ -161,7 +164,7 @@ public class OptimizedLoggingSessionExporterTests
         };
 
         var exporter = new OptimizedLoggingSessionExporter();
-        var exportFilePath = Path.Combine(TestDirectoryPath, "large_" + ExportFileName);
+        var exportFilePath = Path.Combine(TestDirectoryPath, "large_" + EXPORT_FILE_NAME);
         var progress = new Progress<int>();
 
         exporter.ExportLoggingSession(loggingSession, exportFilePath, false, progress, 0, 0, CancellationToken.None);
@@ -193,7 +196,7 @@ public class OptimizedLoggingSessionExporterTests
         };
 
         var exporter = new OptimizedLoggingSessionExporter();
-        var exportFilePath = Path.Combine(TestDirectoryPath, "performance_" + ExportFileName);
+        var exportFilePath = Path.Combine(TestDirectoryPath, "performance_" + EXPORT_FILE_NAME);
         var progress = new Progress<int>();
 
         // Measure execution time and memory
@@ -244,7 +247,7 @@ public class OptimizedLoggingSessionExporterTests
         };
 
         var exporter = new OptimizedLoggingSessionExporter();
-        var exportFilePath = Path.Combine(TestDirectoryPath, "multidevice_" + ExportFileName);
+        var exportFilePath = Path.Combine(TestDirectoryPath, "multidevice_" + EXPORT_FILE_NAME);
         var progress = new Progress<int>();
 
         exporter.ExportLoggingSession(loggingSession, exportFilePath, false, progress, 0, 0, CancellationToken.None);
@@ -290,22 +293,8 @@ public class OptimizedLoggingSessionExporterTests
     [TestCleanup]
     public void CleanUp()
     {
-        var testFiles = new[]
-        {
-            ExportFileName,
-            "relative_" + ExportFileName,
-            "large_" + ExportFileName,
-            "performance_" + ExportFileName,
-            "multidevice_" + ExportFileName
-        };
-
-        foreach (var fileName in testFiles)
-        {
-            var exportFilePath = Path.Combine(TestDirectoryPath, fileName);
-            if (File.Exists(exportFilePath))
-            {
-                File.Delete(exportFilePath);
-            }
-        }
+        // Deleting the whole per-run directory also covers files a future test adds, and cannot
+        // throw into an otherwise-passing test the way the old enumerate-and-delete did.
+        _testDirectory?.Delete();
     }
 }

--- a/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
+++ b/Daqifi.Desktop.Test/Exporter/OptimizedExporterValidationTests.cs
@@ -1,6 +1,7 @@
 using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Exporter;
 using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Test.TestSupport;
 using System.Diagnostics;
 
 namespace Daqifi.Desktop.Test.Exporter;
@@ -8,12 +9,14 @@ namespace Daqifi.Desktop.Test.Exporter;
 [TestClass]
 public class OptimizedExporterValidationTests
 {
-    private static readonly string TestDirectoryPath = Path.Combine(Path.GetTempPath(), "DAQiFi", "OptimizedTests");
+    private TempTestDirectory _testDirectory = null!;
+
+    private string TestDirectoryPath => _testDirectory.FullPath;
 
     [TestInitialize]
     public void Initialize()
     {
-        Directory.CreateDirectory(TestDirectoryPath);
+        _testDirectory = new TempTestDirectory("exporter-validation");
     }
 
     [TestMethod]
@@ -78,9 +81,9 @@ public class OptimizedExporterValidationTests
 
         Console.WriteLine($"Large dataset export took: {stopwatch.ElapsedMilliseconds}ms");
 
-        // Should be reasonably fast for this size
-        Assert.IsLessThan(5000,
-stopwatch.ElapsedMilliseconds, $"Large dataset export should complete in under 5 seconds. Actual: {stopwatch.ElapsedMilliseconds}ms");
+        // Should be reasonably fast for this size — reported, not enforced (see PerformanceBudget).
+        PerformanceBudget.ExpectElapsedUnder(5000, stopwatch.ElapsedMilliseconds,
+            "Validation large dataset (16K samples) export");
     }
 
     [TestMethod]
@@ -232,9 +235,6 @@ stopwatch.ElapsedMilliseconds, $"Large dataset export should complete in under 5
     [TestCleanup]
     public void CleanUp()
     {
-        if (Directory.Exists(TestDirectoryPath))
-        {
-            Directory.Delete(TestDirectoryPath, true);
-        }
+        _testDirectory?.Delete();
     }
 }

--- a/Daqifi.Desktop.Test/TestSupport/PerformanceBudget.cs
+++ b/Daqifi.Desktop.Test/TestSupport/PerformanceBudget.cs
@@ -1,0 +1,77 @@
+namespace Daqifi.Desktop.Test.TestSupport;
+
+/// <summary>
+/// Reports wall-clock performance budgets, and enforces them only when explicitly opted into.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Elapsed time and throughput measure the machine, not the code under test. A concurrent build or
+/// test run in another worktree is enough to push the exporter below a "&gt;50K samples/second"
+/// floor with nothing about the exporter changed — the assertion then fails, passes on re-run, and
+/// teaches everyone to ignore it. That is worse than no assertion at all.
+/// </para>
+/// <para>
+/// So timing budgets are reported by default and never fail the build. Set
+/// <c>DAQIFI_ENFORCE_PERF_ASSERTIONS=1</c> to turn them back into hard failures when benchmarking
+/// deliberately on an otherwise idle machine.
+/// </para>
+/// <para>
+/// This applies to timing only. Load-independent assertions — output correctness, row counts, peak
+/// memory, and the hard <c>[Timeout]</c>/<c>CancellationTokenSource</c> hang guards — stay
+/// unconditional, and remain the real regression signal.
+/// </para>
+/// </remarks>
+internal static class PerformanceBudget
+{
+    #region Constants
+    private const string ENFORCE_VARIABLE = "DAQIFI_ENFORCE_PERF_ASSERTIONS";
+    #endregion
+
+    #region Properties
+    /// <summary>Whether exceeded budgets fail the test rather than just being reported.</summary>
+    public static bool IsEnforced { get; } =
+        Environment.GetEnvironmentVariable(ENFORCE_VARIABLE) is "1" or "true" or "TRUE" or "yes" or "YES";
+    #endregion
+
+    #region Public Methods
+    /// <summary>
+    /// Records that an operation completed in <paramref name="elapsedMs"/> against a budget of
+    /// <paramref name="budgetMs"/> milliseconds.
+    /// </summary>
+    public static void ExpectElapsedUnder(long budgetMs, long elapsedMs, string label)
+    {
+        Report(elapsedMs <= budgetMs, $"{label}: took {elapsedMs}ms, budget {budgetMs}ms");
+    }
+
+    /// <summary>
+    /// Records that an operation sustained <paramref name="samplesPerSecond"/> against a floor of
+    /// <paramref name="minSamplesPerSecond"/>.
+    /// </summary>
+    public static void ExpectThroughputOver(double minSamplesPerSecond, double samplesPerSecond, string label)
+    {
+        Report(
+            samplesPerSecond >= minSamplesPerSecond,
+            FormattableString.Invariant(
+                $"{label}: {samplesPerSecond:F0} samples/second, floor {minSamplesPerSecond:F0} samples/second"));
+    }
+    #endregion
+
+    #region Private Methods
+    private static void Report(bool withinBudget, string message)
+    {
+        if (withinBudget)
+        {
+            Console.WriteLine($"[perf] OK — {message}");
+            return;
+        }
+
+        if (IsEnforced)
+        {
+            Assert.Fail($"[perf] BUDGET EXCEEDED — {message}");
+        }
+
+        Console.WriteLine(
+            $"[perf] BUDGET EXCEEDED — {message} (not enforced; set {ENFORCE_VARIABLE}=1 to fail on this)");
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.Test/TestSupport/TempTestDirectory.cs
+++ b/Daqifi.Desktop.Test/TestSupport/TempTestDirectory.cs
@@ -69,7 +69,11 @@ internal sealed class TempTestDirectory
             {
                 if (attempt == DELETE_ATTEMPTS)
                 {
-                    Console.WriteLine($"Could not delete temp test directory '{FullPath}': {ex.Message}");
+                    // Swallowed so cleanup cannot fail an otherwise-passing test, but reported in
+                    // full — type and stack included — because a leftover directory here means a
+                    // handle the test failed to close, and ex.Message alone won't say which.
+                    Console.WriteLine(
+                        $"Could not delete temp test directory '{FullPath}' after {DELETE_ATTEMPTS} attempts: {ex}");
                     return;
                 }
 

--- a/Daqifi.Desktop.Test/TestSupport/TempTestDirectory.cs
+++ b/Daqifi.Desktop.Test/TestSupport/TempTestDirectory.cs
@@ -1,0 +1,81 @@
+namespace Daqifi.Desktop.Test.TestSupport;
+
+/// <summary>
+/// A temp directory unique to a single test-method invocation, removed best-effort by
+/// <see cref="Delete"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Several test classes used to share a fixed path under <c>%TEMP%\DAQiFi\...</c> with fixed file
+/// names inside it. Two runs on the same machine — a second git worktree, a local run alongside
+/// CI — then wrote the same files and deleted each other's output, so whichever run lost the race
+/// failed with "The process cannot access the file ... because it is being used by another
+/// process". Because the collision happens in shared <c>[TestInitialize]</c>/<c>[TestCleanup]</c>
+/// code, it also took down unrelated tests in the same class. A per-invocation GUID directory
+/// removes the collision instead of narrowing the window.
+/// </para>
+/// <para>
+/// Deliberately not <see cref="IDisposable"/>: the lifetime is owned by MSTest's
+/// <c>[TestInitialize]</c>/<c>[TestCleanup]</c> pair rather than a <c>using</c> scope, and modelling
+/// it as disposable only makes every test class holding one trip CA1001.
+/// </para>
+/// </remarks>
+internal sealed class TempTestDirectory
+{
+    #region Constants
+    private const int DELETE_ATTEMPTS = 3;
+    private const int DELETE_RETRY_DELAY_MS = 50;
+    #endregion
+
+    #region Constructor
+    /// <summary>
+    /// Creates the directory. <paramref name="prefix"/> only makes leftovers easier to attribute;
+    /// uniqueness comes from the GUID.
+    /// </summary>
+    public TempTestDirectory(string prefix)
+    {
+        FullPath = Path.Combine(Path.GetTempPath(), $"daqifi-{prefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(FullPath);
+    }
+    #endregion
+
+    #region Properties
+    /// <summary>Absolute path of the directory. It exists for the lifetime of this instance.</summary>
+    public string FullPath { get; }
+    #endregion
+
+    #region Public Methods
+    /// <summary>Builds a path to <paramref name="fileName"/> inside this directory.</summary>
+    public string GetFilePath(string fileName) => Path.Combine(FullPath, fileName);
+
+    /// <summary>
+    /// Deletes the directory and everything under it. Cleanup must never fail a test that already
+    /// passed, so a handle still held open (an antivirus scan, a lagging <see cref="FileStream"/>
+    /// finalizer) is retried briefly and then reported to the test output rather than thrown.
+    /// </summary>
+    public void Delete()
+    {
+        for (var attempt = 1; attempt <= DELETE_ATTEMPTS; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(FullPath))
+                {
+                    Directory.Delete(FullPath, recursive: true);
+                }
+                return;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                if (attempt == DELETE_ATTEMPTS)
+                {
+                    Console.WriteLine($"Could not delete temp test directory '{FullPath}': {ex.Message}");
+                    return;
+                }
+
+                Thread.Sleep(DELETE_RETRY_DELAY_MS);
+            }
+        }
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ExportDialogViewModelTests.cs
@@ -1,5 +1,6 @@
 using Daqifi.Desktop.Channel;
 using Daqifi.Desktop.Logger;
+using Daqifi.Desktop.Test.TestSupport;
 using Daqifi.Desktop.ViewModels;
 using Microsoft.EntityFrameworkCore;
 using Moq;
@@ -14,25 +15,17 @@ namespace Daqifi.Desktop.Test.ViewModels;
 [TestClass]
 public class ExportDialogViewModelTests
 {
-    private static readonly string TestDirectoryPath =
-        Path.Combine(Path.GetTempPath(), "DAQiFi", "ExportDialogViewModelTests");
+    private TempTestDirectory _testDirectory = null!;
+
+    private string TestDirectoryPath => _testDirectory.FullPath;
 
     [TestInitialize]
-    public void Setup() => Directory.CreateDirectory(TestDirectoryPath);
+    public void Setup() => _testDirectory = new TempTestDirectory("export-dialog-vm");
 
+    // Removes exported CSVs / temp DBs so repeated runs don't accumulate files under %TEMP%.
+    // The directory is unique per test invocation, so this can never delete another run's files.
     [TestCleanup]
-    public void Cleanup()
-    {
-        // Remove exported CSVs / temp DBs so repeated runs don't accumulate files under %TEMP%.
-        try
-        {
-            if (Directory.Exists(TestDirectoryPath)) { Directory.Delete(TestDirectoryPath, recursive: true); }
-        }
-        catch
-        {
-            // Best-effort cleanup.
-        }
-    }
+    public void Cleanup() => _testDirectory?.Delete();
 
     private static ExportDialogViewModel CreateViewModel(IDbContextFactory<LoggingContext> factory = null!)
         => new(factory ?? new Mock<IDbContextFactory<LoggingContext>>().Object, sessionId: 1);


### PR DESCRIPTION
Two independent flake sources in the exporter tests. Both were observed failing during an unrelated PR's verification run and then passing on re-run with no code change.

## 1. Wall-clock throughput floors

`ExportPerformanceTests` asserted `Assert.IsGreaterThan(50000, samplesPerSecond, ...)`. That measures the machine, not the exporter — a concurrent build or test run in another worktree is enough to fail it, and an assertion that fails for reasons unrelated to the code just teaches everyone to re-run and ignore it.

Timing budgets now go through a new `PerformanceBudget` helper. They are **reported on every run** and only **fail the build when `DAQIFI_ENFORCE_PERF_ASSERTIONS=1`**, so the benchmark is still runnable deliberately on an idle machine:

```
[perf] OK — Production optimized exporter (48K samples) throughput: 188235 samples/second, floor 50000 samples/second
```

```bash
DAQIFI_ENFORCE_PERF_ASSERTIONS=1 dotnet test Daqifi.Desktop.Test --filter "FullyQualifiedName~Daqifi.Desktop.Test.Exporter" -tl:on
```

The load-independent assertions stay unconditional and remain the real regression signal: output correctness, row counts, memory ceilings, and the issue #18 stall guards. The memory ceiling in particular is what distinguishes the optimized exporter from the >32GB original.

The issue #18 regression test keeps a hard 45s ceiling on top of its 90s `CancellationTokenSource` watchdog and 120s `[Timeout]` — the original bug was the export appearing to give up around 60s, which is a regression rather than a hang, so the watchdogs alone would not catch it. That export measures 1817ms for 100K samples, so 45s is ~25x headroom: unreachable by machine load, well below the failure it guards. Its 30s budget remains as the finer-grained reported signal on top. (Thanks to Qodo for catching that I had gated this one — it was not the assertion that flaked.)

## 2. Fixed shared temp paths

Four test classes wrote fixed file names into a fixed directory under `%TEMP%\DAQiFi\` and deleted that directory recursively in `[TestCleanup]`. Two runs on the same machine collided, and because the collision lands in shared setup/teardown it took down unrelated tests in the same class.

Each test invocation now gets its own `%TEMP%\daqifi-<prefix>-<guid>` directory via a new `TempTestDirectory` helper, matching what `SessionDataRepositoryTests`, `DaqifiViewModelFirmwareUpdateTests` and others already do. Its delete retries briefly and then reports to test output rather than throwing into an otherwise-passing test.

## Verification

`dotnet build -tl:on` clean, `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests" -tl:on` → **768/768 passing**.

The collision was reproduced directly by running the exporter tests concurrently with themselves.

**Before the change — both runs failed on the first attempt:**

| Run | Failure |
|---|---|
| A | `OptimizedExporter_LargeDataset_MeetsPerformanceTargets` — `TestCleanup ... threw exception. System.IO.IOException: The process cannot access the file 'issue18_db_export.csv' because it is being used by another process.` (the reported symptom, cascading into an unrelated test through the shared cleanup) |
| B | `Export_OnSuccess_ShowsCompleteResultAndWritesFile` — export reported failure because the other run's recursive delete removed the file mid-export |

**After the change:** both concurrent runs pass 32/32.

The `PerformanceBudget` gate was checked in both directions by temporarily setting an unreachable budget: unset → test passes with the overage reported; `=1` → test fails. So the budgets are still live, not silently disabled.

## Scope note

The two classes beyond the reported pair — `OptimizedExporterValidationTests` and `ExportDialogViewModelTests` — are included because they carry the identical defect. `ExportDialogViewModelTests` is what failed in concurrent run B above, so leaving it out would have left the suite flaky against the exact scenario this PR is meant to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
