### PR TITLE
fix(channels): adopt the app's empty channel set on connect

### DIFF
--- a/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
+++ b/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
@@ -289,6 +289,51 @@ public class CoreConnectionTemplateTests
     }
 
     [TestMethod]
+    public void Connect_SucceedsWhenTheDeviceMerelyRefusesToClearChannels()
+    {
+        // Arrange — adoption is best-effort. A device that declines the disable is survivable: the
+        // user can still pick channels by hand, so the connection must stand.
+        var device = new TemplateTestDevice(
+            deviceReportsChannelsEnabled: true,
+            disableAllChannelsException: new InvalidOperationException("Device returned a SCPI error."));
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsTrue(connected, "A refused disable must not fail an otherwise good connection.");
+        Assert.AreEqual(0, device.LoggedConnectFailures.Count, "A refusal is not a connect failure.");
+    }
+
+    /// <summary>
+    /// A dropped transport during adoption must fail the connection, not be swallowed as
+    /// best-effort.
+    /// </summary>
+    /// <remarks>
+    /// Swallowing it would let <c>Connect</c> return <c>true</c> for a device that is already gone,
+    /// so <c>ConnectionManager</c> would add it to <c>ConnectedDevices</c> having skipped both
+    /// <c>LogConnectFailure</c> and <c>CleanupConnection</c>. Same hazard as issue #619, where
+    /// delegating to Core turned disconnected no-ops into throws.
+    /// </remarks>
+    [TestMethod]
+    public void Connect_FailsWhenTheTransportDroppedWhileClearingChannels()
+    {
+        // Arrange
+        var device = new TemplateTestDevice(
+            deviceReportsChannelsEnabled: true,
+            disableAllChannelsException: new InvalidOperationException("Transport is not connected."));
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsFalse(connected, "A dropped transport must fail the connection.");
+        Assert.AreEqual(1, device.LoggedConnectFailures.Count,
+            "The failure must reach the connect template's own handling, not be swallowed.");
+        Assert.IsNull(device.ExposedCoreDevice, "CleanupConnection must have torn the Core device down.");
+    }
+
+    [TestMethod]
     public void Connect_LeavesChannelsAloneWhenTheDeviceReportsNoneEnabled()
     {
         // Arrange — the ordinary case. Regression guard in the other direction: the adopt step must
@@ -331,7 +376,8 @@ public class CoreConnectionTemplateTests
         bool returnNullCoreDevice = false,
         Exception? createException = null,
         Exception? postInitializeException = null,
-        bool deviceReportsChannelsEnabled = false) : AbstractStreamingDevice
+        bool deviceReportsChannelsEnabled = false,
+        Exception? disableAllChannelsException = null) : AbstractStreamingDevice
     {
         public List<string> HookCalls { get; } = [];
         public List<Exception> LoggedConnectFailures { get; } = [];
@@ -380,6 +426,9 @@ public class CoreConnectionTemplateTests
                 {
                     channel.IsEnabled = true;
                 }
+
+                // Armed last so it fails the adopt step specifically, not initialization.
+                CreatedCoreDevice.SendException = disableAllChannelsException;
             });
             CreatedCoreDevice.Connect();
             return CreatedCoreDevice;
@@ -432,6 +481,16 @@ public class CoreConnectionTemplateTests
     /// </summary>
     private sealed class TemplateCoreDevice(Action onInitialize) : CoreStreamingDevice("TemplateCore")
     {
+        /// <summary>
+        /// When set, the next outbound command throws this instead of being swallowed.
+        /// </summary>
+        /// <remarks>
+        /// Core's <c>DisableAllChannels</c> is not virtual, so the connect template's channel-set
+        /// adoption is failed through the transport it ultimately writes to. Armed only after
+        /// initialization, so it targets the adopt step rather than anything Core sends earlier.
+        /// </remarks>
+        public Exception? SendException { get; set; }
+
         public override Task InitializeAsync(
             TimeSpan? channelPopulationTimeout = null,
             CancellationToken cancellationToken = default)
@@ -442,6 +501,10 @@ public class CoreConnectionTemplateTests
 
         public override void Send<T>(IOutboundMessage<T> message)
         {
+            if (SendException != null)
+            {
+                throw SendException;
+            }
         }
 
         /// <summary>

--- a/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
+++ b/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
@@ -257,6 +257,55 @@ public class CoreConnectionTemplateTests
             "The default template must fail safely when CreateCoreDevice is not overridden.");
     }
 
+    /// <summary>
+    /// A device that boots with channels already enabled must not hand the app an active set it
+    /// never chose (issue #811).
+    /// </summary>
+    /// <remarks>
+    /// Firmware persists its enabled set, and since Core 1.4.0 (daqifi-core#409) that set is resynced
+    /// onto <c>IsEnabled</c> from every status message. <see cref="IChannel.IsActive"/> reads straight
+    /// through, so without this every channel tile rendered active while nothing was subscribed to
+    /// <c>LoggingManager</c> — and <c>ChannelsPaneViewModel.SelectAll</c>, which skips tiles already
+    /// reporting active, became a no-op that left Start Logging permanently disabled.
+    /// </remarks>
+    [TestMethod]
+    public void Connect_ClearsChannelsTheDeviceReportsAsAlreadyEnabled()
+    {
+        // Arrange
+        var device = new TemplateTestDevice(deviceReportsChannelsEnabled: true);
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsTrue(connected, "Adopting the channel set must not fail the connection.");
+        Assert.IsTrue(
+            device.CreatedCoreDevice!.Channels!.Count > 0,
+            "Guard: the fixture must actually have populated channels, or this asserts nothing.");
+        Assert.IsTrue(
+            device.CreatedCoreDevice.Channels!.All(channel => !channel.IsEnabled),
+            "The app starts with an empty active set, so a device reporting channels already " +
+            "enabled must be reconciled toward the app rather than the other way around.");
+    }
+
+    [TestMethod]
+    public void Connect_LeavesChannelsAloneWhenTheDeviceReportsNoneEnabled()
+    {
+        // Arrange — the ordinary case. Regression guard in the other direction: the adopt step must
+        // not fire (and must not send a disable) when there is nothing to reconcile.
+        var device = new TemplateTestDevice();
+
+        // Act
+        var connected = device.Connect();
+
+        // Assert
+        Assert.IsTrue(connected);
+        CollectionAssert.AreEqual(
+            ExpectedFullConnectHookCalls,
+            device.HookCalls,
+            "Adopting an already-empty set must not disturb the template's hook sequence.");
+    }
+
     private static DaqifiOutMessage BuildStatusMessage(string? friendlyDeviceName = null)
     {
         return new DaqifiOutMessage
@@ -281,7 +330,8 @@ public class CoreConnectionTemplateTests
     private sealed class TemplateTestDevice(
         bool returnNullCoreDevice = false,
         Exception? createException = null,
-        Exception? postInitializeException = null) : AbstractStreamingDevice
+        Exception? postInitializeException = null,
+        bool deviceReportsChannelsEnabled = false) : AbstractStreamingDevice
     {
         public List<string> HookCalls { get; } = [];
         public List<Exception> LoggedConnectFailures { get; } = [];
@@ -311,7 +361,26 @@ public class CoreConnectionTemplateTests
                 return null;
             }
 
-            CreatedCoreDevice = new TemplateCoreDevice(() => HookCalls.Add("InitializeAsync"));
+            CreatedCoreDevice = new TemplateCoreDevice(() =>
+            {
+                HookCalls.Add("InitializeAsync");
+
+                if (!deviceReportsChannelsEnabled)
+                {
+                    return;
+                }
+
+                // Models firmware that persists its enabled set across power cycles: a bench Nq1 on
+                // 3.7.2 reports analog_in_port_enabled = FFFF, and Core 1.4.0 resyncs IsEnabled from
+                // it (daqifi-core#409). Set directly rather than through the protobuf mask so the
+                // test does not depend on Core's bit layout — what matters is that channels are
+                // already enabled by the time the connect template's adopt step runs.
+                CreatedCoreDevice!.PopulateChannelsFromStatus(BuildStatusMessage());
+                foreach (var channel in CreatedCoreDevice.Channels!)
+                {
+                    channel.IsEnabled = true;
+                }
+            });
             CreatedCoreDevice.Connect();
             return CreatedCoreDevice;
         }

--- a/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
+++ b/Daqifi.Desktop.Test/Device/CoreConnectionTemplateTests.cs
@@ -288,6 +288,14 @@ public class CoreConnectionTemplateTests
             "enabled must be reconciled toward the app rather than the other way around.");
     }
 
+    /// <summary>
+    /// A device that declines the disable must not cost the user the connection.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart to <see cref="Connect_FailsWhenTheTransportDroppedWhileClearingChannels"/>:
+    /// adoption is best-effort precisely because the user can still pick channels by hand, so only
+    /// a genuinely dead transport is allowed to fail the connect.
+    /// </remarks>
     [TestMethod]
     public void Connect_SucceedsWhenTheDeviceMerelyRefusesToClearChannels()
     {
@@ -333,6 +341,13 @@ public class CoreConnectionTemplateTests
         Assert.IsNull(device.ExposedCoreDevice, "CleanupConnection must have torn the Core device down.");
     }
 
+    /// <summary>
+    /// The ordinary case: a device reporting nothing enabled needs no reconciling.
+    /// </summary>
+    /// <remarks>
+    /// Guards the other direction — the adopt step must stay inert when there is nothing to adopt,
+    /// rather than sending a disable on every connect.
+    /// </remarks>
     [TestMethod]
     public void Connect_LeavesChannelsAloneWhenTheDeviceReportsNoneEnabled()
     {
@@ -482,12 +497,19 @@ public class CoreConnectionTemplateTests
     private sealed class TemplateCoreDevice(Action onInitialize) : CoreStreamingDevice("TemplateCore")
     {
         /// <summary>
-        /// When set, the next outbound command throws this instead of being swallowed.
+        /// When set, <b>every</b> outbound command throws this until it is cleared — it is not
+        /// one-shot.
         /// </summary>
         /// <remarks>
         /// Core's <c>DisableAllChannels</c> is not virtual, so the connect template's channel-set
         /// adoption is failed through the transport it ultimately writes to. Armed only after
         /// initialization, so it targets the adopt step rather than anything Core sends earlier.
+        /// <para>
+        /// Persistent rather than one-shot on purpose: <c>DisableAllChannels</c> can send more than
+        /// one message, and the teardown that follows a fatal adoption sends as well. A one-shot
+        /// failure would be consumed by the first of those and let the rest quietly succeed, which
+        /// is exactly the kind of half-failed state these tests exist to catch.
+        /// </para>
         /// </remarks>
         public Exception? SendException { get; set; }
 

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -423,6 +423,7 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
             coreDevice.InitializeAsync().GetAwaiter().GetResult();
 
             OnCoreDeviceInitialized();
+            AdoptDeviceChannelSet(coreDevice);
             return true;
         }
         catch (Exception ex)
@@ -491,6 +492,61 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
     /// </summary>
     protected virtual void OnCoreDeviceInitialized()
     {
+    }
+
+    /// <summary>
+    /// Brings the device's enabled-channel set in line with the app's, which starts empty: a
+    /// freshly connected device has nothing active until the user picks channels.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Required since Core 1.4.0 (daqifi-core#409), which resyncs analog <c>IsEnabled</c> from the
+    /// device's own <c>analog_in_port_enabled</c> on every status message. Firmware persists its
+    /// enabled set across power cycles and a bench Nq1 on 3.7.2 reports <c>FFFF</c> — every analog
+    /// channel enabled — so from the first status message onward the app inherited an active set it
+    /// never asked for.
+    /// </para>
+    /// <para>
+    /// That broke channel activation outright (issue #811). <see cref="IChannel.IsActive"/> reads
+    /// straight through to Core's flag, so every tile rendered active while nothing was subscribed
+    /// to <c>LoggingManager</c>; <c>ChannelsPaneViewModel.SelectAll</c> skips tiles already
+    /// reporting active, so it became a no-op, no channel was ever subscribed, and
+    /// <c>CanToggleLogging</c> — which counts subscribed channels — left Start Logging disabled
+    /// with no way for the user to enable it.
+    /// </para>
+    /// <para>
+    /// Reconciling toward the app rather than the device matches what already happened before
+    /// Core 1.4.0 made the device's view visible: the first enable sends a set-replace mask
+    /// computed from the app's own state, so the app has always owned the enabled set. This just
+    /// makes that ownership explicit at connect instead of implicit at first click.
+    /// </para>
+    /// <para>
+    /// Best-effort: a device that refuses the command is logged and left alone rather than failing
+    /// the connection, since the user can still pick channels by hand.
+    /// </para>
+    /// </remarks>
+    /// <param name="coreDevice">The freshly initialized Core device.</param>
+    private void AdoptDeviceChannelSet(CoreStreamingDevice coreDevice)
+    {
+        var deviceReportedActive = coreDevice.Channels?.Count(channel => channel.IsEnabled) ?? 0;
+        if (deviceReportedActive == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            coreDevice.DisableAllChannels();
+            AppLogger.Information(
+                $"Cleared {deviceReportedActive} channel(s) the device reported as already enabled on " +
+                $"{DisplayIdentifier}, so the app starts from its own empty active set (issue #811).");
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Warning(ex,
+                $"Could not clear the device-reported enabled channels on {DisplayIdentifier}. " +
+                "Channel tiles may show as active before any channel has been selected.");
+        }
     }
 
     /// <summary>

--- a/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
+++ b/Daqifi.Desktop/Device/AbstractStreamingDevice.cs
@@ -541,13 +541,38 @@ public abstract partial class AbstractStreamingDevice : ObservableObject, IStrea
                 $"Cleared {deviceReportedActive} channel(s) the device reported as already enabled on " +
                 $"{DisplayIdentifier}, so the app starts from its own empty active set (issue #811).");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsConnectionFatal(coreDevice, ex))
         {
             AppLogger.Warning(ex,
                 $"Could not clear the device-reported enabled channels on {DisplayIdentifier}. " +
                 "Channel tiles may show as active before any channel has been selected.");
         }
     }
+
+    /// <summary>
+    /// Whether a failure raised while adopting the channel set means the connection itself is gone,
+    /// rather than the device merely declining the command.
+    /// </summary>
+    /// <remarks>
+    /// The distinction decides whether <see cref="Connect"/> can still return <c>true</c>. Adoption
+    /// is best-effort — a device that refuses is survivable, because the user can still pick
+    /// channels by hand — but a dropped transport is not: swallowing it would let
+    /// <see cref="Connect"/> report success and <c>ConnectionManager</c> add a device that is
+    /// already gone, skipping <see cref="LogConnectFailure"/> and <see cref="CleanupConnection"/>.
+    /// Used as an exception filter so a fatal failure propagates to the connect template's own
+    /// catch with its stack intact, instead of being rethrown from a nested frame.
+    /// <para>
+    /// This is the same hazard as issue #619: delegating to Core turns calls that used to no-op
+    /// while disconnected into calls that throw, so every such site has to decide explicitly what a
+    /// disconnect means for it.
+    /// </para>
+    /// </remarks>
+    /// <param name="coreDevice">The device the command was issued against.</param>
+    /// <param name="ex">The failure raised by that command.</param>
+    private static bool IsConnectionFatal(CoreStreamingDevice coreDevice, Exception ex) =>
+        !coreDevice.IsConnected
+        || ex is DeviceNotConnectedException
+        || IsTransportDisconnectedError(ex);
 
     /// <summary>
     /// Logs a failure of the shared <see cref="Connect"/> template. Default logs an error;


### PR DESCRIPTION
Fixes the channel-activation regression the Core 1.4.0 bump introduced.

Closes #811

## Root cause

**Note: #811's original write-up had the mechanism wrong.** It guessed enables were being *cleared*. They are being *inherited*. A hardware probe refuted the first theory; the corrected chain is below and on the issue.

1. Firmware persists its enabled-channel set across power cycles. Measured on the bench Nq1 (firmware 3.7.2): `analog_in_port_enabled = FFFF` — **all 16 analog channels enabled**, straight after `InitializeAsync`, before the app touches anything.
2. Core 1.4.0 (daqifi-core#409) resyncs analog `IsEnabled` from that mask on every status message.
3. `AnalogChannel.IsActive` reads straight through — `get => _coreChannel.IsEnabled;` — so **every channel tile renders active on connect**, while nothing is subscribed or streaming.
4. `ChannelsPaneViewModel.SelectAll` only toggles tiles where `!t.IsActive`, so it filters all of them out and becomes a **no-op**.
5. `ToggleChannel` therefore never runs, so `LoggingManager.Subscribe` is never called and `SubscribedChannels` stays empty.
6. `ActiveChannels` is rebuilt from `SubscribedChannels`, and `CanToggleLogging = ActiveChannels.Count > 0` gates the toggle — so **Start Logging stays disabled with no way for the user to enable it**.

Before 1.4.0 nothing overwrote `IsEnabled`, so channels read inactive at connect and the flow worked.

## The fix

`AdoptDeviceChannelSet` runs once per connect, after `OnCoreDeviceInitialized`. If the device reports channels already enabled, it clears them so the app starts from its own empty active set.

Reconciling toward the app rather than the device is not a new policy — it is the one that was already in force. The first enable sends a **set-replace** mask computed from the app's own state, so the app has always owned the enabled set; Core 1.4.0 merely made the device's disagreeing view visible in the meantime. This moves that ownership from implicit-at-first-click to explicit-at-connect.

Best-effort: a device that refuses the command logs a warning and keeps the connection, since the user can still pick channels by hand.

## Verification

**Bisected on real hardware** (single test, isolation, processes killed between runs, same attached Nyquist on COM3):

| Commit | Core | Result |
|---|---|---|
| `29ee69e` (before the bump) | 1.3.0 | PASS, PASS |
| `main` (after the bump) | 1.4.0 | **FAIL, FAIL** |
| this branch | 1.4.0 | **PASS** |

**Full device-gated FlaUI suite** on this branch: **20/23 pass, up from 10/23 on `main`.**

The 3 remaining failures are pre-existing and unrelated:
- `SdCardImport_ExistingFileOnCard_ImportsToSession` and `SdCardLogging_LogsToSdCard_ThenImportsToSession` — both report `-1` samples importing files dated 2026-06-23 and 2026-07-06. This is the known firmware SD-heap defect (firmware#703): `LIST` works, `GET` returns marker-only. The bench card has been wedged since June and writes no new files.
- `RestartStreamingAfterGap_TimeAxisAnchorsOnNewSession` fails here with `Expected at least 1 connected device tile(s) but found fewer within 60s` — the documented starvation/cascade signature, following the two SD tests that wedge the device. **The same test passes in isolation on this branch**, which is the run recorded in the table above.

**Unit gate: 876/876.** Two new tests in `CoreConnectionTemplateTests`, including a guard that the adopt step does not disturb the template when there is nothing to reconcile. The positive test was **mutation-checked** — commenting out the `AdoptDeviceChannelSet` call makes it fail.

## Note on why this reached `main`

#806 was verified with the unit gate and a Core-level bench probe. The probe drove Core's API directly, so it never exercised the desktop's channel-activation path — it could not have caught this, and reporting the bump as behaviourally clean on that basis was wrong. The FlaUI integration gate is the only automated check that drives real activation. Anything touching device/channel semantics should gate on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
