### PR TITLE
fix(firmware): keep discovery paused for a concurrent HID bootloader flash

### DIFF
--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
@@ -242,50 +242,71 @@ public class BootloaderWatcherTests
     }
 
     [TestMethod]
-    public async Task PrepareFlash_ReportsFlashInProgress_AndRaisesOnBothEdges()
+    public async Task PrepareFlash_MarksFlashInProgress_AndRaisesTheRisingEdge()
     {
         // The connection dialog keys its serial + WiFi discovery on this flag so a coordinator
         // auto-update of another device finishing mid-write can't restart bus probing during the HID
-        // flash, and on the event so the end of the write is a resume trigger (issue #777).
+        // flash (issue #777).
         using var watcher = CreateWatcher();
         watcher.Start();
         _discovery.Raise(PathA, "DAQiFi Bootloader");
         await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
-
         var flagsSeen = new List<bool>();
         watcher.FlashInProgressChanged += (_, _) => flagsSeen.Add(watcher.IsFlashInProgress);
-
         Assert.IsFalse(watcher.IsFlashInProgress, "No flash is in progress before PrepareFlashAsync.");
 
-        var lease = await watcher.PrepareFlashAsync(PathA);
+        await watcher.PrepareFlashAsync(PathA);
+
         Assert.IsTrue(watcher.IsFlashInProgress, "A prepared flash must report as in progress.");
-
-        await lease.DisposeAsync();
-        Assert.IsFalse(watcher.IsFlashInProgress, "Disposing the flash lease must clear the in-progress flag.");
-
-        Assert.AreEqual(2, flagsSeen.Count,
-            "FlashInProgressChanged must fire exactly once per edge.");
-        Assert.IsTrue(flagsSeen[0], "The first event is the rising edge.");
-        Assert.IsFalse(flagsSeen[1], "The second event is the falling edge.");
+        Assert.AreEqual(1, flagsSeen.Count, "The rising edge must fire exactly once.");
+        Assert.IsTrue(flagsSeen[0], "The rising edge must report the flash as in progress.");
     }
 
     [TestMethod]
-    public async Task FlashInProgressChanged_WithThrowingSubscriber_DoesNotFaultTheLease()
+    public async Task DisposingFlashLease_ClearsFlashInProgress_AndRaisesTheFallingEdge()
     {
-        // The falling edge is raised from the flash lease's disposal, which runs in the firmware
-        // dialog's finally. A faulting subscriber must not propagate there and mask the flash outcome.
+        // The falling edge is a subscriber's resume trigger: a write can outlive the modal dialog that
+        // started it, so without it a resume refused mid-write would never be retried (issue #777).
         using var watcher = CreateWatcher();
         watcher.Start();
         _discovery.Raise(PathA, "DAQiFi Bootloader");
         await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+        var lease = await watcher.PrepareFlashAsync(PathA);
+        var flagsSeen = new List<bool>();
+        watcher.FlashInProgressChanged += (_, _) => flagsSeen.Add(watcher.IsFlashInProgress);
 
+        await lease.DisposeAsync();
+
+        Assert.IsFalse(watcher.IsFlashInProgress, "Disposing the flash lease must clear the in-progress flag.");
+        Assert.AreEqual(1, flagsSeen.Count, "The falling edge must fire exactly once.");
+        Assert.IsFalse(flagsSeen[0], "The falling edge must report the flash as finished.");
+        Assert.AreEqual(2, _createdHolds[PathA].BeginHoldCount,
+            "The flag must not clear before the target's re-grab has completed.");
+    }
+
+    [TestMethod]
+    public async Task FlashInProgressChanged_WithThrowingSubscriber_StillReachesLaterSubscribers()
+    {
+        // The falling edge is raised from the flash lease's disposal, which runs in the firmware
+        // dialog's finally. A faulting subscriber must neither propagate there and mask the flash
+        // outcome, nor swallow the edge for a subscriber registered after it.
+        using var watcher = CreateWatcher();
+        watcher.Start();
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
         watcher.FlashInProgressChanged += (_, _) => throw new InvalidOperationException("subscriber blew up");
+        var flagsSeen = new List<bool>();
+        watcher.FlashInProgressChanged += (_, _) => flagsSeen.Add(watcher.IsFlashInProgress);
 
         var lease = await watcher.PrepareFlashAsync(PathA);
         await lease.DisposeAsync();
 
         Assert.IsFalse(watcher.IsFlashInProgress);
         Assert.IsTrue(_discovery.IsRunning, "Discovery must still resume when a subscriber throws.");
+        Assert.AreEqual(2, flagsSeen.Count,
+            "A throwing subscriber must not swallow either edge for the subscribers after it.");
+        Assert.IsTrue(flagsSeen[0]);
+        Assert.IsFalse(flagsSeen[1]);
         _logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Exactly(2));
     }
 

--- a/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
+++ b/Daqifi.Desktop.Test/Device/Firmware/BootloaderWatcherTests.cs
@@ -241,6 +241,54 @@ public class BootloaderWatcherTests
         Assert.IsTrue(_discovery.IsRunning, "Discovery must resume only once both operations complete.");
     }
 
+    [TestMethod]
+    public async Task PrepareFlash_ReportsFlashInProgress_AndRaisesOnBothEdges()
+    {
+        // The connection dialog keys its serial + WiFi discovery on this flag so a coordinator
+        // auto-update of another device finishing mid-write can't restart bus probing during the HID
+        // flash, and on the event so the end of the write is a resume trigger (issue #777).
+        using var watcher = CreateWatcher();
+        watcher.Start();
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+
+        var flagsSeen = new List<bool>();
+        watcher.FlashInProgressChanged += (_, _) => flagsSeen.Add(watcher.IsFlashInProgress);
+
+        Assert.IsFalse(watcher.IsFlashInProgress, "No flash is in progress before PrepareFlashAsync.");
+
+        var lease = await watcher.PrepareFlashAsync(PathA);
+        Assert.IsTrue(watcher.IsFlashInProgress, "A prepared flash must report as in progress.");
+
+        await lease.DisposeAsync();
+        Assert.IsFalse(watcher.IsFlashInProgress, "Disposing the flash lease must clear the in-progress flag.");
+
+        Assert.AreEqual(2, flagsSeen.Count,
+            "FlashInProgressChanged must fire exactly once per edge.");
+        Assert.IsTrue(flagsSeen[0], "The first event is the rising edge.");
+        Assert.IsFalse(flagsSeen[1], "The second event is the falling edge.");
+    }
+
+    [TestMethod]
+    public async Task FlashInProgressChanged_WithThrowingSubscriber_DoesNotFaultTheLease()
+    {
+        // The falling edge is raised from the flash lease's disposal, which runs in the firmware
+        // dialog's finally. A faulting subscriber must not propagate there and mask the flash outcome.
+        using var watcher = CreateWatcher();
+        watcher.Start();
+        _discovery.Raise(PathA, "DAQiFi Bootloader");
+        await WaitUntilAsync(() => watcher.Bootloaders.Count == 1);
+
+        watcher.FlashInProgressChanged += (_, _) => throw new InvalidOperationException("subscriber blew up");
+
+        var lease = await watcher.PrepareFlashAsync(PathA);
+        await lease.DisposeAsync();
+
+        Assert.IsFalse(watcher.IsFlashInProgress);
+        Assert.IsTrue(_discovery.IsRunning, "Discovery must still resume when a subscriber throws.");
+        _logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Exactly(2));
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
     {
         var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(timeoutMs);

--- a/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelFirmwareGateTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/ConnectionDialogViewModelFirmwareGateTests.cs
@@ -1,7 +1,9 @@
 using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Device.Firmware;
 using Daqifi.Desktop.DialogService;
 using Daqifi.Desktop.ViewModels;
 using Moq;
+using System.Collections.ObjectModel;
 using System.Reflection;
 
 namespace Daqifi.Desktop.Test.ViewModels;
@@ -13,6 +15,13 @@ namespace Daqifi.Desktop.Test.ViewModels;
 /// re-enumerating port and strands the update in a timeout. The dialog gates its <c>Start*Discovery</c>
 /// on <see cref="ConnectionManager.IsFirmwareUpdateInProgress"/> so a dialog opened mid-flash never
 /// starts a finder.
+/// <para>
+/// It also covers the second pause reason (issue #777): a dialog-driven HID bootloader flash never sets
+/// <c>ConnectionManager.DeviceBeingUpdated</c>, so a coordinator auto-update of a <em>different</em>
+/// device ending mid-write used to restart discovery inside the window <c>ConnectHid</c> deliberately
+/// quiesced. Both reasons must gate the restart, and — the mirror-image risk — discovery must still come
+/// back once both have cleared, in either order.
+/// </para>
 /// </summary>
 [TestClass]
 public class ConnectionDialogViewModelFirmwareGateTests
@@ -73,6 +82,144 @@ public class ConnectionDialogViewModelFirmwareGateTests
         Assert.IsNull(GetPrivateField(viewModel, "_wifiFinder"));
     }
 
+    [TestMethod]
+    public void StartConnectionFinders_StartsNothing_WhileHidFirmwareDialogOpen()
+    {
+        // issue #777: the HID firmware dialog's quiesce window is a pause reason of its own —
+        // ConnectionManager knows nothing about a manual bootloader flash.
+        var watcher = new FakeBootloaderWatcher();
+        using var viewModel = CreateViewModel(watcher);
+        SetPrivateField(viewModel, "_hidFirmwareDialogOpen", true);
+
+        viewModel.StartConnectionFinders();
+
+        Assert.IsNull(GetPrivateField(viewModel, "_serialFinder"),
+            "Serial discovery must not start while the HID firmware dialog is open.");
+        Assert.IsNull(GetPrivateField(viewModel, "_wifiFinder"),
+            "WiFi discovery must not start while the HID firmware dialog is open.");
+    }
+
+    [TestMethod]
+    public void StartConnectionFinders_StartsNothing_WhileBootloaderFlashInProgress()
+    {
+        // issue #777: a bootloader write can outlive the modal dialog that started it, so the watcher's
+        // own in-progress flag has to gate the restart too.
+        var watcher = new FakeBootloaderWatcher();
+        using var viewModel = CreateViewModel(watcher);
+        watcher.SetFlashInProgress(true);
+
+        viewModel.StartConnectionFinders();
+
+        Assert.IsNull(GetPrivateField(viewModel, "_serialFinder"),
+            "Serial discovery must not start while a HID bootloader write is in flight.");
+        Assert.IsNull(GetPrivateField(viewModel, "_wifiFinder"),
+            "WiFi discovery must not start while a HID bootloader write is in flight.");
+    }
+
+    [TestMethod]
+    public async Task HidFlashWindow_WhenAutoUpdateOfAnotherDeviceEnds_DoesNotRestartDiscovery()
+    {
+        // The issue #777 sequence: device A is auto-updating while the user opens the HID firmware
+        // dialog for device B. A's update finishes mid-window and its FirmwareUpdateInProgressChanged
+        // handler ran the restart unconditionally — re-opening every COM port and resuming WiFi
+        // broadcasts inside the window ConnectHid drained on purpose.
+        var watcher = new FakeBootloaderWatcher();
+        using var viewModel = CreateViewModel(watcher);
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
+
+        var ranInsideWindow = false;
+        await InvokeHidFlashWindowAsync(viewModel, () =>
+        {
+            ranInsideWindow = true;
+            Assert.IsTrue(IsDiscoveryPausedForFirmware(viewModel),
+                "Discovery must be paused for the whole HID firmware dialog window.");
+
+            // Device A's auto-update finishes. This raises the real event and runs the real handler.
+            ConnectionManager.Instance.DeviceBeingUpdated = null;
+
+            Assert.IsNull(GetPrivateField(viewModel, "_serialFinder"),
+                "The auto-update ending must not re-open COM ports during the HID flash window.");
+            Assert.IsNull(GetPrivateField(viewModel, "_wifiFinder"),
+                "The auto-update ending must not resume WiFi broadcasts during the HID flash window.");
+            Assert.IsTrue(IsDiscoveryPausedForFirmware(viewModel),
+                "The HID firmware dialog must keep discovery paused after the auto-update clears.");
+
+            // Keep one reason active across the window's own exit restart so this unit test never spins
+            // up a real COM-port/UDP finder. The resume-after-both-clear behavior is covered separately.
+            ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
+        });
+
+        Assert.IsTrue(ranInsideWindow, "The quiesced window must have run the dialog action.");
+        Assert.IsNull(GetPrivateField(viewModel, "_serialFinder"));
+        Assert.IsNull(GetPrivateField(viewModel, "_wifiFinder"));
+        Assert.IsFalse(GetPrivateFieldValue<bool>(viewModel, "_hidFirmwareDialogOpen"),
+            "The HID firmware dialog pause reason must clear when the dialog closes.");
+    }
+
+    [TestMethod]
+    public void DiscoveryPause_Clears_WhenTheBootloaderFlashFinishesAfterTheAutoUpdate()
+    {
+        // The mirror-image risk of the fix: a guard that refuses the restart must not leave discovery
+        // paused forever. The auto-update clears first, the HID write second — and the watcher's falling
+        // edge is what retries the restart.
+        var watcher = new FakeBootloaderWatcher();
+        using var viewModel = CreateViewModel(watcher);
+        ParkDiscoveryDrains(viewModel);
+
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
+        watcher.SetFlashInProgress(true);
+        Assert.IsTrue(IsDiscoveryPausedForFirmware(viewModel));
+
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+        Assert.IsTrue(IsDiscoveryPausedForFirmware(viewModel),
+            "Discovery must stay paused while the HID bootloader write is still in flight.");
+
+        watcher.SetFlashInProgress(false);
+
+        Assert.IsFalse(IsDiscoveryPausedForFirmware(viewModel),
+            "Discovery must be free to restart once both firmware pause reasons have cleared.");
+        Assert.IsTrue(watcher.FlashInProgressSubscriberCount > 0,
+            "The dialog must subscribe to the watcher's flash-state event, or the write finishing last " +
+            "would leave discovery paused for the rest of the dialog's life.");
+    }
+
+    [TestMethod]
+    public void DiscoveryPause_Clears_WhenTheAutoUpdateFinishesAfterTheBootloaderFlash()
+    {
+        // Same as above with the opposite completion order: the connection manager's own end-event is
+        // then the retry trigger.
+        var watcher = new FakeBootloaderWatcher();
+        using var viewModel = CreateViewModel(watcher);
+        ParkDiscoveryDrains(viewModel);
+
+        ConnectionManager.Instance.DeviceBeingUpdated = CreateUsbDevice();
+        watcher.SetFlashInProgress(true);
+
+        watcher.SetFlashInProgress(false);
+        Assert.IsTrue(IsDiscoveryPausedForFirmware(viewModel),
+            "Discovery must stay paused while the auto-update is still running.");
+
+        ConnectionManager.Instance.DeviceBeingUpdated = null;
+
+        Assert.IsFalse(IsDiscoveryPausedForFirmware(viewModel),
+            "Discovery must be free to restart once both firmware pause reasons have cleared.");
+    }
+
+    [TestMethod]
+    public void Close_UnsubscribesFromTheWatchersFlashEvent()
+    {
+        // The watcher is an app-global singleton: a leaked handler would keep a closed dialog alive and
+        // let it restart discovery long after it was dismissed.
+        var watcher = new FakeBootloaderWatcher();
+        var viewModel = CreateViewModel(watcher);
+        Assert.IsTrue(watcher.FlashInProgressSubscriberCount > 0);
+
+        viewModel.Dispose();
+
+        Assert.AreEqual(0, watcher.FlashInProgressSubscriberCount,
+            "Closing the dialog must unsubscribe it from the app-global watcher's flash event.");
+    }
+
     private static IStreamingDevice CreateUsbDevice()
     {
         var device = new Mock<IStreamingDevice>();
@@ -81,10 +228,46 @@ public class ConnectionDialogViewModelFirmwareGateTests
         return device.Object;
     }
 
-    private static ConnectionDialogViewModel CreateViewModel()
+    private static ConnectionDialogViewModel CreateViewModel(IBootloaderWatcher? watcher = null)
     {
         var dialogService = new Mock<IDialogService>();
-        return new ConnectionDialogViewModel(dialogService.Object);
+        return new ConnectionDialogViewModel(dialogService.Object, watcher);
+    }
+
+    /// <summary>
+    /// Parks both discovery drains on a task that never completes so every restart this test triggers
+    /// defers instead of creating a real COM-port/UDP finder (see <c>RestartDiscoveryWhenDrained</c>).
+    /// The assertions then read the pause gate itself, which is what every <c>Start*Discovery</c>
+    /// consults before touching hardware.
+    /// </summary>
+    private static void ParkDiscoveryDrains(ConnectionDialogViewModel viewModel)
+    {
+        var neverDrains = new TaskCompletionSource().Task;
+        SetPrivateField(viewModel, "_wifiStopTask", neverDrains);
+        SetPrivateField(viewModel, "_serialStopTask", neverDrains);
+    }
+
+    /// <summary>
+    /// Runs the dialog's HID firmware-dialog quiesce window, standing in for the modal
+    /// <c>ShowDialog</c> with <paramref name="whileOpen"/>.
+    /// </summary>
+    private static async Task InvokeHidFlashWindowAsync(ConnectionDialogViewModel viewModel, Action whileOpen)
+    {
+        var method = typeof(ConnectionDialogViewModel).GetMethod(
+            "RunWithHidFlashQuiescedAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method, "RunWithHidFlashQuiescedAsync not found.");
+
+        var task = (Task?)method.Invoke(viewModel, [whileOpen]);
+        Assert.IsNotNull(task);
+        await task;
+    }
+
+    private static bool IsDiscoveryPausedForFirmware(ConnectionDialogViewModel viewModel)
+    {
+        var property = typeof(ConnectionDialogViewModel).GetProperty(
+            "IsDiscoveryPausedForFirmware", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(property, "IsDiscoveryPausedForFirmware not found.");
+        return (bool)property.GetValue(viewModel)!;
     }
 
     private static void InvokePrivate(ConnectionDialogViewModel viewModel, string methodName)
@@ -102,4 +285,78 @@ public class ConnectionDialogViewModelFirmwareGateTests
         Assert.IsNotNull(field, $"{fieldName} not found.");
         return field.GetValue(viewModel);
     }
+
+    private static T GetPrivateFieldValue<T>(ConnectionDialogViewModel viewModel, string fieldName) =>
+        (T)GetPrivateField(viewModel, fieldName)!;
+
+    private static void SetPrivateField(ConnectionDialogViewModel viewModel, string fieldName, object? value)
+    {
+        var field = typeof(ConnectionDialogViewModel).GetField(
+            fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(field, $"{fieldName} not found.");
+        field.SetValue(viewModel, value);
+    }
+
+    #region Fakes
+    /// <summary>
+    /// Minimal <see cref="IBootloaderWatcher"/> stand-in that lets a test drive the flash-in-progress
+    /// state the dialog gates on, and reports how many handlers are attached to the change event.
+    /// </summary>
+    private sealed class FakeBootloaderWatcher : IBootloaderWatcher
+    {
+        private readonly ObservableCollection<HeldBootloader> _bootloaders = [];
+        private EventHandler? _flashInProgressChanged;
+
+        public FakeBootloaderWatcher() => Bootloaders = new ReadOnlyObservableCollection<HeldBootloader>(_bootloaders);
+
+        public ReadOnlyObservableCollection<HeldBootloader> Bootloaders { get; }
+
+        public event EventHandler<BootloaderHoldDroppedEventArgs>? HoldDropped;
+
+        public event EventHandler? FlashInProgressChanged
+        {
+            add => _flashInProgressChanged += value;
+            remove => _flashInProgressChanged -= value;
+        }
+
+        public bool IsFlashInProgress { get; private set; }
+
+        public int FlashInProgressSubscriberCount => _flashInProgressChanged?.GetInvocationList().Length ?? 0;
+
+        public void SetFlashInProgress(bool inProgress)
+        {
+            if (IsFlashInProgress == inProgress)
+            {
+                return;
+            }
+
+            IsFlashInProgress = inProgress;
+            _flashInProgressChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void Start() { }
+
+        public Task<IAsyncDisposable> PrepareFlashAsync(string devicePath)
+        {
+            SetFlashInProgress(true);
+            return Task.FromResult<IAsyncDisposable>(new FakeLease(() => SetFlashInProgress(false)));
+        }
+
+        public Task<IAsyncDisposable> SuspendDiscoveryAsync() =>
+            Task.FromResult<IAsyncDisposable>(new FakeLease(() => { }));
+
+        /// <summary>Raises <see cref="HoldDropped"/>; present so the event is not merely unused.</summary>
+        public void RaiseHoldDropped(string devicePath) =>
+            HoldDropped?.Invoke(this, new BootloaderHoldDroppedEventArgs(devicePath));
+
+        private sealed class FakeLease(Action onDispose) : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync()
+            {
+                onDispose();
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+    #endregion
 }

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -65,6 +65,14 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     public event EventHandler<BootloaderHoldDroppedEventArgs>? HoldDropped;
 
     /// <inheritdoc />
+    public event EventHandler? FlashInProgressChanged;
+
+    /// <inheritdoc />
+    // Volatile read: _flashingPath is written under _gate, but this is polled from callers that hold no
+    // gate (the connection dialog's Start*Discovery guards), so the read must not be hoisted/cached.
+    public bool IsFlashInProgress => Volatile.Read(ref _flashingPath) != null;
+
+    /// <inheritdoc />
     public void Start()
     {
         if (_disposed || _started)
@@ -83,13 +91,15 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     {
         ArgumentNullException.ThrowIfNull(devicePath);
 
+        bool flashStarted;
         await _gate.WaitAsync().ConfigureAwait(false);
         try
         {
             // Pause discovery and mark this device as the flash target so it isn't re-grabbed while the
             // flasher owns it. Other holds are left untouched (they stay wedge-proof).
             _discovery.Stop();
-            _flashingPath = devicePath;
+            flashStarted = _flashingPath == null;
+            Volatile.Write(ref _flashingPath, devicePath);
 
             if (_holds.TryGetValue(devicePath, out var hold))
             {
@@ -102,6 +112,11 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         finally
         {
             _gate.Release();
+        }
+
+        if (flashStarted)
+        {
+            RaiseFlashInProgressChanged();
         }
 
         return new WatcherLease(() => ResumeAfterFlashAsync(devicePath));
@@ -129,10 +144,12 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     #region Resume (lease disposal)
     private async Task ResumeAfterFlashAsync(string devicePath)
     {
+        bool flashEnded;
         await _gate.WaitAsync().ConfigureAwait(false);
         try
         {
-            _flashingPath = null;
+            flashEnded = _flashingPath != null;
+            Volatile.Write(ref _flashingPath, null);
 
             if (_holds.TryGetValue(devicePath, out var hold))
             {
@@ -151,6 +168,30 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
         finally
         {
             _gate.Release();
+        }
+
+        if (flashEnded)
+        {
+            RaiseFlashInProgressChanged();
+        }
+    }
+
+    /// <summary>
+    /// Raises <see cref="FlashInProgressChanged"/>. Always called with <see cref="_gate"/> released:
+    /// subscribers react by marshalling onto the UI thread, and doing that under the gate could
+    /// lock-invert with a UI-thread gate acquisition (the same reason <see cref="HoldDropped"/> is raised
+    /// outside it). Guarded so a faulting subscriber cannot propagate into the flash lease's disposal and
+    /// mask the flash's own outcome.
+    /// </summary>
+    private void RaiseFlashInProgressChanged()
+    {
+        try
+        {
+            FlashInProgressChanged?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "A FlashInProgressChanged subscriber threw while the flash state changed.");
         }
     }
 

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -158,7 +158,8 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
                     if (!hold.IsHolding)
                     {
                         RemoveHold(devicePath, hold);
-                        _logger.Information($"{devicePath} is no longer a bootloader after flashing; dropped from the held list.");
+                        _logger.Information(
+                            $"{devicePath} is no longer a bootloader after flashing; dropped from the held list.");
                     }
                 }
             }

--- a/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderWatcher.cs
@@ -144,35 +144,45 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     #region Resume (lease disposal)
     private async Task ResumeAfterFlashAsync(string devicePath)
     {
-        bool flashEnded;
+        var flashEnded = false;
         await _gate.WaitAsync().ConfigureAwait(false);
         try
         {
-            flashEnded = _flashingPath != null;
-            Volatile.Write(ref _flashingPath, null);
-
-            if (_holds.TryGetValue(devicePath, out var hold))
+            try
             {
-                // Re-grab the exact device by path. A failed/cancelled flash leaves it a bootloader →
-                // re-held. A successful flash left it in application mode → the open fails and we drop it.
-                await hold.BeginHoldAsync().ConfigureAwait(false);
-                if (!hold.IsHolding)
+                if (_holds.TryGetValue(devicePath, out var hold))
                 {
-                    RemoveHold(devicePath, hold);
-                    _logger.Information($"{devicePath} is no longer a bootloader after flashing; dropped from the held list.");
+                    // Re-grab the exact device by path. A failed/cancelled flash leaves it a bootloader →
+                    // re-held. A successful flash left it in application mode → the open fails and we drop it.
+                    await hold.BeginHoldAsync().ConfigureAwait(false);
+                    if (!hold.IsHolding)
+                    {
+                        RemoveHold(devicePath, hold);
+                        _logger.Information($"{devicePath} is no longer a bootloader after flashing; dropped from the held list.");
+                    }
                 }
             }
+            finally
+            {
+                // Clear the marker only once the handoff is complete. IsFlashInProgress is polled with no
+                // gate held (the connection dialog's discovery guards), so clearing it before awaiting the
+                // re-grab would advertise "flash over" while the HID handle is still being reopened and let
+                // the dialog resume bus probing into it. The finally is what keeps an unexpected re-grab
+                // failure from stranding the marker set, which would pause that discovery for good.
+                flashEnded = _flashingPath != null;
+                Volatile.Write(ref _flashingPath, null);
 
-            ResumeDiscoveryIfIdle();
+                ResumeDiscoveryIfIdle();
+            }
         }
         finally
         {
             _gate.Release();
-        }
 
-        if (flashEnded)
-        {
-            RaiseFlashInProgressChanged();
+            if (flashEnded)
+            {
+                RaiseFlashInProgressChanged();
+            }
         }
     }
 
@@ -185,13 +195,25 @@ public sealed class BootloaderWatcher : IBootloaderWatcher, IDisposable
     /// </summary>
     private void RaiseFlashInProgressChanged()
     {
-        try
+        var handlers = FlashInProgressChanged;
+        if (handlers == null)
         {
-            FlashInProgressChanged?.Invoke(this, EventArgs.Empty);
+            return;
         }
-        catch (Exception ex)
+
+        // Invoke each subscriber independently rather than wrapping the multicast delegate in one
+        // try/catch: a single throwing subscriber would otherwise swallow the edge for every handler
+        // registered after it, and for a connection dialog the falling edge is its only resume trigger.
+        foreach (var handler in handlers.GetInvocationList().Cast<EventHandler>())
         {
-            _logger.Error(ex, "A FlashInProgressChanged subscriber threw while the flash state changed.");
+            try
+            {
+                handler(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "A FlashInProgressChanged subscriber threw while the flash state changed.");
+            }
         }
     }
 

--- a/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
+++ b/Daqifi.Desktop/Device/Firmware/IBootloaderWatcher.cs
@@ -27,6 +27,24 @@ public interface IBootloaderWatcher
     /// <summary>Raised when a held bootloader drops off the list (device removed / surprise-detached).</summary>
     event EventHandler<BootloaderHoldDroppedEventArgs>? HoldDropped;
 
+    /// <summary>
+    /// True while a HID bootloader write is in flight — i.e. between <see cref="PrepareFlashAsync"/> and
+    /// the disposal of the lease it returned. The watcher itself uses this to keep HID discovery paused;
+    /// it is public so the connection dialog can key its own serial + WiFi discovery on the same "a
+    /// bootloader is being flashed" fact instead of a parallel flag (issue #777), because a manual flash
+    /// never sets <c>ConnectionManager.DeviceBeingUpdated</c> and so is invisible to
+    /// <c>ConnectionManager.IsFirmwareUpdateInProgress</c>.
+    /// </summary>
+    bool IsFlashInProgress { get; }
+
+    /// <summary>
+    /// Raised on both edges of <see cref="IsFlashInProgress"/>. Subscribers that quiesced their own
+    /// device I/O for the flash use the falling edge to resume: a flash lease is released asynchronously
+    /// and can outlive the dialog that started it, so the dialog's own resume may already have been
+    /// refused by the time the write actually finishes.
+    /// </summary>
+    event EventHandler? FlashInProgressChanged;
+
     /// <summary>Begins discovery and holding. Idempotent; call once at app startup.</summary>
     void Start();
 

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -47,8 +47,12 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
     /// of the window <see cref="ConnectHid"/> deliberately quiesced — most importantly the time the user
     /// spends picking a .hex before the write starts, during which an auto-update ending would otherwise
     /// restart discovery and leave it running when they hit Upload (issue #777).
+    /// <para>
+    /// Volatile: the quiesce window spans awaits, so the write that clears it can land on a thread-pool
+    /// thread when no dispatcher is present (unit tests), while a restart continuation reads it.
+    /// </para>
     /// </summary>
-    private bool _hidFirmwareDialogOpen;
+    private volatile bool _hidFirmwareDialogOpen;
 
     [ObservableProperty]
     private bool _hasNoWiFiDevices = true;
@@ -216,7 +220,7 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
     {
         InvokeOnUiThread(() =>
         {
-            if (_closed || _watcher is not { IsFlashInProgress: false }) { return; }
+            if (_closed || _watcher == null || _watcher.IsFlashInProgress) { return; }
 
             RestartDiscoveryAfterFirmwarePause();
         });

--- a/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/ConnectionDialogViewModel.cs
@@ -40,6 +40,16 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
     /// </summary>
     private readonly IBootloaderWatcher? _watcher;
 
+    /// <summary>
+    /// True from the moment <see cref="ConnectHid"/> starts quiescing discovery until the HID firmware
+    /// dialog it opened has closed. The watcher's own <see cref="IBootloaderWatcher.IsFlashInProgress"/>
+    /// only covers the write itself (<c>PrepareFlashAsync</c> → lease disposal), so this covers the rest
+    /// of the window <see cref="ConnectHid"/> deliberately quiesced — most importantly the time the user
+    /// spends picking a .hex before the write starts, during which an auto-update ending would otherwise
+    /// restart discovery and leave it running when they hit Upload (issue #777).
+    /// </summary>
+    private bool _hidFirmwareDialogOpen;
+
     [ObservableProperty]
     private bool _hasNoWiFiDevices = true;
 
@@ -153,6 +163,12 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
             HasNoHidDevices = _watcher.Bootloaders.Count == 0;
             ((System.Collections.Specialized.INotifyCollectionChanged)_watcher.Bootloaders).CollectionChanged
                 += OnHidDevicesChanged;
+
+            // A HID bootloader write can outlive the modal firmware dialog (closing it mid-flash only
+            // cancels; the watcher's flash lease is released asynchronously afterwards). Subscribe so the
+            // end of the write is a restart trigger of its own — without it, a resume refused while the
+            // write was still running would never be retried (issue #777).
+            _watcher.FlashInProgressChanged += OnBootloaderFlashInProgressChanged;
         }
 
         // Set up the duplicate device handler
@@ -180,16 +196,62 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
             }
             else
             {
-                // Flash finished — bring discovery back so the dialog keeps listing devices. The stop we
-                // issued at flash start may still be draining (a wedged port can hold StopSerialDiscoveryAsync
-                // past its timeout, leaving _serialStopTask incomplete), and Start*Discovery refuses to
-                // start while that drain is in flight. So retry the start once the drain completes rather
-                // than dropping it — otherwise discovery could stay stopped for the rest of the dialog.
-                RestartDiscoveryWhenDrained(_wifiStopTask, StartWiFiDiscovery);
-                RestartDiscoveryWhenDrained(_serialStopTask, StartSerialDiscovery);
+                // Auto-update finished — bring discovery back so the dialog keeps listing devices. The
+                // restart carries the IsDiscoveryPausedForFirmware guard, so it is correctly refused when
+                // a concurrent HID bootloader flash still needs the bus quiet (issue #777); that flash's
+                // own release path calls the restart again.
+                RestartDiscoveryAfterFirmwarePause();
             }
         });
     }
+
+    /// <summary>
+    /// Reacts to a HID bootloader write starting or finishing on the app-global watcher. Only the falling
+    /// edge needs work: <see cref="ConnectHid"/> already drained both transports before the write could
+    /// start, and <see cref="IsDiscoveryPausedForFirmware"/> keeps them from restarting while it runs.
+    /// When it ends, retry the restart — the firmware dialog may already have closed (and had its own
+    /// restart refused) while the write was still unwinding (issue #777).
+    /// </summary>
+    private void OnBootloaderFlashInProgressChanged(object? sender, EventArgs e)
+    {
+        InvokeOnUiThread(() =>
+        {
+            if (_closed || _watcher is not { IsFlashInProgress: false }) { return; }
+
+            RestartDiscoveryAfterFirmwarePause();
+        });
+    }
+
+    /// <summary>
+    /// Brings serial + WiFi discovery back after one of the firmware pause reasons cleared. Both starts
+    /// re-check <see cref="IsDiscoveryPausedForFirmware"/>, so calling this while another reason is still
+    /// active is a harmless no-op — and because every reason calls this when it clears, whichever one
+    /// clears last performs the actual restart. That is what stops a guard from leaving discovery paused
+    /// for the rest of the dialog's life.
+    /// </summary>
+    private void RestartDiscoveryAfterFirmwarePause()
+    {
+        // The stop issued when the pause began may still be draining (a wedged port can hold
+        // StopSerialDiscoveryAsync past its timeout, leaving _serialStopTask incomplete), and
+        // Start*Discovery refuses to start while that drain is in flight. So retry the start once the
+        // drain completes rather than dropping it — otherwise discovery could stay stopped for the rest
+        // of the dialog (issue #738).
+        RestartDiscoveryWhenDrained(_wifiStopTask, StartWiFiDiscovery);
+        RestartDiscoveryWhenDrained(_serialStopTask, StartSerialDiscovery);
+    }
+
+    /// <summary>
+    /// True while some firmware operation needs this dialog's serial + WiFi discovery quiesced: a
+    /// coordinator auto-update (<see cref="ConnectionManager.IsFirmwareUpdateInProgress"/>), an open HID
+    /// firmware dialog, or a HID bootloader write still in flight on the app-global watcher. The last two
+    /// are invisible to the connection manager — a manual flash never sets <c>DeviceBeingUpdated</c> — so
+    /// gating on the connection manager alone let one device's auto-update ending re-open COM ports and
+    /// resume WiFi broadcasts in the middle of another device's HID flash (issue #777).
+    /// </summary>
+    private bool IsDiscoveryPausedForFirmware =>
+        ConnectionManager.Instance.IsFirmwareUpdateInProgress
+        || _hidFirmwareDialogOpen
+        || _watcher?.IsFlashInProgress == true;
 
     /// <summary>
     /// Starts a discovery transport, deferring the start until any in-flight stop/drain for that
@@ -232,10 +294,11 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
         // draining (see _wifiStopTask above) so a fresh finder never races an old one for the socket.
         if (_closed || _wifiFinder != null || _wifiStopTask is { IsCompleted: false }) { return; }
 
-        // Don't run discovery during a firmware update: its per-cycle bus probing can starve the
-        // flash / steal the reconnecting COM port (issue #738). Covers a dialog opened mid-flash;
-        // OnFirmwareUpdateInProgressChanged restarts discovery when the flash ends.
-        if (ConnectionManager.Instance.IsFirmwareUpdateInProgress) { return; }
+        // Don't run discovery during any firmware operation: its per-cycle bus probing can starve the
+        // flash / steal the reconnecting COM port (issue #738) and can starve a HID bootloader's I/O
+        // mid-write (issue #777). Covers a dialog opened mid-flash; the release path of whichever pause
+        // reason clears last restarts discovery.
+        if (IsDiscoveryPausedForFirmware) { return; }
 
         // Reset the bound list to match the new finder's dedup set: a fresh ContinuousDeviceFinder
         // means a fresh, empty live set, so a list that outlives the finder it was populated from
@@ -268,12 +331,13 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
     {
         if (_closed || _serialFinder != null || _serialStopTask is { IsCompleted: false }) { return; }
 
-        // Don't probe COM ports during a firmware update: Core opens/reconnects the device's port
+        // Don't probe COM ports during a firmware operation: Core opens/reconnects the device's port
         // itself across the flash, and the SerialDeviceFinder opens every DAQiFi VID/PID port each
         // cycle — a probe landing in Core's JumpingToApp reconnect window steals the port and strands
-        // the update in a timeout (issue #738). Covers a dialog opened mid-flash;
-        // OnFirmwareUpdateInProgressChanged restarts discovery when the flash ends.
-        if (ConnectionManager.Instance.IsFirmwareUpdateInProgress) { return; }
+        // the update in a timeout (issue #738), and the same probing can starve a HID bootloader's I/O
+        // mid-write on another device (issue #777). Covers a dialog opened mid-flash; the release path
+        // of whichever pause reason clears last restarts discovery.
+        if (IsDiscoveryPausedForFirmware) { return; }
 
         var options = new ContinuousDiscoveryOptions
         {
@@ -523,6 +587,20 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
         var bootloader = enumerable.Cast<HeldBootloader>().FirstOrDefault();
         if (bootloader == null) { return; }
 
+        await RunWithHidFlashQuiescedAsync(() =>
+        {
+            var firmwareDialogViewModel = new FirmwareDialogViewModel(bootloader.DisplayName, bootloader.DevicePath);
+            _dialogService.ShowDialog<FirmwareDialog>(this, firmwareDialogViewModel);
+        });
+    }
+
+    /// <summary>
+    /// Runs the (modal) HID firmware dialog with WiFi + serial discovery quiesced for the whole window,
+    /// then restores discovery.
+    /// </summary>
+    /// <param name="showFirmwareDialog">Shows the modal firmware dialog; returns once it has closed.</param>
+    private async Task RunWithHidFlashQuiescedAsync(Action showFirmwareDialog)
+    {
         // Pause WiFi + serial discovery while the firmware dialog is open: their per-cycle bus probing
         // (serial opens/probes every COM port; WiFi UDP-broadcasts) can starve the bootloader's HID I/O
         // mid-flash. HID discovery and the per-device holds belong to the app-global watcher — it pauses
@@ -531,20 +609,26 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
         // bootloader stays wedge-proof. Awaiting the drains matters: cancel/dispose does NOT abort an
         // in-flight DiscoverAsync cycle, so a still-running probe could otherwise hold a handle when the
         // flasher fires.
-        await StopWiFiDiscoveryAsync();
-        await StopSerialDiscoveryAsync();
-
+        //
+        // The flag goes up BEFORE the drains: a coordinator auto-update of a different device can finish
+        // while we are awaiting them, and its FirmwareUpdateInProgressChanged handler would otherwise
+        // restart the very discovery we are tearing down (issue #777).
+        _hidFirmwareDialogOpen = true;
         try
         {
-            var firmwareDialogViewModel = new FirmwareDialogViewModel(bootloader.DisplayName, bootloader.DevicePath);
-            _dialogService.ShowDialog<FirmwareDialog>(this, firmwareDialogViewModel);
+            await StopWiFiDiscoveryAsync();
+            await StopSerialDiscoveryAsync();
+
+            showFirmwareDialog();
         }
         finally
         {
             // Resume discovery once the flash dialog closes so the device list stays live. The watcher
-            // keeps holding the bootloader (or drops it if the flash succeeded) on its own.
-            StartWiFiDiscovery();
-            StartSerialDiscovery();
+            // keeps holding the bootloader (or drops it if the flash succeeded) on its own. If an
+            // auto-update or a still-unwinding bootloader write is holding the bus, this restart is
+            // refused and that operation's own release path retries it.
+            _hidFirmwareDialogOpen = false;
+            RestartDiscoveryAfterFirmwarePause();
         }
     }
     #endregion
@@ -763,6 +847,7 @@ public partial class ConnectionDialogViewModel : ObservableObject, IDisposable
         {
             ((System.Collections.Specialized.INotifyCollectionChanged)_watcher.Bootloaders).CollectionChanged
                 -= OnHidDevicesChanged;
+            _watcher.FlashInProgressChanged -= OnBootloaderFlashInProgressChanged;
         }
     }
 


### PR DESCRIPTION
Closes #777

## The gap

`ConnectionDialogViewModel.OnFirmwareUpdateInProgressChanged`'s else-branch restarted the dialog's serial + WiFi discovery gated **only** on `ConnectionManager.IsFirmwareUpdateInProgress` (i.e. `DeviceBeingUpdated != null`). A dialog-driven HID bootloader flash — `ConnectHid` → `FirmwareDialogViewModel` → `BootloaderWatcher.PrepareFlashAsync` — sets the watcher's `_flashingPath` and **never** touches `DeviceBeingUpdated`.

So on a multi-device bench, a coordinator auto-update of device A finishing while device B's HID flash was mid-write re-opened every DAQiFi COM port and resumed WiFi UDP broadcasts inside exactly the window `ConnectHid` drained on purpose ("per-cycle bus probing … can starve the bootloader's HID I/O mid-flash").

**Verified upstream before implementing** (the ticket came from an adversarial audit of the Avalonia port). Every claim holds:

- `ConnectHid` awaits `StopWiFiDiscoveryAsync` + `StopSerialDiscoveryAsync`, then shows the firmware dialog modally; the finally restarted both.
- WPF's `ShowDialog` pushes a *nested* dispatcher frame, so the handler's `InvokeOnUiThread` callback really does run while the modal is up — the race is reachable, not theoretical.
- `BootloaderWatcher.ResumeDiscoveryIfIdle` already documents and guards this same manual-flash vs auto-update overlap, but only at the **HID-discovery** layer. Nothing carried that awareness to the dialog's WiFi/serial restart.

## The fix

**Reuse the watcher's existing notion of an in-progress flash** instead of inventing a parallel flag. `IBootloaderWatcher` gains:

- `bool IsFlashInProgress` — `_flashingPath != null`, volatile-read since the dialog polls it holding no gate.
- `event EventHandler? FlashInProgressChanged` — raised on both edges, **outside `_gate`** (same lock-inversion reasoning as `HoldDropped`) and guarded so a faulting subscriber can't propagate into the flash lease's disposal and mask the flash's outcome.

The dialog collapses all three pause reasons into one predicate that both `Start*Discovery` guards and the restart consult:

```csharp
private bool IsDiscoveryPausedForFirmware =>
    ConnectionManager.Instance.IsFirmwareUpdateInProgress
    || _hidFirmwareDialogOpen
    || _watcher?.IsFlashInProgress == true;
```

`_hidFirmwareDialogOpen` is **not** a duplicate of the watcher's flag — the watcher only knows about the write itself (`PrepareFlashAsync` → lease disposal). The dialog's quiesce window is wider on both ends, and both extra slices matter:

- **Before the write.** The user is picking a `.hex`. Gating on `IsFlashInProgress` alone would let the auto-update's end restart discovery here, and it would still be running when they hit Upload — the bug, just moved.
- **Around the drains.** The flag goes up *before* `ConnectHid` awaits the two stops, because the auto-update can end while we're awaiting them and would otherwise restart the discovery we're mid-teardown of.

`ConnectHid`'s body moved into `RunWithHidFlashQuiescedAsync(Action)` so the quiesce window is one reviewable unit (and drivable from a test without a real modal).

## The mirror-image bug, deliberately covered

A guard that refuses a restart is only safe if something reliably retries it. The invariant here: **every pause reason calls the same restart when it clears**, and each restart re-checks the full predicate — so whichever reason clears *last* performs the actual restart, in either order.

That's why `FlashInProgressChanged` exists rather than just the flag. A bootloader write can outlive the modal dialog that started it: closing the firmware dialog mid-flash only *cancels*, and the watcher's flash lease is released asynchronously in `UploadFirmware`'s finally. Without the falling-edge subscription, `ConnectHid`'s exit restart would be refused by a write that was still unwinding and nothing would ever try again — discovery paused for the rest of the dialog's life.

Two tests pin both completion orders. The subscription is torn down in `Close()` (the watcher is an app-global singleton, so a leaked handler would let a dismissed dialog restart discovery).

`ConnectHid`'s exit also now routes through `RestartDiscoveryAfterFirmwarePause`, which defers past an in-flight drain — previously it called `Start*Discovery` directly, so a `StopSerialDiscoveryAsync` that hit its 5s timeout left `_serialStopTask` incomplete and the restart was silently dropped.

## Testing

`dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"` → **813/813 pass**.

`ConnectionDialogViewModelFirmwareGateTests` (+6):
- `StartConnectionFinders_StartsNothing_WhileHidFirmwareDialogOpen` / `_WhileBootloaderFlashInProgress` — each new reason gates both transports.
- `HidFlashWindow_WhenAutoUpdateOfAnotherDeviceEnds_DoesNotRestartDiscovery` — the issue #777 sequence end-to-end: A's real `FirmwareUpdateInProgressChanged` fires inside B's quiesce window, and neither finder is created.
- `DiscoveryPause_Clears_WhenTheBootloaderFlashFinishesAfterTheAutoUpdate` / `_WhenTheAutoUpdateFinishesAfterTheBootloaderFlash` — the mirror-image, both orders.
- `Close_UnsubscribesFromTheWatchersFlashEvent`.

`BootloaderWatcherTests` (+2): the flag and both event edges; and a throwing subscriber neither faults the lease nor blocks HID discovery from resuming.

I confirmed these fail against the pre-fix logic rather than assuming they do — reverting `IsDiscoveryPausedForFirmware` to the old `IsFirmwareUpdateInProgress`-only form makes `DiscoveryPause_Clears_WhenTheBootloaderFlashFinishesAfterTheAutoUpdate` fail on "Discovery must stay paused while the HID bootloader write is still in flight."

Two deliberate test-hygiene choices, both to keep the unit suite off real hardware (a passing `Start*Discovery` opens every DAQiFi VID/PID COM port and starts UDP broadcasting — no existing test in this suite does that):
- The mirror-image tests park both stop-drains on a never-completing task and assert the **pause gate** rather than a live finder. The gate is what every `Start*Discovery` consults before touching hardware.
- The `#777` sequence test re-arms the auto-update before its window exits, so the exit restart is refused too.

## Bench validation: not possible — unit tests only

**Not bench-validated, and it can't be.** Reproducing this needs **two devices flashing concurrently** and only one device is on the bench. Firmware flashing on the bench device is also off-limits (an interrupted flash bricks it, and bootloader bug daqifi-nyquist-firmware#568 makes HID flashes fail probabilistically with no host-side fix). No hardware was touched for this PR — I did not acquire the bench lock.

The change is confined to when discovery is *allowed to start*, and the failure mode it prevents was already recoverable (the device stays in the bootloader), so the risk of shipping on unit coverage is low. The concurrent-flash scenario would need a two-device bench to observe directly.

## Notes

Follows the reasoning and test style of PR #751 / issue #738. No changes to `ConnectionManager` — its firmware gate is about a *connected* device's port, and a sitting HID bootloader isn't one.

Branched off `origin/main` at #784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
