### PR TITLE
fix(firmware): treat a WiFi post-flash reconnect timeout as installed, not failed (#776)

### DIFF
--- a/Daqifi.Desktop.Test/Device/Firmware/FirmwareFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/FirmwareFailureClassifierTests.cs
@@ -17,10 +17,14 @@ namespace Daqifi.Desktop.Test.Device.Firmware;
 public class FirmwareFailureClassifierTests
 {
     #region Constants
+    // See daqifi-core#398 (gap 4) — the upstream ask to replace these unversioned progress strings
+    // with a real discriminator. Until that lands, this is the ONE place to re-check on a Core bump.
+
     /// <summary>
     /// The <c>Operation</c> Core attaches to a PIC32 CRC-verify failure, verified against
     /// Daqifi.Core v1.3.0 (<c>src/Daqifi.Core/Firmware/FirmwareUpdateService.cs</c>, the
     /// <c>TransitionToState(Verifying, ...)</c> immediately before the CRC-verify step).
+    /// See daqifi-core#398 (gap 4).
     /// </summary>
     private const string CORE_PIC32_CRC_VERIFY_OPERATION = "Verifying flash contents via CRC.";
 
@@ -34,6 +38,7 @@ public class FirmwareFailureClassifierTests
     /// <see cref="TimeoutException"/>'s message. <c>FirmwareUpdateException.Operation</c> is
     /// assigned solely from <c>TransitionToState</c>. Recorded here so a Core bump has one obvious
     /// place to re-check — production code deliberately does not match on either string.
+    /// See daqifi-core#398 (gap 4).
     /// </para>
     /// </summary>
     private const string CORE_WIFI_RECONNECT_OPERATION = "Reconnecting device and restoring LAN configuration.";
@@ -93,13 +98,31 @@ public class FirmwareFailureClassifierTests
     [DataRow(FirmwareUpdateState.Failed)]
     [DataRow(FirmwareUpdateState.CleaningUp)]
     [DataRow(FirmwareUpdateState.Recovered)]
-    public void IsPostFlashReconnectTimeout_GenuineFailureStates_AreNotDowngraded(FirmwareUpdateState failedState)
+    public void IsPostFlashReconnectTimeout_Pic32GenuineFailureStates_AreNotDowngraded(
+        FirmwareUpdateState failedState)
     {
-        // Every state that is not a post-flash reconnect keeps the Error/Sentry path on BOTH phases.
+        // Every PIC32 state that is not the JumpingToApp reconnect keeps the Error/Sentry path.
         var exception = new FirmwareUpdateException(failedState, "some operation", "Failure.");
 
         Assert.IsFalse(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
             exception, FirmwareFlashPhase.Pic32));
+    }
+
+    [TestMethod]
+    [DataRow(FirmwareUpdateState.PreparingDevice)]
+    [DataRow(FirmwareUpdateState.WaitingForBootloader)]
+    [DataRow(FirmwareUpdateState.Connecting)]
+    [DataRow(FirmwareUpdateState.ErasingFlash)]
+    [DataRow(FirmwareUpdateState.Programming)]
+    [DataRow(FirmwareUpdateState.Failed)]
+    [DataRow(FirmwareUpdateState.CleaningUp)]
+    [DataRow(FirmwareUpdateState.Recovered)]
+    public void IsPostFlashReconnectTimeout_WifiGenuineFailureStates_AreNotDowngraded(
+        FirmwareUpdateState failedState)
+    {
+        // Every WiFi state that is not the Verifying reconnect keeps the Error/Sentry path.
+        var exception = new FirmwareUpdateException(failedState, "some operation", "Failure.");
+
         Assert.IsFalse(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
             exception, FirmwareFlashPhase.WifiModule));
     }
@@ -126,23 +149,24 @@ public class FirmwareFailureClassifierTests
             FirmwareFailureClassifier.IsPostFlashReconnectTimeout(null!, FirmwareFlashPhase.Pic32));
     }
 
+    // The expected opening is phase-specific and case-sensitive, which is also what proves the two
+    // messages are distinct: the WiFi text reads "WiFi firmware was installed successfully", so it
+    // cannot satisfy the PIC32 row's capital-F "Firmware was installed successfully" and vice versa.
+    // A separate distinctness assertion would need a second Act, so this carries that guarantee.
     [TestMethod]
-    public void BuildInstalledButNotReconnectedMessage_TellsUserTheFirmwareInstalledAndToPowerCycle()
+    [DataRow(FirmwareFlashPhase.Pic32, "Firmware was installed successfully")]
+    [DataRow(FirmwareFlashPhase.WifiModule, "WiFi firmware was installed successfully")]
+    public void BuildInstalledButNotReconnectedMessage_TellsUserTheFirmwareInstalledAndToPowerCycle(
+        FirmwareFlashPhase phase, string expectedOpening)
     {
-        var pic32Message = FirmwareFailureClassifier.BuildInstalledButNotReconnectedMessage(
-            FirmwareFlashPhase.Pic32);
-        var wifiMessage = FirmwareFailureClassifier.BuildInstalledButNotReconnectedMessage(
-            FirmwareFlashPhase.WifiModule);
+        var message = FirmwareFailureClassifier.BuildInstalledButNotReconnectedMessage(phase);
 
-        // Both say "installed" (not "failed") and name the recovery action.
-        StringAssert.Contains(pic32Message, "installed successfully");
-        StringAssert.Contains(pic32Message, "power-cycle");
-        StringAssert.Contains(wifiMessage, "installed successfully");
-        StringAssert.Contains(wifiMessage, "power-cycle");
-
-        // The WiFi variant names the module so the user knows which image is on the device.
-        StringAssert.Contains(wifiMessage, "WiFi firmware");
-        Assert.AreNotEqual(pic32Message, wifiMessage);
+        // Says "installed" (never "failed") and names the recovery action.
+        StringAssert.Contains(message, expectedOpening);
+        StringAssert.Contains(message, "power-cycle");
+        Assert.IsFalse(
+            message.Contains("failed", StringComparison.OrdinalIgnoreCase),
+            "The firmware installed; the message must not tell the user it failed.");
     }
     #endregion
 }

--- a/Daqifi.Desktop.Test/Device/Firmware/FirmwareFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/FirmwareFailureClassifierTests.cs
@@ -1,0 +1,148 @@
+using Daqifi.Core.Firmware;
+using Daqifi.Desktop.Device.Firmware;
+
+namespace Daqifi.Desktop.Test.Device.Firmware;
+
+/// <summary>
+/// Behavior contract for <see cref="FirmwareFailureClassifier"/>: which Core firmware-update
+/// failures are post-flash reconnect timeouts (the image is installed; only the device's return to
+/// normal serial operation timed out) and which are genuine flash failures.
+/// <para>
+/// The load-bearing case is that <see cref="FirmwareUpdateState.Verifying"/> is overloaded across
+/// the two images — the PIC32 CRC check versus the WiFi module's post-flash reconnect — so it must
+/// downgrade on one phase and stay an Error on the other.
+/// </para>
+/// </summary>
+[TestClass]
+public class FirmwareFailureClassifierTests
+{
+    #region Constants
+    /// <summary>
+    /// The <c>Operation</c> Core attaches to a PIC32 CRC-verify failure, verified against
+    /// Daqifi.Core v1.3.0 (<c>src/Daqifi.Core/Firmware/FirmwareUpdateService.cs</c>, the
+    /// <c>TransitionToState(Verifying, ...)</c> immediately before the CRC-verify step).
+    /// </summary>
+    private const string CORE_PIC32_CRC_VERIFY_OPERATION = "Verifying flash contents via CRC.";
+
+    /// <summary>
+    /// The <c>Operation</c> Core attaches to a WiFi post-flash reconnect timeout, verified against
+    /// Daqifi.Core v1.3.0 (<c>src/Daqifi.Core/Firmware/FirmwareUpdateService.cs</c>, the
+    /// <c>TransitionToState(Verifying, ...)</c> that follows the WINC success-marker check).
+    /// <para>
+    /// Note this is NOT <c>"reconnect serial transport after WiFi flash"</c>: that label is the
+    /// <c>ExecuteWithStateTimeoutAsync</c> argument and reaches only the inner
+    /// <see cref="TimeoutException"/>'s message. <c>FirmwareUpdateException.Operation</c> is
+    /// assigned solely from <c>TransitionToState</c>. Recorded here so a Core bump has one obvious
+    /// place to re-check — production code deliberately does not match on either string.
+    /// </para>
+    /// </summary>
+    private const string CORE_WIFI_RECONNECT_OPERATION = "Reconnecting device and restoring LAN configuration.";
+    #endregion
+
+    #region Tests
+    [TestMethod]
+    public void IsPostFlashReconnectTimeout_Pic32JumpingToApp_IsDowngraded()
+    {
+        // The last PIC32 step: reached only after erase + program + CRC-verify all succeeded, so the
+        // firmware is on the device and a power-cycle finishes the job (issue #738).
+        var exception = new FirmwareUpdateException(
+            FirmwareUpdateState.JumpingToApp,
+            "Jumping to application firmware.",
+            "State 'JumpingToApp' timed out.");
+
+        Assert.IsTrue(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
+            exception, FirmwareFlashPhase.Pic32));
+    }
+
+    [TestMethod]
+    public void IsPostFlashReconnectTimeout_WifiVerifying_IsDowngraded()
+    {
+        // The WiFi flow enters Verifying only AFTER the WINC flash tool printed its success marker,
+        // so a timeout here means the module was flashed and only the serial reconnect ran out of
+        // time (issue #776).
+        var exception = new FirmwareUpdateException(
+            FirmwareUpdateState.Verifying,
+            CORE_WIFI_RECONNECT_OPERATION,
+            "Firmware update failed in state 'Verifying' while Reconnecting device and restoring LAN configuration.");
+
+        Assert.IsTrue(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
+            exception, FirmwareFlashPhase.WifiModule));
+    }
+
+    [TestMethod]
+    public void IsPostFlashReconnectTimeout_Pic32CrcVerifying_IsNotDowngraded()
+    {
+        // The whole point of keying on the phase: the SAME state on the PIC32 is the flash CRC
+        // check, a deterministic "the flash does not match the image" failure. Downgrading it would
+        // tell a user with a bad flash that their firmware installed fine.
+        var exception = new FirmwareUpdateException(
+            FirmwareUpdateState.Verifying,
+            CORE_PIC32_CRC_VERIFY_OPERATION,
+            "Firmware update failed in state 'Verifying' while Verifying flash contents via CRC.");
+
+        Assert.IsFalse(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
+            exception, FirmwareFlashPhase.Pic32));
+    }
+
+    [TestMethod]
+    [DataRow(FirmwareUpdateState.PreparingDevice)]
+    [DataRow(FirmwareUpdateState.WaitingForBootloader)]
+    [DataRow(FirmwareUpdateState.Connecting)]
+    [DataRow(FirmwareUpdateState.ErasingFlash)]
+    [DataRow(FirmwareUpdateState.Programming)]
+    [DataRow(FirmwareUpdateState.Failed)]
+    [DataRow(FirmwareUpdateState.CleaningUp)]
+    [DataRow(FirmwareUpdateState.Recovered)]
+    public void IsPostFlashReconnectTimeout_GenuineFailureStates_AreNotDowngraded(FirmwareUpdateState failedState)
+    {
+        // Every state that is not a post-flash reconnect keeps the Error/Sentry path on BOTH phases.
+        var exception = new FirmwareUpdateException(failedState, "some operation", "Failure.");
+
+        Assert.IsFalse(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
+            exception, FirmwareFlashPhase.Pic32));
+        Assert.IsFalse(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
+            exception, FirmwareFlashPhase.WifiModule));
+    }
+
+    [TestMethod]
+    public void IsPostFlashReconnectTimeout_WifiJumpingToApp_IsNotDowngraded()
+    {
+        // The WiFi flow has no bootloader jump, so JumpingToApp is unreachable there. If Core ever
+        // did surface it on this phase we have no evidence the module was programmed — stay on the
+        // Error path rather than guessing.
+        var exception = new FirmwareUpdateException(
+            FirmwareUpdateState.JumpingToApp,
+            "Jumping to application firmware.",
+            "State 'JumpingToApp' timed out.");
+
+        Assert.IsFalse(FirmwareFailureClassifier.IsPostFlashReconnectTimeout(
+            exception, FirmwareFlashPhase.WifiModule));
+    }
+
+    [TestMethod]
+    public void IsPostFlashReconnectTimeout_NullException_Throws()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+            FirmwareFailureClassifier.IsPostFlashReconnectTimeout(null!, FirmwareFlashPhase.Pic32));
+    }
+
+    [TestMethod]
+    public void BuildInstalledButNotReconnectedMessage_TellsUserTheFirmwareInstalledAndToPowerCycle()
+    {
+        var pic32Message = FirmwareFailureClassifier.BuildInstalledButNotReconnectedMessage(
+            FirmwareFlashPhase.Pic32);
+        var wifiMessage = FirmwareFailureClassifier.BuildInstalledButNotReconnectedMessage(
+            FirmwareFlashPhase.WifiModule);
+
+        // Both say "installed" (not "failed") and name the recovery action.
+        StringAssert.Contains(pic32Message, "installed successfully");
+        StringAssert.Contains(pic32Message, "power-cycle");
+        StringAssert.Contains(wifiMessage, "installed successfully");
+        StringAssert.Contains(wifiMessage, "power-cycle");
+
+        // The WiFi variant names the module so the user knows which image is on the device.
+        StringAssert.Contains(wifiMessage, "WiFi firmware");
+        Assert.AreNotEqual(pic32Message, wifiMessage);
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -23,6 +23,41 @@ namespace Daqifi.Desktop.Test.ViewModels;
 [TestClass]
 public class DaqifiViewModelFirmwareUpdateTests
 {
+    #region Constants
+    // The exact strings Daqifi.Core v1.3.0 (the consumed package version) attaches to the two
+    // FirmwareUpdateState.Verifying failures, recorded here so the firmware-classification tests
+    // model real Core exceptions rather than invented ones — and so a Core bump has ONE obvious
+    // place to re-check. Production code deliberately does not match on any of them: the carve-out
+    // keys on the flash phase + FailedState instead (see FirmwareFailureClassifier).
+
+    /// <summary>
+    /// PIC32 CRC-verify failure operation, from Core's <c>TransitionToState(Verifying, ...)</c>
+    /// immediately before the CRC-verify step (<c>src/Daqifi.Core/Firmware/FirmwareUpdateService.cs</c>).
+    /// </summary>
+    private const string CORE_PIC32_CRC_VERIFY_OPERATION = "Verifying flash contents via CRC.";
+
+    /// <summary>
+    /// WiFi post-flash reconnect operation, from Core's <c>TransitionToState(Verifying, ...)</c>
+    /// that follows the WINC success-marker check.
+    /// <para>
+    /// Deliberately NOT <c>"reconnect serial transport after WiFi flash"</c>: that label is Core's
+    /// <c>ExecuteWithStateTimeoutAsync</c> argument and reaches only the inner
+    /// <see cref="TimeoutException"/>'s message. <c>FirmwareUpdateException.Operation</c> is
+    /// assigned solely from <c>TransitionToState</c>.
+    /// </para>
+    /// </summary>
+    private const string CORE_WIFI_RECONNECT_OPERATION = "Reconnecting device and restoring LAN configuration.";
+
+    /// <summary>
+    /// Core's recovery guidance for <c>FirmwareUpdateState.Verifying</c>. Core derives it from the
+    /// failed state alone, so BOTH Verifying failures carry this CRC text — correct for the PIC32
+    /// CRC check, misleading for the WiFi reconnect timeout.
+    /// </summary>
+    private const string CORE_VERIFYING_CRC_GUIDANCE =
+        "Flash verification failed — the device's flash CRC did not match the firmware image. " +
+        "Retry the update and confirm the expected firmware package was selected.";
+    #endregion
+
     private readonly List<string> _tempFiles = [];
     private readonly List<string> _tempDirectories = [];
 
@@ -907,6 +942,177 @@ public class DaqifiViewModelFirmwareUpdateTests
         Assert.AreEqual(1, host.FirmwareErrors.Count);
         StringAssert.Contains(host.FirmwareErrors[0], "ErasingFlash");
         appLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.AtLeastOnce);
+    }
+
+    [TestMethod]
+    public async Task UploadFirmware_WifiPostFlashReconnectTimeout_ReportedAsInstalledWarningNotError()
+    {
+        // Issue #776 — the symmetric case of #738 on the WiFi module. Core's WiFi flow enters
+        // Verifying ONLY after the WINC flash tool printed its success marker, so a timeout in that
+        // state means both firmwares were flashed and verified and the device merely did not come
+        // back on its serial port within VerifyingTimeout. It must be classified exactly like the
+        // PIC32 JumpingToApp case: Warning (no Sentry capture) and an "installed, power-cycle"
+        // message — not the generic Error + "Firmware update failed during '...'" dialog.
+        var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+        var appLogger = new Mock<IAppLogger>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM9", coreDevice);
+        var pic32FirmwarePath = CreateTempFile(".hex");
+        var wifiPackageDirectory = CreateTempDirectory();
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadLatestFirmwareAsync(
+                It.IsAny<string>(),
+                true,
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pic32FirmwarePath);
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadWifiFirmwareAsync(
+                It.IsAny<string>(),
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((wifiPackageDirectory, "v19.7.0"));
+
+        // Unreadable chip info reads as out-of-date, so the WiFi flash actually runs.
+        coreDevice.LanChipInfoResult = null;
+
+        // Exactly what Core v1.3.0 throws for this condition: state Verifying, the operation text
+        // from its Verifying transition, and — critically — the CRC recovery guidance, which Core
+        // maps from FailedState alone and which is therefore WRONG here (nothing CRC-related
+        // happened). The downgraded path must not repeat it to the user.
+        wifiFirmwareUpdateService
+            .Setup(service => service.UpdateWifiModuleAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                wifiPackageDirectory,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new FirmwareUpdateException(
+                FirmwareUpdateState.Verifying,
+                CORE_WIFI_RECONNECT_OPERATION,
+                "Firmware update failed in state 'Verifying' while " + CORE_WIFI_RECONNECT_OPERATION,
+                recoveryGuidance: CORE_VERIFYING_CRC_GUIDANCE,
+                innerException: new TimeoutException(
+                    "State 'Verifying' timed out while attempting to reconnect serial transport " +
+                    "after WiFi flash after 45.0 seconds.")));
+
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice
+        };
+
+        var coordinator = CreateCoordinator(
+            host,
+            pic32FirmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            (_, _) => wifiFirmwareUpdateService.Object,
+            appLogger.Object);
+
+        await coordinator.UploadFirmwareAsync();
+
+        // The user is told the WiFi firmware installed and to power-cycle — not that it failed.
+        Assert.AreEqual(1, host.FirmwareErrors.Count);
+        StringAssert.Contains(host.FirmwareErrors[0], "WiFi firmware was installed successfully");
+        StringAssert.Contains(host.FirmwareErrors[0], "power-cycle");
+
+        // Core's FailedState-derived guidance is misleading here; it must never reach the user.
+        Assert.IsFalse(
+            host.FirmwareErrors[0].Contains("CRC", StringComparison.OrdinalIgnoreCase),
+            "The WiFi reconnect timeout must not repeat Core's PIC32 CRC guidance.");
+        Assert.IsFalse(
+            host.FirmwareErrors[0].Contains("failed", StringComparison.OrdinalIgnoreCase),
+            "The firmware installed; the message must not tell the user it failed.");
+
+        // Logged at Warning (file only), never at Error (which captures to Sentry).
+        appLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.AtLeastOnce);
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        appLogger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task UploadFirmware_Pic32CrcVerifyFailure_StillReportedAsErrorToSentry()
+    {
+        // The other direction of issue #776, and the reason the carve-out cannot simply add
+        // "|| FailedState == Verifying": on the PIC32 that state is the flash CRC check. A CRC
+        // mismatch is a genuine, deterministic failure — the flash does NOT match the image — so it
+        // must keep the Error (Sentry) path and Core's "CRC did not match" recovery guidance.
+        //
+        // Driven through a full AUTO update (not a manual PIC32-only upload) so it also proves the
+        // coordinator is still on the PIC32 phase while the PIC32 step runs: if the WiFi phase were
+        // latched too early, this genuine failure would be silently downgraded.
+        var pic32FirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var wifiFirmwareUpdateService = new Mock<IFirmwareUpdateService>();
+        var firmwareDownloadService = new Mock<IFirmwareDownloadService>();
+        var appLogger = new Mock<IAppLogger>();
+
+        using var coreDevice = new TestCoreStreamingDevice("DAQiFi Core");
+        coreDevice.Connect();
+
+        var serialDevice = CreateSerialDeviceWithCoreDevice("COM9", coreDevice);
+        var pic32FirmwarePath = CreateTempFile(".hex");
+
+        firmwareDownloadService
+            .Setup(service => service.DownloadLatestFirmwareAsync(
+                It.IsAny<string>(),
+                true,
+                It.IsAny<IProgress<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pic32FirmwarePath);
+
+        var wifiFactoryCalls = 0;
+
+        pic32FirmwareUpdateService
+            .Setup(service => service.UpdateFirmwareAsync(
+                It.IsAny<Daqifi.Core.Device.IStreamingDevice>(),
+                pic32FirmwarePath,
+                It.IsAny<IProgress<FirmwareUpdateProgress>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new FirmwareUpdateException(
+                FirmwareUpdateState.Verifying,
+                CORE_PIC32_CRC_VERIFY_OPERATION,
+                "Firmware update failed in state 'Verifying' while " + CORE_PIC32_CRC_VERIFY_OPERATION,
+                recoveryGuidance: CORE_VERIFYING_CRC_GUIDANCE));
+
+        var host = new FakeFirmwareUpdateHost
+        {
+            SelectedDevice = serialDevice
+        };
+
+        var coordinator = CreateCoordinator(
+            host,
+            pic32FirmwareUpdateService.Object,
+            firmwareDownloadService.Object,
+            (_, _) =>
+            {
+                wifiFactoryCalls++;
+                return wifiFirmwareUpdateService.Object;
+            },
+            appLogger.Object);
+
+        await coordinator.UploadFirmwareAsync();
+
+        // Reported as the failure it is, with Core's CRC guidance intact.
+        Assert.AreEqual(1, host.FirmwareErrors.Count);
+        StringAssert.Contains(host.FirmwareErrors[0], "Firmware update failed");
+        StringAssert.Contains(host.FirmwareErrors[0], "Verifying");
+        StringAssert.Contains(host.FirmwareErrors[0], "CRC did not match");
+
+        // Captured to Sentry, and never downgraded to the "installed, power-cycle" message.
+        appLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.AtLeastOnce);
+        Assert.IsFalse(
+            host.FirmwareErrors[0].Contains("installed successfully", StringComparison.Ordinal),
+            "A CRC mismatch must never be reported as an installed firmware.");
+
+        // The PIC32 step threw, so the WiFi flash was never attempted.
+        Assert.AreEqual(0, wifiFactoryCalls);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFirmwareUpdateTests.cs
@@ -29,6 +29,9 @@ public class DaqifiViewModelFirmwareUpdateTests
     // model real Core exceptions rather than invented ones — and so a Core bump has ONE obvious
     // place to re-check. Production code deliberately does not match on any of them: the carve-out
     // keys on the flash phase + FailedState instead (see FirmwareFailureClassifier).
+    //
+    // See daqifi-core#398 (gap 4) — the upstream ask to replace these unversioned progress strings,
+    // and the FailedState-derived recovery guidance below, with a real discriminator.
 
     /// <summary>
     /// PIC32 CRC-verify failure operation, from Core's <c>TransitionToState(Verifying, ...)</c>

--- a/Daqifi.Desktop/Device/Firmware/FirmwareFailureClassifier.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareFailureClassifier.cs
@@ -96,9 +96,17 @@ public static class FirmwareFailureClassifier
     /// Verified against Daqifi.Core v1.3.0, the consumed package version
     /// (<c>FirmwareUpdateService.cs</c>: PIC32 CRC-verify and jump at the <c>ErasingFlash</c> →
     /// <c>JumpingToApp</c> sequence, WiFi success-marker check immediately followed by the
-    /// <c>Verifying</c> transition and <c>WaitForSerialReconnectAsync</c>). A dedicated Core-side
-    /// signal — so consumers need not infer "the image is on the device" from state + phase — is
-    /// requested as daqifi-core#397; this classifier is the desktop-side fix in the meantime.
+    /// <c>Verifying</c> transition and <c>WaitForSerialReconnectAsync</c>).
+    /// </para>
+    /// <para>
+    /// <b>Upstream:</b> this classifier is a workaround, tracked as daqifi-core#398 (gap 4). Core
+    /// knows at every throw site whether the image was written, but exposes no machine-readable way
+    /// to say so — the only other discriminator available is a UI progress string that was never an
+    /// API contract and could be reworded in any release without anyone noticing. Core's
+    /// <c>BuildRecoveryGuidance</c> has the same root cause: it maps by <c>FailedState</c> alone, so
+    /// Core itself already emits the PIC32 CRC text for a *successful* WiFi flash. Once Core lands a
+    /// dedicated state or flag for the post-flash reconnect, the phase parameter and this type can
+    /// be replaced by a direct check on that signal.
     /// </para>
     /// </remarks>
     public static bool IsPostFlashReconnectTimeout(FirmwareUpdateException exception, FirmwareFlashPhase phase)

--- a/Daqifi.Desktop/Device/Firmware/FirmwareFailureClassifier.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareFailureClassifier.cs
@@ -1,0 +1,129 @@
+using Daqifi.Core.Firmware;
+
+namespace Daqifi.Desktop.Device.Firmware;
+
+/// <summary>
+/// Which firmware image was being flashed when a <see cref="FirmwareUpdateException"/> was thrown.
+/// <para>
+/// Core reuses one <see cref="FirmwareUpdateState"/> machine for both images, so
+/// <see cref="FirmwareUpdateState.Verifying"/> means two different things depending on the image:
+/// CRC verification for the PIC32 and the post-flash serial reconnect for the WiFi module. Only the
+/// caller knows which flash it was running, so the phase has to be supplied alongside the exception.
+/// </para>
+/// </summary>
+public enum FirmwareFlashPhase
+{
+    /// <summary>
+    /// The PIC32 application-firmware flash: erase → program → CRC-verify → jump to application.
+    /// </summary>
+    Pic32 = 0,
+
+    /// <summary>
+    /// The WINC1500 WiFi-module flash: external WINC tool → success-marker check → serial reconnect
+    /// and LAN restore.
+    /// </summary>
+    WifiModule = 1
+}
+
+/// <summary>
+/// Decides whether a Core <see cref="FirmwareUpdateException"/> describes a genuine flash failure or
+/// a <em>post-flash reconnect timeout</em> — the firmware was fully written and verified and only the
+/// device's return to normal serial operation timed out.
+/// <para>
+/// A post-flash reconnect timeout is a device/environmental condition a power-cycle finishes, not an
+/// app defect: it is logged at Warning (no Sentry capture) and reported to the user as installed.
+/// Issue #738 / PR #751 established that treatment for the PIC32 case; issue #776 extends it to the
+/// symmetric WiFi-module case.
+/// </para>
+/// </summary>
+public static class FirmwareFailureClassifier
+{
+    #region Constants
+    /// <summary>
+    /// Shown when the PIC32 flash finished (erase + program + CRC-verify all passed) but the device
+    /// did not re-enumerate its serial port in time (issue #738).
+    /// </summary>
+    internal const string PIC32_INSTALLED_NO_RECONNECT_MESSAGE =
+        "Firmware was installed successfully, but the device did not return to normal mode on its " +
+        "own. Please power-cycle the device (unplug and replug its USB cable), then reconnect.";
+
+    /// <summary>
+    /// Shown when the WINC flash finished (the flash tool reported its success marker) but the device
+    /// did not re-enumerate its serial port in time (issue #776).
+    /// </summary>
+    internal const string WIFI_INSTALLED_NO_RECONNECT_MESSAGE =
+        "WiFi firmware was installed successfully, but the device did not return to normal mode on " +
+        "its own. Please power-cycle the device (unplug and replug its USB cable), then reconnect.";
+    #endregion
+
+    #region Public Methods
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="exception"/> is a post-flash reconnect timeout: the
+    /// firmware image was completely written and verified, and the failure is only that the device
+    /// did not come back on its serial port in time.
+    /// </summary>
+    /// <param name="exception">The exception Core threw. Never null.</param>
+    /// <param name="phase">Which image was being flashed when it was thrown.</param>
+    /// <returns>
+    /// <c>true</c> if the flash itself succeeded and only the reconnect timed out; <c>false</c> for
+    /// every genuine flash failure (which must keep the Error/Sentry path).
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The discriminator is <em>structural</em>, deliberately not a match on
+    /// <see cref="FirmwareUpdateException.Operation"/>. That property carries whatever text Core
+    /// passed to its last <c>TransitionToState</c> call ("Reconnecting device and restoring LAN
+    /// configuration." for the WiFi reconnect, "Verifying flash contents via CRC." for the PIC32
+    /// CRC pass) — free-form prose with no published constant, so matching it would silently stop
+    /// working the first time Core reworded a log line. The flash phase plus the failed state is
+    /// exact and needs no literal:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>PIC32</b> — <see cref="FirmwareUpdateState.JumpingToApp"/> is the LAST step and is entered
+    /// only after erase + program + CRC-verify all succeeded, so the firmware is already installed.
+    /// <see cref="FirmwareUpdateState.Verifying"/> on this image is the CRC check, a real failure
+    /// ("the device's flash CRC did not match"), and is intentionally NOT downgraded.
+    /// </description></item>
+    /// <item><description>
+    /// <b>WiFi module</b> — the WiFi flow enters <see cref="FirmwareUpdateState.Verifying"/> at
+    /// exactly one place, and only after Core has confirmed the WINC flash tool printed its success
+    /// marker; the state covers the reconnect + LAN restore alone. It never enters
+    /// <see cref="FirmwareUpdateState.JumpingToApp"/> (there is no bootloader jump).
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// Verified against Daqifi.Core v1.3.0, the consumed package version
+    /// (<c>FirmwareUpdateService.cs</c>: PIC32 CRC-verify and jump at the <c>ErasingFlash</c> →
+    /// <c>JumpingToApp</c> sequence, WiFi success-marker check immediately followed by the
+    /// <c>Verifying</c> transition and <c>WaitForSerialReconnectAsync</c>). A dedicated Core-side
+    /// signal — so consumers need not infer "the image is on the device" from state + phase — is
+    /// requested as daqifi-core#397; this classifier is the desktop-side fix in the meantime.
+    /// </para>
+    /// </remarks>
+    public static bool IsPostFlashReconnectTimeout(FirmwareUpdateException exception, FirmwareFlashPhase phase)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return phase switch
+        {
+            FirmwareFlashPhase.Pic32 => exception.FailedState == FirmwareUpdateState.JumpingToApp,
+            FirmwareFlashPhase.WifiModule => exception.FailedState == FirmwareUpdateState.Verifying,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// The user-facing message for a post-flash reconnect timeout: the firmware installed, and the
+    /// device needs a power-cycle to finish the job.
+    /// </summary>
+    /// <param name="phase">Which image was being flashed.</param>
+    /// <returns>The message to present, phrased for the image that was flashed.</returns>
+    public static string BuildInstalledButNotReconnectedMessage(FirmwareFlashPhase phase)
+    {
+        return phase == FirmwareFlashPhase.WifiModule
+            ? WIFI_INSTALLED_NO_RECONNECT_MESSAGE
+            : PIC32_INSTALLED_NO_RECONNECT_MESSAGE;
+    }
+    #endregion
+}

--- a/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
+++ b/Daqifi.Desktop/Device/Firmware/FirmwareUpdateCoordinator.cs
@@ -182,6 +182,12 @@ public class FirmwareUpdateCoordinator : IDisposable
         _host.IsFirmwareUploading = true;
         _appLogger.AddBreadcrumb("firmware", $"Firmware update started for {serialStreamingDevice.Name}");
 
+        // Which image the run is on when it faults. Core reuses one state machine for both, so
+        // FirmwareUpdateState.Verifying is ambiguous on its own (PIC32 CRC-verify vs the WiFi
+        // module's post-flash reconnect) and the failure classifier needs this to tell them apart.
+        // Declared outside the try so the catch below can read it.
+        var flashPhase = FirmwareFlashPhase.Pic32;
+
         try
         {
             // Quiesce inside the try so a fault here still runs the finally (which clears
@@ -259,6 +265,7 @@ public class FirmwareUpdateCoordinator : IDisposable
 
             if (!isManualUpload)
             {
+                flashPhase = FirmwareFlashPhase.WifiModule;
                 await UpdateWifiModuleAsync(coreDevice, serialStreamingDevice, _firmwareUploadCts.Token);
             }
 
@@ -274,7 +281,7 @@ public class FirmwareUpdateCoordinator : IDisposable
         }
         catch (FirmwareUpdateException ex)
         {
-            HandleFirmwareUpdateException(ex);
+            HandleFirmwareUpdateException(ex, flashPhase);
         }
         catch (Exception ex)
         {
@@ -735,32 +742,36 @@ public class FirmwareUpdateCoordinator : IDisposable
         return normalized;
     }
 
-    private void HandleFirmwareUpdateException(FirmwareUpdateException exception)
+    private void HandleFirmwareUpdateException(FirmwareUpdateException exception, FirmwareFlashPhase phase)
     {
         _host.HasErrorOccured = true;
 
-        // A JumpingToApp failure is categorically different from a mid-flash failure: it is the LAST
-        // PIC32 step and only runs after erase + program + CRC-verify all succeeded, so the firmware is
-        // already installed and verified — the device just didn't re-open its serial port in time. Treat
-        // it as an expected device/environmental condition (a power-cycle finishes the job), not an app
-        // bug: log at Warning (no Sentry capture) and tell the user their firmware installed rather than
+        // A post-flash reconnect timeout is categorically different from a mid-flash failure: the image
+        // was fully written and verified and only the device's return to normal serial operation timed
+        // out. On the PIC32 that is the JumpingToApp step (reached only after erase + program +
+        // CRC-verify all succeeded, issue #738); on the WiFi module it is the Verifying step, which Core
+        // enters only after the WINC flash tool reported its success marker (issue #776). Treat both as
+        // an expected device/environmental condition (a power-cycle finishes the job), not an app bug:
+        // log at Warning (no Sentry capture) and tell the user their firmware installed rather than
         // claiming it failed. Mirrors the serial/WiFi connect classification (issues #589 / #740) and
-        // stops this from filing Sentry issues like DAQIFI-DESKTOP-1N (issue #738).
-        if (exception.FailedState == FirmwareUpdateState.JumpingToApp)
+        // stops this from filing Sentry issues like DAQIFI-DESKTOP-1N.
+        //
+        // Note the asymmetry the classifier encodes: Verifying is downgraded ONLY on the WiFi module.
+        // On the PIC32 the same state is the flash CRC check — a genuine failure that keeps its
+        // Error/Sentry path and its "CRC did not match" recovery guidance.
+        if (FirmwareFailureClassifier.IsPostFlashReconnectTimeout(exception, phase))
         {
             _appLogger.AddBreadcrumb(
                 "firmware",
-                $"Firmware installed but device did not reconnect: {exception.FailedState}",
+                $"Firmware installed but device did not reconnect: {exception.FailedState} ({phase})",
                 Common.Loggers.BreadcrumbLevel.Warning);
             _appLogger.Warning(
                 exception,
-                "Firmware was installed and verified, but the device did not automatically return to " +
-                "application mode after the flash. This is a device/environmental condition (power-cycle " +
-                "recovers it), not an app failure.");
+                $"Firmware was installed and verified ({phase}), but the device did not automatically " +
+                "return to application mode after the flash. This is a device/environmental condition " +
+                "(power-cycle recovers it), not an app failure.");
 
-            _host.ShowFirmwareError(
-                "Firmware was installed successfully, but the device did not return to normal mode on its " +
-                "own. Please power-cycle the device (unplug and replug its USB cable), then reconnect.");
+            _host.ShowFirmwareError(FirmwareFailureClassifier.BuildInstalledButNotReconnectedMessage(phase));
             return;
         }
 

--- a/Daqifi.Desktop/Loggers/AppLoggerLoggerProvider.cs
+++ b/Daqifi.Desktop/Loggers/AppLoggerLoggerProvider.cs
@@ -60,8 +60,9 @@ public sealed class AppLoggerLoggerProvider : ILoggerProvider
             // at LogError from its own viewpoint, but the desktop's FirmwareUpdateCoordinator is the
             // authority on firmware-outcome severity: it captures genuine flash failures to Sentry
             // itself (a direct AppLogger.Error, not through this bridge) AND downgrades expected
-            // device/environmental outcomes — most notably a post-verify JumpingToApp reconnect timeout,
-            // where the firmware is already installed and a power-cycle finishes the job (issue #738).
+            // device/environmental outcomes — most notably a post-flash reconnect timeout (the PIC32's
+            // JumpingToApp step, issue #738, and the WiFi module's Verifying step, issue #776), where
+            // the firmware is already installed and a power-cycle finishes the job.
             // Forwarding Core's duplicate Error to Sentry would both double-report real failures and
             // undo the coordinator's environmental downgrade, auto-filing noise issues like
             // DAQIFI-DESKTOP-1N. So route this category's Error/Critical to the file only; the

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -2113,6 +2113,28 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         catch (FirmwareUpdateException ex)
         {
             HasErrorOccured = true;
+
+            // Same carve-out as the combined auto-update path (FirmwareUpdateCoordinator): a
+            // post-flash reconnect timeout means the WINC image was written and its success marker
+            // confirmed, and only the device's serial re-enumeration ran out of time. That is a
+            // device/environmental condition a power-cycle finishes — Warning (no Sentry) and an
+            // "installed, power-cycle" message, not a scary flash-failure dialog (issue #776).
+            if (FirmwareFailureClassifier.IsPostFlashReconnectTimeout(ex, FirmwareFlashPhase.WifiModule))
+            {
+                _appLogger.AddBreadcrumb(
+                    "firmware",
+                    $"WiFi firmware installed but device did not reconnect: {ex.FailedState}",
+                    Common.Loggers.BreadcrumbLevel.Warning);
+                _appLogger.Warning(
+                    ex,
+                    "WiFi firmware was installed and verified, but the device did not automatically " +
+                    "return to normal mode after the flash. This is a device/environmental condition " +
+                    "(power-cycle recovers it), not an app failure.");
+
+                ShowWifiFirmwareInstalledPowerCycleDialog();
+                return;
+            }
+
             _appLogger.Error(ex, $"WiFi firmware flash failed during '{ex.Operation}' ({ex.FailedState}).");
             _appLogger.AddBreadcrumb("firmware", $"WiFi firmware update failed: {ex.FailedState}", Common.Loggers.BreadcrumbLevel.Error);
             ShowWifiFlashFailedDialog();
@@ -2228,6 +2250,32 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             var errorDialogViewModel = new ErrorDialogViewModel(
                 "WiFi firmware flash failed. Disconnect the device, ensure power is cycled, and try again.");
             _dialogService.ShowDialog<ErrorDialog>(this, errorDialogViewModel);
+        }
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null)
+        {
+            ShowDialog();
+            return;
+        }
+
+        dispatcher.Invoke(ShowDialog);
+    }
+
+    /// <summary>
+    /// User-facing message for a WiFi flash that completed but whose post-flash serial reconnect timed
+    /// out. The image is on the module — only the device's return to normal mode is outstanding — so
+    /// the user is told it installed and asked to power-cycle, not that the flash failed (issue #776).
+    /// Presented through the same dialog as a failure because the user still has an action to take;
+    /// the wording, and the Warning-level logging behind it, are what differ.
+    /// </summary>
+    private void ShowWifiFirmwareInstalledPowerCycleDialog()
+    {
+        void ShowDialog()
+        {
+            var dialogViewModel = new ErrorDialogViewModel(
+                FirmwareFailureClassifier.BuildInstalledButNotReconnectedMessage(FirmwareFlashPhase.WifiModule));
+            _dialogService.ShowDialog<ErrorDialog>(this, dialogViewModel);
         }
 
         var dispatcher = Application.Current?.Dispatcher;


### PR DESCRIPTION
## Summary

`FirmwareUpdateCoordinator.HandleFirmwareUpdateException` downgrades a **PIC32** post-flash reconnect timeout (`FailedState == JumpingToApp`) to a Warning with an "installed, power-cycle" message and no Sentry capture — that was the #738 / #751 fix. The symmetric **WiFi-module** case (a slow serial re-enumeration *after a successful WINC flash*) is thrown by Core as `FailedState == Verifying`, missed the `JumpingToApp`-only test, and fell through to the generic branch: `AppLogger.Error` (Sentry capture) plus a *"Firmware update failed during '…' (Verifying)"* dialog — **even though both firmwares were fully flashed and verified**.

Closes #776

## Why it isn't a one-line `|| FailedState == Verifying`

`Verifying` is overloaded across the two images (Daqifi.Core v1.3.0, `src/Daqifi.Core/Firmware/FirmwareUpdateService.cs`):

| image | `Verifying` means | correct treatment |
|---|---|---|
| PIC32 | flash CRC check (`InvalidDataException` on mismatch) | **genuine failure** — keep Error/Sentry + "CRC did not match" guidance |
| WiFi module | post-flash serial reconnect + LAN restore, entered **only after** the WINC tool's success marker was confirmed | **benign environmental** — downgrade |

So the carve-out has to know *which image was being flashed*. A new `FirmwareFailureClassifier` takes the exception plus a `FirmwareFlashPhase`:

- `Pic32` + `JumpingToApp` → downgrade (unchanged, #738)
- `WifiModule` + `Verifying` → downgrade (**new**, #776)
- `Pic32` + `Verifying` → stays an Error, with Core's CRC guidance intact
- everything else → stays an Error

`UploadFirmwareAsync` tracks the phase and flips it to `WifiModule` immediately before `UpdateWifiModuleAsync`, so a PIC32 fault during an auto-update is still classified as PIC32.

## Correction to the ticket's diagnosis (please read)

The ticket says the exception carries `Operation = "reconnect serial transport after WiFi flash"` and that the fix should key on that literal. **That is not what Core throws.** Reading v1.3.0 source at the consumed version:

- `_currentOperation` is assigned in exactly two places, both inside `TransitionToState` (`:2568`, `:2581`) — nowhere else.
- The WiFi flow does `TransitionToState(Verifying, "Reconnecting device and restoring LAN configuration.")` (`:892`), then passes `"reconnect serial transport after WiFi flash"` to `ExecuteWithStateTimeoutAsync` (`:897`), whose `operation` parameter is used **only** to build `BuildStateTimeoutMessage` — i.e. it reaches the inner `TimeoutException`'s *message*, never the `FirmwareUpdateException`.
- The catch captures `failedOperation = _currentOperation` (`:921`) and hands it to `CreateFirmwareUpdateException` (`:926`).

Net: the thrown exception has `Operation == "Reconnecting device and restoring LAN configuration."` (and the PIC32 CRC case has `"Verifying flash contents via CRC."`). **A carve-out keyed on the ticket's literal would have matched nothing and shipped as a silent no-op.**

Both strings are unversioned UI progress prose with no published constant either way, so this PR keys on the structural signal (phase + state) and **pins the actual Core v1.3.0 literals in the tests** as named constants with pointers to their Core source — one obvious place to re-check on a Core bump, without production behavior depending on Core's log wording.

## Bonus: Core's recovery guidance is wrong for this case

`BuildRecoveryGuidance` (`:2533-2534`) maps by `FailedState` alone, so a WiFi reconnect timeout arrives carrying the **PIC32 CRC** guidance — *"Flash verification failed — the device's flash CRC did not match the firmware image."* A user whose WiFi flash succeeded was being told their flash CRC mismatched. The downgraded path never surfaces `RecoveryGuidance`, and a test asserts the string `CRC` cannot appear in the message.

## Also fixed: the WiFi-only flash path

`DaqifiViewModel.UpdateWifiFirmwareOnly` (the user-initiated "update just the WiFi module" command) had its own copy of the generic `Error` + `ShowWifiFlashFailedDialog` branch and the identical bug — arguably hit more directly, since it is the pure WiFi flash. It now uses the same classifier.

## Upstream

**This carve-out is a workaround for daqifi/daqifi-core#398 (gap 4)** and should be replaced with a direct state/flag check once Core lands one.

Core knows at every throw site whether the image was actually written, but exposes no machine-readable way to say so. The only discriminator it offers is a UI progress string that was never an API contract and could be reworded in any release without anyone noticing — which is exactly the trap the ticket's prescribed `Operation` literal fell into (see the correction section above: that literal does not exist on the thrown exception, so matching it would have been a silent no-op). The misleading CRC recovery guidance has the same root cause: `BuildRecoveryGuidance` keys on `FailedState` alone.

Proposed Core fix in #398: a dedicated state or flag for the post-flash reconnect, with guidance keyed on the same discriminator. When that lands, `FirmwareFlashPhase` and `FirmwareFailureClassifier` can both go away in favour of a direct check, and the pinned test constants can be deleted. Both the classifier's XML remarks and the pinned constants carry a `See daqifi-core#398 (gap 4)` pointer so a Core bump has one place to look.

## Testing

**Unit only — no bench validation.** Reproducing this on hardware requires an actual WiFi firmware flash plus a 45-second reconnect timeout, and flashing the bench device was explicitly out of scope (an interrupted flash bricks it, and bootloader firmware bug daqifi-nyquist-firmware#568 makes HID flashes fail probabilistically with no host-side fix). **No hardware was touched for this PR — I did not acquire the bench lock.** The claims above are read off Core's source and asserted against exceptions constructed exactly as Core constructs them.

- **Full fast gate: 830/830 pass** (`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`).
- New `Daqifi.Desktop.Test/Device/Firmware/FirmwareFailureClassifierTests.cs` — the phase × state matrix, including the two that matter (WiFi `Verifying` downgrades; PIC32 `Verifying` does not), every genuine-failure state on both phases, WiFi `JumpingToApp` (unreachable in Core, so not downgraded rather than guessed), null-argument, and the message contract.
- New in `DaqifiViewModelFirmwareUpdateTests` — both directions end-to-end through `UploadFirmwareAsync`:
  - `UploadFirmware_WifiPostFlashReconnectTimeout_ReportedAsInstalledWarningNotError` — asserts the "WiFi firmware was installed successfully… power-cycle" message, that neither `CRC` nor `failed` appears in it, `Warning` called, `Error` **never** called.
  - `UploadFirmware_Pic32CrcVerifyFailure_StillReportedAsErrorToSentry` — driven through a full **auto** update (not a manual PIC32-only upload) so it also proves the WiFi phase isn't latched early; asserts the Error path, Core's CRC guidance survives to the user, and the WiFi flash was never attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
