### PR TITLE
fix(devices): marshal device-reported friendly-name updates to the UI thread

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
@@ -142,11 +142,13 @@ public class DaqifiViewModelFriendlyNameTests
     }
 
     [TestMethod]
-    public void DeviceReportsName_AfterSelectionMovedOn_LeavesTheNewDrawerAlone()
+    public void SelectionMovingOn_DetachesThePreviousDevicesNameUpdates()
     {
-        // Arrange — unsubscription races the async inbound-message pipeline, so an update from a
-        // device the user has navigated away from can still reach the handler. Now that the guard
-        // runs on the UI thread at apply time, it is checked against the drawer's current selection.
+        // Arrange — the first line of defence against a name from a device the user has navigated
+        // away from landing in the successor's drawer: OnSelectedDeviceChanged unsubscribes the
+        // outgoing device. (The apply-time `device != SelectedDevice` guard in the handler covers
+        // the residual case this cannot reach — an update already in flight when the selection
+        // changes, which needs a real dispatcher queue to stage and so is not simulated here.)
         var device = CreateNotifyingDevice("Name From Old Device");
         var viewModel = CreateViewModel(device.Object);
         viewModel.SelectedDevice = CreateConnectedDevice().Object;

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Daqifi.Desktop.Device;
 using Daqifi.Desktop.DialogService;
 using Daqifi.Desktop.ViewModels;
@@ -6,9 +7,10 @@ using Moq;
 namespace Daqifi.Desktop.Test.ViewModels;
 
 /// <summary>
-/// Covers the failure contract of the Devices drawer's NAME field: which exceptions
-/// <see cref="DaqifiViewModel.SetFriendlyName"/> turns into inline feedback, and which message
-/// the user sees for each.
+/// Covers the Devices drawer's NAME field: the failure contract of
+/// <see cref="DaqifiViewModel.SetFriendlyName"/> (which exceptions become inline feedback, and the
+/// message the user sees for each), and the edit buffer's behaviour when the device reports a name
+/// of its own from a background thread (issue #778).
 /// </summary>
 [TestClass]
 public class DaqifiViewModelFriendlyNameTests
@@ -102,11 +104,127 @@ public class DaqifiViewModelFriendlyNameTests
         Assert.IsFalse(viewModel.FriendlyNameApplied, "The applied banner belongs to the drawer that is now closed.");
     }
 
+    [TestMethod]
+    public void DeviceReportsName_FromBackgroundThread_UpdatesTheDrawerField()
+    {
+        // Arrange — the device's FriendlyName PropertyChanged is raised on Core's inbound-message
+        // consumer thread (a dedicated background Thread in Core's StreamMessageConsumer), never on
+        // the UI thread. The handler marshals through UiThreadHelper, which runs inline in this
+        // WPF-runtime-free test host (Application.Current is null); the point of raising from a real
+        // background thread is that the hop must neither block nor silently drop the update there.
+        var device = CreateNotifyingDevice("Bench Rig 7");
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SeedPendingFriendlyName("Bench Rig 3");
+
+        // Act
+        RaiseFriendlyNameChangedOnBackgroundThread(device);
+
+        // Assert
+        Assert.AreEqual("Bench Rig 7", viewModel.PendingFriendlyName);
+    }
+
+    [TestMethod]
+    public void DeviceReportsName_WhileUserIsTyping_DoesNotClobberTheInProgressEdit()
+    {
+        // Arrange — issue #778: a late-duplicate SYSTem:SYSInfoPB? status response (Core re-sends
+        // the request while waiting for channels to populate, so a stale one can land after
+        // Connect() returns and the drawer is open) must not seed over what the user is typing.
+        var device = CreateNotifyingDevice("Name From Device");
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SeedPendingFriendlyName("Bench Rig 3");
+        viewModel.PendingFriendlyName = "Bench Rig 4";  // user edit — marks the buffer dirty
+
+        // Act
+        RaiseFriendlyNameChangedOnBackgroundThread(device);
+
+        // Assert
+        Assert.AreEqual("Bench Rig 4", viewModel.PendingFriendlyName);
+    }
+
+    [TestMethod]
+    public void DeviceReportsName_AfterSelectionMovedOn_LeavesTheNewDrawerAlone()
+    {
+        // Arrange — unsubscription races the async inbound-message pipeline, so an update from a
+        // device the user has navigated away from can still reach the handler. Now that the guard
+        // runs on the UI thread at apply time, it is checked against the drawer's current selection.
+        var device = CreateNotifyingDevice("Name From Old Device");
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SelectedDevice = CreateConnectedDevice().Object;
+        viewModel.SeedPendingFriendlyName("Successor Rig");
+
+        // Act
+        RaiseFriendlyNameChangedOnBackgroundThread(device);
+
+        // Assert
+        Assert.AreEqual("Successor Rig", viewModel.PendingFriendlyName);
+    }
+
+    [TestMethod]
+    public void DeviceReportsEmptyName_FromBackgroundThread_ClearsTheDrawerField()
+    {
+        // Arrange — the second reachability path in issue #778: transport instances are reused
+        // across reconnects on the same COM port, and AbstractStreamingDevice.OnStatusMessageReceived
+        // assigns friendly_device_name unconditionally, so a device with no name set reports empty.
+        // A clean buffer must follow that clear rather than keep the previous device's name.
+        var device = CreateNotifyingDevice(string.Empty);
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SeedPendingFriendlyName("Previous Device Name");
+
+        // Act
+        RaiseFriendlyNameChangedOnBackgroundThread(device);
+
+        // Assert
+        Assert.AreEqual(string.Empty, viewModel.PendingFriendlyName);
+    }
+
+    [TestMethod]
+    public void DeviceReportsUnrelatedProperty_LeavesTheDrawerFieldAlone()
+    {
+        // Arrange — a streaming device raises other change notifications too (AbstractStreamingDevice
+        // raises IsConnected from its Core status handler, for one); only FriendlyName may touch the
+        // edit buffer, and only it should pay for the dispatcher hop.
+        var device = CreateNotifyingDevice("Name From Device");
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SeedPendingFriendlyName("Bench Rig 3");
+
+        // Act
+        device.As<INotifyPropertyChanged>().Raise(
+            d => d.PropertyChanged += null, new PropertyChangedEventArgs(nameof(IStreamingDevice.IsConnected)));
+
+        // Assert
+        Assert.AreEqual("Bench Rig 3", viewModel.PendingFriendlyName);
+    }
+
+    /// <summary>
+    /// Raises the device's <see cref="IStreamingDevice.FriendlyName"/> change notification from a
+    /// thread-pool thread and waits for it, mirroring how Core's message-consumer thread delivers
+    /// status-driven name updates.
+    /// </summary>
+    private static void RaiseFriendlyNameChangedOnBackgroundThread(Mock<IStreamingDevice> device)
+    {
+        Task.Run(() => device.As<INotifyPropertyChanged>().Raise(
+                d => d.PropertyChanged += null,
+                new PropertyChangedEventArgs(nameof(IStreamingDevice.FriendlyName))))
+            .GetAwaiter().GetResult();
+    }
+
     private static Mock<IStreamingDevice> CreateConnectedDevice()
     {
         var device = new Mock<IStreamingDevice>();
         device.SetupGet(d => d.IsConnected).Returns(true);
         device.SetupGet(d => d.DeviceDisplayName).Returns("12345");
+        return device;
+    }
+
+    /// <summary>
+    /// Builds a connected device that also implements <see cref="INotifyPropertyChanged"/>, which is
+    /// what <c>DaqifiViewModel</c> subscribes to when the selected device changes.
+    /// </summary>
+    private static Mock<IStreamingDevice> CreateNotifyingDevice(string friendlyName)
+    {
+        var device = CreateConnectedDevice();
+        device.SetupGet(d => d.FriendlyName).Returns(friendlyName);
+        device.As<INotifyPropertyChanged>();
         return device;
     }
 

--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
@@ -197,6 +197,49 @@ public class DaqifiViewModelFriendlyNameTests
         Assert.AreEqual("Bench Rig 3", viewModel.PendingFriendlyName);
     }
 
+    [TestMethod]
+    public void DeviceReportsName_DoesNotMutateTheBufferOnTheEventThread()
+    {
+        // Arrange — the guard against this PR silently regressing. The other tests here run in a
+        // host with no Application.Current, where UiThreadHelper deliberately falls back to running
+        // inline, so they would still pass if the handler went back to mutating the UI-bound buffer
+        // straight from the message-consumer thread. Swapping in an invoker that captures the action
+        // instead of running it makes the hop itself observable: nothing may reach the buffer until
+        // the marshalled action is actually run.
+        var device = CreateNotifyingDevice("Name From Device");
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SeedPendingFriendlyName("Bench Rig 3");
+        Action? marshalled = null;
+        viewModel.UiInvoker = (action, _) => marshalled = action;
+
+        // Act
+        RaiseFriendlyNameChangedOnBackgroundThread(device);
+
+        // Assert
+        Assert.IsNotNull(marshalled, "The update was not handed to the UI-thread invoker at all.");
+        Assert.AreEqual(
+            "Bench Rig 3", viewModel.PendingFriendlyName,
+            "The edit buffer was mutated on the event thread instead of being marshalled.");
+    }
+
+    [TestMethod]
+    public void DeviceReportsName_AppliesTheNameOnceTheMarshalledActionRuns()
+    {
+        // Arrange — the other half of the contract: the update must be deferred, not discarded.
+        var device = CreateNotifyingDevice("Name From Device");
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SeedPendingFriendlyName("Bench Rig 3");
+        Action? marshalled = null;
+        viewModel.UiInvoker = (action, _) => marshalled = action;
+        RaiseFriendlyNameChangedOnBackgroundThread(device);
+
+        // Act — stand in for the dispatcher draining its queue on the UI thread.
+        marshalled!();
+
+        // Assert
+        Assert.AreEqual("Name From Device", viewModel.PendingFriendlyName);
+    }
+
     /// <summary>
     /// Raises the device's <see cref="IStreamingDevice.FriendlyName"/> change notification from a
     /// thread-pool thread and waits for it, mirroring how Core's message-consumer thread delivers

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1052,6 +1052,20 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         }
     }
 
+    /// <summary>
+    /// Marshals a drawer-buffer update onto the UI thread. Defaults to
+    /// <see cref="UiThreadHelper.InvokeOnUiThread"/> and is only swapped by tests.
+    /// </summary>
+    /// <remarks>
+    /// The seam exists because the hop is otherwise unobservable in the unit-test host: with no
+    /// <c>Application.Current</c> the production helper runs its action inline, so a regression that
+    /// mutated the edit buffer straight from the event thread would still pass. Substituting an
+    /// invoker that captures the action instead of running it makes "the mutation goes through the
+    /// hop" directly assertable, without standing up a process-global WPF <c>Application</c> that
+    /// other test classes rely on being absent.
+    /// </remarks>
+    internal Action<Action, string?> UiInvoker { get; set; } = UiThreadHelper.InvokeOnUiThread;
+
     private void OnSelectedDeviceFriendlyNameChanged(object? sender, PropertyChangedEventArgs e)
     {
         // PropertyChangedEventArgs is immutable, so this filter is safe to run on the raising
@@ -1079,7 +1093,7 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         //
         // The guards below deliberately live inside the hop: evaluating them here would be exactly
         // the unsynchronized cross-thread read this is fixing.
-        UiThreadHelper.InvokeOnUiThread(
+        UiInvoker(
             () => ApplyDeviceFriendlyName(device),
             "Dispatcher unavailable while syncing the Devices drawer NAME field; update dropped.");
     }

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -100,6 +100,21 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     /// </summary>
     private bool _isSeedingPendingFriendlyName;
 
+    /// <summary>
+    /// Marshals a drawer-buffer update onto the UI thread — the mechanism that keeps the three
+    /// fields above UI-thread-confined. Defaults to <see cref="UiThreadHelper.InvokeOnUiThread"/>
+    /// and is only swapped by tests.
+    /// </summary>
+    /// <remarks>
+    /// The seam exists because the hop is otherwise unobservable in the unit-test host: with no
+    /// <c>Application.Current</c> the production helper runs its action inline, so a regression that
+    /// mutated the edit buffer straight from the event thread would still pass. Substituting an
+    /// invoker that captures the action instead of running it makes "the mutation goes through the
+    /// hop" directly assertable, without standing up a process-global WPF <c>Application</c> that
+    /// other test classes rely on being absent.
+    /// </remarks>
+    internal Action<Action, string?> UiInvoker { get; set; } = UiThreadHelper.InvokeOnUiThread;
+
     [ObservableProperty]
     private bool _friendlyNameApplied;
 
@@ -1051,20 +1066,6 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             newNotifier.PropertyChanged += OnSelectedDeviceFriendlyNameChanged;
         }
     }
-
-    /// <summary>
-    /// Marshals a drawer-buffer update onto the UI thread. Defaults to
-    /// <see cref="UiThreadHelper.InvokeOnUiThread"/> and is only swapped by tests.
-    /// </summary>
-    /// <remarks>
-    /// The seam exists because the hop is otherwise unobservable in the unit-test host: with no
-    /// <c>Application.Current</c> the production helper runs its action inline, so a regression that
-    /// mutated the edit buffer straight from the event thread would still pass. Substituting an
-    /// invoker that captures the action instead of running it makes "the mutation goes through the
-    /// hop" directly assertable, without standing up a process-global WPF <c>Application</c> that
-    /// other test classes rely on being absent.
-    /// </remarks>
-    internal Action<Action, string?> UiInvoker { get; set; } = UiThreadHelper.InvokeOnUiThread;
 
     private void OnSelectedDeviceFriendlyNameChanged(object? sender, PropertyChangedEventArgs e)
     {

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -87,9 +87,17 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     /// device's <see cref="IStreamingDevice.FriendlyName"/> changes. Reset whenever the buffer is
     /// (re)seeded programmatically.
     /// </summary>
+    /// <remarks>
+    /// UI-thread-confined, and unsynchronized because of it: the device-reported updates that read
+    /// it arrive on a background thread and are marshalled by
+    /// <see cref="OnSelectedDeviceFriendlyNameChanged"/> before they touch this field (issue #778).
+    /// </remarks>
     private bool _pendingFriendlyNameDirty;
 
-    /// <summary>Guards <see cref="OnPendingFriendlyNameChanged"/> during a programmatic seed.</summary>
+    /// <summary>
+    /// Guards <see cref="OnPendingFriendlyNameChanged"/> during a programmatic seed.
+    /// UI-thread-confined for the same reason as <see cref="_pendingFriendlyNameDirty"/>.
+    /// </summary>
     private bool _isSeedingPendingFriendlyName;
 
     [ObservableProperty]
@@ -1046,20 +1054,56 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
 
     private void OnSelectedDeviceFriendlyNameChanged(object? sender, PropertyChangedEventArgs e)
     {
+        // PropertyChangedEventArgs is immutable, so this filter is safe to run on the raising
+        // thread — and it keeps the common case (any other property changing) from paying for a
+        // dispatcher hop.
         if (e.PropertyName != nameof(IStreamingDevice.FriendlyName))
         {
             return;
         }
-        // Don't clobber an in-progress edit, and ignore stale events from a device that is no
-        // longer selected (unsubscription races with the async inbound-message pipeline).
-        if (_pendingFriendlyNameDirty || sender != SelectedDevice)
+        if (sender is not IStreamingDevice device)
         {
             return;
         }
-        if (sender is IStreamingDevice device)
+
+        // This event does not arrive on the UI thread. Core raises StatusMessageReceived from its
+        // inbound-message consumer (a dedicated background thread), which is what drives
+        // AbstractStreamingDevice.OnStatusMessageReceived's FriendlyName write; the optimistic
+        // write at the end of AbstractStreamingDevice.SetFriendlyName runs on a thread-pool thread
+        // because SetFriendlyName is invoked via Task.Run. The drawer's edit buffer
+        // (PendingFriendlyName, _pendingFriendlyNameDirty, _isSeedingPendingFriendlyName) is
+        // otherwise touched only by the UI thread as the user types, and those flags carry no
+        // synchronization — so an update landing mid-edit could seed over the in-progress edit, or
+        // race the dirty flag and let the next update wipe it (issue #778). Marshaling the whole
+        // body keeps every one of those fields UI-thread-confined.
+        //
+        // The guards below deliberately live inside the hop: evaluating them here would be exactly
+        // the unsynchronized cross-thread read this is fixing.
+        UiThreadHelper.InvokeOnUiThread(
+            () => ApplyDeviceFriendlyName(device),
+            "Dispatcher unavailable while syncing the Devices drawer NAME field; update dropped.");
+    }
+
+    /// <summary>
+    /// Applies <paramref name="device"/>'s reported <see cref="IStreamingDevice.FriendlyName"/> to
+    /// the drawer's edit buffer. Always runs on the UI thread — see
+    /// <see cref="OnSelectedDeviceFriendlyNameChanged"/>, which marshals it there.
+    /// </summary>
+    private void ApplyDeviceFriendlyName(IStreamingDevice device)
+    {
+        // Don't clobber an in-progress edit, and ignore stale events from a device that is no
+        // longer selected (unsubscription races with the async inbound-message pipeline). Both are
+        // evaluated against the drawer's state at apply time, which is the state the user is
+        // actually looking at.
+        if (_pendingFriendlyNameDirty || device != SelectedDevice)
         {
-            SeedPendingFriendlyName(device.FriendlyName);
+            return;
         }
+
+        // Read the name here rather than capturing it when the event was raised: if several updates
+        // queue up behind each other the last one wins either way, and reading at apply time can
+        // never seed a value the device has already superseded.
+        SeedPendingFriendlyName(device.FriendlyName);
     }
 
     private async Task ShowFriendlyNameAppliedStatusAsync()


### PR DESCRIPTION
## Problem

The Devices drawer's NAME field is backed by a small edit buffer on `DaqifiViewModel` — `PendingFriendlyName` plus two plain, non-volatile flags, `_pendingFriendlyNameDirty` and `_isSeedingPendingFriendlyName`. Two handlers write it, and until now they did so from two different threads with no lock and no marshaling:

- `OnPendingFriendlyNameChanged` — UI thread, as the user types.
- `OnSelectedDeviceFriendlyNameChanged` — **not** the UI thread.

A device-reported name arriving mid-edit could therefore `SeedPendingFriendlyName(...)` straight over the in-progress edit, or race the dirty flag so the edit was never marked and the next update wiped it. Impact is a silently lost in-progress edit in a narrow window: no crash, and no wrong NVM write, since Save sends whatever is visible.

## Verifying the diagnosis

The ticket came out of an adversarial audit of the Avalonia port, so I checked each claim against this repo and Core `1.3.0` (the consumed version) rather than taking it on trust. All of it holds upstream:

**The handler runs off the UI thread.** `AbstractStreamingDevice.OnStatusMessageReceived` assigns `FriendlyName` (an `[ObservableProperty]`), and it is wired to Core's `StatusMessageReceived` in `SubscribeCoreDeviceEvents`. In Core, that event is raised by `DaqifiDevice.OnStatusMessageReceived` → `RaiseClassifiedEvent`, reached from the consumer loop whose owner is `StreamMessageConsumer.cs:168` — `_consumerThread = new Thread(ProcessMessages)`. A dedicated background thread, confirmed.

**Reachability path 1 — late-duplicate `SYSTem:SYSInfoPB?`.** Confirmed, and it is by design rather than incidental: Core's `WaitForChannelsPopulatedAsync` documents that it *"re-send[s] the request periodically until channels populate or the timeout elapses."* Multiple `GetDeviceInfo` requests can be outstanding, so a response to an earlier one can land after `InitializeAsync` — and therefore after `Connect()` — has returned, i.e. once the drawer can be open and the user typing.

**Reachability path 2 — reused-transport reconnect.** Confirmed, and this repo already documents it, in the remarks on `OnStatusMessageReceived`: `SerialStreamingDevice` instances are reused across reconnects on the same COM port, which is why the field is assigned unconditionally (including clearing to empty).

**One path the ticket didn't mention, which is not narrow at all.** `AbstractStreamingDevice.SetFriendlyName` ends with an optimistic `FriendlyName = name`, and `DaqifiViewModel.SetFriendlyName` invokes it via `await Task.Run(...)`. So *every successful save* raised this handler on a thread-pool thread, deterministically — not just in a rare timing window. It was benign in practice (the buffer is dirty, so the handler returned early) but it was an unsynchronized cross-thread read of those flags on the completely ordinary path.

## Fix

Marshal `OnSelectedDeviceFriendlyNameChanged`'s body onto the dispatcher via `UiThreadHelper.InvokeOnUiThread` — the seam this repo already uses for exactly this (`ConnectionManager`, `AbstractStreamingDevice.OnCoreStatusChanged`, `ConnectionDialogViewModel`). It `BeginInvoke`s, so a background caller can never block on the UI thread, and it runs the action **inline** when `Application.Current` is null, which is what keeps it working in the WPF-runtime-free unit-test host. (It is reached through an `internal UiInvoker` indirection that defaults to it, so the hop is assertable in tests — see below.)

Three details worth flagging for review:

- **The guards moved inside the hop.** Checking `_pendingFriendlyNameDirty` / `SelectedDevice` before dispatching would be precisely the unsynchronized cross-thread read this is meant to eliminate. They are now evaluated against the drawer's state at apply time, which is the state the user is actually looking at.
- **The `e.PropertyName` filter stays outside it.** `PropertyChangedEventArgs` is immutable, so it is safe on the raising thread, and it keeps every unrelated property change on a streaming device from paying for a dispatcher hop.
- **The name is read at apply time, not captured at raise time.** If several updates queue up, the last one wins either way, and reading late can never seed a value the device has already superseded.

Deliberately **not** a repo-wide threading refactor. The systemic device-path convention the ticket notes — no device-path INPC handler marshals; the binding layer handles visual updates — is untouched. This is scoped to the one piece of device-path state that is a mutable UI edit buffer rather than a display value, which is what makes it different from its neighbours.

## Tests

Seven tests added to `DaqifiViewModelFriendlyNameTests.cs`.

**Proving the hop itself.** `DaqifiViewModel` gets an `internal Action<Action, string?> UiInvoker` seam defaulting to `UiThreadHelper.InvokeOnUiThread`. Two tests swap in an invoker that captures the action instead of running it:

- the edit buffer is still untouched after the event, and the action did reach the invoker — i.e. nothing was written on the event thread;
- running the captured action applies the name — i.e. the update is deferred, not dropped.

I verified these actually bite instead of assuming it: temporarily reverting the handler to a direct `ApplyDeviceFriendlyName(device)` call fails both, while the other nine still pass.

**Behaviour, raising `PropertyChanged` from a real background thread:**

- a clean buffer follows a device-reported name;
- an in-progress edit survives one (the #778 case);
- selection moving on detaches the previous device's updates;
- an empty reported name clears a clean buffer (the reused-transport reconnect path);
- a non-`FriendlyName` property change doesn't touch the buffer.

These five run inline, since `Application.Current` is null in the test host — they pin the inline-fallback contract (the update must be applied, not dropped or deadlocked, when there is no dispatcher) rather than the marshaling. I chose the injectable seam over an STA/message-pump test for the marshaling half because `Application.Current` is process-global, MSTest v4 parallelizes at class level, and other test classes here rely on it being null (see the comment in `PlotModelFactoryTests`) — a real `Application` would trade one assertion for cross-class flakiness.

One test-honesty note, since I caught it in my own review: the "selection moved on" test originally claimed to prove a name from a *deselected* device is ignored, by raising on the outgoing device after selection moved. That held vacuously — `OnSelectedDeviceChanged` unsubscribes the outgoing device, so the raise reached no handler at all. It now asserts the unsubscription itself, which is real and does fail if that detach regresses. The handler's apply-time `device != SelectedDevice` guard therefore covers only the residual in-flight case and is defence-in-depth; the commit says so.

Full unit gate: **812/812 green.**



## Bench validation

Ran on the attached device (COM3, serial `9090539562006014104`), worktree Debug build, bench mutex held:

`dotnet test Daqifi.Desktop.UITest --filter "FullyQualifiedName~FriendlyNameTests"` → **1/1 passed** (122s).

This is a genuine test of the changed code path, not just a smoke check. `SetFriendlyName_PersistsAcrossReconnect` sets a name through the drawer, asserts the field shows it, then disconnects, reconnects the same physical device, streams a frame, and asserts the drawer shows the name the *device* reports. That last assertion arrives via `OnSelectedDeviceFriendlyNameChanged` on Core's background consumer thread, through the new dispatcher hop, into the bound field — with a real `Application.Current` and a real message loop, so `BeginInvoke` was actually taken. Had the hop dropped the update or deadlocked, that assertion would have failed.

What I did **not** do on the bench is reproduce the race itself. It is a narrow interleaving by the ticket's own framing, and I have no reliable way to land a status-message-driven update inside a keystroke on demand; claiming otherwise would be dressing up a green regression run as something it isn't.

Device NVM housekeeping: the friendly name read `UITest-163622` before the run (itself a leftover from an earlier run of this same UI test). The test left it at `UITest-170710`; I set it back to `UITest-163622` and confirmed the restore on a fresh connection.

## Related

Touches the same friendly-name region as #784 (`chore(device): delegate friendly-name SCPI and validation to Core`), which merged into `main` while this was in progress — so this branches off the post-#784 tree and there is no conflict. #784 rewrote the save path (`SetFriendlyName` and its `SeedPendingFriendlyName` call site); this changes only the device-reported update path, and the two compose.

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
