### PR TITLE
fix(streaming): serialize the timestamp frequency apply against a session reset

### DIFF
--- a/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
+++ b/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
@@ -1,0 +1,409 @@
+using Daqifi.Desktop.Device;
+using Daqifi.Core.Communication.Messages;
+using Daqifi.Core.Device;
+using CoreStreamingDevice = Daqifi.Core.Device.DaqifiStreamingDevice;
+
+namespace Daqifi.Desktop.Test.Device;
+
+/// <summary>
+/// Tests that a UI-thread stream stop/start can never interleave with the transport thread's
+/// per-session clock-frequency apply (issue #782).
+/// <para>
+/// <c>ResetAll()</c> discards the device's reported clock configuration along with the session
+/// baseline, so the frequency and the "already applied" gate have to change together. A reset landing
+/// between the apply and the gate write leaves the gate latched with no frequency, and nothing reports
+/// it — Core reverts to its processor-wide 20 ns (50 MHz) fallback silently — so the session just
+/// reconstructs every timestamp scaled by 50/42 against firmware's 42 MHz streaming timer.
+/// </para>
+/// <para>
+/// The interleave is driven deterministically rather than by a stress loop: the fixture substitutes an
+/// instrumented <see cref="ITimestampProcessor"/> whose <c>SetTimestampFrequency</c> starts a real
+/// stop/start on another thread and gives it a window to land, which is exactly the sequence the
+/// serialization has to make impossible.
+/// </para>
+/// </summary>
+[TestClass]
+public class TimestampProcessorSerializationTests : IDisposable
+{
+    #region Constants
+    /// <summary>
+    /// Clock frequency the fixture's device reports, matching the bench hardware: an Nq1 on firmware
+    /// 3.7.2 reports 42 MHz, not the 50 MHz Core falls back to when no frequency is applied.
+    /// </summary>
+    private const uint DEVICE_TIMESTAMP_FREQUENCY = 42_000_000;
+
+    /// <summary>One 100 Hz sample period, in device counter ticks at the frequency above.</summary>
+    private const uint SAMPLE_PERIOD_TICKS = DEVICE_TIMESTAMP_FREQUENCY / 100;
+
+    /// <summary>
+    /// A stop-to-start gap in device counter ticks, comfortably past the leftover-frame window so the
+    /// restarted session's frames are accepted rather than discarded as prior-session leftovers.
+    /// </summary>
+    private const uint RESTART_GAP_TICKS = DEVICE_TIMESTAMP_FREQUENCY * 13;
+
+    /// <summary>Arbitrary starting value of the device's free-running counter.</summary>
+    private const uint FIRST_FRAME_TIMESTAMP = 1_000_000_000;
+
+    /// <summary>
+    /// How long the racing stop/start is given to complete while the transport thread is still inside
+    /// its guarded region. Long enough that an unserialized reset — a handful of field writes and two
+    /// no-op Core sends — would comfortably finish; bounded so the serialized case cannot deadlock.
+    /// </summary>
+    private const int RESET_PROBE_TIMEOUT_MS = 250;
+
+    /// <summary>Generous ceiling on waits that must succeed, so a hang fails as an assertion.</summary>
+    private const int PROGRESS_TIMEOUT_MS = 30_000;
+
+    private const string SET_FREQUENCY_CALL = "SetTimestampFrequency";
+    private const string PROCESS_TIMESTAMP_CALL = "ProcessTimestamp";
+    private const string RESET_ALL_CALL = "ResetAll";
+    #endregion
+
+    #region Fields
+    private InterleavingTestDevice _device = null!;
+    #endregion
+
+    #region Setup and Teardown
+    [TestInitialize]
+    public void Setup()
+    {
+        _device = new InterleavingTestDevice();
+    }
+
+    // MSTest disposes the test-class instance after each test, releasing the device's Core connection
+    // instead of leaking one per test (CA1001).
+    public void Dispose()
+    {
+        _device.Dispose();
+        GC.SuppressFinalize(this);
+    }
+    #endregion
+
+    #region Tests
+    [TestMethod]
+    public void ResetRacingTheFrequencyApply_CannotLandBeforeTheGateIsWritten()
+    {
+        // Arrange & Act
+        RunFrequencyApplyRacedByStopStart();
+
+        // Assert — the racing stop/start was already running and trying to reset while the transport
+        // thread held the frame open, so if it completed there, the gate write that follows would have
+        // latched "applied" over a frequency the reset had just dropped.
+        Assert.IsTrue(_device.RacingStopStartWasRunning,
+            "Precondition: the racing stop/start should have started before the guarded region ended.");
+        Assert.IsFalse(_device.RacingStopStartCompletedInsideTheGuardedRegion,
+            "A stream stop/start must not be able to reset the timestamp processor while a frame is "
+            + "between its frequency apply and the gate write that records it.");
+    }
+
+    [TestMethod]
+    public void ResetRacingTheFrequencyApply_CannotSplitTheApplyFromTheReconstructionItWasAppliedFor()
+    {
+        // Arrange & Act
+        RunFrequencyApplyRacedByStopStart();
+
+        // Assert — a reset between the apply and this frame's reconstruction would silently revert the
+        // frame to the 50 MHz fallback tick and re-baseline it, so the apply and the ProcessTimestamp
+        // it was performed for have to stay adjacent.
+        var calls = _device.ProcessorCalls;
+        var applyIndex = calls.IndexOf(SET_FREQUENCY_CALL);
+        Assert.AreNotEqual(-1, applyIndex, "The session should have applied the device-reported frequency.");
+        Assert.IsTrue(applyIndex + 1 < calls.Count, "The apply should have been followed by a reconstruction.");
+        Assert.AreEqual(PROCESS_TIMESTAMP_CALL, calls[applyIndex + 1],
+            $"Nothing may run between the frequency apply and the frame's reconstruction; "
+            + $"observed call order was [{string.Join(", ", calls)}].");
+    }
+
+    [TestMethod]
+    public void ResetRacingTheFrequencyApply_LeavesTheRestartedSessionOnTheDeviceReportedClock()
+    {
+        // Arrange — a stop/start raced the previous session's frequency apply and has now landed, so
+        // the restarted session starts with the processor's frequency table cleared
+        RunFrequencyApplyRacedByStopStart();
+
+        // Act — two frames of the restarted session exactly one device-second apart at the reported
+        // frequency, a restart gap past the racing session's last counter value
+        var restartTimestamp = FIRST_FRAME_TIMESTAMP + SAMPLE_PERIOD_TICKS + RESTART_GAP_TICKS;
+        _device.RouteStreamFrame(restartTimestamp);
+        _device.RouteStreamFrame(restartTimestamp + DEVICE_TIMESTAMP_FREQUENCY);
+
+        // Assert — a gate left latched over a dropped frequency never re-applies, so the whole
+        // restarted session would reconstruct this pair 0.84 s apart against the 50 MHz fallback, with
+        // the error compounding because each timestamp is the previous one plus elapsed ticks
+        Assert.IsTrue(_device.DispatchedMessages.Count >= 2, "The restarted session should have dispatched frames.");
+        var deltaTicks = _device.DispatchedMessages[^1].TimestampTicks - _device.DispatchedMessages[^2].TimestampTicks;
+        var deltaSeconds = deltaTicks / (double)TimeSpan.TicksPerSecond;
+        Assert.AreEqual(1.0, deltaSeconds, 1e-6,
+            "One device-second of counter ticks should reconstruct to one second after a stop/start "
+            + "raced the previous session's frequency apply.");
+        Assert.AreEqual(1.0 / DEVICE_TIMESTAMP_FREQUENCY, _device.EffectiveTickPeriod, 1e-15,
+            "The restarted session should have re-applied the device-reported frequency rather than "
+            + "silently falling back to Core's 20 ns default.");
+    }
+    #endregion
+
+    #region Helpers
+    /// <summary>
+    /// Runs one streaming session whose first frequency apply is raced by a real stop/start on another
+    /// thread, and returns once that stop/start has finished. A fresh connection holds the first frame
+    /// until its successor validates the pair as same-session data, so the apply — and with it the
+    /// armed race — happens inside the second routed frame.
+    /// </summary>
+    private void RunFrequencyApplyRacedByStopStart()
+    {
+        _device.InitializeStreaming();
+        _device.RouteStreamFrame(FIRST_FRAME_TIMESTAMP);
+        _device.ArmStopStartDuringFrequencyApply();
+        _device.RouteStreamFrame(FIRST_FRAME_TIMESTAMP + SAMPLE_PERIOD_TICKS);
+        _device.WaitForRacingStopStart();
+    }
+    #endregion
+
+    #region Test Doubles
+    /// <summary>
+    /// A device whose timestamp processor can start a real stop/start from inside the frequency apply,
+    /// so the ordering the serialization forbids is attempted on every run instead of being waited for.
+    /// </summary>
+    private sealed class InterleavingTestDevice : AbstractStreamingDevice, IDisposable
+    {
+        private const uint DEVICE_SERIAL_NUMBER = 12345;
+        private const int ANALOG_PORT_COUNT = 1;
+
+        private readonly SilentCoreDevice _coreDevice;
+        private readonly RecordingTimestampProcessor _processor;
+        private readonly ManualResetEventSlim _racingStopStartStarted = new(false);
+        private readonly ManualResetEventSlim _racingStopStartCompleted = new(false);
+        private Thread? _racingStopStart;
+        private Exception? _racingStopStartFailure;
+
+        public InterleavingTestDevice()
+        {
+            _processor = new RecordingTimestampProcessor(new TimestampProcessor());
+
+            // The production processor is init-only precisely so a test double can substitute an
+            // instrumented one here; nothing can swap it afterwards.
+            FrameTimestampProcessor = _processor;
+
+            _coreDevice = new SilentCoreDevice();
+            _coreDevice.Connect();
+
+            var statusMessage = new DaqifiOutMessage
+            {
+                DevicePn = "Nq1",
+                DeviceSn = DEVICE_SERIAL_NUMBER,
+                DeviceFwRev = "3.7.2",
+                AnalogInPortNum = ANALOG_PORT_COUNT,
+                AnalogInRes = 4095,
+                TimestampFreq = DEVICE_TIMESTAMP_FREQUENCY,
+            };
+            statusMessage.AnalogInCalM.Add(1.0f);
+            statusMessage.AnalogInCalB.Add(0.0f);
+            statusMessage.AnalogInIntScaleM.Add(1.0f);
+            statusMessage.AnalogInPortRange.Add(5.0f);
+
+            _coreDevice.Metadata.UpdateFromProtobuf(statusMessage);
+
+            // What actually publishes Core's TimestampFrequency — and therefore what the desktop
+            // reads when deciding which frequency to apply. Metadata alone leaves it at zero.
+            _coreDevice.PopulateChannelsFromStatus(statusMessage);
+        }
+
+        public List<DeviceMessage> DispatchedMessages { get; } = [];
+
+        /// <summary>Calls the device made on its timestamp processor, in the order they happened.</summary>
+        public List<string> ProcessorCalls => _processor.Calls;
+
+        /// <summary>
+        /// The tick period Core would use for this device's frames — the device-reported one when a
+        /// frequency is applied, and the silent 20 ns fallback when it is not.
+        /// </summary>
+        public double EffectiveTickPeriod =>
+            _processor.GetTickPeriod(DEVICE_SERIAL_NUMBER.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        /// <summary>Whether the racing stop/start had actually begun before the guarded region ended.</summary>
+        public bool RacingStopStartWasRunning { get; private set; }
+
+        /// <summary>
+        /// Whether the racing stop/start ran to completion while the transport thread was still between
+        /// the frequency apply and the gate write — the interleaving the fix has to make impossible.
+        /// </summary>
+        public bool RacingStopStartCompletedInsideTheGuardedRegion { get; private set; }
+
+        public override ConnectionType ConnectionType => ConnectionType.Usb;
+
+        protected override CoreStreamingDevice? CoreDeviceForStreaming => _coreDevice;
+
+        public override bool Connect() => true;
+
+        public override bool Disconnect() => true;
+
+        public override bool Write(string command) => true;
+
+        protected override void SendMessage(IOutboundMessage<string> message)
+        {
+        }
+
+        protected override void DispatchDeviceMessage(DeviceMessage deviceMessage)
+        {
+            DispatchedMessages.Add(deviceMessage);
+        }
+
+        /// <summary>
+        /// Routes a frame through the desktop's inbound path — the handler Core invokes when it raises
+        /// the classified <c>StreamMessageReceived</c> event. Core's own decode step is left out; these
+        /// tests read the dispatched <see cref="DeviceMessage"/>s rather than channel samples.
+        /// </summary>
+        public void RouteStreamFrame(uint deviceTimestamp) => OnStreamMessageReceived(new DaqifiOutMessage
+        {
+            MsgTimeStamp = deviceTimestamp,
+            DeviceSn = DEVICE_SERIAL_NUMBER,
+            DeviceFwRev = "3.7.2",
+            AnalogInDataFloat = { 1.25f }
+        });
+
+        /// <summary>
+        /// Arms a one-shot race: the next frequency apply starts a real stop/start on another thread
+        /// and does not return until that thread is running and has been given
+        /// <see cref="RESET_PROBE_TIMEOUT_MS"/> to complete.
+        /// </summary>
+        public void ArmStopStartDuringFrequencyApply()
+        {
+            _processor.OnFrequencyApplied = RaceStopStartAgainstThisFrame;
+        }
+
+        /// <summary>
+        /// Waits for the armed stop/start to finish and surfaces anything it threw. Safe to call when
+        /// nothing was armed.
+        /// </summary>
+        public void WaitForRacingStopStart()
+        {
+            var racingStopStart = _racingStopStart;
+            if (racingStopStart == null)
+            {
+                return;
+            }
+
+            Assert.IsTrue(racingStopStart.Join(PROGRESS_TIMEOUT_MS),
+                "The racing stop/start should complete once the guarded region is released.");
+            if (_racingStopStartFailure != null)
+            {
+                Assert.Fail($"The racing stop/start threw: {_racingStopStartFailure}");
+            }
+        }
+
+        public void Dispose()
+        {
+            _racingStopStart?.Join(PROGRESS_TIMEOUT_MS);
+            _racingStopStartStarted.Dispose();
+            _racingStopStartCompleted.Dispose();
+            _coreDevice.Dispose();
+        }
+
+        /// <summary>
+        /// Runs on the transport thread, from inside the frequency apply. Starts the stop/start a user
+        /// could trigger at this instant and gives it a real window to land before the gate write that
+        /// follows.
+        /// </summary>
+        private void RaceStopStartAgainstThisFrame()
+        {
+            _processor.OnFrequencyApplied = null;
+
+            _racingStopStart = new Thread(() =>
+            {
+                _racingStopStartStarted.Set();
+                try
+                {
+                    StopStreaming();
+                    InitializeStreaming();
+                }
+                catch (Exception ex)
+                {
+                    _racingStopStartFailure = ex;
+                }
+
+                _racingStopStartCompleted.Set();
+            })
+            {
+                IsBackground = true,
+                Name = "Racing stop/start"
+            };
+            _racingStopStart.Start();
+
+            RacingStopStartWasRunning = _racingStopStartStarted.Wait(PROGRESS_TIMEOUT_MS);
+            RacingStopStartCompletedInsideTheGuardedRegion = _racingStopStartCompleted.Wait(RESET_PROBE_TIMEOUT_MS);
+        }
+    }
+
+    /// <summary>
+    /// Forwards every call to a real <see cref="TimestampProcessor"/>, recording the order they arrive
+    /// in and exposing a one-shot hook that fires inside the frequency apply.
+    /// </summary>
+    private sealed class RecordingTimestampProcessor(ITimestampProcessor inner) : ITimestampProcessor
+    {
+        private readonly List<string> _calls = [];
+
+        /// <summary>
+        /// Invoked at the end of <see cref="SetTimestampFrequency"/>, on the calling thread and inside
+        /// whatever region the caller is holding. Assigned and cleared from that same thread.
+        /// </summary>
+        public Action? OnFrequencyApplied { get; set; }
+
+        public double TickPeriod => inner.TickPeriod;
+
+        /// <summary>A snapshot of the recorded calls; the list itself is written from two threads.</summary>
+        public List<string> Calls
+        {
+            get
+            {
+                lock (_calls)
+                {
+                    return [.. _calls];
+                }
+            }
+        }
+
+        public void SetTimestampFrequency(string deviceId, uint frequencyHz)
+        {
+            inner.SetTimestampFrequency(deviceId, frequencyHz);
+            Record(SET_FREQUENCY_CALL);
+            OnFrequencyApplied?.Invoke();
+        }
+
+        public double GetTickPeriod(string deviceId) => inner.GetTickPeriod(deviceId);
+
+        public TimestampResult ProcessTimestamp(string deviceId, uint deviceTimestamp)
+        {
+            Record(PROCESS_TIMESTAMP_CALL);
+            return inner.ProcessTimestamp(deviceId, deviceTimestamp);
+        }
+
+        public void Reset(string deviceId)
+        {
+            Record(nameof(Reset));
+            inner.Reset(deviceId);
+        }
+
+        public void ResetAll()
+        {
+            Record(RESET_ALL_CALL);
+            inner.ResetAll();
+        }
+
+        private void Record(string call)
+        {
+            lock (_calls)
+            {
+                _calls.Add(call);
+            }
+        }
+    }
+
+    /// <summary>A transport-less Core streaming device: commands are accepted and dropped.</summary>
+    private sealed class SilentCoreDevice() : CoreStreamingDevice("TestDevice")
+    {
+        public override void Send<T>(IOutboundMessage<T> message)
+        {
+        }
+    }
+    #endregion
+}

--- a/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
+++ b/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
@@ -334,19 +334,21 @@ public class TimestampProcessorSerializationTests : IDisposable
         /// </summary>
         public void Dispose()
         {
-            // The racing thread signals both events, so they can only be disposed once it has
-            // provably exited. If the join times out, the test has already failed on that timeout —
-            // disposing here would then hand the still-running worker an ObjectDisposedException on a
-            // background thread, masking the real failure and destabilizing the test host. Leaking
-            // two ManualResetEventSlim instances on that path is by far the cheaper outcome.
+            // Nothing the racing thread can still touch may be disposed until it has provably
+            // exited. It signals both events, and its StopStreaming/InitializeStreaming run against
+            // the Core device — so all three are on that thread's reachable set. If the join times
+            // out, the test has already failed on that timeout; disposing here would then hand the
+            // still-running worker an ObjectDisposedException on a background thread, masking the
+            // real failure and destabilizing the test host. Leaking two ManualResetEventSlim
+            // instances and one transport-less Core device on that path is by far the cheaper
+            // outcome.
             var racingThreadExited = _racingStopStart?.Join(PROGRESS_TIMEOUT_MS) ?? true;
             if (racingThreadExited)
             {
                 _racingResetAtBoundary.Dispose();
                 _racingStopStartCompleted.Dispose();
+                _coreDevice.Dispose();
             }
-
-            _coreDevice.Dispose();
         }
 
         /// <summary>

--- a/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
+++ b/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
@@ -328,11 +328,24 @@ public class TimestampProcessorSerializationTests : IDisposable
             }
         }
 
+        /// <summary>
+        /// Releases the fixture's Core connection, and the race handshake signals once the racing
+        /// thread can no longer touch them.
+        /// </summary>
         public void Dispose()
         {
-            _racingStopStart?.Join(PROGRESS_TIMEOUT_MS);
-            _racingResetAtBoundary.Dispose();
-            _racingStopStartCompleted.Dispose();
+            // The racing thread signals both events, so they can only be disposed once it has
+            // provably exited. If the join times out, the test has already failed on that timeout —
+            // disposing here would then hand the still-running worker an ObjectDisposedException on a
+            // background thread, masking the real failure and destabilizing the test host. Leaking
+            // two ManualResetEventSlim instances on that path is by far the cheaper outcome.
+            var racingThreadExited = _racingStopStart?.Join(PROGRESS_TIMEOUT_MS) ?? true;
+            if (racingThreadExited)
+            {
+                _racingResetAtBoundary.Dispose();
+                _racingStopStartCompleted.Dispose();
+            }
+
             _coreDevice.Dispose();
         }
 
@@ -437,12 +450,25 @@ public class TimestampProcessorSerializationTests : IDisposable
     }
 
     /// <summary>
-    /// Swallows the device's diagnostics, except for the one breadcrumb
-    /// (<see cref="RESET_BOUNDARY_BREADCRUMB"/>) that <c>StopStreaming</c> records immediately before
-    /// its guarded region — which it turns into the signal the race probe starts from.
+    /// Turns the one breadcrumb <c>StopStreaming</c> records immediately before its guarded region
+    /// (<see cref="RESET_BOUNDARY_BREADCRUMB"/>) into the signal the race probe starts from.
     /// </summary>
+    /// <remarks>
+    /// Every other member is a deliberate no-op: the device under test logs routinely (sleep-state
+    /// changes, leftover-frame discards) and none of it is what these tests observe. Swallowing it
+    /// also keeps the suite from writing to the real NLog sink for diagnostics no one reads.
+    /// </remarks>
+    /// <param name="reachedResetBoundary">
+    /// Set when the racing thread reaches the statement immediately before the guarded region.
+    /// </param>
     private sealed class BoundarySignallingAppLogger(ManualResetEventSlim reachedResetBoundary) : IAppLogger
     {
+        /// <summary>
+        /// Signals <c>reachedResetBoundary</c> on the reset-boundary breadcrumb; ignores all others.
+        /// </summary>
+        /// <param name="category">Breadcrumb category. Unused — the message alone identifies the boundary.</param>
+        /// <param name="message">Breadcrumb message, matched against <see cref="RESET_BOUNDARY_BREADCRUMB"/>.</param>
+        /// <param name="level">Breadcrumb severity. Unused.</param>
         public void AddBreadcrumb(
             string category,
             string message,
@@ -454,35 +480,55 @@ public class TimestampProcessorSerializationTests : IDisposable
             }
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
+        /// <param name="message">Ignored.</param>
         public void Information(string message)
         {
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
+        /// <param name="message">Ignored.</param>
         public void Warning(string message)
         {
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
+        /// <param name="ex">Ignored.</param>
+        /// <param name="message">Ignored.</param>
         public void Warning(Exception ex, string message)
         {
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
+        /// <param name="message">Ignored.</param>
         public void Error(string message)
         {
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
+        /// <param name="ex">Ignored.</param>
+        /// <param name="message">Ignored.</param>
         public void Error(Exception ex, string message)
         {
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
+        /// <param name="model">Ignored.</param>
+        /// <param name="serialNumber">Ignored.</param>
+        /// <param name="firmwareVersion">Ignored.</param>
+        /// <param name="connectionType">Ignored.</param>
+        /// <param name="activeChannels">Ignored.</param>
         public void SetDeviceContext(
             string model, string serialNumber, string firmwareVersion, string connectionType, int activeChannels)
         {
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
         public void ClearDeviceContext()
         {
         }
 
+        /// <summary>No-op. See the class remarks.</summary>
         public void Shutdown()
         {
         }

--- a/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
+++ b/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device;
 using Daqifi.Core.Communication.Messages;
 using Daqifi.Core.Device;
@@ -16,10 +18,12 @@ namespace Daqifi.Desktop.Test.Device;
 /// reconstructs every timestamp scaled by 50/42 against firmware's 42 MHz streaming timer.
 /// </para>
 /// <para>
-/// The interleave is driven deterministically rather than by a stress loop: the fixture substitutes an
+/// The interleave is driven deterministically rather than by a stress loop. The fixture substitutes an
 /// instrumented <see cref="ITimestampProcessor"/> whose <c>SetTimestampFrequency</c> starts a real
-/// stop/start on another thread and gives it a window to land, which is exactly the sequence the
-/// serialization has to make impossible.
+/// stop/start on another thread, and an instrumented <see cref="IAppLogger"/> that reports when that
+/// thread reaches the statement immediately preceding <c>StopStreaming</c>'s guarded region. The probe
+/// therefore starts only once the reset is genuinely at the critical-section boundary, rather than
+/// timing a thread that may not have got there yet.
 /// </para>
 /// </summary>
 [TestClass]
@@ -45,14 +49,22 @@ public class TimestampProcessorSerializationTests : IDisposable
     private const uint FIRST_FRAME_TIMESTAMP = 1_000_000_000;
 
     /// <summary>
-    /// How long the racing stop/start is given to complete while the transport thread is still inside
-    /// its guarded region. Long enough that an unserialized reset — a handful of field writes and two
-    /// no-op Core sends — would comfortably finish; bounded so the serialized case cannot deadlock.
+    /// How long the racing reset is watched for completion <em>after</em> it has already reached the
+    /// statement immediately before the guarded region — so this measures blocking, not thread
+    /// start-up latency. All that remains for an unserialized reset at that point is taking the lock
+    /// and clearing two fields.
     /// </summary>
     private const int RESET_PROBE_TIMEOUT_MS = 250;
 
     /// <summary>Generous ceiling on waits that must succeed, so a hang fails as an assertion.</summary>
     private const int PROGRESS_TIMEOUT_MS = 30_000;
+
+    /// <summary>
+    /// The breadcrumb <c>StopStreaming</c> records on the statement immediately preceding its
+    /// <c>ResetAll</c> + gate-clear region. Reaching it means the racing thread has finished every
+    /// step before the lock and has nothing left to do but acquire it.
+    /// </summary>
+    private const string RESET_BOUNDARY_BREADCRUMB = "Streaming stopped";
 
     private const string SET_FREQUENCY_CALL = "SetTimestampFrequency";
     private const string PROCESS_TIMESTAMP_CALL = "ProcessTimestamp";
@@ -64,14 +76,17 @@ public class TimestampProcessorSerializationTests : IDisposable
     #endregion
 
     #region Setup and Teardown
+    /// <summary>Builds a fresh device fixture, with its own instrumented processor and logger.</summary>
     [TestInitialize]
     public void Setup()
     {
         _device = new InterleavingTestDevice();
     }
 
-    // MSTest disposes the test-class instance after each test, releasing the device's Core connection
-    // instead of leaking one per test (CA1001).
+    /// <summary>
+    /// Releases the fixture's Core connection. MSTest disposes the test-class instance after each
+    /// test, so this keeps the suite from leaking one connected device per test (CA1001).
+    /// </summary>
     public void Dispose()
     {
         _device.Dispose();
@@ -83,15 +98,21 @@ public class TimestampProcessorSerializationTests : IDisposable
     [TestMethod]
     public void ResetRacingTheFrequencyApply_CannotLandBeforeTheGateIsWritten()
     {
-        // Arrange & Act
-        RunFrequencyApplyRacedByStopStart();
+        // Arrange — a session holding its first frame, with a stop/start armed to fire from inside
+        // the frequency apply
+        StartSessionAndArmTheRace();
 
-        // Assert — the racing stop/start was already running and trying to reset while the transport
-        // thread held the frame open, so if it completed there, the gate write that follows would have
-        // latched "applied" over a frequency the reset had just dropped.
-        Assert.IsTrue(_device.RacingStopStartWasRunning,
-            "Precondition: the racing stop/start should have started before the guarded region ended.");
-        Assert.IsFalse(_device.RacingStopStartCompletedInsideTheGuardedRegion,
+        // Act — the successor frame releases the held pair, so the apply (and the armed race) happens
+        // inside this call
+        DriveTheRacedFrame();
+
+        // Assert — the racing reset had reached the statement immediately before its guarded region
+        // while the transport thread still held the frame open, so if it had completed there, the gate
+        // write that follows would have latched "applied" over a frequency the reset just dropped
+        Assert.IsTrue(_device.RacingResetReachedTheBoundary,
+            "Precondition: the racing stop/start should have reached the reset's critical-section "
+            + "boundary before the guarded region ended.");
+        Assert.IsFalse(_device.RacingResetCompletedInsideTheGuardedRegion,
             "A stream stop/start must not be able to reset the timestamp processor while a frame is "
             + "between its frequency apply and the gate write that records it.");
     }
@@ -99,12 +120,15 @@ public class TimestampProcessorSerializationTests : IDisposable
     [TestMethod]
     public void ResetRacingTheFrequencyApply_CannotSplitTheApplyFromTheReconstructionItWasAppliedFor()
     {
-        // Arrange & Act
-        RunFrequencyApplyRacedByStopStart();
+        // Arrange
+        StartSessionAndArmTheRace();
+
+        // Act
+        DriveTheRacedFrame();
 
         // Assert — a reset between the apply and this frame's reconstruction would silently revert the
         // frame to the 50 MHz fallback tick and re-baseline it, so the apply and the ProcessTimestamp
-        // it was performed for have to stay adjacent.
+        // it was performed for have to stay adjacent
         var calls = _device.ProcessorCalls;
         var applyIndex = calls.IndexOf(SET_FREQUENCY_CALL);
         Assert.AreNotEqual(-1, applyIndex, "The session should have applied the device-reported frequency.");
@@ -119,7 +143,8 @@ public class TimestampProcessorSerializationTests : IDisposable
     {
         // Arrange — a stop/start raced the previous session's frequency apply and has now landed, so
         // the restarted session starts with the processor's frequency table cleared
-        RunFrequencyApplyRacedByStopStart();
+        StartSessionAndArmTheRace();
+        DriveTheRacedFrame();
 
         // Act — two frames of the restarted session exactly one device-second apart at the reported
         // frequency, a restart gap past the racing session's last counter value
@@ -144,16 +169,23 @@ public class TimestampProcessorSerializationTests : IDisposable
 
     #region Helpers
     /// <summary>
-    /// Runs one streaming session whose first frequency apply is raced by a real stop/start on another
-    /// thread, and returns once that stop/start has finished. A fresh connection holds the first frame
-    /// until its successor validates the pair as same-session data, so the apply — and with it the
-    /// armed race — happens inside the second routed frame.
+    /// Starts a streaming session and routes its first frame, which a fresh connection holds until a
+    /// successor validates the pair as same-session data, then arms the race. Nothing has reached
+    /// <c>ProcessStreamMessage</c> yet, so no frequency has been applied.
     /// </summary>
-    private void RunFrequencyApplyRacedByStopStart()
+    private void StartSessionAndArmTheRace()
     {
         _device.InitializeStreaming();
         _device.RouteStreamFrame(FIRST_FRAME_TIMESTAMP);
         _device.ArmStopStartDuringFrequencyApply();
+    }
+
+    /// <summary>
+    /// Routes the successor frame, which releases the held pair and so performs the session's first
+    /// frequency apply — firing the armed race — and returns once that race has finished.
+    /// </summary>
+    private void DriveTheRacedFrame()
+    {
         _device.RouteStreamFrame(FIRST_FRAME_TIMESTAMP + SAMPLE_PERIOD_TICKS);
         _device.WaitForRacingStopStart();
     }
@@ -171,7 +203,7 @@ public class TimestampProcessorSerializationTests : IDisposable
 
         private readonly SilentCoreDevice _coreDevice;
         private readonly RecordingTimestampProcessor _processor;
-        private readonly ManualResetEventSlim _racingStopStartStarted = new(false);
+        private readonly ManualResetEventSlim _racingResetAtBoundary = new(false);
         private readonly ManualResetEventSlim _racingStopStartCompleted = new(false);
         private Thread? _racingStopStart;
         private Exception? _racingStopStartFailure;
@@ -180,9 +212,10 @@ public class TimestampProcessorSerializationTests : IDisposable
         {
             _processor = new RecordingTimestampProcessor(new TimestampProcessor());
 
-            // The production processor is init-only precisely so a test double can substitute an
-            // instrumented one here; nothing can swap it afterwards.
+            // Both dependencies are init-only precisely so a test double can substitute an
+            // instrumented one here; nothing can swap them afterwards.
             FrameTimestampProcessor = _processor;
+            AppLogger = new BoundarySignallingAppLogger(_racingResetAtBoundary);
 
             _coreDevice = new SilentCoreDevice();
             _coreDevice.Connect();
@@ -218,16 +251,20 @@ public class TimestampProcessorSerializationTests : IDisposable
         /// frequency is applied, and the silent 20 ns fallback when it is not.
         /// </summary>
         public double EffectiveTickPeriod =>
-            _processor.GetTickPeriod(DEVICE_SERIAL_NUMBER.ToString(System.Globalization.CultureInfo.InvariantCulture));
-
-        /// <summary>Whether the racing stop/start had actually begun before the guarded region ended.</summary>
-        public bool RacingStopStartWasRunning { get; private set; }
+            _processor.GetTickPeriod(DEVICE_SERIAL_NUMBER.ToString(CultureInfo.InvariantCulture));
 
         /// <summary>
-        /// Whether the racing stop/start ran to completion while the transport thread was still between
-        /// the frequency apply and the gate write — the interleaving the fix has to make impossible.
+        /// Whether the racing thread reached the statement immediately before <c>StopStreaming</c>'s
+        /// guarded region while the transport thread still held that region open. Without this, a
+        /// completion timeout would only prove the thread had not got going yet.
         /// </summary>
-        public bool RacingStopStartCompletedInsideTheGuardedRegion { get; private set; }
+        public bool RacingResetReachedTheBoundary { get; private set; }
+
+        /// <summary>
+        /// Whether the racing reset ran to completion while the transport thread was still between the
+        /// frequency apply and the gate write — the interleaving the fix has to make impossible.
+        /// </summary>
+        public bool RacingResetCompletedInsideTheGuardedRegion { get; private set; }
 
         public override ConnectionType ConnectionType => ConnectionType.Usb;
 
@@ -263,8 +300,8 @@ public class TimestampProcessorSerializationTests : IDisposable
 
         /// <summary>
         /// Arms a one-shot race: the next frequency apply starts a real stop/start on another thread
-        /// and does not return until that thread is running and has been given
-        /// <see cref="RESET_PROBE_TIMEOUT_MS"/> to complete.
+        /// and does not return until that thread has reached the reset's critical-section boundary and
+        /// then been watched for <see cref="RESET_PROBE_TIMEOUT_MS"/>.
         /// </summary>
         public void ArmStopStartDuringFrequencyApply()
         {
@@ -294,15 +331,15 @@ public class TimestampProcessorSerializationTests : IDisposable
         public void Dispose()
         {
             _racingStopStart?.Join(PROGRESS_TIMEOUT_MS);
-            _racingStopStartStarted.Dispose();
+            _racingResetAtBoundary.Dispose();
             _racingStopStartCompleted.Dispose();
             _coreDevice.Dispose();
         }
 
         /// <summary>
         /// Runs on the transport thread, from inside the frequency apply. Starts the stop/start a user
-        /// could trigger at this instant and gives it a real window to land before the gate write that
-        /// follows.
+        /// could trigger at this instant, waits until it is provably at the reset's critical-section
+        /// boundary, and only then measures whether it can get past it before the gate write.
         /// </summary>
         private void RaceStopStartAgainstThisFrame()
         {
@@ -310,7 +347,6 @@ public class TimestampProcessorSerializationTests : IDisposable
 
             _racingStopStart = new Thread(() =>
             {
-                _racingStopStartStarted.Set();
                 try
                 {
                     StopStreaming();
@@ -329,8 +365,10 @@ public class TimestampProcessorSerializationTests : IDisposable
             };
             _racingStopStart.Start();
 
-            RacingStopStartWasRunning = _racingStopStartStarted.Wait(PROGRESS_TIMEOUT_MS);
-            RacingStopStartCompletedInsideTheGuardedRegion = _racingStopStartCompleted.Wait(RESET_PROBE_TIMEOUT_MS);
+            // Signalled by the instrumented logger from StopStreaming's last statement before the
+            // guarded region, so from here an unserialized reset has only the lock left to take.
+            RacingResetReachedTheBoundary = _racingResetAtBoundary.Wait(PROGRESS_TIMEOUT_MS);
+            RacingResetCompletedInsideTheGuardedRegion = _racingStopStartCompleted.Wait(RESET_PROBE_TIMEOUT_MS);
         }
     }
 
@@ -395,6 +433,58 @@ public class TimestampProcessorSerializationTests : IDisposable
             {
                 _calls.Add(call);
             }
+        }
+    }
+
+    /// <summary>
+    /// Swallows the device's diagnostics, except for the one breadcrumb
+    /// (<see cref="RESET_BOUNDARY_BREADCRUMB"/>) that <c>StopStreaming</c> records immediately before
+    /// its guarded region — which it turns into the signal the race probe starts from.
+    /// </summary>
+    private sealed class BoundarySignallingAppLogger(ManualResetEventSlim reachedResetBoundary) : IAppLogger
+    {
+        public void AddBreadcrumb(
+            string category,
+            string message,
+            Common.Loggers.BreadcrumbLevel level = Common.Loggers.BreadcrumbLevel.Info)
+        {
+            if (message == RESET_BOUNDARY_BREADCRUMB)
+            {
+                reachedResetBoundary.Set();
+            }
+        }
+
+        public void Information(string message)
+        {
+        }
+
+        public void Warning(string message)
+        {
+        }
+
+        public void Warning(Exception ex, string message)
+        {
+        }
+
+        public void Error(string message)
+        {
+        }
+
+        public void Error(Exception ex, string message)
+        {
+        }
+
+        public void SetDeviceContext(
+            string model, string serialNumber, string firmwareVersion, string connectionType, int activeChannels)
+        {
+        }
+
+        public void ClearDeviceContext()
+        {
+        }
+
+        public void Shutdown()
+        {
         }
     }
 

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -79,7 +79,38 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     private int _pwmFrequencyHz = CoreStreamingDevice.DefaultPwmFrequencyHz;
 
-    private readonly TimestampProcessor _timestampProcessor = new();
+    /// <summary>
+    /// Serializes the reset / apply / reconstruct sequence on <see cref="FrameTimestampProcessor"/>
+    /// and its <see cref="_timestampFrequencyApplied"/> gate (issue #782). <c>ResetAll</c> runs on the
+    /// UI thread (<see cref="InitializeStreaming"/> / <see cref="StopStreaming"/>) while
+    /// <c>SetTimestampFrequency</c> and <c>ProcessTimestamp</c> run on the transport thread, driven by
+    /// the fire-and-forget inbound message pipeline.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Core's <see cref="TimestampProcessor"/> is itself thread-safe — concurrent maps plus a
+    /// per-device lock around <c>ProcessTimestamp</c> — so what is being protected here is the
+    /// desktop's own two-part invariant, not Core's internals: <c>ResetAll()</c> discards the device's
+    /// reported <em>clock configuration</em> along with the session baseline, so the gate and the
+    /// frequency it stands for have to change together. Unserialized, a reset interleaved between the
+    /// transport thread's apply and its gate write drops the just-applied frequency yet leaves the gate
+    /// latched "applied". Nothing reports that: <c>SetTimestampFrequency(id, 0)</c> reverts silently
+    /// and <c>GetTickPeriod</c> silently falls back to the processor-wide 20 ns (50 MHz) default, so
+    /// the session simply reconstructs every timestamp scaled by 50/42 ≈ 1.19 against firmware's
+    /// 42 MHz streaming timer. Holding the lock across the reconstruction as well keeps a frame's
+    /// timestamp on the frequency that was applied for it.
+    /// </para>
+    /// <para>
+    /// A leaf lock: nothing inside any guarded region raises events, performs I/O, marshals to the
+    /// dispatcher, or re-enters this device, so it cannot participate in a lock cycle and never holds
+    /// the hot streaming path for longer than a few dictionary lookups.
+    /// </para>
+    /// </remarks>
+    // See daqifi-core#398 (gap 3): the gate this guards exists only because ResetAll() discards the
+    // device's reported frequency along with the session baseline. If Core preserves it across a
+    // baseline reset, the gate — and most of this lock — goes away.
+    private readonly object _timestampProcessorSync = new();
+
     private List<SdCardFile> _sdCardFiles = [];
 
     // Leftover-frame detection state (issue #573). The last-seen counter is tracked for every
@@ -138,11 +169,24 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     private double? _currentFrameFirmwareDeltaMs;
 
     /// <summary>
-    /// Whether the device-reported clock frequency has been applied to <see cref="_timestampProcessor"/>
-    /// for the current streaming session. Cleared alongside every <c>ResetAll()</c>, which per Core's
-    /// contract also drops per-device frequencies.
+    /// Whether the device-reported clock frequency has been applied to
+    /// <see cref="FrameTimestampProcessor"/> for the current streaming session. Cleared alongside every
+    /// <c>ResetAll()</c>, which per Core's contract also drops per-device frequencies. Every read and
+    /// write is serialized under <see cref="_timestampProcessorSync"/> (issue #782), which supplies the
+    /// cross-thread ordering and visibility a bare — or even <c>volatile</c> — flag could not: the gate
+    /// and the frequency it stands for have to change together or not at all.
     /// </summary>
     private bool _timestampFrequencyApplied;
+
+    /// <summary>
+    /// Core's rollover-aware reconstruction of each stream frame's timestamp, guarded by
+    /// <see cref="_timestampProcessorSync"/>. Typed as <see cref="ITimestampProcessor"/> and
+    /// <c>init</c>-only so a derived test double can substitute an instrumented processor in its own
+    /// constructor — which is what makes the apply/gate/reset serialization assertable against a
+    /// deliberately interleaved reset instead of only under a nondeterministic stress loop. Production
+    /// code still cannot swap it after construction.
+    /// </summary>
+    protected ITimestampProcessor FrameTimestampProcessor { get; init; } = new TimestampProcessor();
 
     /// <summary>
     /// The Core streaming device created by the shared <see cref="Connect"/> template,
@@ -697,20 +741,33 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         // rather than at session start because this is where the device-id key is known to match
         // the one ProcessTimestamp uses, and re-applied per session because InitializeStreaming's
         // ResetAll() drops per-device frequencies along with the baselines.
-        if (!_timestampFrequencyApplied && TimestampFrequency != 0)
+        //
+        // Apply, gate write and reconstruction all run under _timestampProcessorSync so a UI-thread
+        // ResetAll can neither interleave between the apply and its gate write — which would silently
+        // strand the whole session on the 50 MHz fallback (issue #782) — nor drop the frequency
+        // between the apply and the reconstruction it was applied for. Only the three frame-derived
+        // scalars leave the lock; everything after it (debug dispatch, DeviceMessage construction,
+        // the logging handoff) stays outside.
+        DateTime messageTimestamp;
+        bool rollover;
+        double? firmwareDeltaMs;
+        lock (_timestampProcessorSync)
         {
-            _timestampProcessor.SetTimestampFrequency(deviceId, TimestampFrequency);
-            _timestampFrequencyApplied = true;
-        }
+            if (!_timestampFrequencyApplied && TimestampFrequency != 0)
+            {
+                FrameTimestampProcessor.SetTimestampFrequency(deviceId, TimestampFrequency);
+                _timestampFrequencyApplied = true;
+            }
 
-        // Use Core's TimestampProcessor for rollover handling
-        var timestampResult = _timestampProcessor.ProcessTimestamp(deviceId, message.MsgTimeStamp);
-        var messageTimestamp = timestampResult.Timestamp;
-        var rollover = timestampResult.WasRollover;
-        // Firmware-measured inter-message delta (immune to TCP jitter); null for the first message.
-        var firmwareDeltaMs = timestampResult.IsFirstMessage
-            ? (double?)null
-            : timestampResult.SecondsBetweenMessages * 1000.0;
+            // Use Core's TimestampProcessor for rollover handling
+            var timestampResult = FrameTimestampProcessor.ProcessTimestamp(deviceId, message.MsgTimeStamp);
+            messageTimestamp = timestampResult.Timestamp;
+            rollover = timestampResult.WasRollover;
+            // Firmware-measured inter-message delta (immune to TCP jitter); null for the first message.
+            firmwareDeltaMs = timestampResult.IsFirstMessage
+                ? (double?)null
+                : timestampResult.SecondsBetweenMessages * 1000.0;
+        }
 
         // Open the gate for Core's decode of this exact frame, which runs synchronously right
         // after this method returns (see _acceptChannelSamples).
@@ -1162,8 +1219,12 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         // With a counter reference (any frame seen on this connection), leftovers are recognized
         // directly; without one (first session after connect — the device's leftover survives a
         // disconnect/reconnect), the first frame is held and validated against its successor.
-        _timestampProcessor.ResetAll();
-        _timestampFrequencyApplied = false;
+        lock (_timestampProcessorSync)
+        {
+            FrameTimestampProcessor.ResetAll();
+            _timestampFrequencyApplied = false;
+        }
+
         _discardedLeftoverFrameCount = 0;
         _checkForLeftoverFrames = _hasSeenDeviceTimestamp;
         _pendingFirstFrameValidation = !_hasSeenDeviceTimestamp;
@@ -1195,8 +1256,11 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
         AppLogger.AddBreadcrumb("streaming", "Streaming stopped");
 
         // Reset timestamp processor state for clean restart
-        _timestampProcessor.ResetAll();
-        _timestampFrequencyApplied = false;
+        lock (_timestampProcessorSync)
+        {
+            FrameTimestampProcessor.ResetAll();
+            _timestampFrequencyApplied = false;
+        }
 
         foreach (var channel in DataChannels)
         {


### PR DESCRIPTION
Closes #782

## The race

`AbstractStreamingDevice` applies the device-reported streaming-clock frequency to its
`TimestampProcessor` once per session, on the first frame that reaches `ProcessStreamMessage`, gated by
`_timestampFrequencyApplied`. Verified against `origin/main`: that apply runs on the **transport
thread** (fire-and-forget inbound message pipeline) while `ResetAll()` + gate-clear run on the **UI
thread** (`InitializeStreaming`, `StopStreaming`), with nothing serializing the two, and the gate is a
plain non-`volatile` `bool`.

1. transport thread reads the gate as false → enters
2. transport thread calls `SetTimestampFrequency(deviceId, freq)`
3. **UI thread interleaves** `ResetAll()` — which drops per-device frequencies — and clears the gate
4. transport thread sets `_timestampFrequencyApplied = true`

The gate now reads "applied" over a frequency that is gone, so the session never re-applies it.

## Why it is invisible

Nothing surfaces the dropped frequency. `ResetAll()` clears the device's reported **clock
configuration** along with the session baseline; `SetTimestampFrequency(id, 0)` reverts silently rather
than erroring; `GetTickPeriod` silently falls back to the processor-wide 20 ns (50 MHz) default. So the
whole session reconstructs against 50 MHz while current firmware clocks the streaming timer at 42 MHz —
every timestamp scaled by 50/42 ≈ 1.19, no exception and no log line. Same error class as #573 / #770,
in the stop/start-during-active-stream window.

**Correction to the ticket's secondary claim:** #782 says Core's `TimestampProcessor` is not
thread-safe. It is — `ConcurrentDictionary` for both maps, a per-device `lock (state.SyncLock)` around
`ProcessTimestamp`'s critical section, and the class doc says so explicitly (verified in Core v1.3.0
source). There is no data race inside Core. What this PR protects is the **desktop's own** gate-vs-reset
invariant against a Core API that fails silently when the frequency is missing.

## The fix

One `_timestampProcessorSync` leaf lock around:

- the apply → gate write → `ProcessTimestamp` sequence in `ProcessStreamMessage`, so a reset can neither
  split the apply from its gate write nor split the apply from the reconstruction it was performed for
  (three frame-derived scalars are captured inside and consumed outside, keeping the scope tight)
- both `ResetAll()` + gate-clear sites (`InitializeStreaming`, `StopStreaming`)

Lock scope was checked against the "don't hold a hot-path lock across anything slow" rule: nothing in a
guarded region raises events, performs I/O, marshals to the dispatcher, or re-enters the device — it is
a few dictionary lookups at the 100 Hz frame cadence. Debug dispatch, `DeviceMessage` construction and
the logging handoff all stay outside. No `volatile` was added; every access is now under the lock, which
supplies the ordering the bare flag could not (and which `volatile` alone would not have fixed either —
the two writes have to be atomic together, not merely visible).

The processor field became an `init`-only `ITimestampProcessor` property so a derived test double can
substitute an instrumented processor, matching the existing `AppLogger { get; init; }` seam in the same
class. Production code still cannot swap it after construction.

## Tests

New `Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs` — three tests driving the
interleave **deterministically** rather than hoping a stress loop trips it. The instrumented processor's
`SetTimestampFrequency` starts a real `StopStreaming()` + `InitializeStreaming()` on another thread and
gives it a bounded window to land, which is exactly the ordering the lock must forbid:

- `…CannotLandBeforeTheGateIsWritten` — the racing stop/start was running and could not complete while
  the frame was between its apply and the gate write.
- `…CannotSplitTheApplyFromTheReconstructionItWasAppliedFor` — the recorded processor call order has
  `ProcessTimestamp` immediately after `SetTimestampFrequency`, with no `ResetAll` in between.
- `…LeavesTheRestartedSessionOnTheDeviceReportedClock` — the invariant's user-visible consequence: after
  the raced reset, one device-second of counter ticks still reconstructs to 1.0 s and the effective tick
  period is the device's 1/42 MHz.

**Sensitivity checked**: with the three `lock` statements neutralized, all three fail — including the
headline assertion reporting `actual: 0.84` seconds, i.e. the exact 50/42 scale error.

Full unit gate: **808/808 green**.

## Bench validation

Ran on the attached bench device (USB, COM3) with this branch's Debug build — no firmware flash
involved:

`dotnet test Daqifi.Desktop.UITest --filter "FullyQualifiedName~RestartStreamingAfterGap_TimeAxisAnchorsOnNewSession"` → **Passed**

That is the ticket's scenario end-to-end, driven through the real GUI against the device: connect,
enable all analog channels, stream a session, **stop, and start again within the same app session**
(with a deliberate 8 s gap — the stop/start-during-active-stream window #782 describes), then assert
via the live plot's stats hook that the restarted session's time axis anchors on its own data
(`firstx` ≥ 0 and near zero) and spans only the time actually streamed, not the stop-to-start gap.
Both sessions streamed, both persisted, and the harness self-cleaned them; nothing else regressed.

Two earlier attempts failed on contention artifacts rather than on this change — the box was at ~60 %
CPU from concurrent work at the time. One hit the documented `Expected at least 1 connected device
tile within 60s` starvation signature (never connected). In the other, the restarted session
legitimately streamed 8.19 s before the plot-growth poll returned, tripping the test's 8 s span bound;
**its timestamp-anchoring assertions passed** — that bound is a duration ceiling, and this change
cannot inflate the axis (a lost frequency scales reconstructed time *down* by 50/42, never up). The
pass above was the isolated re-run.

**Commit coverage:** the bench run was against af934ba. The two follow-up commits (e63c241, fb4583a)
are Qodo review fixes confined to `TimestampProcessorSerializationTests.cs` — `git diff af934ba..HEAD
-- Daqifi.Desktop/` is empty, so the production code that ran on hardware is byte-identical to HEAD's.

## Upstream

This lock is a workaround for **daqifi/daqifi-core#398 (gap 3)**. `TimestampProcessor.ResetAll()` clears
`_deviceStates` (session baselines — correct) *and* `_deviceTickPeriods` (the device-reported clock
frequency, which is configuration, not session state), and there is no baseline-only reset to call
instead. The `_timestampFrequencyApplied` gate exists **only** because the frequency has to be re-applied
after every reset — if Core preserves configured frequencies across a baseline reset, the gate and most
of this lock go away.

Worth noting as evidence for fixing it upstream: **daqifi/daqifi-avalonia#68** arrived at the same
`_timestampProcessorSync` object lock around the same four sites independently. Two codebases writing
identical mitigations around one API is the argument for changing the API. This PR keeps the two
codebases convergent; it differs from the port only in dropping the "Core is not thread-safe"
justification (which is not accurate) and in adding the test seam and the deterministic tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

