### PR TITLE
fix(sd-import): normalize Core's transport timeout and stop aborting the batch on one bad file

### DIFF
--- a/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
@@ -69,10 +69,10 @@ public class SdCardDownloadFailureTests
         // only care that the operation timed out still catch it.
         StringAssert.Contains(ex.Message, FileName);
         Assert.IsInstanceOfType<TimeoutException>(ex);
-        Assert.IsTrue(ex.IsProlongedSilence,
+        Assert.IsTrue(ex.IsProlongedFailure,
             "The watchdog watched the device say nothing for the full window, which is what makes " +
             "this one broad enough to abandon a batch import over.");
-        Assert.AreEqual(STALL_TIMEOUT, ex.StallTimeout);
+        Assert.AreEqual(STALL_TIMEOUT, ex.Elapsed);
     }
 
     [TestMethod]
@@ -102,10 +102,66 @@ public class SdCardDownloadFailureTests
         StringAssert.Contains(ex.Message, FileName);
         Assert.AreSame(transportTimeout, ex.InnerException,
             "Core's own message carries the byte count, which is the only diagnostic the log gets.");
-        Assert.IsFalse(ex.IsProlongedSilence,
+        Assert.IsFalse(ex.IsProlongedFailure,
             "The transport gave up in well under a second, so this says far less about the card " +
             "than the watchdog firing does and must not abort a batch (issue #780).");
-        Assert.IsNull(ex.StallTimeout);
+    }
+
+    [TestMethod]
+    public async Task Download_WhenCoreBurnsTheWholeStallWindowFirst_CountsAsProlonged()
+    {
+        // Arrange — Core reports its 30-minute transfer cap through the same untyped
+        // TimeoutException as its half-second serial read timeout. Treating both as cheap
+        // per-file failures would let a batch pay that wait once for every remaining file, so
+        // what separates them is how long the attempt actually ran.
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, IProgress<SdCardTransferProgress> progress, CancellationToken ct) =>
+            {
+                // Keep reporting progress so the desktop's own watchdog never fires: this has to
+                // be Core's cap being reached, not ours.
+                for (var i = 1; i <= 8; i++)
+                {
+                    await Task.Delay(STALL_TIMEOUT / 4, ct);
+                    progress?.Report(new SdCardTransferProgress(i * 1024L, FileName));
+                }
+
+                throw new TimeoutException("SD card file download timed out after 1800 seconds.");
+            });
+
+        // Act
+        var ex = await Assert.ThrowsExactlyAsync<SdCardDownloadStalledException>(() =>
+            _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, CancellationToken.None));
+
+        // Assert
+        Assert.IsTrue(ex.IsProlongedFailure,
+            "An attempt that already cost the full stall window must not be repeated per file.");
+        Assert.IsTrue(ex.Elapsed >= STALL_TIMEOUT);
+    }
+
+    [TestMethod]
+    public async Task Download_WhenTheCallerCancelsAndTheTransportTimesOut_StaysCancelled()
+    {
+        // Arrange — over serial the read does not observe the cancellation token, so pressing
+        // cancel can surface as a transport timeout rather than a cancellation. Relabelling that
+        // as a stall would report a device fault the user caused themselves, and would let a
+        // batch import carry on past a cancel instead of stopping.
+        using var cts = new CancellationTokenSource();
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, IProgress<SdCardTransferProgress> _, CancellationToken _) =>
+            {
+                await cts.CancelAsync();
+                throw new TimeoutException("Transport stream closed before receiving the EOF marker.");
+            });
+
+        // Act
+        var download = () => _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, cts.Token);
+
+        // Assert
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(download);
     }
 
     [TestMethod]
@@ -119,9 +175,12 @@ public class SdCardDownloadFailureTests
                 It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new SdCardNotPresentException(new List<string>(), "No card"));
 
-        // Act & Assert
-        await Assert.ThrowsExactlyAsync<SdCardNotPresentException>(() =>
-            _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, CancellationToken.None));
+        // Act
+        var download = () => _importer.DownloadWithStallWatchdogAsync(
+            _mockDevice.Object, FileName, CancellationToken.None);
+
+        // Assert
+        await Assert.ThrowsExactlyAsync<SdCardNotPresentException>(download);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
@@ -72,7 +72,7 @@ public class SdCardDownloadFailureTests
         Assert.IsTrue(ex.IsProlongedFailure,
             "The watchdog watched the device say nothing for the full window, which is what makes " +
             "this one broad enough to abandon a batch import over.");
-        Assert.AreEqual(STALL_TIMEOUT, ex.Elapsed);
+        Assert.AreEqual(STALL_TIMEOUT, ex.SilentFor);
     }
 
     [TestMethod]
@@ -108,25 +108,54 @@ public class SdCardDownloadFailureTests
     }
 
     [TestMethod]
-    public async Task Download_WhenCoreBurnsTheWholeStallWindowFirst_CountsAsProlonged()
+    public async Task Download_WhenALongHealthyTransferTimesOutAtTheEnd_StaysPerFile()
     {
-        // Arrange — Core reports its 30-minute transfer cap through the same untyped
-        // TimeoutException as its half-second serial read timeout. Treating both as cheap
-        // per-file failures would let a batch pay that wait once for every remaining file, so
-        // what separates them is how long the attempt actually ran.
+        // Arrange — a large file that streams steadily for several stall windows and then hits one
+        // brief transport timeout. The device was alive right up to the failure, so this says
+        // nothing about the card and must not abort the batch. Measuring the whole attempt instead
+        // of the silence would classify it as device-wide purely for being a big file.
         _mockDevice
             .Setup(d => d.DownloadSdCardFileAsync(
                 It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
             .Returns(async (string _, IProgress<SdCardTransferProgress> progress, CancellationToken ct) =>
             {
-                // Keep reporting progress so the desktop's own watchdog never fires: this has to
-                // be Core's cap being reached, not ours.
                 for (var i = 1; i <= 8; i++)
                 {
                     await Task.Delay(STALL_TIMEOUT / 4, ct);
                     progress?.Report(new SdCardTransferProgress(i * 1024L, FileName));
                 }
 
+                // Fails immediately after the last chunk — no silence to speak of.
+                throw new TimeoutException("Transport stream closed before receiving the EOF marker.");
+            });
+
+        // Act
+        var ex = await Assert.ThrowsExactlyAsync<SdCardDownloadStalledException>(() =>
+            _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, CancellationToken.None));
+
+        // Assert
+        Assert.IsFalse(ex.IsProlongedFailure,
+            "The device was delivering data until the moment it failed, so the remaining files are " +
+            "still worth trying.");
+        Assert.IsTrue(ex.SilentFor < STALL_TIMEOUT,
+            $"Expected the reported silence to be shorter than the stall window, but it was {ex.SilentFor}. " +
+            "Reporting total transfer time here is the bug this guards.");
+    }
+
+    [TestMethod]
+    public async Task Download_WhenTheDeviceGoesQuietThenCoreTimesOut_CountsAsProlonged()
+    {
+        // Arrange — the device delivers a chunk, then goes quiet for longer than the stall window
+        // before Core reports the timeout itself. Core raises its half-second serial read timeout
+        // and its 30-minute transfer cap through the identical untyped exception, so silence — not
+        // exception identity — is what says this one is broad enough to stop a batch over.
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, IProgress<SdCardTransferProgress> progress, CancellationToken _) =>
+            {
+                progress?.Report(new SdCardTransferProgress(1024L, FileName));
+                await Task.Delay(STALL_TIMEOUT * 2, CancellationToken.None);
                 throw new TimeoutException("SD card file download timed out after 1800 seconds.");
             });
 
@@ -136,8 +165,8 @@ public class SdCardDownloadFailureTests
 
         // Assert
         Assert.IsTrue(ex.IsProlongedFailure,
-            "An attempt that already cost the full stall window must not be repeated per file.");
-        Assert.IsTrue(ex.Elapsed >= STALL_TIMEOUT);
+            "Silence for the full stall window must not be paid again for every remaining file.");
+        Assert.IsTrue(ex.SilentFor >= STALL_TIMEOUT);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
+++ b/Daqifi.Desktop.Test/Loggers/SdCardDownloadFailureTests.cs
@@ -29,7 +29,7 @@ public class SdCardDownloadFailureTests
 
     // Long enough that scheduling jitter cannot trip it spuriously, short enough to keep the test
     // fast. The production value is SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT.
-    private static readonly TimeSpan StallTimeout = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan STALL_TIMEOUT = TimeSpan.FromMilliseconds(300);
 
     private Mock<IStreamingDevice> _mockDevice = null!;
     private SdCardSessionImporter _importer = null!;
@@ -43,7 +43,7 @@ public class SdCardDownloadFailureTests
         // The watchdog runs entirely before anything is written, so a stub context factory is
         // enough — these tests never reach the database.
         _importer = new SdCardSessionImporter(
-            new Mock<IDbContextFactory<LoggingContext>>().Object, StallTimeout);
+            new Mock<IDbContextFactory<LoggingContext>>().Object, STALL_TIMEOUT);
     }
 
     [TestMethod]
@@ -69,6 +69,59 @@ public class SdCardDownloadFailureTests
         // only care that the operation timed out still catch it.
         StringAssert.Contains(ex.Message, FileName);
         Assert.IsInstanceOfType<TimeoutException>(ex);
+        Assert.IsTrue(ex.IsProlongedSilence,
+            "The watchdog watched the device say nothing for the full window, which is what makes " +
+            "this one broad enough to abandon a batch import over.");
+        Assert.AreEqual(STALL_TIMEOUT, ex.StallTimeout);
+    }
+
+    [TestMethod]
+    public async Task Download_WhenCoreReportsATimeout_BecomesAStallRatherThanABareTimeout()
+    {
+        // Arrange — issue #779. Over USB serial the watchdog above never gets to fire: Core's
+        // serial transport drops SerialPort.ReadTimeout to 500ms and hands the raw BaseStream to
+        // SdCardFileReceiver, .NET's SerialStream returns 0 bytes on a read timeout instead of
+        // throwing or honouring the token, and the receiver treats that as fatal. So a wedged
+        // device produces this — a plain TimeoutException in about half a second — and never the
+        // cancellation the watchdog converts. Unnormalised it fell through to the classifier's
+        // default arm: a Sentry issue plus "check the device connection", which is the exact #754
+        // behaviour the stall machinery was written to eliminate.
+        var transportTimeout = new TimeoutException(
+            "Transport stream closed before receiving the EOF marker. Received 0 bytes.");
+
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(transportTimeout);
+
+        // Act
+        var ex = await Assert.ThrowsExactlyAsync<SdCardDownloadStalledException>(() =>
+            _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, CancellationToken.None));
+
+        // Assert
+        StringAssert.Contains(ex.Message, FileName);
+        Assert.AreSame(transportTimeout, ex.InnerException,
+            "Core's own message carries the byte count, which is the only diagnostic the log gets.");
+        Assert.IsFalse(ex.IsProlongedSilence,
+            "The transport gave up in well under a second, so this says far less about the card " +
+            "than the watchdog firing does and must not abort a batch (issue #780).");
+        Assert.IsNull(ex.StallTimeout);
+    }
+
+    [TestMethod]
+    public async Task Download_WhenTheDeviceFailsForANonTimeoutReason_IsLeftAlone()
+    {
+        // Arrange — regression guard on the scope of the #779 normalisation. Only timeouts out of
+        // the download call become stalls; a typed device condition Core already names must reach
+        // the classifier unchanged so it keeps its own state and guidance.
+        _mockDevice
+            .Setup(d => d.DownloadSdCardFileAsync(
+                It.IsAny<string>(), It.IsAny<IProgress<SdCardTransferProgress>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SdCardNotPresentException(new List<string>(), "No card"));
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<SdCardNotPresentException>(() =>
+            _importer.DownloadWithStallWatchdogAsync(_mockDevice.Object, FileName, CancellationToken.None));
     }
 
     [TestMethod]
@@ -77,8 +130,8 @@ public class SdCardDownloadFailureTests
         // Arrange — a slow but healthy transfer: it runs for several stall windows, reporting a
         // chunk at a time. Regression guard against turning the watchdog into a wall-clock cap,
         // which would break exactly the large downloads it is supposed to protect.
-        var totalTransferTime = StallTimeout * 4;
-        var chunkInterval = StallTimeout / 4;
+        var totalTransferTime = STALL_TIMEOUT * 4;
+        var chunkInterval = STALL_TIMEOUT / 4;
         var expected = new SdCardDownloadResult(FileName, 4096, totalTransferTime, "C:\\temp\\file.bin");
 
         _mockDevice

--- a/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
@@ -130,6 +130,16 @@ public class DeviceLogsViewModelImportTests
         }
     }
 
+    /// <summary>
+    /// The stall a wedged device actually produces over USB serial: Core's transport timeout,
+    /// normalised by the importer, having given up in well under the desktop's stall window.
+    /// </summary>
+    private static SdCardDownloadStalledException QuickTransportStall(string fileName) =>
+        new(fileName,
+            new TimeoutException("Transport stream closed before receiving the EOF marker."),
+            elapsed: TimeSpan.FromMilliseconds(500),
+            patienceWindow: TimeSpan.FromSeconds(90));
+
     private IEnumerable<string> ImportedFileNames() =>
         _mockImporter.Invocations
             .Where(invocation => invocation.Method.Name == nameof(ISdCardSessionImporter.ImportFromDeviceAsync))
@@ -199,8 +209,7 @@ public class DeviceLogsViewModelImportTests
         // actually produces. Before the importer normalised it, the bare TimeoutException hit the
         // classifier's default arm and filed a Sentry issue on every attempt.
         await SettleInitialRefreshAsync();
-        SetupImportToThrow(new SdCardDownloadStalledException(
-            FileName, new TimeoutException("Transport stream closed before receiving the EOF marker.")));
+        SetupImportToThrow(QuickTransportStall(FileName));
 
         // Act
         await ImportAsync();
@@ -413,10 +422,7 @@ public class DeviceLogsViewModelImportTests
         await SettleInitialRefreshAsync();
         AddDeviceFiles(THREE_FILES);
 
-        SetupImportToFailOnly(
-            new SdCardDownloadStalledException(
-                "log_b.bin", new TimeoutException("Transport stream closed before receiving the EOF marker.")),
-            "log_b.bin");
+        SetupImportToFailOnly(QuickTransportStall("log_b.bin"), "log_b.bin");
 
         // Act
         await _viewModel.ImportAllFilesCommand.ExecuteAsync(null);
@@ -433,7 +439,7 @@ public class DeviceLogsViewModelImportTests
         // Arrange — the completion dialog used to say "Import stopped early: power-cycle the
         // device" for a benign empty log, which is advice for a fault that is not there.
         var outcome = new ImportAllOutcome { TotalCount = 3, ImportedCount = 2 };
-        outcome.RecordSkip("log_a.bin", SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE);
+        outcome.RecordSkip("log_a.bin", SdCardFailureClassifier.EMPTY_TRANSFER_GUIDANCE);
 
         // Act
         var summary = DeviceLogsViewModel.BuildImportAllSummary(outcome);
@@ -443,7 +449,7 @@ public class DeviceLogsViewModelImportTests
         StringAssert.Contains(summary, "Skipped 1 file(s)");
         StringAssert.Contains(summary, "log_a.bin",
             "Naming the skipped file is what lets the user retry it individually.");
-        StringAssert.Contains(summary, SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE);
+        StringAssert.Contains(summary, SdCardFailureClassifier.EMPTY_TRANSFER_GUIDANCE);
         Assert.IsFalse(summary.Contains("Import stopped"),
             "Nothing stopped: the batch ran to the end, so the dialog must not claim otherwise.");
         Assert.IsFalse(summary.Contains(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE),
@@ -458,7 +464,7 @@ public class DeviceLogsViewModelImportTests
         var outcome = new ImportAllOutcome { TotalCount = 8, ImportedCount = 0 };
         for (var i = 0; i < 8; i++)
         {
-            outcome.RecordSkip($"log_{i}.bin", SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE);
+            outcome.RecordSkip($"log_{i}.bin", SdCardFailureClassifier.EMPTY_TRANSFER_GUIDANCE);
         }
 
         // Act
@@ -468,7 +474,7 @@ public class DeviceLogsViewModelImportTests
         StringAssert.Contains(summary, "log_4.bin");
         Assert.IsFalse(summary.Contains("log_5.bin"), "Only the first few names are listed.");
         StringAssert.Contains(summary, "...and 3 more");
-        Assert.AreEqual(1, CountOccurrences(summary, SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE),
+        Assert.AreEqual(1, CountOccurrences(summary, SdCardFailureClassifier.EMPTY_TRANSFER_GUIDANCE),
             "Identical guidance must be stated once, not once per file.");
     }
 

--- a/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
@@ -1,6 +1,7 @@
 using Daqifi.Core.Device.SdCard;
 using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device;
+using Daqifi.Desktop.Logger;
 using Daqifi.Desktop.Loggers;
 using Daqifi.Desktop.Models;
 using Daqifi.Desktop.ViewModels;
@@ -23,9 +24,13 @@ public class DeviceLogsViewModelImportTests
 {
     private const string FileName = "log_20260623_143217.bin";
 
+    /// <summary>A three-file card, in the order the device lists them.</summary>
+    private static readonly string[] THREE_FILES = ["log_a.bin", "log_b.bin", "log_c.bin"];
+
     private Mock<IStreamingDevice> _mockDevice = null!;
     private Mock<ISdCardSessionImporter> _mockImporter = null!;
     private Mock<IAppLogger> _mockLogger = null!;
+    private List<LoggingSession> _publishedSessions = null!;
     private DeviceLogsViewModel _viewModel = null!;
 
     [TestInitialize]
@@ -39,11 +44,15 @@ public class DeviceLogsViewModelImportTests
         _mockImporter = new Mock<ISdCardSessionImporter>();
         _mockLogger = new Mock<IAppLogger>();
 
+        // Production publishes to LoggingManager.Instance, whose constructor resolves services
+        // from App.ServiceProvider and therefore throws under test. Collect them here instead.
+        _publishedSessions = [];
+
         // DeviceLogsViewModel's constructor reads the process-wide ConnectionManager.Instance
         // singleton; other test classes leave devices on it, so reset it for order-independence.
         ConnectionManager.Instance.ConnectedDevices.Clear();
 
-        _viewModel = new DeviceLogsViewModel(_mockLogger.Object, _mockImporter.Object)
+        _viewModel = new DeviceLogsViewModel(_mockLogger.Object, _mockImporter.Object, _publishedSessions.Add)
         {
             SelectedDevice = _mockDevice.Object
         };
@@ -82,6 +91,50 @@ public class DeviceLogsViewModelImportTests
     private Task ImportAsync(string fileName = FileName) =>
         _viewModel.ImportFileCommand.ExecuteAsync(new SdCardFile { FileName = fileName });
 
+    /// <summary>
+    /// Drives the importer per file: the named files throw <paramref name="failure"/>, every other
+    /// file imports cleanly. Lets a batch test show that a failure on one file does not cost the
+    /// user the ones after it.
+    /// </summary>
+    private void SetupImportToFailOnly(Exception failure, params string[] failingFiles)
+    {
+        var sessionId = 0;
+        _mockImporter
+            .Setup(i => i.ImportFromDeviceAsync(
+                It.IsAny<IStreamingDevice>(),
+                It.IsAny<string>(),
+                It.IsAny<ImportOptions>(),
+                It.IsAny<IProgress<ImportProgress>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task<SdCardImportResult> (IStreamingDevice _, string fileName, ImportOptions _,
+                IProgress<ImportProgress> _, CancellationToken _) =>
+            {
+                if (failingFiles.Contains(fileName))
+                {
+                    throw failure;
+                }
+
+                return Task.FromResult(new SdCardImportResult
+                {
+                    Session = new LoggingSession(sessionId++, $"SD Import - {fileName}"),
+                    TimestampQuality = new ImportTimestampQuality()
+                });
+            });
+    }
+
+    private void AddDeviceFiles(params string[] fileNames)
+    {
+        foreach (var name in fileNames)
+        {
+            _viewModel.DeviceFiles.Add(new SdCardFile { FileName = name });
+        }
+    }
+
+    private IEnumerable<string> ImportedFileNames() =>
+        _mockImporter.Invocations
+            .Where(invocation => invocation.Method.Name == nameof(ISdCardSessionImporter.ImportFromDeviceAsync))
+            .Select(invocation => (string)invocation.Arguments[1]);
+
     [TestMethod]
     public async Task ImportFile_EmptyTransfer_LogsWarningNotError()
     {
@@ -101,26 +154,29 @@ public class DeviceLogsViewModelImportTests
     }
 
     [TestMethod]
-    public async Task ImportFile_EmptyTransfer_SurfacesPowerCycleGuidanceOnTheCardPanel()
+    public async Task ImportFile_EmptyTransfer_LeavesTheFileListVisibleForAPerFileRetry()
     {
         // Arrange
         await SettleInitialRefreshAsync();
+        AddDeviceFiles("log_a.bin", "log_b.bin");
         SetupImportToThrow(new SdCardEmptyTransferException(FileName));
 
         // Act
         await ImportAsync();
 
-        // Assert — the user gets an actionable state instead of a silent busy overlay.
-        Assert.AreEqual(SdCardState.Error, _viewModel.SdCardState);
-        Assert.IsTrue(_viewModel.HasSdCardError);
-        Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, _viewModel.SdCardErrorGuidance);
-        Assert.IsFalse(string.IsNullOrEmpty(_viewModel.SdCardErrorMessage));
+        // Assert — issue #780: the SD card error panel *replaces* the file list, so painting one
+        // file's failure onto it takes away the per-file retry that skipping the file is supposed
+        // to leave available. The failure still reaches the user through the import dialog.
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState);
+        Assert.IsFalse(_viewModel.HasSdCardError);
+        Assert.IsTrue(_viewModel.HasFiles, "The remaining files must stay reachable one by one.");
     }
 
     [TestMethod]
-    public async Task ImportFile_DownloadStalled_LogsWarningAndReportsTheStall()
+    public async Task ImportFile_WatchdogDetectedStall_SurfacesPowerCycleGuidanceOnTheCardPanel()
     {
-        // Arrange — what the importer's stall watchdog raises when the device goes quiet.
+        // Arrange — what the importer's stall watchdog raises when the device goes quiet for the
+        // full window. That is card-wide, so it does belong on the panel.
         await SettleInitialRefreshAsync();
         SetupImportToThrow(new SdCardDownloadStalledException(FileName, TimeSpan.FromSeconds(90)));
 
@@ -131,7 +187,29 @@ public class DeviceLogsViewModelImportTests
         _mockLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
         _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
         Assert.AreEqual(SdCardState.Error, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasSdCardError);
         Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, _viewModel.SdCardErrorGuidance);
+        Assert.IsFalse(string.IsNullOrEmpty(_viewModel.SdCardErrorMessage));
+    }
+
+    [TestMethod]
+    public async Task ImportFile_TransportDetectedStall_LogsWarningNotError()
+    {
+        // Arrange — issue #779: over USB serial this, not the watchdog, is what a wedged device
+        // actually produces. Before the importer normalised it, the bare TimeoutException hit the
+        // classifier's default arm and filed a Sentry issue on every attempt.
+        await SettleInitialRefreshAsync();
+        SetupImportToThrow(new SdCardDownloadStalledException(
+            FileName, new TimeoutException("Transport stream closed before receiving the EOF marker.")));
+
+        // Act
+        await ImportAsync();
+
+        // Assert
+        _mockLogger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Once);
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never,
+            "The whole point of #779 is that this stopped reaching the Sentry path.");
+        _mockLogger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
@@ -230,16 +308,13 @@ public class DeviceLogsViewModelImportTests
     [TestMethod]
     public async Task ImportAllFiles_WhenCardIsUnavailable_StopsAfterTheFirstFile()
     {
-        // Arrange — three files on a device whose SD subsystem is wedged. Every download would
-        // burn Core's full retry window (~50s observed on the bench), so the batch must give up
-        // rather than make the user wait through all of them.
+        // Arrange — three files on a device with no card in the slot. Nothing on it can be read,
+        // and each attempt burns a multi-second timeout, so the batch must give up rather than
+        // make the user wait through all of them.
         await SettleInitialRefreshAsync();
-        foreach (var name in new[] { "log_a.bin", "log_b.bin", "log_c.bin" })
-        {
-            _viewModel.DeviceFiles.Add(new SdCardFile { FileName = name });
-        }
+        AddDeviceFiles(THREE_FILES);
 
-        SetupImportToThrow(new SdCardEmptyTransferException("log_a.bin"));
+        SetupImportToThrow(new SdCardNotPresentException(new List<string>(), "No card"));
 
         // Act
         await _viewModel.ImportAllFilesCommand.ExecuteAsync(null);
@@ -264,10 +339,7 @@ public class DeviceLogsViewModelImportTests
         // Arrange — a per-file SCPI rejection says nothing about the other files, so the batch
         // must carry on. Counterpart to the early-abort case above.
         await SettleInitialRefreshAsync();
-        foreach (var name in new[] { "log_a.bin", "log_b.bin", "log_c.bin" })
-        {
-            _viewModel.DeviceFiles.Add(new SdCardFile { FileName = name });
-        }
+        AddDeviceFiles(THREE_FILES);
 
         SetupImportToThrow(new SdCardOperationException(
             "SCPI error", new List<string>(), "-200,\"Execution error\"", null));
@@ -285,5 +357,152 @@ public class DeviceLogsViewModelImportTests
                 It.IsAny<CancellationToken>()),
             Times.Exactly(3));
         _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ImportAllFiles_WhenTheFirstFileIsEmpty_StillImportsEveryHealthyFileAfterIt()
+    {
+        // Arrange — issue #780, the whole point of the change. An interrupted logging session
+        // routinely leaves a 0-byte file on a FAT card, and Core raises the same exception for it
+        // as for a wedged subsystem. Aborting on it dropped every later file silently, and since
+        // the device lists files in the same order every time, a retry stopped at the same file —
+        // making the rest unreachable through Import All entirely.
+        await SettleInitialRefreshAsync();
+        AddDeviceFiles(THREE_FILES);
+
+        SetupImportToFailOnly(new SdCardEmptyTransferException("log_a.bin"), "log_a.bin");
+
+        // Act
+        await _viewModel.ImportAllFilesCommand.ExecuteAsync(null);
+
+        // Assert
+        CollectionAssert.AreEqual(
+            THREE_FILES,
+            ImportedFileNames().ToList(),
+            "Every file must be attempted; the empty one is skipped, not treated as the end of the card.");
+        Assert.AreEqual(2, _publishedSessions.Count,
+            "Both healthy files must actually have been imported.");
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ImportAllFiles_WhenAFileIsSkipped_LeavesTheCardPanelAndFileListAlone()
+    {
+        // Arrange — a skipped file must not put the card into an error state: that hides the file
+        // list, which is where the user would retry the skipped file from.
+        await SettleInitialRefreshAsync();
+        AddDeviceFiles("log_a.bin", "log_b.bin");
+
+        SetupImportToFailOnly(new SdCardEmptyTransferException("log_a.bin"), "log_a.bin");
+
+        // Act
+        await _viewModel.ImportAllFilesCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(SdCardState.Ok, _viewModel.SdCardState);
+        Assert.IsTrue(_viewModel.HasFiles);
+        Assert.IsFalse(_viewModel.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task ImportAllFiles_WhenTheTransportTimesOut_KeepsGoingAndStaysOffTheErrorPath()
+    {
+        // Arrange — #779 and #780 together on the transport that actually ships. Core's plain
+        // TimeoutException, normalised by the importer, must neither file a Sentry issue nor end
+        // the batch.
+        await SettleInitialRefreshAsync();
+        AddDeviceFiles(THREE_FILES);
+
+        SetupImportToFailOnly(
+            new SdCardDownloadStalledException(
+                "log_b.bin", new TimeoutException("Transport stream closed before receiving the EOF marker.")),
+            "log_b.bin");
+
+        // Act
+        await _viewModel.ImportAllFilesCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(3, ImportedFileNames().Count());
+        Assert.AreEqual(2, _publishedSessions.Count);
+        _mockLogger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void BuildImportAllSummary_WhenFilesAreSkipped_ReportsThemAsSkippedNotAsACardWideAbort()
+    {
+        // Arrange — the completion dialog used to say "Import stopped early: power-cycle the
+        // device" for a benign empty log, which is advice for a fault that is not there.
+        var outcome = new ImportAllOutcome { TotalCount = 3, ImportedCount = 2 };
+        outcome.RecordSkip("log_a.bin", SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE);
+
+        // Act
+        var summary = DeviceLogsViewModel.BuildImportAllSummary(outcome);
+
+        // Assert
+        StringAssert.Contains(summary, "Imported 2 of 3 files.");
+        StringAssert.Contains(summary, "Skipped 1 file(s)");
+        StringAssert.Contains(summary, "log_a.bin",
+            "Naming the skipped file is what lets the user retry it individually.");
+        StringAssert.Contains(summary, SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE);
+        Assert.IsFalse(summary.Contains("Import stopped"),
+            "Nothing stopped: the batch ran to the end, so the dialog must not claim otherwise.");
+        Assert.IsFalse(summary.Contains(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE),
+            "Issue #780: a skipped file is not evidence the device needs a power cycle.");
+    }
+
+    [TestMethod]
+    public void BuildImportAllSummary_WhenManyFilesAreSkipped_ListsAFewAndCountsTheRestOnce()
+    {
+        // Arrange — a card full of empty logs must not produce a dialog taller than the screen,
+        // and repeating identical guidance per file is noise.
+        var outcome = new ImportAllOutcome { TotalCount = 8, ImportedCount = 0 };
+        for (var i = 0; i < 8; i++)
+        {
+            outcome.RecordSkip($"log_{i}.bin", SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE);
+        }
+
+        // Act
+        var summary = DeviceLogsViewModel.BuildImportAllSummary(outcome);
+
+        // Assert
+        StringAssert.Contains(summary, "log_4.bin");
+        Assert.IsFalse(summary.Contains("log_5.bin"), "Only the first few names are listed.");
+        StringAssert.Contains(summary, "...and 3 more");
+        Assert.AreEqual(1, CountOccurrences(summary, SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE),
+            "Identical guidance must be stated once, not once per file.");
+    }
+
+    [TestMethod]
+    public void BuildImportAllSummary_WhenTheCardIsUnavailable_SaysWhereItStoppedAndWhy()
+    {
+        // Arrange — the early abort is still reported, and still carries the power-cycle advice.
+        var outcome = new ImportAllOutcome
+        {
+            TotalCount = 4,
+            ImportedCount = 1,
+            AbortedOnFile = "log_b.bin",
+            AbortingFailure = SdCardFailureClassifier.Classify(
+                new SdCardDownloadStalledException("log_b.bin", TimeSpan.FromSeconds(90)))
+        };
+
+        // Act
+        var summary = DeviceLogsViewModel.BuildImportAllSummary(outcome);
+
+        // Assert
+        StringAssert.Contains(summary, "Import stopped at log_b.bin");
+        StringAssert.Contains(summary, SdCardFailureClassifier.POWER_CYCLE_GUIDANCE);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = haystack.IndexOf(needle, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal);
+        }
+
+        return count;
     }
 }

--- a/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DeviceLogsViewModelImportTests.cs
@@ -136,9 +136,16 @@ public class DeviceLogsViewModelImportTests
     /// </summary>
     private static SdCardDownloadStalledException QuickTransportStall(string fileName) =>
         new(fileName,
-            new TimeoutException("Transport stream closed before receiving the EOF marker."),
-            elapsed: TimeSpan.FromMilliseconds(500),
-            patienceWindow: TimeSpan.FromSeconds(90));
+            silentFor: TimeSpan.FromMilliseconds(500),
+            patienceWindow: TimeSpan.FromSeconds(90),
+            new TimeoutException("Transport stream closed before receiving the EOF marker."));
+
+    /// <summary>
+    /// The stall the desktop's own watchdog raises: the device delivered nothing for the full
+    /// window, which is the one download failure broad enough to abandon a batch import over.
+    /// </summary>
+    private static SdCardDownloadStalledException WatchdogStall(string fileName) =>
+        new(fileName, silentFor: TimeSpan.FromSeconds(90), patienceWindow: TimeSpan.FromSeconds(90));
 
     private IEnumerable<string> ImportedFileNames() =>
         _mockImporter.Invocations
@@ -188,7 +195,7 @@ public class DeviceLogsViewModelImportTests
         // Arrange — what the importer's stall watchdog raises when the device goes quiet for the
         // full window. That is card-wide, so it does belong on the panel.
         await SettleInitialRefreshAsync();
-        SetupImportToThrow(new SdCardDownloadStalledException(FileName, TimeSpan.FromSeconds(90)));
+        SetupImportToThrow(WatchdogStall(FileName));
 
         // Act
         await ImportAsync();
@@ -488,7 +495,7 @@ public class DeviceLogsViewModelImportTests
             ImportedCount = 1,
             AbortedOnFile = "log_b.bin",
             AbortingFailure = SdCardFailureClassifier.Classify(
-                new SdCardDownloadStalledException("log_b.bin", TimeSpan.FromSeconds(90)))
+                WatchdogStall("log_b.bin"))
         };
 
         // Act

--- a/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
@@ -27,7 +27,8 @@ public class SdCardFailureClassifierTests
 
         // Assert
         Assert.IsTrue(failure.IsExpectedDeviceCondition,
-            "A device that serves no data is a device condition, so it must log at Warning and not file a Sentry issue.");
+            "A device that serves no data is a device condition, so it must log at Warning and not " +
+            "file a Sentry issue.");
         Assert.IsFalse(failure.IsCardUnavailable,
             "Issue #780: Core cannot tell a genuinely empty 0-byte log from a wedged subsystem, so " +
             "this must not abort a batch and strand every file listed after it.");

--- a/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
@@ -33,7 +33,7 @@ public class SdCardFailureClassifierTests
             "Issue #780: Core cannot tell a genuinely empty 0-byte log from a wedged subsystem, so " +
             "this must not abort a batch and strand every file listed after it.");
         Assert.AreEqual(SdCardState.Error, failure.State);
-        Assert.AreEqual(SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE, failure.Guidance,
+        Assert.AreEqual(SdCardFailureClassifier.EMPTY_TRANSFER_GUIDANCE, failure.Guidance,
             "The advice has to cover both readings, not send the user after a power cycle they may not need.");
     }
 
@@ -57,14 +57,17 @@ public class SdCardFailureClassifierTests
     }
 
     [TestMethod]
-    public void Classify_TransportDetectedStall_IsExpectedDeviceConditionAndKeepsTheBatchGoing()
+    public void Classify_QuickTransportStall_IsExpectedDeviceConditionAndKeepsTheBatchGoing()
     {
         // Arrange — issue #779: over USB serial Core's SdCardFileReceiver raises a plain
         // TimeoutException within about half a second, long before the watchdog. The importer
         // normalises it to this type so it stops landing on the Sentry path, but it gives up too
         // fast and too ambiguously to justify writing off the whole card.
         var ex = new SdCardDownloadStalledException(
-            FileName, new TimeoutException("Transport stream closed before receiving the EOF marker."));
+            FileName,
+            new TimeoutException("Transport stream closed before receiving the EOF marker."),
+            elapsed: TimeSpan.FromMilliseconds(500),
+            patienceWindow: TimeSpan.FromSeconds(90));
 
         // Act
         var failure = SdCardFailureClassifier.Classify(ex);
@@ -76,6 +79,29 @@ public class SdCardFailureClassifierTests
             "It costs under a second to try the next file, and this one may just be unreadable.");
         Assert.AreEqual(SdCardState.Error, failure.State);
         Assert.AreEqual(SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE, failure.Guidance);
+        Assert.AreNotEqual(SdCardFailureClassifier.EMPTY_TRANSFER_GUIDANCE, failure.Guidance,
+            "A stall can interrupt a transfer that was already delivering data, so the advice must " +
+            "not diagnose an empty file the way the empty-transfer arm does.");
+    }
+
+    [TestMethod]
+    public void Classify_ProlongedTransportStall_StopsTheBatchLikeTheWatchdogWould()
+    {
+        // Arrange — Core reports its 30-minute transfer cap through the same untyped
+        // TimeoutException as its half-second read timeout. Letting a batch pay that wait once
+        // per remaining file would be far worse than the abort #780 removed.
+        var ex = new SdCardDownloadStalledException(
+            FileName,
+            new TimeoutException("SD card file download timed out after 1800 seconds."),
+            elapsed: TimeSpan.FromMinutes(30),
+            patienceWindow: TimeSpan.FromSeconds(90));
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.IsTrue(failure.IsCardUnavailable);
+        Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, failure.Guidance);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
@@ -16,10 +16,10 @@ public class SdCardFailureClassifierTests
     private const string FileName = "log_20260623_143217.bin";
 
     [TestMethod]
-    public void Classify_EmptyTransfer_IsExpectedDeviceConditionAndAdvisesPowerCycle()
+    public void Classify_EmptyTransfer_IsExpectedDeviceConditionButDoesNotWriteOffTheCard()
     {
-        // Arrange — the exact exception Core 1.3.0 throws for the wedged SD subsystem, and the
-        // one Sentry issue #754 was filed from.
+        // Arrange — the exact exception Core 1.3.0 throws when the device serves a marker-only
+        // transfer, and the one Sentry issue #754 was filed from.
         var ex = new SdCardEmptyTransferException(FileName);
 
         // Act
@@ -27,18 +27,21 @@ public class SdCardFailureClassifierTests
 
         // Assert
         Assert.IsTrue(failure.IsExpectedDeviceCondition,
-            "A wedged SD subsystem is a device condition, so it must log at Warning and not file a Sentry issue.");
-        Assert.IsTrue(failure.IsCardUnavailable,
-            "Nothing else on the card will download either, so a batch import must stop early.");
+            "A device that serves no data is a device condition, so it must log at Warning and not file a Sentry issue.");
+        Assert.IsFalse(failure.IsCardUnavailable,
+            "Issue #780: Core cannot tell a genuinely empty 0-byte log from a wedged subsystem, so " +
+            "this must not abort a batch and strand every file listed after it.");
         Assert.AreEqual(SdCardState.Error, failure.State);
-        Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, failure.Guidance,
-            "Only a power cycle clears this state, so that is what the user must be told.");
+        Assert.AreEqual(SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE, failure.Guidance,
+            "The advice has to cover both readings, not send the user after a power cycle they may not need.");
     }
 
     [TestMethod]
-    public void Classify_DownloadStalled_IsExpectedDeviceConditionAndAdvisesPowerCycle()
+    public void Classify_WatchdogDetectedStall_AdvisesPowerCycleAndStopsTheBatch()
     {
-        // Arrange — what the importer's stall watchdog throws when the device goes quiet.
+        // Arrange — what the importer's stall watchdog throws when the device goes quiet: silence
+        // for the full 90-second window. That is unambiguously device-wide, so it is the one
+        // download failure worth abandoning the rest of the batch over.
         var ex = new SdCardDownloadStalledException(FileName, TimeSpan.FromSeconds(90));
 
         // Act
@@ -46,9 +49,32 @@ public class SdCardFailureClassifierTests
 
         // Assert
         Assert.IsTrue(failure.IsExpectedDeviceCondition);
-        Assert.IsTrue(failure.IsCardUnavailable);
+        Assert.IsTrue(failure.IsCardUnavailable,
+            "90 seconds of total silence per file makes grinding through the rest of the batch pointless and slow.");
         Assert.AreEqual(SdCardState.Error, failure.State);
         Assert.AreEqual(SdCardFailureClassifier.POWER_CYCLE_GUIDANCE, failure.Guidance);
+    }
+
+    [TestMethod]
+    public void Classify_TransportDetectedStall_IsExpectedDeviceConditionAndKeepsTheBatchGoing()
+    {
+        // Arrange — issue #779: over USB serial Core's SdCardFileReceiver raises a plain
+        // TimeoutException within about half a second, long before the watchdog. The importer
+        // normalises it to this type so it stops landing on the Sentry path, but it gives up too
+        // fast and too ambiguously to justify writing off the whole card.
+        var ex = new SdCardDownloadStalledException(
+            FileName, new TimeoutException("Transport stream closed before receiving the EOF marker."));
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.IsTrue(failure.IsExpectedDeviceCondition,
+            "This is the #754 condition on the transport that actually ships, so it must stay off the Error path.");
+        Assert.IsFalse(failure.IsCardUnavailable,
+            "It costs under a second to try the next file, and this one may just be unreadable.");
+        Assert.AreEqual(SdCardState.Error, failure.State);
+        Assert.AreEqual(SdCardFailureClassifier.INCOMPLETE_TRANSFER_GUIDANCE, failure.Guidance);
     }
 
     [TestMethod]
@@ -83,11 +109,29 @@ public class SdCardFailureClassifierTests
         Assert.AreEqual(string.Empty, failure.StatusMessage,
             "The 'no card installed' panel is self-explanatory; a raw device string would only add noise.");
         Assert.IsTrue(failure.IsExpectedDeviceCondition);
+        Assert.IsTrue(failure.IsCardUnavailable,
+            "An empty slot is unambiguously device-wide: no file on it can be read.");
+    }
+
+    [TestMethod]
+    public void Classify_Busy_IsUnambiguouslyDeviceWide()
+    {
+        // Arrange — the device is logging to the card itself, so nothing on it can be served.
+        // Along with a missing card this is one of only two conditions broad enough to abandon a
+        // batch import over (issue #780).
+        var ex = new SdCardBusyException(new List<string>(), "Card busy");
+
+        // Act
+        var failure = SdCardFailureClassifier.Classify(ex);
+
+        // Assert
+        Assert.AreEqual(SdCardState.Error, failure.State);
+        Assert.IsTrue(failure.IsExpectedDeviceCondition);
         Assert.IsTrue(failure.IsCardUnavailable);
     }
 
     [TestMethod]
-    public void Classify_FilesystemError_SurfacesTheDeviceMessage()
+    public void Classify_FilesystemError_SurfacesTheDeviceMessageAndKeepsTheRestOfTheCardUsable()
     {
         // Arrange
         const string deviceMessage = "FS corrupt";
@@ -100,6 +144,9 @@ public class SdCardFailureClassifierTests
         Assert.AreEqual(SdCardState.Error, failure.State);
         Assert.AreEqual(deviceMessage, failure.StatusMessage);
         Assert.IsTrue(failure.IsExpectedDeviceCondition);
+        Assert.IsFalse(failure.IsCardUnavailable,
+            "Issue #780: a filesystem error can be one corrupt directory entry, so the other files " +
+            "are still worth trying rather than being dropped unattempted.");
         Assert.AreEqual(SdCardFailureClassifier.GENERIC_CARD_GUIDANCE, failure.Guidance);
     }
 

--- a/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/SdCardFailureClassifierTests.cs
@@ -43,7 +43,8 @@ public class SdCardFailureClassifierTests
         // Arrange — what the importer's stall watchdog throws when the device goes quiet: silence
         // for the full 90-second window. That is unambiguously device-wide, so it is the one
         // download failure worth abandoning the rest of the batch over.
-        var ex = new SdCardDownloadStalledException(FileName, TimeSpan.FromSeconds(90));
+        var ex = new SdCardDownloadStalledException(
+            FileName, silentFor: TimeSpan.FromSeconds(90), patienceWindow: TimeSpan.FromSeconds(90));
 
         // Act
         var failure = SdCardFailureClassifier.Classify(ex);
@@ -65,9 +66,9 @@ public class SdCardFailureClassifierTests
         // fast and too ambiguously to justify writing off the whole card.
         var ex = new SdCardDownloadStalledException(
             FileName,
-            new TimeoutException("Transport stream closed before receiving the EOF marker."),
-            elapsed: TimeSpan.FromMilliseconds(500),
-            patienceWindow: TimeSpan.FromSeconds(90));
+            silentFor: TimeSpan.FromMilliseconds(500),
+            patienceWindow: TimeSpan.FromSeconds(90),
+            new TimeoutException("Transport stream closed before receiving the EOF marker."));
 
         // Act
         var failure = SdCardFailureClassifier.Classify(ex);
@@ -89,12 +90,13 @@ public class SdCardFailureClassifierTests
     {
         // Arrange — Core reports its 30-minute transfer cap through the same untyped
         // TimeoutException as its half-second read timeout. Letting a batch pay that wait once
-        // per remaining file would be far worse than the abort #780 removed.
+        // per remaining file would be far worse than the abort #780 removed, so what decides it
+        // is how long the device had been quiet, not which Core code path raised it.
         var ex = new SdCardDownloadStalledException(
             FileName,
-            new TimeoutException("SD card file download timed out after 1800 seconds."),
-            elapsed: TimeSpan.FromMinutes(30),
-            patienceWindow: TimeSpan.FromSeconds(90));
+            silentFor: TimeSpan.FromMinutes(30),
+            patienceWindow: TimeSpan.FromSeconds(90),
+            new TimeoutException("SD card file download timed out after 1800 seconds."));
 
         // Act
         var failure = SdCardFailureClassifier.Classify(ex);

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -218,7 +218,7 @@ suffix), also hosted by `MainWindow.xaml`.
 | Logged Data → APP LOGS / DEVICE LOGS sub-tabs | `AppLogsTab` / `DeviceLogsTab` | `View/Prototype/LoggedDataPanePrototype.xaml` |
 | SD refresh button / status line / file list | `RefreshSdCardFilesButton` / `SdCardStatusText` / `SdCardFileList` | `View/DeviceLogsView.xaml` |
 | Per-row SD file IMPORT button | `ImportSdCardFileButton` | `View/DeviceLogsView.xaml` |
-| **IMPORT ALL** SD files button (batch import: skips a per-file failure and carries on, aborting only when the card itself is unavailable — issues #779/#780) | `ImportAllSdCardFilesButton` | `View/DeviceLogsView.xaml` |
+| **IMPORT ALL** SD files button (see note below) | `ImportAllSdCardFilesButton` | `View/DeviceLogsView.xaml` |
 | Per-row SD file NAME cell (for deterministic file-name reads) | `SdCardFileNameText` | `View/DeviceLogsView.xaml` |
 | Profiles: saved-profile list | `ProfileList` | `View/ProfilesPane.xaml` |
 | Profiles: per-tile settings (gear) → opens the edit drawer | `ProfileSettingsButton` | `View/ProfilesPane.xaml` |
@@ -313,13 +313,24 @@ why.
 13. **The Logged Data pane's two sub-tabs are mutually exclusive in the UIA tree.** APP LOGS
     (`AppLogsTab`, the default — hosts `LoggedSessionList`) and DEVICE LOGS (`DeviceLogsTab` —
     hosts the SD card browser: `SdCardFileList`, `RefreshSdCardFilesButton`, the per-row
-    `ImportSdCardFileButton`) each bind their content's `Visibility` to their radio's
-    `IsChecked`. A `Collapsed` subtree is absent from the UIA tree, so **only the selected
-    sub-tab's content is reachable**. After working on DEVICE LOGS (e.g. importing a file) you
-    must switch back to APP LOGS before reading `LoggedSessionList` — `GetLoggedSessionCount`
-    now does this via `SelectAppLogsSubTab` so it is robust regardless of the prior sub-tab.
-    Both sub-tab radios are driven by `IsChecked` (no bound `Command`), so the SelectionItem
-    pattern switches them reliably (cf. gotcha #12).
+    `ImportSdCardFileButton`, and `ImportAllSdCardFilesButton`) each bind their content's
+    `Visibility` to their radio's `IsChecked`. A `Collapsed` subtree is absent from the UIA tree,
+    so **only the selected sub-tab's content is reachable**. After working on DEVICE LOGS (e.g.
+    importing a file) you must switch back to APP LOGS before reading `LoggedSessionList` —
+    `GetLoggedSessionCount` now does this via `SelectAppLogsSubTab` so it is robust regardless of
+    the prior sub-tab. Both sub-tab radios are driven by `IsChecked` (no bound `Command`), so the
+    SelectionItem pattern switches them reliably (cf. gotcha #12).
+
+    Note this cuts both ways: `GetLoggedSessionCount` leaves you on APP LOGS, so read the session
+    count **before** navigating to DEVICE LOGS, or `ImportAllSdCardFilesButton` will not be in the
+    tree when you go to invoke it.
+
+    **What IMPORT ALL does** (issues #779/#780), since a scenario asserting on it needs to know:
+    a failure that may be specific to one file — an empty log, a corrupt entry, a short transport
+    stall — is skipped and the batch carries on, with the file named in the completion dialog. Only
+    a card-wide fault (no card, card busy, or the device silent for the full 90 s stall window)
+    stops the batch early. A skipped file therefore leaves the card state `Ok` and the file list
+    on screen, so it can still be retried through its own row.
 
 14. **MahApps `ShowMessageAsync` dialogs are NOT suppressed in test mode.** The test-mode
     no-op message box (`NoOpMessageBoxService`) only covers the firewall-warning path; the

--- a/Daqifi.Desktop.UITest/README.md
+++ b/Daqifi.Desktop.UITest/README.md
@@ -218,6 +218,7 @@ suffix), also hosted by `MainWindow.xaml`.
 | Logged Data → APP LOGS / DEVICE LOGS sub-tabs | `AppLogsTab` / `DeviceLogsTab` | `View/Prototype/LoggedDataPanePrototype.xaml` |
 | SD refresh button / status line / file list | `RefreshSdCardFilesButton` / `SdCardStatusText` / `SdCardFileList` | `View/DeviceLogsView.xaml` |
 | Per-row SD file IMPORT button | `ImportSdCardFileButton` | `View/DeviceLogsView.xaml` |
+| **IMPORT ALL** SD files button (batch import: skips a per-file failure and carries on, aborting only when the card itself is unavailable — issues #779/#780) | `ImportAllSdCardFilesButton` | `View/DeviceLogsView.xaml` |
 | Per-row SD file NAME cell (for deterministic file-name reads) | `SdCardFileNameText` | `View/DeviceLogsView.xaml` |
 | Profiles: saved-profile list | `ProfileList` | `View/ProfilesPane.xaml` |
 | Profiles: per-tile settings (gear) → opens the edit drawer | `ProfileSettingsButton` | `View/ProfilesPane.xaml` |

--- a/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
+++ b/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
@@ -1,26 +1,42 @@
 namespace Daqifi.Desktop.Loggers;
 
 /// <summary>
-/// Thrown when a device accepts an SD card download request and then stops sending data, with the
-/// transfer neither completing nor failing. Raised by the desktop's own stall watchdog (see
-/// <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>), because Daqifi.Core exposes no
-/// timeout on either public <c>DownloadSdCardFileAsync</c> overload.
+/// Thrown when a device accepts an SD card download request and then fails to deliver the file,
+/// with the transfer neither completing nor failing as a device condition Core can name.
+///
+/// Two different detections raise it, and they carry different weight:
+/// <list type="bullet">
+/// <item>
+/// The desktop's own stall watchdog (see <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>)
+/// observing prolonged silence. Daqifi.Core exposes no timeout on either public
+/// <c>DownloadSdCardFileAsync</c> overload, so the desktop has to impose that bound itself.
+/// <see cref="StallTimeout"/> is set and <see cref="IsProlongedSilence"/> is <c>true</c>: a device
+/// that has said nothing for that long is not going to serve the next file either.
+/// </item>
+/// <item>
+/// Core reporting a transport-level <see cref="TimeoutException"/> out of the download call.
+/// <see cref="StallTimeout"/> is <c>null</c>, the transport's own exception is the
+/// <see cref="Exception.InnerException"/>, and <see cref="IsProlongedSilence"/> is <c>false</c> —
+/// this can be one bad file rather than a wedged subsystem (issue #779).
+/// </item>
+/// </list>
 ///
 /// Derives from <see cref="TimeoutException"/> so callers that only care that the operation timed
 /// out still catch it, while giving the SD failure classifier a type that means specifically
-/// "this device went silent". Classifying every <see cref="TimeoutException"/> as a wedged SD
-/// subsystem would tell a user to power-cycle their device over an unrelated timeout — and would
+/// "this transfer did not complete". Classifying every <see cref="TimeoutException"/> as an SD
+/// failure would tell a user to power-cycle their device over an unrelated timeout — and would
 /// keep that unrelated timeout off the Error path, where it belongs.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "RCS1194:Implement exception constructors",
-    Justification = "This exception exists to carry FileName and StallTimeout — the classifier reads them, " +
-                    "and the message is built from them. The standard parameterless/message-only constructors " +
-                    "would allow a stall report that names neither the file nor the timeout, so the type is " +
-                    "sealed with the single constructor that can produce a meaningful instance.")]
+    Justification = "This exception exists to carry FileName plus how the stall was detected — the classifier " +
+                    "reads them, and the message is built from them. The standard parameterless/message-only " +
+                    "constructors would allow a stall report that names neither the file nor the detection, so " +
+                    "the type is sealed with the two constructors that can produce a meaningful instance.")]
 public sealed class SdCardDownloadStalledException : TimeoutException
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="SdCardDownloadStalledException"/> class.
+    /// Initializes a stall detected by the desktop's own watchdog: the device delivered nothing at
+    /// all for <paramref name="stallTimeout"/>.
     /// </summary>
     /// <param name="fileName">The SD card file whose transfer stalled.</param>
     /// <param name="stallTimeout">How long the device was silent before the download was abandoned.</param>
@@ -32,9 +48,35 @@ public sealed class SdCardDownloadStalledException : TimeoutException
         StallTimeout = stallTimeout;
     }
 
+    /// <summary>
+    /// Initializes a stall the transport detected first, before the watchdog could: Core's
+    /// <c>SdCardFileReceiver</c> raises a plain <see cref="TimeoutException"/> as soon as a read
+    /// returns no bytes, which over USB serial happens within about half a second.
+    /// </summary>
+    /// <param name="fileName">The SD card file whose transfer stalled.</param>
+    /// <param name="transportTimeout">The timeout Core reported, kept as the inner exception.</param>
+    public SdCardDownloadStalledException(string fileName, TimeoutException transportTimeout)
+        : base($"The transfer of '{fileName}' stopped before the device signalled end of file.",
+               transportTimeout)
+    {
+        FileName = fileName;
+        StallTimeout = null;
+    }
+
     /// <summary>The SD card file whose transfer stalled.</summary>
     public string FileName { get; }
 
-    /// <summary>How long the device was silent before the download was abandoned.</summary>
-    public TimeSpan StallTimeout { get; }
+    /// <summary>
+    /// How long the device was silent before the desktop's watchdog abandoned the download, or
+    /// <c>null</c> when the transport reported the timeout before the watchdog could fire.
+    /// </summary>
+    public TimeSpan? StallTimeout { get; }
+
+    /// <summary>
+    /// <c>true</c> when the desktop watched the device say nothing for <see cref="StallTimeout"/>.
+    /// That is unambiguously device-wide, so a batch import gives up rather than spend the same
+    /// wait on every remaining file. A transport-reported timeout is not: it can be a single
+    /// unreadable file, and gives up in well under a second, so the batch skips it and continues.
+    /// </summary>
+    public bool IsProlongedSilence => StallTimeout.HasValue;
 }

--- a/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
+++ b/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
@@ -7,9 +7,9 @@ namespace Daqifi.Desktop.Loggers;
 /// Two different detections raise it — the desktop's own stall watchdog (see
 /// <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>), which exists because Daqifi.Core
 /// exposes no timeout on either public <c>DownloadSdCardFileAsync</c> overload, and Core reporting
-/// a transport-level <see cref="TimeoutException"/> out of the download call (issue #779). What
-/// separates them for the caller is not which fired but <see cref="IsProlongedFailure"/>: how much
-/// the attempt cost before it gave up.
+/// a transport-level <see cref="TimeoutException"/> out of the download call (issue #779). Both are
+/// measured the same way, by <see cref="SilentFor"/>: how long the device had gone without
+/// delivering anything when the attempt was abandoned.
 ///
 /// Derives from <see cref="TimeoutException"/> so callers that only care that the operation timed
 /// out still catch it, while giving the SD failure classifier a type that means specifically
@@ -18,70 +18,67 @@ namespace Daqifi.Desktop.Loggers;
 /// keep that unrelated timeout off the Error path, where it belongs.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "RCS1194:Implement exception constructors",
-    Justification = "This exception exists to carry FileName plus what the failed attempt cost — the classifier " +
-                    "reads them, and the message is built from them. The standard parameterless/message-only " +
-                    "constructors would allow a stall report that names neither the file nor the duration, so " +
-                    "the type is sealed with the two constructors that can produce a meaningful instance.")]
+    Justification = "This exception exists to carry FileName plus how long the device had been quiet — the " +
+                    "classifier reads them, and the message is built from them. The standard parameterless/" +
+                    "message-only constructors would allow a stall report that names neither the file nor the " +
+                    "silence, so the type is sealed with the single constructor that can produce a meaningful " +
+                    "instance.")]
 public sealed class SdCardDownloadStalledException : TimeoutException
 {
     /// <summary>
-    /// Initializes a stall detected by the desktop's own watchdog: the device delivered nothing at
-    /// all for <paramref name="stallTimeout"/>, which is by definition a prolonged failure.
+    /// Initializes a new instance of the <see cref="SdCardDownloadStalledException"/> class.
     /// </summary>
     /// <param name="fileName">The SD card file whose transfer stalled.</param>
-    /// <param name="stallTimeout">How long the device was silent before the download was abandoned.</param>
-    public SdCardDownloadStalledException(string fileName, TimeSpan stallTimeout)
-        : base($"The device sent no data for '{fileName}' for {stallTimeout.TotalSeconds:N0} seconds, " +
-               "so the download was abandoned.")
-    {
-        FileName = fileName;
-        Elapsed = stallTimeout;
-        IsProlongedFailure = true;
-    }
-
-    /// <summary>
-    /// Initializes a stall the transport reported before the watchdog could: Core's
-    /// <c>SdCardFileReceiver</c> raises a plain <see cref="TimeoutException"/> as soon as a read
-    /// returns no bytes, which over USB serial happens within about half a second. Core also
-    /// raises one from its own 30-minute transfer cap, which is the same type but nothing like
-    /// the same cost — hence <paramref name="elapsed"/>.
-    /// </summary>
-    /// <param name="fileName">The SD card file whose transfer stalled.</param>
-    /// <param name="transportTimeout">The timeout Core reported, kept as the inner exception.</param>
-    /// <param name="elapsed">How long the download ran before Core gave up on it.</param>
+    /// <param name="silentFor">
+    /// How long the device had delivered nothing when the download was abandoned. For the
+    /// desktop's own watchdog this is its full stall window, since that is precisely what the
+    /// watchdog waits for.
+    /// </param>
     /// <param name="patienceWindow">
-    /// The desktop's own stall window. An attempt that ran at least this long counts as prolonged.
+    /// The desktop's stall window. Silence lasting at least this long counts as prolonged.
+    /// </param>
+    /// <param name="transportTimeout">
+    /// The timeout Core reported, when the transport detected the stall before the watchdog could.
+    /// <c>null</c> when the watchdog raised this itself.
     /// </param>
     public SdCardDownloadStalledException(
         string fileName,
-        TimeoutException transportTimeout,
-        TimeSpan elapsed,
-        TimeSpan patienceWindow)
-        : base($"The transfer of '{fileName}' stopped after {elapsed.TotalSeconds:N1} seconds, " +
-               "before the device signalled end of file.",
-               transportTimeout)
+        TimeSpan silentFor,
+        TimeSpan patienceWindow,
+        TimeoutException? transportTimeout = null)
+        : base(BuildMessage(fileName, silentFor, transportTimeout), transportTimeout)
     {
         FileName = fileName;
-        Elapsed = elapsed;
-
-        // Core reports its half-second serial read timeout and its 30-minute transfer cap through
-        // the identical exception type, so duration is the only thing separating "cheap, and
-        // possibly just this file" from "expensive, and evidence about the device". Anything that
-        // already cost the desktop its full stall window is the latter.
-        IsProlongedFailure = elapsed >= patienceWindow;
+        SilentFor = silentFor;
+        IsProlongedFailure = silentFor >= patienceWindow;
     }
 
     /// <summary>The SD card file whose transfer stalled.</summary>
     public string FileName { get; }
 
-    /// <summary>How long the download ran before it was abandoned.</summary>
-    public TimeSpan Elapsed { get; }
+    /// <summary>
+    /// How long the device had delivered nothing when the download was abandoned. Deliberately the
+    /// silence, not the total transfer time: a large file that streamed steadily for ten minutes
+    /// and then hit one brief transport timeout says nothing bad about the device, and must not be
+    /// read the same way as ten minutes of nothing. This is the same thing
+    /// <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/> bounds.
+    /// </summary>
+    public TimeSpan SilentFor { get; }
 
     /// <summary>
-    /// <c>true</c> when the attempt consumed at least the desktop's full stall window before
-    /// failing. That makes it both evidence about the device rather than about one file, and far
-    /// too expensive to repeat for every remaining file — so a batch import gives up on these and
-    /// carries on past the rest.
+    /// <c>true</c> when the device had been quiet for at least the desktop's full stall window.
+    /// That makes it evidence about the device rather than about one file, and far too expensive to
+    /// repeat for every remaining file — so a batch import gives up on these, and carries on past
+    /// the rest.
     /// </summary>
     public bool IsProlongedFailure { get; }
+
+    private static string BuildMessage(string fileName, TimeSpan silentFor, TimeoutException? transportTimeout)
+    {
+        return transportTimeout == null
+            ? $"The device sent no data for '{fileName}' for {silentFor.TotalSeconds:N0} seconds, " +
+              "so the download was abandoned."
+            : $"The transfer of '{fileName}' stopped before the device signalled end of file, " +
+              $"after {silentFor.TotalSeconds:N1} seconds without data.";
+    }
 }

--- a/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
+++ b/Daqifi.Desktop/Loggers/SdCardDownloadStalledException.cs
@@ -4,22 +4,12 @@ namespace Daqifi.Desktop.Loggers;
 /// Thrown when a device accepts an SD card download request and then fails to deliver the file,
 /// with the transfer neither completing nor failing as a device condition Core can name.
 ///
-/// Two different detections raise it, and they carry different weight:
-/// <list type="bullet">
-/// <item>
-/// The desktop's own stall watchdog (see <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>)
-/// observing prolonged silence. Daqifi.Core exposes no timeout on either public
-/// <c>DownloadSdCardFileAsync</c> overload, so the desktop has to impose that bound itself.
-/// <see cref="StallTimeout"/> is set and <see cref="IsProlongedSilence"/> is <c>true</c>: a device
-/// that has said nothing for that long is not going to serve the next file either.
-/// </item>
-/// <item>
-/// Core reporting a transport-level <see cref="TimeoutException"/> out of the download call.
-/// <see cref="StallTimeout"/> is <c>null</c>, the transport's own exception is the
-/// <see cref="Exception.InnerException"/>, and <see cref="IsProlongedSilence"/> is <c>false</c> —
-/// this can be one bad file rather than a wedged subsystem (issue #779).
-/// </item>
-/// </list>
+/// Two different detections raise it — the desktop's own stall watchdog (see
+/// <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>), which exists because Daqifi.Core
+/// exposes no timeout on either public <c>DownloadSdCardFileAsync</c> overload, and Core reporting
+/// a transport-level <see cref="TimeoutException"/> out of the download call (issue #779). What
+/// separates them for the caller is not which fired but <see cref="IsProlongedFailure"/>: how much
+/// the attempt cost before it gave up.
 ///
 /// Derives from <see cref="TimeoutException"/> so callers that only care that the operation timed
 /// out still catch it, while giving the SD failure classifier a type that means specifically
@@ -28,15 +18,15 @@ namespace Daqifi.Desktop.Loggers;
 /// keep that unrelated timeout off the Error path, where it belongs.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "RCS1194:Implement exception constructors",
-    Justification = "This exception exists to carry FileName plus how the stall was detected — the classifier " +
+    Justification = "This exception exists to carry FileName plus what the failed attempt cost — the classifier " +
                     "reads them, and the message is built from them. The standard parameterless/message-only " +
-                    "constructors would allow a stall report that names neither the file nor the detection, so " +
+                    "constructors would allow a stall report that names neither the file nor the duration, so " +
                     "the type is sealed with the two constructors that can produce a meaningful instance.")]
 public sealed class SdCardDownloadStalledException : TimeoutException
 {
     /// <summary>
     /// Initializes a stall detected by the desktop's own watchdog: the device delivered nothing at
-    /// all for <paramref name="stallTimeout"/>.
+    /// all for <paramref name="stallTimeout"/>, which is by definition a prolonged failure.
     /// </summary>
     /// <param name="fileName">The SD card file whose transfer stalled.</param>
     /// <param name="stallTimeout">How long the device was silent before the download was abandoned.</param>
@@ -45,38 +35,53 @@ public sealed class SdCardDownloadStalledException : TimeoutException
                "so the download was abandoned.")
     {
         FileName = fileName;
-        StallTimeout = stallTimeout;
+        Elapsed = stallTimeout;
+        IsProlongedFailure = true;
     }
 
     /// <summary>
-    /// Initializes a stall the transport detected first, before the watchdog could: Core's
+    /// Initializes a stall the transport reported before the watchdog could: Core's
     /// <c>SdCardFileReceiver</c> raises a plain <see cref="TimeoutException"/> as soon as a read
-    /// returns no bytes, which over USB serial happens within about half a second.
+    /// returns no bytes, which over USB serial happens within about half a second. Core also
+    /// raises one from its own 30-minute transfer cap, which is the same type but nothing like
+    /// the same cost — hence <paramref name="elapsed"/>.
     /// </summary>
     /// <param name="fileName">The SD card file whose transfer stalled.</param>
     /// <param name="transportTimeout">The timeout Core reported, kept as the inner exception.</param>
-    public SdCardDownloadStalledException(string fileName, TimeoutException transportTimeout)
-        : base($"The transfer of '{fileName}' stopped before the device signalled end of file.",
+    /// <param name="elapsed">How long the download ran before Core gave up on it.</param>
+    /// <param name="patienceWindow">
+    /// The desktop's own stall window. An attempt that ran at least this long counts as prolonged.
+    /// </param>
+    public SdCardDownloadStalledException(
+        string fileName,
+        TimeoutException transportTimeout,
+        TimeSpan elapsed,
+        TimeSpan patienceWindow)
+        : base($"The transfer of '{fileName}' stopped after {elapsed.TotalSeconds:N1} seconds, " +
+               "before the device signalled end of file.",
                transportTimeout)
     {
         FileName = fileName;
-        StallTimeout = null;
+        Elapsed = elapsed;
+
+        // Core reports its half-second serial read timeout and its 30-minute transfer cap through
+        // the identical exception type, so duration is the only thing separating "cheap, and
+        // possibly just this file" from "expensive, and evidence about the device". Anything that
+        // already cost the desktop its full stall window is the latter.
+        IsProlongedFailure = elapsed >= patienceWindow;
     }
 
     /// <summary>The SD card file whose transfer stalled.</summary>
     public string FileName { get; }
 
-    /// <summary>
-    /// How long the device was silent before the desktop's watchdog abandoned the download, or
-    /// <c>null</c> when the transport reported the timeout before the watchdog could fire.
-    /// </summary>
-    public TimeSpan? StallTimeout { get; }
+    /// <summary>How long the download ran before it was abandoned.</summary>
+    public TimeSpan Elapsed { get; }
 
     /// <summary>
-    /// <c>true</c> when the desktop watched the device say nothing for <see cref="StallTimeout"/>.
-    /// That is unambiguously device-wide, so a batch import gives up rather than spend the same
-    /// wait on every remaining file. A transport-reported timeout is not: it can be a single
-    /// unreadable file, and gives up in well under a second, so the batch skips it and continues.
+    /// <c>true</c> when the attempt consumed at least the desktop's full stall window before
+    /// failing. That makes it both evidence about the device rather than about one file, and far
+    /// too expensive to repeat for every remaining file — so a batch import gives up on these and
+    /// carries on past the rest.
     /// </summary>
-    public bool IsProlongedSilence => StallTimeout.HasValue;
+    public bool IsProlongedFailure { get; }
 }

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -231,10 +231,19 @@ public class SdCardSessionImporter : ISdCardSessionImporter
         using var stallCts = new CancellationTokenSource();
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, stallCts.Token);
 
+        // How long the device has been quiet is what tells a stalled transfer apart from a slow
+        // one, and Core reports both through the same untyped exception, so the desktop has to
+        // measure it. Written from the progress callback and read from the catch blocks, which can
+        // be different threads — hence the volatile tick count rather than a TimeSpan field.
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
+        long lastProgressTicks = 0;
+
         stallCts.CancelAfter(_downloadStallTimeout);
         var transferProgress = new SynchronousProgress<SdCardTransferProgress>(_ =>
         {
             // Another chunk arrived, so the device is alive — restart the deadline.
+            Volatile.Write(ref lastProgressTicks, elapsed.Elapsed.Ticks);
+
             try
             {
                 stallCts.CancelAfter(_downloadStallTimeout);
@@ -245,11 +254,6 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             }
         });
 
-        // How long the attempt cost is what decides whether a batch import should stop on it, so
-        // it has to be measured here: Core reports its half-second serial read timeout and its
-        // 30-minute transfer cap through the same untyped exception.
-        var elapsed = System.Diagnostics.Stopwatch.StartNew();
-
         try
         {
             return await device.DownloadSdCardFileAsync(fileName, transferProgress, linkedCts.Token);
@@ -257,8 +261,11 @@ public class SdCardSessionImporter : ISdCardSessionImporter
         catch (OperationCanceledException) when (stallCts.IsCancellationRequested && !ct.IsCancellationRequested)
         {
             // Distinguish our watchdog from a caller-requested cancel: only the watchdog becomes a
-            // stall, so a genuine user cancel still propagates as OperationCanceledException.
-            throw new SdCardDownloadStalledException(fileName, _downloadStallTimeout);
+            // stall, so a genuine user cancel still propagates as OperationCanceledException. The
+            // watchdog fires on exactly one condition — the full stall window with nothing arriving
+            // — so that window is the silence, by construction.
+            throw new SdCardDownloadStalledException(
+                fileName, _downloadStallTimeout, _downloadStallTimeout);
         }
         catch (TimeoutException ex)
         {
@@ -287,7 +294,13 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             // hardware failed when in fact they stopped it themselves.
             ct.ThrowIfCancellationRequested();
 
-            throw new SdCardDownloadStalledException(fileName, ex, elapsed.Elapsed, _downloadStallTimeout);
+            // Report the silence, not the total transfer time. A large file that streamed steadily
+            // for ten minutes and then hit one brief transport timeout is a healthy device and one
+            // unlucky file; ten minutes of nothing is a wedged subsystem. Measuring the whole
+            // attempt would collapse those two into the same answer and abort a batch import over
+            // the first of them.
+            var silentFor = elapsed.Elapsed - TimeSpan.FromTicks(Volatile.Read(ref lastProgressTicks));
+            throw new SdCardDownloadStalledException(fileName, silentFor, _downloadStallTimeout, ex);
         }
     }
 

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -299,7 +299,15 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             // unlucky file; ten minutes of nothing is a wedged subsystem. Measuring the whole
             // attempt would collapse those two into the same answer and abort a batch import over
             // the first of them.
-            var silentFor = elapsed.Elapsed - TimeSpan.FromTicks(Volatile.Read(ref lastProgressTicks));
+            //
+            // Read the last-progress stamp BEFORE sampling the clock. The callback runs on Core's
+            // thread, so sampling the clock first would let a chunk landing in between stamp a
+            // time later than the "now" it is subtracted from, and report a negative silence. This
+            // order cannot: the stopwatch only moves forward, so a stamp read earlier is never
+            // ahead of a reading taken after it. A chunk arriving in the gap merely makes the
+            // reported silence slightly conservative, which is the harmless direction.
+            var lastProgress = TimeSpan.FromTicks(Volatile.Read(ref lastProgressTicks));
+            var silentFor = elapsed.Elapsed - lastProgress;
             throw new SdCardDownloadStalledException(fileName, silentFor, _downloadStallTimeout, ex);
         }
     }

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -245,6 +245,11 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             }
         });
 
+        // How long the attempt cost is what decides whether a batch import should stop on it, so
+        // it has to be measured here: Core reports its half-second serial read timeout and its
+        // 30-minute transfer cap through the same untyped exception.
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
+
         try
         {
             return await device.DownloadSdCardFileAsync(fileName, transferProgress, linkedCts.Token);
@@ -275,7 +280,14 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             // reports still reach the log.
             //
             // Workaround: retire once Core reports stalls with a type. See daqifi-core#398 (gap 1).
-            throw new SdCardDownloadStalledException(fileName, ex);
+            //
+            // A caller-requested cancel wins over all of that. Over serial the read does not
+            // observe the token, so pressing cancel can surface as a transport timeout rather than
+            // a cancellation — and reporting that back as a device fault would tell the user their
+            // hardware failed when in fact they stopped it themselves.
+            ct.ThrowIfCancellationRequested();
+
+            throw new SdCardDownloadStalledException(fileName, ex, elapsed.Elapsed, _downloadStallTimeout);
         }
     }
 

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -20,9 +20,10 @@ public interface ISdCardSessionImporter
     /// <summary>
     /// Downloads an SD card log file from a connected USB device and imports it.
     /// </summary>
-    /// <exception cref="TimeoutException">
-    /// Thrown when the device stops sending data mid-transfer (see
-    /// <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>).
+    /// <exception cref="SdCardDownloadStalledException">
+    /// Thrown when the device stops sending data mid-transfer — either because the desktop's own
+    /// watchdog ran out of patience (see <see cref="SdCardSessionImporter.DOWNLOAD_STALL_TIMEOUT"/>)
+    /// or because the transport reported a timeout first.
     /// </exception>
     Task<SdCardImportResult> ImportFromDeviceAsync(
         IStreamingDevice device,
@@ -218,8 +219,9 @@ public class SdCardSessionImporter : ISdCardSessionImporter
     /// trips it.
     /// </summary>
     /// <exception cref="SdCardDownloadStalledException">
-    /// Thrown when no data arrives for <see cref="_downloadStallTimeout"/>. Callers surface this
-    /// as an expected device condition rather than an app error.
+    /// Thrown when no data arrives for <see cref="_downloadStallTimeout"/>, or when the transport
+    /// reports a timeout of its own first. Callers surface this as an expected device condition
+    /// rather than an app error.
     /// </exception>
     internal async Task<SdCardDownloadResult> DownloadWithStallWatchdogAsync(
         IStreamingDevice device,
@@ -252,6 +254,26 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             // Distinguish our watchdog from a caller-requested cancel: only the watchdog becomes a
             // stall, so a genuine user cancel still propagates as OperationCanceledException.
             throw new SdCardDownloadStalledException(fileName, _downloadStallTimeout);
+        }
+        catch (TimeoutException ex)
+        {
+            // Issue #779: over USB serial — the only transport SD import supports — the watchdog
+            // above is effectively unreachable. Core's serial transport drops SerialPort.ReadTimeout
+            // to 500ms after connect and hands the raw BaseStream to SdCardFileReceiver, and .NET's
+            // SerialStream returns 0 bytes on a read timeout rather than throwing or honouring the
+            // token. The receiver treats a 0-byte read as fatal, so a wedged device raises a plain
+            // TimeoutException in about half a second — never as the cancellation the catch above
+            // is waiting for, which left this whole degradation path dead code on real hardware.
+            //
+            // Caught by type rather than by message, and deliberately not tied to that one throw
+            // site: SdCardFileReceiver raises TimeoutException from three places (the 0-byte read
+            // plus two paths for its own 30-minute cap), and Core is free to add more. What makes
+            // the normalisation safe is the *scope* — a timeout out of the download call is by
+            // definition a transfer that did not complete, whereas a TimeoutException from anywhere
+            // else in the import says nothing about the SD card and must keep the generic Error
+            // path. Core's exception is preserved as the inner one so the byte count and reason it
+            // reports still reach the log.
+            throw new SdCardDownloadStalledException(fileName, ex);
         }
     }
 

--- a/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
+++ b/Daqifi.Desktop/Loggers/SdCardSessionImporter.cs
@@ -273,6 +273,8 @@ public class SdCardSessionImporter : ISdCardSessionImporter
             // else in the import says nothing about the SD card and must keep the generic Error
             // path. Core's exception is preserved as the inner one so the byte count and reason it
             // reports still reach the log.
+            //
+            // Workaround: retire once Core reports stalls with a type. See daqifi-core#398 (gap 1).
             throw new SdCardDownloadStalledException(fileName, ex);
         }
     }

--- a/Daqifi.Desktop/View/DeviceLogsView.xaml
+++ b/Daqifi.Desktop/View/DeviceLogsView.xaml
@@ -122,6 +122,7 @@
 
             <Button Grid.Column="3"
                     Style="{StaticResource AccentPillButton}"
+                    AutomationProperties.AutomationId="ImportAllSdCardFilesButton"
                     Command="{Binding ImportAllFilesCommand}"
                     ToolTip="Import all files to application"
                     IsEnabled="{Binding CanAccessSdCard}">

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -514,7 +514,8 @@ public partial class DeviceLogsViewModel : ObservableObject
 
         if (outcome.AbortingFailure != null)
         {
-            message.Append(CultureInfo.CurrentCulture, $"\n\nImport stopped at {outcome.AbortedOnFile}: {outcome.AbortingFailure.Guidance}");
+            message.Append(CultureInfo.CurrentCulture,
+                $"\n\nImport stopped at {outcome.AbortedOnFile}: {outcome.AbortingFailure.Guidance}");
         }
 
         if (outcome.TimestampWarningCount > 0)

--- a/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DeviceLogsViewModel.cs
@@ -36,6 +36,15 @@ public enum SdCardState
 
 public partial class DeviceLogsViewModel : ObservableObject
 {
+    #region Constants
+    /// <summary>
+    /// How many skipped file names the completion dialog lists before collapsing the rest into a
+    /// count. A card carrying dozens of empty logs would otherwise produce a dialog taller than
+    /// the screen.
+    /// </summary>
+    private const int MAX_LISTED_SKIPPED_FILES = 5;
+    #endregion
+
     private readonly IAppLogger _logger;
 
     /// <summary>
@@ -43,6 +52,13 @@ public partial class DeviceLogsViewModel : ObservableObject
     /// importer from the service provider (which is not available under unit test).
     /// </summary>
     private readonly ISdCardSessionImporter? _importerOverride;
+
+    /// <summary>
+    /// Where a freshly imported session is published, injected by tests. <c>null</c> in production,
+    /// where it goes to <see cref="LoggingManager.Instance"/> — a singleton tests cannot touch,
+    /// because its constructor resolves services from <see cref="App.ServiceProvider"/>.
+    /// </summary>
+    private readonly Action<LoggingSession>? _sessionSinkOverride;
 
     [ObservableProperty]
     private bool _isBusy;
@@ -157,10 +173,17 @@ public partial class DeviceLogsViewModel : ObservableObject
     /// import path without the <see cref="App.ServiceProvider"/> / <see cref="Application.Current"/>
     /// singletons, neither of which exists under test.
     /// </summary>
-    internal DeviceLogsViewModel(IAppLogger? logger, ISdCardSessionImporter? importer)
+    /// <param name="logger">Logger to report failures through.</param>
+    /// <param name="importer">Importer to run imports with.</param>
+    /// <param name="sessionSink">Where successfully imported sessions are published.</param>
+    internal DeviceLogsViewModel(
+        IAppLogger? logger,
+        ISdCardSessionImporter? importer,
+        Action<LoggingSession>? sessionSink = null)
     {
         _logger = logger ?? AppLogger.Instance;
         _importerOverride = importer;
+        _sessionSinkOverride = sessionSink;
 
         ConnectedDevices = new ObservableCollection<IStreamingDevice>();
         DeviceFiles = new ObservableCollection<SdCardFile>();
@@ -378,11 +401,7 @@ public partial class DeviceLogsViewModel : ObservableObject
         if (device is not { ConnectionType: ConnectionType.Usb } || DeviceFiles == null || !DeviceFiles.Any()) return;
 
         var filesToImport = DeviceFiles.ToList();
-        var successCount = 0;
-        var failCount = 0;
-        var timestampWarningCount = 0;
-
-        SdCardFailure? abortingFailure = null;
+        var outcome = new ImportAllOutcome { TotalCount = filesToImport.Count };
 
         try
         {
@@ -409,44 +428,34 @@ public partial class DeviceLogsViewModel : ObservableObject
 
                     if (result.TimestampQuality.HasDegenerateTimeAxis)
                     {
-                        timestampWarningCount++;
+                        outcome.TimestampWarningCount++;
                     }
 
-                    successCount++;
+                    outcome.ImportedCount++;
                 }
                 catch (Exception ex)
                 {
                     var failure = HandleImportFailure(ex, file.FileName, device);
-                    failCount++;
 
                     if (failure.IsCardUnavailable)
                     {
                         // The card itself is gone or wedged: every remaining file would fail the
                         // same way, each burning the same multi-second timeout. Stop here.
-                        abortingFailure = failure;
+                        outcome.AbortingFailure = failure;
+                        outcome.AbortedOnFile = file.FileName;
                         break;
                     }
+
+                    // Anything else may be specific to this file — an empty log, one corrupt
+                    // directory entry, a rejected command. Skip it and keep going: aborting here
+                    // silently dropped every later healthy file, and because the device lists
+                    // files in the same order every time, a retry stopped at the same file
+                    // (issue #780).
+                    outcome.RecordSkip(file.FileName, failure.Guidance);
                 }
             }
 
-            var message = $"Imported {successCount} of {filesToImport.Count} files.";
-            if (failCount > 0)
-            {
-                message += $"\n{failCount} file(s) failed to import.";
-            }
-
-            if (abortingFailure != null)
-            {
-                message += $"\n\nImport stopped early: {abortingFailure.Guidance}";
-            }
-
-            if (timestampWarningCount > 0)
-            {
-                message += $"\nWarning: {timestampWarningCount} file(s) have missing or unusable per-sample " +
-                           "timestamps; their sessions' time axes may be flat or partially collapsed.";
-            }
-
-            await ShowMessage("Import Complete", message, MessageDialogStyle.Affirmative);
+            await ShowMessage("Import Complete", BuildImportAllSummary(outcome), MessageDialogStyle.Affirmative);
         }
         catch (Exception ex)
         {
@@ -460,6 +469,62 @@ public partial class DeviceLogsViewModel : ObservableObject
             IsBusy = false;
             BusyMessage = string.Empty;
         }
+    }
+
+    /// <summary>
+    /// Builds the text of the "Import Complete" dialog from what the batch actually did.
+    ///
+    /// Skipped files are reported as skipped, by name, with the advice that applies to them — not
+    /// as a card-wide abort. Telling the user to power-cycle the device because one log file was
+    /// empty sent them after a fault that was not there and hid the fact that every other file
+    /// imported fine (issue #780).
+    /// </summary>
+    /// <param name="outcome">What the batch imported, skipped, and stopped at.</param>
+    /// <returns>The message body shown in the completion dialog.</returns>
+    internal static string BuildImportAllSummary(ImportAllOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        var message = new StringBuilder();
+        message.Append(CultureInfo.CurrentCulture, $"Imported {outcome.ImportedCount} of {outcome.TotalCount} files.");
+
+        if (outcome.SkippedFiles.Count > 0)
+        {
+            message.Append(CultureInfo.CurrentCulture, $"\n\nSkipped {outcome.SkippedFiles.Count} file(s).");
+            message.Append(" You can retry any of them on their own from the file list.");
+
+            foreach (var fileName in outcome.SkippedFiles.Take(MAX_LISTED_SKIPPED_FILES))
+            {
+                message.Append(CultureInfo.CurrentCulture, $"\n  • {fileName}");
+            }
+
+            var undisplayed = outcome.SkippedFiles.Count - MAX_LISTED_SKIPPED_FILES;
+            if (undisplayed > 0)
+            {
+                message.Append(CultureInfo.CurrentCulture, $"\n  • ...and {undisplayed} more");
+            }
+
+            // One line per distinct reason: a card holding both an empty log and a corrupt one
+            // needs both pieces of advice, but a card holding ten empty logs needs it once.
+            foreach (var guidance in outcome.SkipGuidance)
+            {
+                message.Append(CultureInfo.CurrentCulture, $"\n\n{guidance}");
+            }
+        }
+
+        if (outcome.AbortingFailure != null)
+        {
+            message.Append(CultureInfo.CurrentCulture, $"\n\nImport stopped at {outcome.AbortedOnFile}: {outcome.AbortingFailure.Guidance}");
+        }
+
+        if (outcome.TimestampWarningCount > 0)
+        {
+            message.Append(CultureInfo.CurrentCulture,
+                $"\n\nWarning: {outcome.TimestampWarningCount} file(s) have missing or unusable per-sample");
+            message.Append(" timestamps; their sessions' time axes may be flat or partially collapsed.");
+        }
+
+        return message.ToString();
     }
 
     /// <summary>
@@ -480,16 +545,27 @@ public partial class DeviceLogsViewModel : ObservableObject
     /// <summary>
     /// Publishes a freshly imported session to the session list on the UI thread.
     /// </summary>
-    private static void AddImportedSession(LoggingSession session)
+    private void AddImportedSession(LoggingSession session)
     {
+        void Publish()
+        {
+            if (_sessionSinkOverride != null)
+            {
+                _sessionSinkOverride(session);
+                return;
+            }
+
+            LoggingManager.Instance.LoggingSessions.Add(session);
+        }
+
         var dispatcher = Application.Current?.Dispatcher;
         if (dispatcher != null && !dispatcher.CheckAccess())
         {
-            dispatcher.Invoke(() => LoggingManager.Instance.LoggingSessions.Add(session));
+            dispatcher.Invoke(Publish);
         }
         else
         {
-            LoggingManager.Instance.LoggingSessions.Add(session);
+            Publish();
         }
     }
 
@@ -508,10 +584,13 @@ public partial class DeviceLogsViewModel : ObservableObject
     {
         var failure = SdCardFailureClassifier.Classify(ex);
 
-        // Only an expected device condition tells us anything about the card. An unexpected
-        // failure (a defect in the import pipeline, a database error) must not blame the card and
-        // hide a perfectly good file list behind an error panel.
-        if (failure.IsExpectedDeviceCondition && ReferenceEquals(SelectedDevice, device))
+        // Only a card-wide device condition belongs on the SD card panel. That panel *replaces*
+        // the file list, so showing a single file's failure there hides every healthy file and
+        // takes away the per-file retry that skipping the file exists to leave available (issue
+        // #780). An unexpected failure (a defect in the import pipeline, a database error) says
+        // nothing about the card either. Both still reach the user through the import dialog.
+        if (failure is { IsExpectedDeviceCondition: true, IsCardUnavailable: true }
+            && ReferenceEquals(SelectedDevice, device))
         {
             ApplyFailureState(failure);
         }
@@ -556,5 +635,60 @@ public partial class DeviceLogsViewModel : ObservableObject
         }
 
         await window.ShowMessageAsync(title, message, dialogStyle);
+    }
+}
+
+/// <summary>
+/// What an "Import All" run did, in the terms its completion dialog reports. Accumulated as the
+/// batch runs and handed to <see cref="DeviceLogsViewModel.BuildImportAllSummary"/>, which is
+/// separated out so the wording can be unit-tested without a WPF dialog.
+/// </summary>
+internal sealed class ImportAllOutcome
+{
+    private readonly List<string> _skippedFiles = [];
+    private readonly List<string> _skipGuidance = [];
+
+    /// <summary>How many files the batch started with.</summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>How many files imported successfully.</summary>
+    public int ImportedCount { get; set; }
+
+    /// <summary>How many imported sessions came out with an unusable time axis.</summary>
+    public int TimestampWarningCount { get; set; }
+
+    /// <summary>
+    /// Files that failed for a reason that may be specific to them, in list order. The batch
+    /// carried on past each of these, and the user can still retry them individually.
+    /// </summary>
+    public IReadOnlyList<string> SkippedFiles => _skippedFiles;
+
+    /// <summary>
+    /// The distinct guidance sentences the skipped files produced, in first-seen order. Deduped
+    /// so ten empty logs read out their advice once rather than ten times.
+    /// </summary>
+    public IReadOnlyList<string> SkipGuidance => _skipGuidance;
+
+    /// <summary>
+    /// The card-wide failure that ended the batch early, or <c>null</c> if it ran to completion.
+    /// </summary>
+    public SdCardFailure? AbortingFailure { get; set; }
+
+    /// <summary>The file the batch stopped at, set with <see cref="AbortingFailure"/>.</summary>
+    public string? AbortedOnFile { get; set; }
+
+    /// <summary>
+    /// Records a file the batch skipped and carried on past.
+    /// </summary>
+    /// <param name="fileName">The file that failed.</param>
+    /// <param name="guidance">What the user should do about it.</param>
+    public void RecordSkip(string fileName, string guidance)
+    {
+        _skippedFiles.Add(fileName);
+
+        if (!_skipGuidance.Contains(guidance))
+        {
+            _skipGuidance.Add(guidance);
+        }
     }
 }

--- a/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
+++ b/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
@@ -66,15 +66,25 @@ public static class SdCardFailureClassifier
         "The device's SD card subsystem is not responding. Power-cycle the device and try again.";
 
     /// <summary>
-    /// Guidance for a transfer that delivered nothing for one file. Core deliberately cannot tell a
+    /// Guidance for a transfer that delivered nothing at all for one file. Core cannot tell a
     /// genuinely empty (0-byte) log — routinely left behind on a FAT card by an interrupted logging
     /// session — from an SD subsystem that was not ready when it opened the file, so the advice has
     /// to cover both: this file is skipped, and the power cycle is only worth reaching for when
     /// every file behaves the same way.
     /// </summary>
-    internal const string INCOMPLETE_TRANSFER_GUIDANCE =
+    internal const string EMPTY_TRANSFER_GUIDANCE =
         "The device sent no data for this file, which may simply be an empty log. If every file " +
         "fails the same way, power-cycle the device and try again.";
+
+    /// <summary>
+    /// Guidance for a transfer that stopped part-way. Distinct from
+    /// <see cref="EMPTY_TRANSFER_GUIDANCE"/> because a stall can interrupt a transfer that was
+    /// already delivering data, and how much arrived is not knowable here — so this must not
+    /// diagnose an empty file the way that one does.
+    /// </summary>
+    internal const string INCOMPLETE_TRANSFER_GUIDANCE =
+        "The device stopped sending this file before it was complete. Try importing it on its " +
+        "own; if every file fails the same way, power-cycle the device and try again.";
 
     /// <summary>Guidance for a device with no card in the slot.</summary>
     internal const string NO_CARD_GUIDANCE =
@@ -120,7 +130,7 @@ public static class SdCardFailureClassifier
             SdCardEmptyTransferException => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device returned no data for this file.",
-                Guidance: INCOMPLETE_TRANSFER_GUIDANCE,
+                Guidance: EMPTY_TRANSFER_GUIDANCE,
                 IsExpectedDeviceCondition: true,
                 IsCardUnavailable: false),
 
@@ -156,17 +166,18 @@ public static class SdCardFailureClassifier
             // TimeoutException: an unrelated timeout reaching here is not evidence that the SD
             // subsystem is wedged, and must keep the Error path.
             //
-            // How the stall was detected decides how far it generalises. The desktop's watchdog
-            // firing means the device said nothing for 90 seconds — device-wide, and worth
-            // aborting a batch over, since every remaining file would cost another 90 seconds. A
-            // transport-reported timeout gives up in well under a second and can be one unreadable
-            // file, so it is treated like any other per-file failure (issue #779).
+            // What the attempt cost decides how far it generalises. A prolonged failure — the
+            // watchdog seeing 90 seconds of silence, or Core's 30-minute transfer cap elapsing —
+            // is evidence about the device, and repeating it for every remaining file would cost
+            // the user that wait again per file. A transport timeout that gave up in well under a
+            // second is neither: it can be one unreadable file, so it is treated like any other
+            // per-file failure (issue #779).
             SdCardDownloadStalledException stalled => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device stopped responding during the transfer.",
-                Guidance: stalled.IsProlongedSilence ? POWER_CYCLE_GUIDANCE : INCOMPLETE_TRANSFER_GUIDANCE,
+                Guidance: stalled.IsProlongedFailure ? POWER_CYCLE_GUIDANCE : INCOMPLETE_TRANSFER_GUIDANCE,
                 IsExpectedDeviceCondition: true,
-                IsCardUnavailable: stalled.IsProlongedSilence),
+                IsCardUnavailable: stalled.IsProlongedFailure),
 
             _ => new SdCardFailure(
                 State: SdCardState.Error,

--- a/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
+++ b/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
@@ -115,6 +115,8 @@ public static class SdCardFailureClassifier
             // FAT card, is therefore indistinguishable from a wedged subsystem. Treat it as
             // per-file: one benign empty file used to make every file listed after it unimportable
             // through Import All (issue #780).
+            //
+            // Revisit once Core makes the empty-transfer check size-aware. See daqifi-core#398 (gap 2).
             SdCardEmptyTransferException => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device returned no data for this file.",

--- a/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
+++ b/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
@@ -166,12 +166,11 @@ public static class SdCardFailureClassifier
             // TimeoutException: an unrelated timeout reaching here is not evidence that the SD
             // subsystem is wedged, and must keep the Error path.
             //
-            // What the attempt cost decides how far it generalises. A prolonged failure — the
-            // watchdog seeing 90 seconds of silence, or Core's 30-minute transfer cap elapsing —
-            // is evidence about the device, and repeating it for every remaining file would cost
-            // the user that wait again per file. A transport timeout that gave up in well under a
-            // second is neither: it can be one unreadable file, so it is treated like any other
-            // per-file failure (issue #779).
+            // How long the device had been quiet decides how far it generalises. Silence lasting
+            // the full stall window is evidence about the device, and repeating that wait for
+            // every remaining file would cost the user it again per file. A transport timeout on a
+            // device that was delivering data until moments before is neither: it can be one
+            // unreadable file, so it is treated like any other per-file failure (issue #779).
             SdCardDownloadStalledException stalled => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device stopped responding during the transfer.",

--- a/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
+++ b/Daqifi.Desktop/ViewModels/SdCardFailureClassifier.cs
@@ -24,9 +24,15 @@ namespace Daqifi.Desktop.ViewModels;
 /// anything else is a genuine defect and keeps the Error path.
 /// </param>
 /// <param name="IsCardUnavailable">
-/// <c>true</c> when the SD subsystem — not just this one file — is unusable, so further file
-/// operations against the same device would fail the same way. Batch imports stop early on these
-/// rather than retrying every remaining file through the same multi-second failure.
+/// <c>true</c> only when the SD subsystem — not just this one file — is unmistakably unusable, so
+/// further file operations against the same device would fail the same way. Batch imports stop
+/// early on these rather than retrying every remaining file through the same multi-second failure.
+///
+/// Deliberately narrow. A condition that <i>might</i> be specific to one file must not set this:
+/// <c>ImportAllFiles</c> abandons the rest of the batch, and because the file list comes back in
+/// the same order every time, the files after the failing one become unreachable through Import
+/// All entirely (issue #780). Skipping the one file and carrying on costs a failed download;
+/// aborting costs the user every later healthy file.
 /// </param>
 public sealed record SdCardFailure(
     SdCardState State,
@@ -59,6 +65,17 @@ public static class SdCardFailureClassifier
     internal const string POWER_CYCLE_GUIDANCE =
         "The device's SD card subsystem is not responding. Power-cycle the device and try again.";
 
+    /// <summary>
+    /// Guidance for a transfer that delivered nothing for one file. Core deliberately cannot tell a
+    /// genuinely empty (0-byte) log — routinely left behind on a FAT card by an interrupted logging
+    /// session — from an SD subsystem that was not ready when it opened the file, so the advice has
+    /// to cover both: this file is skipped, and the power cycle is only worth reaching for when
+    /// every file behaves the same way.
+    /// </summary>
+    internal const string INCOMPLETE_TRANSFER_GUIDANCE =
+        "The device sent no data for this file, which may simply be an empty log. If every file " +
+        "fails the same way, power-cycle the device and try again.";
+
     /// <summary>Guidance for a device with no card in the slot.</summary>
     internal const string NO_CARD_GUIDANCE =
         "No SD card is installed in the device. Insert a card and refresh.";
@@ -88,16 +105,25 @@ public static class SdCardFailureClassifier
                 IsExpectedDeviceCondition: true,
                 IsCardUnavailable: true),
 
-            // The device opened the file and closed it again without sending a byte. Core only
-            // throws this after exhausting its own retries, so by the time it reaches us the SD
-            // subsystem is wedged rather than merely slow.
+            // The device opened the file and closed it again without sending a byte, after Core
+            // exhausted its own retries.
+            //
+            // Core's own doc calls this "never a valid download for a file the directory listing
+            // reports as non-empty" — but SdCardFileReceiver has no access to the listed size at
+            // the point it throws, so it raises the same exception for any marker-only transfer.
+            // A genuinely 0-byte log, which an interrupted logging session routinely leaves on a
+            // FAT card, is therefore indistinguishable from a wedged subsystem. Treat it as
+            // per-file: one benign empty file used to make every file listed after it unimportable
+            // through Import All (issue #780).
             SdCardEmptyTransferException => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device returned no data for this file.",
-                Guidance: POWER_CYCLE_GUIDANCE,
+                Guidance: INCOMPLETE_TRANSFER_GUIDANCE,
                 IsExpectedDeviceCondition: true,
-                IsCardUnavailable: true),
+                IsCardUnavailable: false),
 
+            // Unambiguously device-wide: the device is using the card itself, so no file on it can
+            // be downloaded until logging stops.
             SdCardBusyException => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device's SD card is busy.",
@@ -105,12 +131,14 @@ public static class SdCardFailureClassifier
                 IsExpectedDeviceCondition: true,
                 IsCardUnavailable: true),
 
+            // A filesystem error can be the whole card or one corrupt directory entry, and the
+            // device message does not say which — so skip this file rather than write off the rest.
             SdCardFilesystemException filesystem => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: filesystem.DeviceMessage ?? filesystem.Message,
                 Guidance: GENERIC_CARD_GUIDANCE,
                 IsExpectedDeviceCondition: true,
-                IsCardUnavailable: true),
+                IsCardUnavailable: false),
 
             SdCardOperationException operation => new SdCardFailure(
                 State: SdCardState.Error,
@@ -121,16 +149,22 @@ public static class SdCardFailureClassifier
                 // is still worth trying.
                 IsCardUnavailable: false),
 
-            // Raised by the desktop's own stall watchdog (see SdCardSessionImporter) when the
-            // device stops sending data mid-transfer without ever failing the request. Matched by
-            // its specific type, not by TimeoutException: an unrelated timeout reaching here is
-            // not evidence that the SD subsystem is wedged, and must keep the Error path.
-            SdCardDownloadStalledException => new SdCardFailure(
+            // Raised by SdCardSessionImporter when the device stops sending data mid-transfer
+            // without ever failing the request. Matched by its specific type, not by
+            // TimeoutException: an unrelated timeout reaching here is not evidence that the SD
+            // subsystem is wedged, and must keep the Error path.
+            //
+            // How the stall was detected decides how far it generalises. The desktop's watchdog
+            // firing means the device said nothing for 90 seconds — device-wide, and worth
+            // aborting a batch over, since every remaining file would cost another 90 seconds. A
+            // transport-reported timeout gives up in well under a second and can be one unreadable
+            // file, so it is treated like any other per-file failure (issue #779).
+            SdCardDownloadStalledException stalled => new SdCardFailure(
                 State: SdCardState.Error,
                 StatusMessage: "The device stopped responding during the transfer.",
-                Guidance: POWER_CYCLE_GUIDANCE,
+                Guidance: stalled.IsProlongedSilence ? POWER_CYCLE_GUIDANCE : INCOMPLETE_TRANSFER_GUIDANCE,
                 IsExpectedDeviceCondition: true,
-                IsCardUnavailable: true),
+                IsCardUnavailable: stalled.IsProlongedSilence),
 
             _ => new SdCardFailure(
                 State: SdCardState.Error,


### PR DESCRIPTION
Closes #779
Closes #780

Both tickets rewrite `SdCardFailureClassifier`, so they ship together.

Both diagnoses were verified against the Daqifi.Core **1.3.0** source (the version this repo consumes) before implementing, not taken on trust.

## #779 — the stall degradation was dead code on the only transport SD import supports

Verified upstream:

- `SerialStreamTransport.ConnectAsync` drops `SerialPort.ReadTimeout` to **500 ms** immediately after opening the port.
- `DaqifiDevice.ExecuteRawCaptureAsync` hands `_transport.Stream` — the raw `SerialPort.BaseStream` — straight to `SdCardFileReceiver`.
- `.NET`'s `SerialStream.ReadAsync` returns **0 bytes** on a read timeout: it does not throw, and does not observe the cancellation token mid-read.
- `SdCardFileReceiver.ReceiveAsync` treats `bytesRead == 0` as fatal and throws a **plain `TimeoutException`** ("Transport stream closed before receiving the EOF marker…").

So a device that wedges mid-transfer surfaced a plain `TimeoutException` in about half a second — long before the desktop's 90 s watchdog, and never as a cancellation. `DownloadWithStallWatchdogAsync`'s OCE-only catch missed it, `SdCardDownloadStalledException` was never produced, and the classifier's `default` arm fired: `LogError` (Sentry) plus "check the device connection". That is exactly the #754 behaviour #755 was written to eliminate, reproduced on the transport that actually ships.

**Fix:** `DownloadWithStallWatchdogAsync` also catches `TimeoutException`, **scoped to the `DownloadSdCardFileAsync` call**, and re-throws the typed `SdCardDownloadStalledException` with Core's exception preserved as the inner one (its byte count is the only diagnostic the log gets). Caught by type, not by message — and deliberately not tied to one throw site: `SdCardFileReceiver` raises `TimeoutException` from three places (the 0-byte read plus two paths for its own 30-minute cap), and Core is free to add more. What makes the normalisation safe is the **scope**: a timeout out of the download call is by definition a transfer that did not complete, while a `TimeoutException` from anywhere else in the import keeps the generic Error path.

A caller-requested cancel takes precedence over all of it (`ct.ThrowIfCancellationRequested()` before wrapping). The same serial behaviour this fix is about means pressing cancel can also surface as a transport timeout rather than a cancellation, and reporting that back as a device fault would tell the user their hardware failed when they stopped it themselves.

## #780 — Import All aborted on the first empty file and stranded every file after it

`SdCardEmptyTransferException`'s own XML doc in Core calls it "never a valid download for a file the directory listing reports as non-empty" — but the receiver has **no access to the listed size** at the point it throws (`SdCardFileReceiver` throws on any marker-only transfer). So Core *intends* the condition to be unambiguous while its behaviour is not: a genuinely 0-byte log, routinely left behind on a FAT card by an interrupted logging session, raises the identical exception as a wedged SD subsystem. The exception's own message ("retry or power-cycle the device") is the wrong guidance for the benign case.

Because that was marked `IsCardUnavailable`, `ImportAllFiles` `break`ed the batch on it. Every file listed after the empty one was silently skipped, and since the device lists files in the same order every time, a retry stopped at the same file — making the later files unreachable through Import All entirely. `SdCardFilesystemException` (one corrupt directory entry) triggered the same over-broad abort.

**Fix:** `IsCardUnavailable` is now reserved for the unambiguously device-wide conditions.

| Condition | `IsCardUnavailable` | Why |
|---|---|---|
| `SdCardNotPresentException` | yes | Empty slot — nothing on it can be read. |
| `SdCardBusyException` | yes | Device is logging to the card itself. |
| `SdCardDownloadStalledException`, device quiet ≥ 90 s | yes | Silence that long is about the device, and repeating it per file is unacceptable. |
| `SdCardDownloadStalledException`, device quiet < 90 s | **no** | The device was delivering data until moments before; can be one unreadable file (#779). |
| `SdCardEmptyTransferException` | **no** | Ambiguous — may be a benign empty log. |
| `SdCardFilesystemException` | **no** | May be one corrupt directory entry. |
| `SdCardOperationException` | no | Unchanged; a rejected SCPI command can be file-specific. |

To support that split, `SdCardDownloadStalledException` carries the transport's own exception and an `IsProlongedFailure` flag — see the section below on how it is decided. A stall on a device that was streaming data a moment earlier and one on a device that has said nothing for 90 seconds are not equally strong evidence, and only the second justifies writing off the rest of the card.

## Surfacing it sensibly

Two user-facing consequences of "the batch now continues" needed handling:

- **The completion dialog** no longer says "Import stopped early: power-cycle the device" for a benign empty file. Skipped files are reported *as skipped*, by name (first 5, then a count), with their guidance deduped — a card holding ten empty logs states the advice once. "Import stopped at &lt;file&gt;" appears only when the card really was unavailable. New guidance string for the ambiguous family covers both readings: *"The device sent no data for this file, which may simply be an empty log. If every file fails the same way, power-cycle the device and try again."*
- **The SD card panel** is now painted only for card-wide conditions. That panel *replaces* the file list in the view (`HasFiles` requires `SdCardState == Ok`), so a per-file failure landing there hid every healthy file and took away the one-by-one retry that skipping the file exists to preserve — which would have defeated the point of #780's fix. Per-file failures still reach the user through the import dialog, and still log at Warning.

The summary text moved into `DeviceLogsViewModel.BuildImportAllSummary` so its wording is unit-testable without a WPF dialog. `DeviceLogsViewModel` also gains a session-sink test seam, because publishing an imported session goes through `LoggingManager.Instance`, whose constructor resolves services from `App.ServiceProvider` and therefore throws under test — without it, no test could exercise a *successful* import at all.

## How long the device was quiet decides how far a stall generalises

The least obvious part of the design, and it took both review rounds to land. Core reports its ~500 ms serial read timeout **and** its 30-minute transfer cap through the identical untyped `TimeoutException`, so the exception itself says nothing about how bad things are.

What the importer measures is the **silence** — how long the device had delivered nothing when the attempt was abandoned:

```csharp
var silentFor = elapsed.Elapsed - TimeSpan.FromTicks(Volatile.Read(ref lastProgressTicks));
...
IsProlongedFailure = silentFor >= patienceWindow;
```

Deliberately not the total transfer time. A large file that streamed steadily for ten minutes and then hit one brief transport timeout is a healthy device and one unlucky file; ten minutes of *nothing* is a wedged subsystem. Measuring the whole attempt collapses those into the same answer and aborts a batch over the first of them.

This is also the thing `DOWNLOAD_STALL_TIMEOUT` already documents itself as bounding ("this bounds a stall, not the total transfer"), so the watchdog path and the transport path end up judged by one criterion rather than two conflicting ones — the watchdog fires on exactly the full window of silence, by construction.

One trade this makes knowingly: a device that *dribbles* data for 30 minutes and then trips Core's cap is per-file, so a batch could pay that per file. That requires the device to be actively delivering data for half an hour, which is not a state that says "the card is unusable", and the alternative penalises the far likelier healthy-transfer-glitch case. daqifi-core#398 gap 1 is what would let the desktop tell those apart properly rather than by inference.

## Tests

All green: **820/820** (`--filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests"`).

Added:

- `Download_WhenCoreReportsATimeout_BecomesAStallRatherThanABareTimeout` — the #779 core case: Core's plain `TimeoutException` becomes the typed stall, inner exception preserved, not prolonged.
- `Download_WhenALongHealthyTransferTimesOutAtTheEnd_StaysPerFile` — progress past the stall window, then an immediate timeout: stays per-file, and asserts the reported silence is shorter than the window, so measuring total transfer time fails it.
- `Download_WhenTheDeviceGoesQuietThenCoreTimesOut_CountsAsProlonged` — one chunk, then real silence past the window, then Core's timeout: stops the batch.
- `Download_WhenTheCallerCancelsAndTheTransportTimesOut_StaysCancelled` — over serial the read does not observe the token, so a cancel can arrive as a transport timeout; it must not be relabelled a device fault.
- `Download_WhenTheDeviceFailsForANonTimeoutReason_IsLeftAlone` — regression guard on the normalisation's scope.
- `Classify_QuickTransportStall_…` / `Classify_ProlongedTransportStall_…` / `Classify_WatchdogDetectedStall_…` — the three cases classify as intended, including that the quick stall does not use the empty-file wording (a stall can interrupt a transfer that was already delivering).
- `Classify_Busy_IsUnambiguouslyDeviceWide`, and updated empty-transfer / filesystem cases.
- `ImportAllFiles_WhenTheFirstFileIsEmpty_StillImportsEveryHealthyFileAfterIt` — the #780 regression: all three files attempted, both healthy ones actually imported.
- `ImportAllFiles_WhenTheTransportTimesOut_KeepsGoingAndStaysOffTheErrorPath` — #779 and #780 together.
- `ImportAllFiles_WhenAFileIsSkipped_LeavesTheCardPanelAndFileListAlone`, `ImportFile_EmptyTransfer_LeavesTheFileListVisibleForAPerFileRetry`.
- Three `BuildImportAllSummary_…` tests pinning the dialog wording, including that a skipped file never produces power-cycle advice or a "stopped early" claim.

Existing tests that asserted the old classification were updated rather than deleted, and the assertions now name the ticket that changed them.

## Bench validation — confirmed on hardware

The device was power-cycled, which cleared the SD wedge that had blocked an earlier attempt, and IMPORT ALL was then driven through the real GUI against the attached Nq1 on COM3 (throwaway FlaUI diagnostic, since removed; the `AutomationId` it needed is the one small production change kept).

**Baseline — healthy card, 30 files.** All 30 imported in 33 seconds, sizes 186 B to 44,716 B. Dialog read exactly `Imported 30 of 30 files.` — no skip list, no abort line. Correct, but it does not exercise #780, because nothing failed.

**Producing the ambiguous case.** No naturally-occurring 0-byte file was on the card, so one was made the way the ticket says users make them: an SD logging session started and stopped the instant the device confirmed it had engaged — an interrupted logging session, non-destructively (nothing deleted, nothing formatted, no firmware touched). That left `log_20260728_190448.bin`. Separately and unplanned, the SD subsystem partially degraded again part-way through the next batch, which produced the *same* exception on many pre-existing files. Both are `SdCardEmptyTransferException`; the desktop cannot tell them apart — which is the ticket's whole argument, now observed rather than argued:

| Case | Time to fail | Exception |
|---|---|---|
| Genuinely empty file from the interrupted session | **0.8 s** | `SdCardEmptyTransferException` |
| Degraded subsystem, pre-existing healthy file | **~26 s** (Core's retries) | `SdCardEmptyTransferException` |

**The regression, disproved.** 31 files, and the **very first one failed**:

```
FAIL log_20260623_143217.bin        <- pre-fix, the batch ends here and imports NOTHING
FAIL iso_A_1.bin
   ... 10 more failures ...
OK   log_20260716_161823.bin        <- imported AFTER 12 prior failures
FAIL log_20260717_091630.bin
FAIL log_20260717_220628.bin
OK   log_20260718_151901.bin
OK   bench_pr2.bin
OK   bench_compat.bin
OK   log_20260718_153457.bin
   ... 14 more failures, every remaining file still attempted ...
FAIL log_20260728_190448.bin        <- the manufactured empty file, 31st and last
```

Every one of the 31 files was attempted. **5 healthy files were imported that the pre-fix code would have dropped unattempted**, since it aborted on the first `SdCardEmptyTransferException` and this run's first file was exactly that. Final dialog: `Imported 5 of 31 files.`

**The completion dialog**, read off the screen verbatim at the end of a repeat run with the same outcome:

```
Imported 5 of 31 files.

Skipped 26 file(s). You can retry any of them on their own from the file list.
  • log_20260623_143217.bin
  • iso_A_1.bin
  • log_20260629_134710.bin
  • log_20260630_144223.bin
  • log_20260630_150456.bin
  • ...and 21 more

The device sent no data for this file, which may simply be an empty log. If every
file fails the same way, power-cycle the device and try again.
```

Every part of the #780 wording change is in there: the failures are reported **as skipped files, named**, capped at five with the rest counted; the user is told they can retry them individually; and 26 identical failures produce the guidance **once**, not 26 times. There is no `Import stopped at …` line — that is the card-wide abort wording, and it is correctly absent. The power-cycle advice survives only as the conditional second clause of the per-file guidance rather than as a verdict about the card; on this particular run every file *was* failing the same way, so that condition genuinely applied.

The same screen capture also confirms the `HandleImportFailure` gating change, which is harder to see any other way: with 26 files having just failed, the status line still read **`· SD card OK · 31 files`** and the file list was still on screen with its per-row IMPORT buttons. Before this PR those failures would have driven `SdCardState` to `Error`, replacing the list with the error panel and removing the very retry the dialog now points at.

Also confirmed in the same run:

- Every failure logged at **`LEVEL=WARN`**, never `Error` — so none of the 26 reached Sentry. That is the #754/#779 behaviour holding on hardware.
- The log guidance is this PR's new wording, not the old unconditional "The device's SD card subsystem is not responding. Power-cycle the device and try again."
- The 90 s watchdog did **not** misfire. The slowest failure, `p703probe.bin` (44 KB), took 77 s of Core retries and still came out as the per-file empty-transfer condition rather than a prolonged stall.

**The cost this makes visible:** on a card where most files fail, continuing is slow — 26 failures at ~26 s each ran about 13 minutes, where the old code would have stopped in 26 seconds. That is the trade #780 asks for and it is the right one, because the old code bought that speed by discarding healthy files it never attempted: on this very run the first file failed, so the pre-fix batch would have imported **nothing at all**.

**daqifi-core#399** (the 11-minute hang with no watchdog fire) was filed from the earlier attempt on the *wedged* device. A healthy device not reproducing it is expected and is not evidence against it — nothing here contradicts that issue.

## Upstream — both changes are workarounds

Both fixes exist only because Core cannot currently express what the desktop needs to know. They are tracked as gaps 1 and 2 of **daqifi/daqifi-core#398** ("api: retire four downstream workarounds"), and both can be simplified once Core lands the corresponding change:

- **Gap 1** — `SdCardFileReceiver` throws a bare, untyped `TimeoutException`, from three separate sites, whose message ("stream closed") is wrong on serial where `bytesRead == 0` is the ordinary 500 ms read-timeout signal. Message-matching is therefore not viable, which is why the desktop normalises by *scope* instead. Once Core reports stalls with a type in the `SdCardOperationException` hierarchy, the scoped `catch (TimeoutException)` in `DownloadWithStallWatchdogAsync` can go, and with it the transport-timeout constructor on `SdCardDownloadStalledException`.
- **Gap 2** — `SdCardEmptyTransferException` cannot honour the precondition its own XML doc states, because the receiver never sees the size the directory listing reported. Once Core makes that check size-aware, a genuinely 0-byte file returns 0 bytes instead of throwing, the exception regains its "wedged subsystem" meaning, and the classifier's empty-transfer arm can go back to `IsCardUnavailable: true`.

One-line pointers to #398 sit at both sites in the code, so the bandaids are findable and removable rather than mistaken for design.

## Notes

- No firmware was flashed and no destructive device operation was performed. Nothing was read from or written to the device beyond SCPI queries and SD `GET`s the app issues normally.
- `DeviceLogsView.xaml` gains one `AutomationId` on the IMPORT ALL button, documented in the UITest README's AutomationId map. Every other control in that toolbar already has one; without it the batch path #780 is about cannot be driven from the FlaUI harness at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
