### PR TITLE
fix(devices): unsubscribe the friendly-name handler in DaqifiViewModel.Dispose

### DIFF
--- a/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
+++ b/Daqifi.Desktop.Test/ViewModels/DaqifiViewModelFriendlyNameTests.cs
@@ -240,6 +240,50 @@ public class DaqifiViewModelFriendlyNameTests
         Assert.AreEqual("Name From Device", viewModel.PendingFriendlyName);
     }
 
+    [TestMethod]
+    public void Dispose_DetachesTheSelectedDevicesNameUpdates()
+    {
+        // Arrange — the drawer's NAME-field sync is subscribed on whichever device is SelectedDevice,
+        // not on the _subscribedDevices set Dispose loops over, so it needs its own teardown. Left
+        // attached, the selected device keeps the disposed view model rooted — exactly the leak the
+        // rest of Dispose exists to prevent (issue #592) — and a late name update still runs against
+        // a disposed view model.
+        var device = CreateNotifyingDevice("Name From Device");
+        var viewModel = CreateViewModel(device.Object);
+        viewModel.SeedPendingFriendlyName("Bench Rig 3");
+
+        // Act
+        viewModel.Dispose();
+        RaiseFriendlyNameChangedOnBackgroundThread(device);
+
+        // Assert
+        Assert.AreEqual(
+            "Bench Rig 3", viewModel.PendingFriendlyName,
+            "A device-reported name reached the edit buffer after the view model was disposed.");
+    }
+
+    [TestMethod]
+    public void SelectingADeviceAfterDispose_DoesNotReattachTheNameUpdates()
+    {
+        // Arrange — Dispose runs from MainWindow's Closing handler, not Closed, so the window is
+        // still alive when it returns: another Closing handler cancelling the close leaves a device
+        // tile clickable, and that click assigns SelectedDevice. Re-attaching there would undo the
+        // teardown and root the disposed view model on the newly selected device.
+        var viewModel = CreateViewModel(CreateConnectedDevice().Object);
+        viewModel.Dispose();
+        var successor = CreateNotifyingDevice("Name From Successor");
+
+        // Act
+        viewModel.SelectedDevice = successor.Object;
+        viewModel.SeedPendingFriendlyName("Bench Rig 3");
+        RaiseFriendlyNameChangedOnBackgroundThread(successor);
+
+        // Assert
+        Assert.AreEqual(
+            "Bench Rig 3", viewModel.PendingFriendlyName,
+            "The disposed view model re-subscribed to the newly selected device.");
+    }
+
     /// <summary>
     /// Raises the device's <see cref="IStreamingDevice.FriendlyName"/> change notification from a
     /// thread-pool thread and waits for it, mirroring how Core's message-consumer thread delivers

--- a/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
+++ b/Daqifi.Desktop/ViewModels/DaqifiViewModel.cs
@@ -1053,7 +1053,8 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     /// <see cref="IStreamingDevice.FriendlyName"/>, which can arrive asynchronously (fire-and-forget
     /// inbound-message handling) after the drawer has already opened. Re-subscribes on every
     /// selection change so only the currently selected device's updates apply — an update from a
-    /// device the user has since deselected/disconnected from must not touch the buffer.
+    /// device the user has since deselected/disconnected from must not touch the buffer. Torn down in
+    /// <see cref="Dispose"/>, which is also why a disposed view model never re-attaches.
     /// </summary>
     partial void OnSelectedDeviceChanged(IStreamingDevice? oldValue, IStreamingDevice? newValue)
     {
@@ -1061,7 +1062,12 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         {
             oldNotifier.PropertyChanged -= OnSelectedDeviceFriendlyNameChanged;
         }
-        if (newValue is INotifyPropertyChanged newNotifier)
+
+        // Detaching is always safe, but re-attaching after Dispose would undo its teardown and root
+        // this view model on the newly selected device again. Reachable because Dispose runs from
+        // MainWindow's Closing handler, not Closed: if any other Closing handler cancels the close,
+        // the window stays open and a device-tile click still assigns SelectedDevice.
+        if (!_disposed && newValue is INotifyPropertyChanged newNotifier)
         {
             newNotifier.PropertyChanged += OnSelectedDeviceFriendlyNameChanged;
         }
@@ -2581,8 +2587,8 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
     /// main window closes (see <c>MainWindow</c>). Consolidates the previously ad-hoc cleanup into a
     /// single deterministic path (issue #592): the disk-space coordinator, the transient
     /// network-settings status timer, the SD-card elapsed-time timer, and the long-lived singleton /
-    /// per-device event subscriptions wired up in the constructor (which would otherwise pin this view
-    /// model for the life of the process).
+    /// per-device event subscriptions wired up in the constructor and as devices are connected or
+    /// selected (which would otherwise pin this view model for the life of the process).
     /// </summary>
     public void Dispose()
     {
@@ -2615,8 +2621,17 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
         // view model alive after the window closes. (-= is a no-op for handlers that were never wired,
         // e.g. in non-window-init construction paths.)
         ConnectionManager.Instance.PropertyChanged -= UpdateUi;
-        LoggingManager.Instance.PropertyChanged -= UpdateUi;
         ConnectedDevices.CollectionChanged -= OnConnectedDevicesCollectionChanged;
+
+        // Go through TryGetLoggingManager rather than LoggingManager.Instance: the first touch of
+        // Instance *constructs* the singleton, whose parameterless constructor resolves from
+        // App.ServiceProvider and throws when that is absent. Null here is exactly the
+        // non-window-init path, where the handler was never wired in the first place.
+        var loggingManager = TryGetLoggingManager();
+        if (loggingManager != null)
+        {
+            loggingManager.PropertyChanged -= UpdateUi;
+        }
 
         // Per-device subscriptions (logging-state PropertyChanged + debug-data) wired up as devices
         // are added in OnConnectedDevicesCollectionChanged. Left subscribed, a device keeps this VM
@@ -2627,6 +2642,15 @@ public partial class DaqifiViewModel : ObservableObject, IFirmwareUpdateHost, IL
             UnsubscribeDeviceEvents(device);
         }
         _subscribedDevices.Clear();
+
+        // The drawer's NAME-field sync is subscribed on a different axis than _subscribedDevices —
+        // whichever device is currently SelectedDevice (see OnSelectedDeviceChanged) — so the loop
+        // above does not reach it. Left subscribed, the selected device keeps this VM rooted and a
+        // late name update would still run ApplyDeviceFriendlyName against a disposed VM.
+        if (SelectedDevice is INotifyPropertyChanged selectedNotifier)
+        {
+            selectedNotifier.PropertyChanged -= OnSelectedDeviceFriendlyNameChanged;
+        }
 
         // The session-list view model observes the singleton LoggingManager.LoggingSessions collection.
         _loggingSessionList.DetachCollection();


### PR DESCRIPTION
## Problem

`OnSelectedDeviceChanged` subscribes `OnSelectedDeviceFriendlyNameChanged` to whichever device is
currently `SelectedDevice`, but `Dispose()` never detached it.

That subscription lives on a different axis than the `_subscribedDevices` set `Dispose()` loops over,
and `UnsubscribeDeviceEvents` only removes `OnDeviceLoggingStateChanged` and `DebugDataReceived` — so
nothing reached the friendly-name handler. Every other subscription the view model owns
(`ConnectionManager.Instance.PropertyChanged`, `LoggingManager.Instance.PropertyChanged`,
`ConnectedDevices.CollectionChanged`, the per-device handlers) is torn down; this one was missed.

With a device selected when the window closes, that device keeps the disposed view model rooted —
exactly the leak the rest of `Dispose()` exists to prevent (issue #592) — and a late device-reported
`FriendlyName` update can still run `ApplyDeviceFriendlyName` against a disposed view model. Harmless
today (it only writes the drawer's edit buffer), but not intentional.

Pre-existing; deliberately out of scope for #792 (issue #778), which only marshaled that handler onto
the UI thread.

## Changes

**1. Detach in `Dispose()`** — symmetric with how `OnSelectedDeviceChanged` attaches.

**2. Guard the subscribe side on `_disposed`.** `Dispose()` runs from `MainWindow`'s **`Closing`**
handler, not `Closed`, so the window is still alive when it returns: if any other `Closing` handler
cancels the close, the window stays open and a device-tile click still assigns `SelectedDevice`
(`DevicesPaneViewModel` → `_shell.SelectedDevice = tile.Device`), re-attaching the handler and undoing
the teardown. One condition on a flag that already exists. Happy to drop this half if reviewers think
the cancelled-close path isn't worth defending — the leak fix stands on its own.

**3. `Dispose()`'s `LoggingManager` teardown moves to the existing `TryGetLoggingManager()` seam.**
This was needed to make `Dispose()` callable from the tests at all: the first touch of
`LoggingManager.Instance` *constructs* the singleton, and its parameterless constructor resolves from
`App.ServiceProvider`, which is null outside the running app — so `Dispose()` threw
`ArgumentNullException` before ever reaching the friendly-name code. The existing comment there
("`-=` is a no-op for handlers that were never wired, e.g. in non-window-init construction paths") was
true of the `-=` but not of the `.Instance` access in front of it.

Production behaviour is unchanged: `App.OnStartup` builds `ServiceProvider` with
`IDbContextFactory<LoggingContext>` registered (it `GetRequiredService`s that same factory during
startup) well before the main window exists, so `TryGetLoggingManager()` returns `Instance` there.
Null is exactly the non-window-init path — where the constructor's host-init block never ran and the
handler was never wired.

## Tests

Two new cases in `DaqifiViewModelFriendlyNameTests`, both verified non-vacuous by reverting each fix
in turn and watching only the matching test fail:

- `Dispose_DetachesTheSelectedDevicesNameUpdates` — after `Dispose()`, raising the device's
  `FriendlyName` `PropertyChanged` from a background thread no longer touches `PendingFriendlyName`.
- `SelectingADeviceAfterDispose_DoesNotReattachTheNameUpdates` — assigning `SelectedDevice` after
  `Dispose()` does not re-subscribe.

These are also the first coverage of `DaqifiViewModel.Dispose()` — it was previously uncallable from
the test host for the reason in change 3.

## Verification

- `dotnet build -tl:on` — succeeded, no warnings.
- `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests" -tl:on` —
  **866 passed, 0 failed**.
- Exercised the changed shutdown path for real: launched the worktree Debug build, then sent
  `CloseMainWindow()` (WM_CLOSE) so the `Closing` handler and `Dispose()` actually ran. The app exited
  cleanly within the timeout and the app log recorded no `ERROR`/`FATAL` — the relevant check for
  change 3, since a `Dispose()` that threw would surface as an unhandled dispatcher exception out of
  `MainWindow`'s `Closing` lambda.
- No hardware needed for any of the above; the change has no device-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
