### PR TITLE
deps: bump Daqifi.Core to 1.4.0 and classify SerialPortConnectException

### DIFF
--- a/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
+++ b/Daqifi.Desktop.Test/Device/SerialStreamingDeviceLogConnectFailureTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using Daqifi.Core.Communication.Transport;
 using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device.SerialDevice;
 using Moq;
@@ -153,6 +155,65 @@ public class SerialStreamingDeviceLogConnectFailureTests
         // ...and via the exception-carrying overload specifically: the message-only Error(string)
         // synthesizes an AppLogErrorException, which would strand the real stack trace out of Sentry.
         logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    [DataRow(SerialPortConnectFailure.NotFound)]
+    [DataRow(SerialPortConnectFailure.InUse)]
+    [DataRow(SerialPortConnectFailure.AccessDenied)]
+    public void LogConnectFailure_WithClassifiedSerialPortConnectFailure_LogsWarningAndNotError(
+        SerialPortConnectFailure reason)
+    {
+        // Arrange — Core 1.4.0 (daqifi-core#427) translates SerialPort.Open failures into this typed
+        // exception. It derives from IOException, so it matches NEITHER of the FileNotFoundException
+        // / UnauthorizedAccessException arms that used to catch a missing or busy port. Without the
+        // Reason arms, all three of these — the most common things a user hits — reach the default
+        // Error path and are captured to Sentry as app bugs (issue #801).
+        var logger = new Mock<IAppLogger>();
+        var device = new TestableSerialStreamingDevice("COM_TEST_801", logger.Object);
+        var ex = new SerialPortConnectException("COM_TEST_801", reason, $"Serial open failed: {reason}");
+
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert
+        logger.Verify(l => l.Warning(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Error(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void LogConnectFailure_WithUnknownSerialPortConnectFailure_LogsError()
+    {
+        // Arrange — the guard in the other direction. SerialPortConnectFailure.Unknown means Core saw
+        // a serial-open failure it could NOT classify, which is worth investigating, so it must keep
+        // reaching the Error/Sentry path rather than being blanket-downgraded with its siblings.
+        var logger = new Mock<IAppLogger>();
+        var device = new TestableSerialStreamingDevice("COM_TEST_801", logger.Object);
+        var ex = new SerialPortConnectException(
+            "COM_TEST_801", SerialPortConnectFailure.Unknown, "Serial open failed for an unknown reason");
+
+        // Act
+        device.ExposedLogConnectFailure(ex);
+
+        // Assert
+        logger.Verify(l => l.Error(ex, It.IsAny<string>()), Times.Once);
+        logger.Verify(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+        logger.Verify(l => l.Error(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void SerialPortConnectException_DerivesFromIoException_NotTheLegacyPlatformTypes()
+    {
+        // The structural fact that makes the arms above necessary, asserted directly so a future Core
+        // change to the hierarchy fails here with an explanatory name rather than silently re-routing
+        // routine connect failures to Sentry. This is the third time Core changed a thrown type and a
+        // classification arm quietly stopped matching (#775, #779, #801); this test is the tripwire.
+        var ex = new SerialPortConnectException("COM_TEST_801", SerialPortConnectFailure.NotFound, "x");
+
+        Assert.IsInstanceOfType<IOException>(ex);
+        Assert.IsNotInstanceOfType<FileNotFoundException>(ex);
+        Assert.IsNotInstanceOfType<UnauthorizedAccessException>(ex);
     }
 
     /// <summary>

--- a/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
+++ b/Daqifi.Desktop.Test/Device/TimestampProcessorSerializationTests.cs
@@ -424,6 +424,12 @@ public class TimestampProcessorSerializationTests : IDisposable
 
         public double GetTickPeriod(string deviceId) => inner.GetTickPeriod(deviceId);
 
+        /// <summary>
+        /// Added to <see cref="ITimestampProcessor"/> in Core 1.4.0. Forwarded, not recorded: these
+        /// tests observe the apply/reset ordering, and this is a pure query.
+        /// </summary>
+        public bool HasTimestampFrequency(string deviceId) => inner.HasTimestampFrequency(deviceId);
+
         public TimestampResult ProcessTimestamp(string deviceId, uint deviceTimestamp)
         {
             Record(PROCESS_TIMESTAMP_CALL);

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-		<PackageReference Include="Daqifi.Core" Version="1.3.0" />
+		<PackageReference Include="Daqifi.Core" Version="1.4.0" />
 		<PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="10.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
 		<PackageReference Include="MahApps.Metro.IconPacks.Material" Version="6.2.1" />

--- a/Daqifi.Desktop/Device/Firmware/BootloaderSessionStreamingDeviceAdapter.cs
+++ b/Daqifi.Desktop/Device/Firmware/BootloaderSessionStreamingDeviceAdapter.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Daqifi.Core.Channel;
 using Daqifi.Core.Communication.Messages;
 using CoreConnectionStatus = Daqifi.Core.Device.ConnectionStatus;
+using CoreDeviceErrorEventArgs = Daqifi.Core.Device.DeviceErrorEventArgs;
 using CoreDeviceStatusEventArgs = Daqifi.Core.Device.DeviceStatusEventArgs;
 using CoreMessageReceivedEventArgs = Daqifi.Core.Device.MessageReceivedEventArgs;
 using CoreStreamingDevice = Daqifi.Core.Device.IStreamingDevice;
@@ -35,6 +36,17 @@ public sealed class BootloaderSessionStreamingDeviceAdapter : CoreStreamingDevic
     /// make that contract part of the code instead of an unused-field warning.
     /// </summary>
     public event EventHandler<CoreMessageReceivedEventArgs>? MessageReceived
+    {
+        add { }
+        remove { }
+    }
+
+    /// <summary>
+    /// Never raised, for the same reason as <see cref="MessageReceived"/>: this adapter runs no
+    /// read loop, message producer, or consumer, so it has no background work that could fail.
+    /// Added to <c>IDevice</c> in Core 1.4.0 (daqifi-core#415).
+    /// </summary>
+    public event EventHandler<CoreDeviceErrorEventArgs>? ErrorOccurred
     {
         add { }
         remove { }
@@ -80,7 +92,8 @@ public sealed class BootloaderSessionStreamingDeviceAdapter : CoreStreamingDevic
 
     // Channel management and device-control members (channel/DIO/analog-output members added to
     // Core's IStreamingDevice in 0.24.0; the PWM members and PwmFrequencyHz in 1.0.0; the ADC
-    // calibration and NVM persistence members in 1.3.0) are intentionally no-op here: the device
+    // calibration and NVM persistence members in 1.3.0; ErrorOccurred — on IDevice rather than
+    // IStreamingDevice — in 1.4.0) are intentionally no-op here: the device
     // is already in firmware-update mode and this adapter does not configure channels, drive
     // outputs, calibrate, persist NVM, or reboot through the streaming command path.
     // PwmFrequencyHz => 0 matches Core's documented "none commanded this session" sentinel.

--- a/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/SerialDevice/SerialStreamingDevice.cs
@@ -100,6 +100,31 @@ public partial class SerialStreamingDevice : AbstractStreamingDevice, ILanChipIn
     {
         switch (ex)
         {
+            // Core 1.4.0 (daqifi-core#427) translates SerialPort.Open failures into a typed
+            // SerialPortConnectException carrying a stable, cross-platform SerialPortConnectFailure
+            // reason. These arms must come first: the exception derives from IOException, so without
+            // them every missing or busy port — the two most common things a user hits — falls
+            // through to the default Error arm and is captured to Sentry as an app bug (issue #801).
+            //
+            // Matching on the reason rather than the platform exception type is also the first time
+            // this classification can be correct. Core's investigation found a missing port and a
+            // busy port throw byte-identical exceptions on macOS, the inner IOException message is
+            // not stable across processes for the same port, and the inner HResult is a stale errno.
+            // The FileNotFoundException/UnauthorizedAccessException arms below were matching on
+            // platform-specific accidents; they are kept as a fallback for any path that still
+            // surfaces the raw platform exception rather than Core's translated one.
+            case SerialPortConnectException { Reason: SerialPortConnectFailure.NotFound }:
+                AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is not available");
+                break;
+            case SerialPortConnectException { Reason: SerialPortConnectFailure.InUse }:
+                AppLogger.Warning(ex, $"Cannot connect on {PortName}: port is in use by another process");
+                break;
+            case SerialPortConnectException { Reason: SerialPortConnectFailure.AccessDenied }:
+                AppLogger.Warning(ex, $"Cannot connect on {PortName}: access denied");
+                break;
+            // SerialPortConnectFailure.Unknown is deliberately NOT handled here. It means Core saw a
+            // serial-open failure it could not classify, which is genuinely worth investigating, so
+            // it falls through to the default Error arm.
             case FileNotFoundException:
                 // .NET's SerialPort.Open throws FileNotFoundException when the COM port no
                 // longer exists (device unplugged, never present, or renamed). Treat as a


### PR DESCRIPTION
Bumps `Daqifi.Core` 1.3.0 -> 1.4.0 and takes the one change that **must** ship in the same PR as the bump.

Closes #802
Closes #801

## Why these are one PR

Core 1.4.0 (daqifi-core#427) translates `SerialPort.Open()` failures into a typed `SerialPortConnectException` carrying a stable `SerialPortConnectFailure` reason. It derives from `IOException`, so it matches **neither** the `FileNotFoundException` nor the `UnauthorizedAccessException` arm in `SerialStreamingDevice.LogConnectFailure`.

Bumping without the new arms means a missing port and a busy port - the two most common things a user hits - fall through to the `default:` arm, `AppLogger.Error`, i.e. Sentry. That is the regression #801 was filed to pre-empt.

## What changed

**The bump** (2 mechanical fixes, both predicted in #802):
- `BootloaderSessionStreamingDeviceAdapter` implements Core's `IDevice` directly, so it gains `ErrorOccurred`. No-op accessors, matching the existing `MessageReceived` treatment. Its version-history comment is extended to note the member arrived on `IDevice` rather than `IStreamingDevice`.
- The `RecordingTimestampProcessor` test fake gains `HasTimestampFrequency`, forwarded to the inner processor.

**The classification** (`SerialStreamingDevice.cs`):
- New arms for `NotFound`, `InUse`, `AccessDenied` -> `Warning`.
- `SerialPortConnectFailure.Unknown` deliberately **not** handled, so it still reaches `Error`/Sentry. Unknown means Core saw a serial-open failure it could not classify, which is worth investigating.
- The old `FileNotFoundException` / `UnauthorizedAccessException` arms are **kept** as a fallback for any path that still surfaces the raw platform exception rather than Core's translated one.

Per Core's own investigation, matching on `Reason` is also the first time this classification can be correct at all: a missing port and a busy port throw byte-identical exceptions on macOS, the inner message is not stable across processes for the same port, and the inner `HResult` is a stale errno. The old arms were matching on platform-specific accidents.

## Tests

Added to `SerialStreamingDeviceLogConnectFailureTests`:
- Each of the three classified reasons logs `Warning` and never `Error` (both `Error` overloads verified - the message-only one synthesizes an `AppLogErrorException` and would also reach Sentry).
- `Unknown` still logs `Error` - the guard in the other direction, so "downgrade everything" cannot pass.
- `SerialPortConnectException_DerivesFromIoException_NotTheLegacyPlatformTypes` asserts the hierarchy fact that makes the arms necessary.

That last one is deliberate. This is the **third** time Core changed a thrown type and a desktop classification arm silently stopped matching (#775, #779, #801) - each time discovered from Sentry volume rather than from a red test. It is a tripwire for the next one.

## Verification

- `dotnet build -tl:on` - clean, zero warnings
- `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests" -tl:on` - **871/871 pass**

Notably the bump is behaviorally clean: unlike 1.1.1 -> 1.3.0, no existing test changed meaning. This is despite Core splitting `DaqifiStreamingDevice` and `FirmwareUpdateService` into collaborators and extracting `SdCardOperations`.

Bench pass to follow on this branch - the riskiest behavioral delta is Core's new `SerialStreamTransport` drop detection (write-probe plus port-presence poll), which is not covered by unit tests here.

## What this unblocks

#803, #804, #805, #679, #716, #752 (Stage 3), #704, #66. See the index comment on #802.

## Note for reviewers

`SerialPortConnectFailure.Unknown` reaching Sentry is a judgment call, not an oversight. If routine unclassified serial failures show up in Sentry volume after this ships, downgrading it is a one-line change - but starting permissive would hide a real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
