### PR TITLE
chore(connection): delete the WMI unplug watcher now that Core detects serial drops

### DIFF
--- a/Daqifi.Desktop.Test/ConnectionManagerFirmwareGateTests.cs
+++ b/Daqifi.Desktop.Test/ConnectionManagerFirmwareGateTests.cs
@@ -10,16 +10,29 @@ namespace Daqifi.Desktop.Test;
 /// in-progress-state transitions must raise <see cref="ConnectionManager.FirmwareUpdateInProgressChanged"/>
 /// so an open connection dialog can pause its discovery.
 /// </summary>
+/// <remarks>
+/// Also covers the <c>OnDeviceConnectionLost</c> teardown itself, which since issue #752 stage 3 is the
+/// only unplug-detection path — the <c>Win32_DeviceChangeEvent</c> WMI watcher that used to raise the
+/// same notification is gone, so its <c>LastDisconnectReason</c>/<c>NotifyConnection</c> surface is
+/// asserted here instead. Every device mock leaves <c>DataChannels</c> empty on purpose: the teardown's
+/// unsubscribe loop dereferences <c>LoggingManager.Instance</c>, whose lazy singleton resolves from
+/// <c>App.ServiceProvider</c> and therefore throws (and caches that throw process-wide) outside the
+/// running app.
+/// </remarks>
 [TestClass]
 public class ConnectionManagerFirmwareGateTests
 {
+    private const string DISPLAY_NAME = "Nyquist-1 (SN-TEST)";
+
     [TestCleanup]
     public void TestCleanup()
     {
-        // ConnectionManager is a process-wide singleton; leave the gate and device list clear for
-        // other tests.
+        // ConnectionManager is a process-wide singleton; leave the gate, device list and pending
+        // disconnect notification clear for other tests.
         ConnectionManager.Instance.DeviceBeingUpdated = null;
         ConnectionManager.Instance.ConnectedDevices.Clear();
+        ConnectionManager.Instance.NotifyConnection = false;
+        ConnectionManager.Instance.LastDisconnectReason = string.Empty;
     }
 
     [TestMethod]
@@ -127,6 +140,64 @@ public class ConnectionManagerFirmwareGateTests
             new ConnectionLostEventArgs("cable pulled"));
 
         other.Verify(d => d.Disconnect(), Times.Once);
+    }
+
+    [TestMethod]
+    public void OnDeviceConnectionLost_SurfacesNotificationNamingTheDeviceAndReason()
+    {
+        // The user-visible half of the teardown, and the only thing the deleted WMI watcher
+        // contributed that Disconnect() itself does not do: DaqifiViewModel shows an error dialog off
+        // NotifyConnection and reads its text from LastDisconnectReason, so a silent teardown would
+        // leave a device vanishing from the UI with no explanation (issues #638, #752).
+        var device = CreateDevice(ConnectionType.Usb);
+        device.SetupGet(d => d.DeviceDisplayName).Returns(DISPLAY_NAME);
+        device.SetupGet(d => d.DataChannels).Returns([]);
+        ConnectionManager.Instance.ConnectedDevices.Add(device.Object);
+
+        InvokePrivate("OnDeviceConnectionLost", device.Object,
+            new ConnectionLostEventArgs("connection lost"));
+
+        Assert.IsTrue(ConnectionManager.Instance.NotifyConnection);
+        StringAssert.Contains(ConnectionManager.Instance.LastDisconnectReason, DISPLAY_NAME);
+        StringAssert.Contains(ConnectionManager.Instance.LastDisconnectReason, "connection lost");
+    }
+
+    [TestMethod]
+    public void OnDeviceConnectionLost_RaisesNoNotification_ForDeviceBeingUpdated()
+    {
+        // Core 1.4.0 reports the flashing device's mid-flash drop within ~3s (daqifi-core#382), so the
+        // carve-out now runs on every update rather than only when the WMI watcher happened to notice.
+        // Besides not tearing the device down, it must not pop a "device disconnected" dialog over a
+        // running firmware update.
+        var device = CreateDevice(ConnectionType.Usb);
+        device.SetupGet(d => d.DeviceDisplayName).Returns(DISPLAY_NAME);
+        device.SetupGet(d => d.DataChannels).Returns([]);
+        ConnectionManager.Instance.ConnectedDevices.Add(device.Object);
+        ConnectionManager.Instance.DeviceBeingUpdated = device.Object;
+
+        InvokePrivate("OnDeviceConnectionLost", device.Object,
+            new ConnectionLostEventArgs("connection lost"));
+
+        Assert.IsFalse(ConnectionManager.Instance.NotifyConnection);
+        Assert.AreEqual(string.Empty, ConnectionManager.Instance.LastDisconnectReason);
+        Assert.IsTrue(ConnectionManager.Instance.ConnectedDevices.Contains(device.Object));
+    }
+
+    [TestMethod]
+    public void OnDeviceConnectionLost_IgnoresDeviceThatIsNoLongerConnected()
+    {
+        // A user-initiated Disconnect racing Core's drop detection: the device is already gone from
+        // ConnectedDevices, so re-running the teardown would double-dispose it and raise a spurious
+        // "disconnected unexpectedly" dialog for something the user did on purpose.
+        var device = CreateDevice(ConnectionType.Usb);
+        device.SetupGet(d => d.DeviceDisplayName).Returns(DISPLAY_NAME);
+        device.SetupGet(d => d.DataChannels).Returns([]);
+
+        InvokePrivate("OnDeviceConnectionLost", device.Object,
+            new ConnectionLostEventArgs("connection lost"));
+
+        device.Verify(d => d.Disconnect(), Times.Never);
+        Assert.IsFalse(ConnectionManager.Instance.NotifyConnection);
     }
 
     [TestMethod]

--- a/Daqifi.Desktop/App.xaml.cs
+++ b/Daqifi.Desktop/App.xaml.cs
@@ -199,8 +199,6 @@ public partial class App
 
     protected override void OnExit(ExitEventArgs e)
     {
-        // Release the WMI device-removal watcher the connection manager holds for the process lifetime.
-        ConnectionManager.Instance.Dispose();
         AppLogger.Instance.Shutdown();
         base.OnExit(e);
     }

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -8,6 +8,34 @@ using DeviceIdentity = Daqifi.Core.Device.DeviceIdentity;
 
 namespace Daqifi.Desktop;
 
+/// <summary>
+/// Process-lifetime singleton owning the set of currently connected devices and the app-level
+/// aggregate connection status the UI binds to.
+/// </summary>
+/// <remarks>
+/// Responsibilities that are deliberately app-level policy rather than Core's:
+/// <list type="bullet">
+/// <item><description>
+/// The aggregate <see cref="ConnectionStatus"/>. Core's <c>ConnectionStatus</c> is per-device;
+/// this is the single status the shell renders.
+/// </description></item>
+/// <item><description>
+/// Duplicate-device resolution across transports, and the <c>KeepExisting</c>/<c>SwitchToNew</c>
+/// prompt the connection dialog renders. Matching itself delegates to Core's
+/// <see cref="DeviceIdentity"/> (issue #752, stage 1).
+/// </description></item>
+/// <item><description>
+/// The firmware-update carve-out: a device being flashed drops its transport as an expected part
+/// of the flash, and Core owns reconnecting it, so this class must not tear it down (issue #738).
+/// </description></item>
+/// </list>
+/// <para>
+/// Spontaneous transport drops arrive via <see cref="IDevice.ConnectionLost"/> and are handled by
+/// <see cref="OnDeviceConnectionLost"/>. This class previously also ran a <c>Win32_DeviceChangeEvent</c>
+/// WMI watcher to catch serial unplugs; Core 1.4.0 detects those itself, so the watcher was removed
+/// (issue #752, stage 3).
+/// </para>
+/// </remarks>
 public partial class ConnectionManager : ObservableObject
 {
     #region Properties

--- a/Daqifi.Desktop/ConnectionManager.cs
+++ b/Daqifi.Desktop/ConnectionManager.cs
@@ -1,28 +1,15 @@
 ﻿using Daqifi.Desktop.Common.Loggers;
 using Daqifi.Desktop.Device;
-using Daqifi.Desktop.Device.SerialDevice;
 using Daqifi.Desktop.Helpers;
 using Daqifi.Desktop.Logger;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.IO.Ports;
-using System.Management;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DeviceIdentity = Daqifi.Core.Device.DeviceIdentity;
 
 namespace Daqifi.Desktop;
 
-public partial class ConnectionManager : ObservableObject, IDisposable
+public partial class ConnectionManager : ObservableObject
 {
-    #region Private Variables
-    /// <summary>
-    /// WMI watcher for USB device-removal events. Null when the watcher could not be created
-    /// (WMI unavailable); disposed from <see cref="Dispose"/> at application exit.
-    /// </summary>
-    private readonly ManagementEventWatcher? _deviceRemovedWatcher;
-    private bool _isDisposed;
-    #endregion
-
     #region Properties
     [ObservableProperty]
     private DAQiFiConnectionStatus _connectionStatus = DAQiFiConnectionStatus.Disconnected;
@@ -152,50 +139,9 @@ public partial class ConnectionManager : ObservableObject, IDisposable
     private ConnectionManager()
     {
         ConnectedDevices = new List<IStreamingDevice>();
-
-        try
-        {
-            // EventType 3 is Device Removal
-            var deviceRemovedQuery = new WqlEventQuery("SELECT * FROM Win32_DeviceChangeEvent WHERE EventType = 3");
-
-            _deviceRemovedWatcher = new ManagementEventWatcher(deviceRemovedQuery);
-            _deviceRemovedWatcher.EventArrived += (sender, eventArgs) => CheckIfSerialDeviceWasRemoved();
-            _deviceRemovedWatcher.Start();
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Instance.Error(ex, "Failed to initialize ManagementEventWatcher: " + ex.Message);
-        }
-
     }
 
     public static ConnectionManager Instance => instance;
-
-    /// <summary>
-    /// Stops and releases the WMI device-removal watcher. Called from <c>App.OnExit</c>; the
-    /// connection manager is a process-lifetime singleton, so this runs exactly once.
-    /// </summary>
-    public void Dispose()
-    {
-        if (_isDisposed)
-        {
-            return;
-        }
-
-        _isDisposed = true;
-
-        try
-        {
-            _deviceRemovedWatcher?.Stop();
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Instance.Warning($"Failed to stop the device-removal watcher: {ex.Message}");
-        }
-
-        _deviceRemovedWatcher?.Dispose();
-        GC.SuppressFinalize(this);
-    }
 
     #endregion
 
@@ -372,12 +318,24 @@ public partial class ConnectionManager : ObservableObject, IDisposable
     /// <summary>
     /// Handles a device's <see cref="IDevice.ConnectionLost"/> event — Core detected a
     /// spontaneous transport drop (reboot, unplug, WiFi/TCP timeout, HID disconnect) that this
-    /// class would otherwise never learn about (issue #638). Mirrors the existing
-    /// <see cref="CheckIfSerialDeviceWasRemoved"/> teardown: unsubscribe the device's channels,
-    /// tear the connection down via <see cref="Disconnect(IStreamingDevice)"/> (which always
-    /// re-runs a fresh Core device + <c>InitializeAsync</c> on the next connect), and surface a
+    /// class would otherwise never learn about (issue #638). Unsubscribes the device's channels,
+    /// tears the connection down via <see cref="Disconnect(IStreamingDevice)"/> (which always
+    /// re-runs a fresh Core device + <c>InitializeAsync</c> on the next connect), and surfaces a
     /// notification naming the device and the reason.
     /// </summary>
+    /// <remarks>
+    /// This is the only unplug-detection path (issue #752, stage 3). It replaced a
+    /// <c>Win32_DeviceChangeEvent</c> WMI watcher that re-enumerated
+    /// <c>SerialPort.GetPortNames()</c> on every USB removal on the machine: Core 1.4.0
+    /// (daqifi-core#382/#403) made <c>SerialStreamTransport</c> poll for its own port's continued
+    /// presence and raise <c>ConnectionStatus.Lost</c>, which reaches here as a
+    /// <see cref="ConnectionLostEventArgs"/>. Core requires two consecutive misses of a one-second
+    /// poll, so a physically unplugged device is reported within roughly three seconds even with
+    /// no traffic — the idle case the WMI watcher existed to cover — and the check is armed only
+    /// when the port was visible to that probe at connect time, so it cannot report a false drop.
+    /// The replacement is strictly wider: the watcher only ever tore down
+    /// <c>SerialStreamingDevice</c>s, while this fires for every transport.
+    /// </remarks>
     private void OnDeviceConnectionLost(object? sender, ConnectionLostEventArgs e)
     {
         if (sender is not IStreamingDevice device)
@@ -421,8 +379,10 @@ public partial class ConnectionManager : ObservableObject, IDisposable
     /// <summary>
     /// True when <paramref name="device"/> is the device currently undergoing a firmware update. During
     /// an update the device's serial transport drops and re-enumerates as an expected part of the flash,
-    /// and Core owns the reconnect — so the desktop's disconnect-detection paths must leave that device's
+    /// and Core owns the reconnect — so <see cref="OnDeviceConnectionLost"/> must leave that device's
     /// connection untouched rather than disposing the Core device Core is reconnecting (issue #738).
+    /// This carve-out matters more since Core 1.4.0, not less: Core now reports the mid-flash drop
+    /// itself, within about three seconds of the device leaving the bus (issue #752, stage 3).
     /// </summary>
     /// <remarks>
     /// The firmware flow always drives the exact connected instance, so reference equality is the primary
@@ -445,67 +405,6 @@ public partial class ConnectionManager : ObservableObject, IDisposable
 
         return !string.IsNullOrWhiteSpace(updating.DeviceSerialNo)
             && string.Equals(updating.DeviceSerialNo, device.DeviceSerialNo, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private void CheckIfSerialDeviceWasRemoved()
-    {
-        NotifyConnection = false;
-        var bw = new BackgroundWorker();
-        bw.DoWork += delegate
-        {
-            HashSet<string> availableSerialPorts;
-            try
-            {
-                availableSerialPorts = new HashSet<string>(
-                    SerialPort.GetPortNames(),
-                    StringComparer.OrdinalIgnoreCase);
-            }
-            catch (Exception ex)
-            {
-                AppLogger.Instance.Error(ex, "Failed to enumerate serial ports after device change.");
-                return;
-            }
-
-            var devicesToRemove = ConnectedDevices
-                .OfType<SerialStreamingDevice>()
-                .Where(device =>
-                    string.IsNullOrWhiteSpace(device.Port?.PortName) ||
-                    !availableSerialPorts.Contains(device.Port.PortName))
-                .Cast<IStreamingDevice>()
-                .ToList();
-
-            foreach (var serialDevice in devicesToRemove)
-            {
-                System.Windows.Application.Current.Dispatcher.Invoke(delegate
-                {
-                    // The device being flashed drops off the COM port when it reboots mid-update — an
-                    // expected part of the flash that Core reconnects itself. Tearing it down here would
-                    // dispose the Core device out from under Core's JumpingToApp reconnect and time the
-                    // update out (issue #738), so skip it entirely (same guard as OnDeviceConnectionLost).
-                    if (IsDeviceBeingUpdated(serialDevice))
-                    {
-                        return;
-                    }
-
-                    foreach (var channel in serialDevice.DataChannels)
-                    {
-                        LoggingManager.Instance.Unsubscribe(channel);
-                    }
-
-                    Disconnect(serialDevice);
-
-                    if (!NotifyConnection)
-                    {
-                        // Scoped to this device so a later notification never shows a stale
-                        // reason string left over from a previous, unrelated disconnect.
-                        LastDisconnectReason = $"{serialDevice.DeviceDisplayName} disconnected (port removed).";
-                        NotifyConnection = true;
-                    }
-                });
-            }
-        };
-
-        bw.RunWorkerAsync();
     }
 
     /// <summary>

--- a/Daqifi.Desktop/Daqifi.Desktop.csproj
+++ b/Daqifi.Desktop/Daqifi.Desktop.csproj
@@ -65,7 +65,6 @@
 		</PackageReference>
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
 		<PackageReference Include="System.IO.Ports" Version="10.0.10" />
-		<PackageReference Include="System.Management" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Stacked on #806 (`chore/core-1.4.0-bump`) — review that first; this PR's diff is only the last commit.

Partially addresses #752 (stage 3). **Stage 2 stays open** — `DaqifiDeviceRegistry` adoption is still blocked on daqifi-core#333, which is open, so this does not close the issue.

## What this deletes

Core 1.4.0 (daqifi-core#382 / #403) made `SerialStreamTransport` detect a physically unplugged serial device instead of trusting `SerialPort.IsOpen` — which, as Core's own source comment puts it, reflects the OS handle and stays open after the cable is pulled. The drop now surfaces as `ConnectionStatus.Lost`, which `AbstractStreamingDevice.OnCoreStatusChanged` already forwards as `ConnectionLost` and `ConnectionManager.OnDeviceConnectionLost` already handles. So the `Win32_DeviceChangeEvent` watcher is redundant:

- `_deviceRemovedWatcher` and its `WqlEventQuery` / `ManagementEventWatcher` setup
- `CheckIfSerialDeviceWasRemoved` in full, with its `BackgroundWorker` and `SerialPort.GetPortNames()` enumeration
- `ConnectionManager`'s now-empty `IDisposable` implementation, and the `ConnectionManager.Instance.Dispose()` call in `App.OnExit` (the watcher was the only thing it released)
- the explicit `System.Management` package reference

Net: **-126 / +93**, of which the +93 is docs and three new tests.

## This deletes a safety net — here is the evidence it is replaced

Verified against the Core source at the consumed tag (`v1.4.0`), not against the issue text.

### 1. `OnDeviceConnectionLost` vs `CheckIfSerialDeviceWasRemoved`, side by side

Everything load-bearing is present in both; every difference favors the surviving path.

| Step | WMI path | `ConnectionLost` path |
|---|---|---|
| Firmware-update carve-out | `IsDeviceBeingUpdated` skip | same guard, same method |
| Already-torn-down guard | none (list derived from `ConnectedDevices`) | `!ConnectedDevices.Contains(device)` |
| Channel unsubscribe | `LoggingManager.Instance.Unsubscribe` per channel | identical |
| Teardown | `Disconnect(device)` | identical |
| Notification | `LastDisconnectReason` + `NotifyConnection = true` | identical |
| UI marshaling | `System.Windows.Application.Current.Dispatcher.Invoke` — NREs when `Application.Current` is null | `UiThreadHelper.InvokeOnUiThread` — runs inline with no dispatcher, and skips a shutting-down one |
| Device scope | `.OfType<SerialStreamingDevice>()` only | every transport |

Two genuine behavior differences, both deliberate and neither worth porting:

- **`NotifyConnection = false` at the top of the WMI handler.** It fired on *every* USB removal anywhere on the machine — a thumb drive included — and `NotifyConnection` is a one-shot flag that `DaqifiViewModel` consumes to show the disconnect dialog. Unplugging an unrelated device could therefore swallow a pending disconnect notification before the VM ever saw it. That is a latent bug, not behavior to preserve.
- **The `if (!NotifyConnection)` guard** around setting the reason meant that when several devices dropped together, only the first got a notification. `ConnectionLost` fires per device, so each drop now gets its own — strictly better, and the reason string can no longer be a stale leftover.

Wording changes from `"<device> disconnected (port removed)."` to `"<device> disconnected (connection lost)."`, mapped from Core's `ConnectionStatus.Lost`.

### 2. Core's detection fires for an *idle* device, not just mid-stream

This was the whole reason a WMI watcher existed, so it is the claim that mattered most. `TransportConnectionWatchdog` (Core, internal) runs two independent detectors:

- **Port-presence polling** at `DefaultPresencePollInterval` = **1 second**, requiring `PresenceMissThreshold` = **2 consecutive misses**. This is what covers the idle case — it needs no traffic at all. Bound: two intervals plus up to one interval of phase, i.e. **roughly three seconds**. The probe is `SerialPort.GetPortNames()` containing the port (plus a device-node check on Unix) — no WMI, so nothing platform-specific is lost.
- **I/O fault escalation** at 5 consecutive failures with no successful transfer in between — a few hundred ms under traffic, and a single recovered read never disconnects.

Two details that make this safe rather than merely equivalent:

- `StartDropDetection` **arms the presence check only if the probe can already see the port at connect time**. If a platform enumerated the port under a spelling the probe cannot match, the check stays off rather than tearing down a healthy connection. `SerialStreamingDevice` passes the same `Port.PortName` the desktop enumerated, so on Windows it is always armed.
- A probe that *throws* clears the miss run instead of counting it — "absent, could-not-observe, absent" cannot satisfy the two-miss threshold.

`DisconnectAsync` disarms both detectors before closing the port, so an intentional disconnect never reports as a loss. And `DaqifiDevice.OnTransportStatusChanged` only raises `Lost` when `Status == Connected && !_isDisconnecting`.

The desktop wiring is in place: `SerialStreamingDevice.CreateCoreDevice` constructs `new SerialStreamTransport(Port.PortName, enableDtr: true)` with the default liveness interval, and `ConnectionManager.Connect` subscribes `device.ConnectionLost += OnDeviceConnectionLost` for every device.

### 3. The #738 firmware carve-out survives untouched and still gates the surviving path

`IsDeviceBeingUpdated(device)` is the first thing `OnDeviceConnectionLost` does, before the `Contains` guard and before any teardown — unchanged by this PR. This matters **more** now, not less: the WMI watcher only noticed a mid-flash drop if Windows happened to raise a removal event, whereas Core now reports it within ~3 s on every flash. The doc comment on `IsDeviceBeingUpdated` was updated to say so, and a new test asserts the carve-out raises no notification either (tearing down silently and popping a "device disconnected" dialog over a running flash are separate failures).

## `System.Management`

Removable, and removed. It was referenced only by `ConnectionManager.cs` — nothing else in the solution touches `System.Management`, `ManagementEventWatcher`, `ManagementObjectSearcher`, or any `Win32_*` class. The pin was not load-bearing either: `Daqifi.Core` 1.4.0 references `System.Management` 10.0.10 unconditionally for its own WMI USB-descriptor lookup, so the assembly still resolves transitively at the same version and `System.Management.dll` is still copied to the output.

## Testing

- `dotnet build -tl:on` — clean, zero new warnings.
- `dotnet test --filter "TestCategory!=Ui&FullyQualifiedName!~WindowsFirewallWrapperTests" -tl:on` — **874 passing, 0 failed** (871 on the parent branch + 3 new).

New tests in `ConnectionManagerFirmwareGateTests`, which already owns the `OnDeviceConnectionLost` cases:

- `OnDeviceConnectionLost_SurfacesNotificationNamingTheDeviceAndReason` — the user-visible half of the teardown, previously uncovered
- `OnDeviceConnectionLost_RaisesNoNotification_ForDeviceBeingUpdated` — #738 carve-out, notification side
- `OnDeviceConnectionLost_IgnoresDeviceThatIsNoLongerConnected` — user disconnect racing Core's detection

They live in that existing class rather than a new one on purpose: MSTest here parallelizes at class level, and `ConnectionManager` is a process-wide singleton, so a third class mutating it would race the two that already do. Every device mock leaves `DataChannels` empty — the unsubscribe loop dereferences `LoggingManager.Instance`, whose lazy singleton resolves from `App.ServiceProvider` and throws (and caches the throw process-wide) outside the running app.

**Not hardware-tested.** The bench device is being shared with a concurrent agent, so I did not open COM3 or launch the app. The two bench checks named in #752 still want a human: unplug a connected USB device and confirm teardown plus a notification naming it within ~3 s, and run a firmware flash to confirm the carve-out still suppresses teardown.

## Not done here

#708's "Deliberately not filed" entry still records the WMI watcher as legitimate app-level code and should be updated to point at this PR. I left the issue edit to you rather than modifying it unprompted.

## Rebase note

When #806 squash-merges, this branch will go conflicting against a duplicate of the pre-squash commit. Rebase, do not merge main:

```bash
git rebase --onto origin/main 3597765170efbbede6c86d6cfc8086db637543ce
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
